### PR TITLE
Sync production probes + restore Dockerfile-referenced overlay

### DIFF
--- a/local/prefill-probe.py
+++ b/local/prefill-probe.py
@@ -1,0 +1,92 @@
+# LOCAL to this cluster; not part of the vendored upstream kit.
+#
+# Cold-prefill TTFT probe for the dual-rail A/B (W2 follow-up).
+# Sends a UNIQUE (never-cached) long prompt, streams 16 tokens, reports
+# time-to-first-token and prefill throughput. Run from the Mac via the tunnel:
+#
+#   uv run python local/prefill-probe.py --tokens 100000 --runs 2
+#
+# Uniqueness matters: every run salts the prompt so the prefix cache cannot
+# hit; keep other traffic off (the co-batch bug also poisons the timing).
+import argparse
+import json
+import random
+import time
+import urllib.request
+
+WORDS = (
+    "ledger harbor quantum velvet orbit lattice ember cascade nickel prairie "
+    "sonnet glacier turbine mosaic saffron zephyr basalt meridian copper vault"
+).split()
+
+
+def unique_prompt(n_tokens: int) -> str:
+    rng = random.Random(time.time_ns())
+    # ~1 token per word for common short words; oversize slightly, the server
+    # reports the real prompt_tokens back.
+    body = " ".join(rng.choice(WORDS) for _ in range(int(n_tokens * 0.95)))
+    return f"[salt {rng.getrandbits(64):x}] {body}\n\nReply with the single word: done."
+
+
+def one_run(base: str, model: str, n_tokens: int, timeout: int) -> dict:
+    req = {
+        "model": model,
+        "prompt": unique_prompt(n_tokens),
+        "max_tokens": 16,
+        "temperature": 0,
+        "stream": True,
+        "stream_options": {"include_usage": True},
+    }
+    t0 = time.monotonic()
+    ttft = None
+    usage = {}
+    r = urllib.request.urlopen(
+        urllib.request.Request(
+            f"{base}/completions",
+            data=json.dumps(req).encode(),
+            headers={"Content-Type": "application/json"},
+        ),
+        timeout=timeout,
+    )
+    for raw in r:
+        line = raw.decode().strip()
+        if not line.startswith("data: ") or line == "data: [DONE]":
+            continue
+        chunk = json.loads(line[6:])
+        if ttft is None and chunk.get("choices") and (
+            chunk["choices"][0].get("text")
+        ):
+            ttft = time.monotonic() - t0
+        if chunk.get("usage"):
+            usage = chunk["usage"]
+    total = time.monotonic() - t0
+    pt = usage.get("prompt_tokens", 0)
+    return {
+        "prompt_tokens": pt,
+        "ttft_s": round(ttft, 2) if ttft else None,
+        "prefill_tok_s": round(pt / ttft, 1) if ttft and pt else None,
+        "total_s": round(total, 2),
+    }
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--base", default="http://127.0.0.1:18000/v1")
+    ap.add_argument("--model", default="GLM-5.3-Flash-EXL3")
+    ap.add_argument("--tokens", type=int, default=100000)
+    ap.add_argument("--runs", type=int, default=2)
+    ap.add_argument("--timeout", type=int, default=1800)
+    args = ap.parse_args()
+
+    results = []
+    for i in range(args.runs):
+        res = one_run(args.base, args.model, args.tokens, args.timeout)
+        results.append(res)
+        print(f"run {i + 1}: {json.dumps(res)}", flush=True)
+    rates = sorted(r["prefill_tok_s"] for r in results if r["prefill_tok_s"])
+    if rates:
+        print(f"median prefill tok/s: {rates[len(rates) // 2]}")
+
+
+if __name__ == "__main__":
+    main()

--- a/local/w2-nccl-allreduce.sh
+++ b/local/w2-nccl-allreduce.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# LOCAL to this cluster; not part of the vendored upstream kit.
+#
+# W2 — NCCL all_reduce measurement (radar plan, docs/06-improvement-plan.md).
+# Run ON spark1 as nvidia, with production STOPPED on both nodes:
+#
+#   systemctl --user stop vllm-glm53exl3-watchdog.timer
+#   systemctl --user stop vllm-glm53exl3.service
+#   bash ~/GLM-5.3-Flash-EXL3-2x-DGX-Sparks/local/w2-nccl-allreduce.sh
+#
+# Measures NCCL-layer all_reduce bus bandwidth over the CX7 fabric, twice:
+#   leg A: single-rail (prod config: rocep1s0f1, MERGE_NICS=0)
+#   leg B: dual-rail   (rocep1s0f1 + roceP2p1s0f1, MERGE_NICS=1)
+# Env mirrors start.sh's nccl_common exactly (RoCEv2, GID 3, NVLS/CUMEM off).
+# Sweep 8B..256MB covers everything TP=2 moves here: decode all_reduces are
+# tens-of-KB (latency-bound); a full 3584-token prefill chunk is tens-of-MB.
+#
+# REFUSES to run if a glm53 container is up on either node — the test wants
+# the GPUs and would fight the serving pair for unified memory.
+set -euo pipefail
+
+WORKER=192.168.177.11
+IF=enp1s0f1np1
+BIN=/home/nvidia/nccl-tests/build/all_reduce_perf
+LIBS=/home/nvidia/nccl/build/lib:/usr/local/cuda/lib64
+OUT="$HOME/w2-nccl-allreduce-$(date -u +%Y%m%dT%H%M%SZ).log"
+
+die() { echo "FATAL: $*" >&2; exit 1; }
+
+[ -x "$BIN" ] || die "missing $BIN"
+ssh -o BatchMode=yes "nvidia@$WORKER" "test -x $BIN" || die "missing $BIN on worker"
+docker ps --format '{{.Names}}' | grep -q glm53 && die "glm53 container running on head — stop production first"
+ssh -o BatchMode=yes "nvidia@$WORKER" "docker ps --format '{{.Names}}' | grep -q glm53" \
+    && die "glm53 container running on worker — stop production first"
+
+run_leg() { # $1=label $2=NCCL_IB_HCA $3=NCCL_IB_MERGE_NICS
+    echo "=== leg $1  (HCA=$2 MERGE_NICS=$3) ===" | tee -a "$OUT"
+    mpirun -np 2 -H "192.168.177.10:1,${WORKER}:1" \
+        --mca btl_tcp_if_include "$IF" --mca oob_tcp_if_include "$IF" \
+        -x "LD_LIBRARY_PATH=$LIBS" \
+        -x NCCL_IB_DISABLE=0 -x NCCL_IB_ROCE_VERSION_NUM=2 -x NCCL_IB_GID_INDEX=3 \
+        -x NCCL_NET=IB -x NCCL_NET_PLUGIN=none \
+        -x NCCL_NVLS_ENABLE=0 -x NCCL_CUMEM_ENABLE=0 \
+        -x NCCL_IGNORE_CPU_AFFINITY=1 -x NCCL_CROSS_NIC=0 \
+        -x "NCCL_IB_HCA=$2" -x "NCCL_IB_MERGE_NICS=$3" \
+        -x "NCCL_SOCKET_IFNAME=$IF" -x NCCL_DEBUG=WARN \
+        "$BIN" -b 8 -e 268435456 -f 2 -g 1 -w 5 -n 20 2>&1 | tee -a "$OUT"
+    echo | tee -a "$OUT"
+}
+
+echo "W2 NCCL all_reduce sweep  $(date -u +%Y-%m-%dT%H:%M:%SZ)" | tee "$OUT"
+run_leg A-single-rail "rocep1s0f1" 0
+run_leg B-dual-rail   "rocep1s0f1,roceP2p1s0f1" 1
+echo "Log: $OUT"

--- a/local/w4-hol-probe.py
+++ b/local/w4-hol-probe.py
@@ -1,0 +1,95 @@
+# LOCAL to this cluster; not part of the vendored upstream kit.
+#
+# W4 head-of-line probe: fire a long UNIQUE (uncacheable) prefill, then after a
+# delay fire a short request and measure its TTFT — the number a tool-call
+# client sees when it lands behind a long cold prefill. Run from the Mac:
+#
+#   uv run python local/w4-hol-probe.py --long-tokens 180000 --delay 20
+import argparse
+import json
+import random
+import threading
+import time
+import urllib.request
+
+WORDS = (
+    "ledger harbor quantum velvet orbit lattice ember cascade nickel prairie "
+    "sonnet glacier turbine mosaic saffron zephyr basalt meridian copper vault"
+).split()
+
+
+def unique_text(n: int) -> str:
+    rng = random.Random(time.time_ns())
+    return f"[salt {rng.getrandbits(64):x}] " + " ".join(
+        rng.choice(WORDS) for _ in range(int(n * 0.95))
+    )
+
+
+def stream_request(base, model, prompt, max_tokens, timeout, out):
+    req = {
+        "model": model,
+        "prompt": prompt,
+        "max_tokens": max_tokens,
+        "temperature": 0,
+        "stream": True,
+        "stream_options": {"include_usage": True},
+    }
+    t0 = time.monotonic()
+    r = urllib.request.urlopen(
+        urllib.request.Request(
+            f"{base}/completions",
+            data=json.dumps(req).encode(),
+            headers={"Content-Type": "application/json"},
+        ),
+        timeout=timeout,
+    )
+    for raw in r:
+        line = raw.decode().strip()
+        if not line.startswith("data: ") or line == "data: [DONE]":
+            continue
+        chunk = json.loads(line[6:])
+        if out.get("ttft") is None and chunk.get("choices") and chunk["choices"][0].get("text"):
+            out["ttft"] = time.monotonic() - t0
+        if chunk.get("usage"):
+            out["usage"] = chunk["usage"]
+    out["total"] = time.monotonic() - t0
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--base", default="http://127.0.0.1:18000/v1")
+    ap.add_argument("--model", default="GLM-5.3-Flash-EXL3")
+    ap.add_argument("--long-tokens", type=int, default=180000)
+    ap.add_argument("--delay", type=float, default=20.0)
+    ap.add_argument("--timeout", type=int, default=1800)
+    args = ap.parse_args()
+
+    long_out, short_out = {"ttft": None}, {"ttft": None}
+    long_prompt = unique_text(args.long_tokens) + "\n\nReply: done."
+    short_prompt = unique_text(900) + "\n\nCount from 1 to 30, comma separated."
+
+    t = threading.Thread(
+        target=stream_request,
+        args=(args.base, args.model, long_prompt, 16, args.timeout, long_out),
+    )
+    t.start()
+    time.sleep(args.delay)
+    t_short0 = time.monotonic()
+    stream_request(args.base, args.model, short_prompt, 60, args.timeout, short_out)
+    short_wall = time.monotonic() - t_short0
+    t.join()
+
+    lp = long_out.get("usage", {}).get("prompt_tokens", 0)
+    print(json.dumps({
+        "long_prompt_tokens": lp,
+        "long_ttft_s": round(long_out["ttft"], 1) if long_out["ttft"] else None,
+        "long_prefill_tok_s": round(lp / long_out["ttft"], 1) if long_out["ttft"] and lp else None,
+        "short_sent_at_s": args.delay,
+        "short_ttft_s": round(short_out["ttft"], 2) if short_out["ttft"] else None,
+        "short_wall_s": round(short_wall, 2),
+        "short_prompt_tokens": short_out.get("usage", {}).get("prompt_tokens", 0),
+    }))
+
+
+if __name__ == "__main__":
+    main()

--- a/overlay/qwen3_dflash2.py
+++ b/overlay/qwen3_dflash2.py
@@ -1,0 +1,298 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""DFlash2 draft: grouped dynamic conv + candidate selector.
+
+Port of vLLM main `qwen3_dflash2.py` onto this glm53-flash image. The image's
+LogitsProcessor has no `get_top_k_tokens`; candidate top-k uses gathered
+logits + `torch.topk` instead.
+"""
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+from vllm.compilation.backends import set_model_tag
+from vllm.compilation.decorators import support_torch_compile
+from vllm.config import CacheConfig, VllmConfig
+from vllm.model_executor.layers.linear import ReplicatedLinear
+from vllm.model_executor.layers.logits_processor import LogitsProcessor
+from vllm.model_executor.layers.quantization.base_config import QuantizationConfig
+
+from .qwen3_dflash import (
+    DFlashQwen3DecoderLayer,
+    DFlashQwen3ForCausalLM,
+    DFlashQwen3Model,
+)
+from .utils import maybe_prefix
+
+
+def _grouped_conv(
+    hidden_states: torch.Tensor,
+    delta: torch.Tensor,
+    base: torch.Tensor,
+    block_size: int,
+    num_groups: int,
+    group_size: int,
+    taps: int,
+) -> torch.Tensor:
+    blocks = hidden_states.unflatten(-1, (num_groups, group_size))
+    coefficients = base.view(1, taps, num_groups, group_size) + delta.unsqueeze(-1)
+    output = coefficients[:, 0] * blocks
+    position = torch.arange(hidden_states.shape[0], device=hidden_states.device)
+    if block_size & (block_size - 1) == 0:
+        position = position & (block_size - 1)
+    else:
+        position = position % block_size
+    for tap in range(1, taps):
+        shifted = F.pad(blocks[:-tap], (0, 0, 0, 0, tap, 0))
+        output += coefficients[:, tap] * shifted * (position >= tap).view(-1, 1, 1)
+    return output.flatten(-2)
+
+
+class DFlashGroupedConv(nn.Module):
+    def __init__(
+        self,
+        hidden_size: int,
+        taps: int,
+        group_size: int,
+        block_size: int,
+        params_dtype: torch.dtype,
+        prefix: str,
+    ) -> None:
+        super().__init__()
+        if hidden_size % group_size:
+            raise ValueError(
+                f"conv_group_size={group_size} must divide hidden_size={hidden_size}."
+            )
+        self.block_size = block_size
+        self.taps = taps
+        self.group_size = group_size
+        self.num_groups = hidden_size // group_size
+        self.base_kernel = nn.Parameter(
+            torch.empty(2, taps, hidden_size, dtype=params_dtype),
+            requires_grad=False,
+        )
+        self.kernel_projection = ReplicatedLinear(
+            hidden_size,
+            2 * taps * self.num_groups,
+            bias=False,
+            params_dtype=params_dtype,
+            quant_config=None,
+            prefix=maybe_prefix(prefix, "kernel_projection"),
+            return_bias=False,
+        )
+
+    def _convolve(
+        self, hidden_states: torch.Tensor, delta: torch.Tensor, side: int
+    ) -> torch.Tensor:
+        return _grouped_conv(
+            hidden_states,
+            delta,
+            self.base_kernel[side],
+            self.block_size,
+            self.num_groups,
+            self.group_size,
+            self.taps,
+        )
+
+    def prepare(self, hidden_states: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        coefficients = self.kernel_projection(hidden_states).reshape(
+            hidden_states.shape[0], 2, self.taps, self.num_groups
+        )
+        return self._convolve(hidden_states, coefficients[:, 0], 0), coefficients[:, 1]
+
+    def finish(
+        self, hidden_states: torch.Tensor, coefficients: torch.Tensor
+    ) -> torch.Tensor:
+        return self._convolve(hidden_states, coefficients, 1)
+
+
+class DFlash2Qwen3DecoderLayer(DFlashQwen3DecoderLayer):
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        *,
+        config,
+        layer_idx: int,
+        cache_config: CacheConfig | None = None,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__(
+            vllm_config,
+            config=config,
+            layer_idx=layer_idx,
+            cache_config=cache_config,
+            quant_config=quant_config,
+            prefix=prefix,
+        )
+        draft_config = config.dflash_config
+        speculative_config = vllm_config.speculative_config
+        assert speculative_config is not None
+        conv_args = dict(
+            hidden_size=config.hidden_size,
+            taps=int(draft_config["conv_kernel_size"]),
+            group_size=int(draft_config["conv_group_size"]),
+            # Query tokens per request: the bonus token plus the mask tokens.
+            block_size=1 + speculative_config.num_speculative_tokens,
+            params_dtype=vllm_config.model_config.dtype,
+        )
+        self.attention_conv = DFlashGroupedConv(
+            **conv_args, prefix=maybe_prefix(prefix, "attention_conv")
+        )
+        self.mlp_conv = DFlashGroupedConv(
+            **conv_args, prefix=maybe_prefix(prefix, "mlp_conv")
+        )
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        residual: torch.Tensor | None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if residual is not None:
+            hidden_states, residual = self.input_layernorm(hidden_states, residual)
+        else:
+            residual = hidden_states
+            hidden_states = self.input_layernorm(hidden_states)
+
+        hidden_states, coefficients = self.attention_conv.prepare(hidden_states)
+        hidden_states = self.self_attn(positions=positions, hidden_states=hidden_states)
+        hidden_states = self.attention_conv.finish(hidden_states, coefficients)
+
+        hidden_states, residual = self.post_attention_layernorm(hidden_states, residual)
+        hidden_states, coefficients = self.mlp_conv.prepare(hidden_states)
+        hidden_states = self.mlp(hidden_states)
+        hidden_states = self.mlp_conv.finish(hidden_states, coefficients)
+        return hidden_states, residual
+
+
+def _score_edges(
+    predecessor_table: torch.Tensor,
+    successor_table: torch.Tensor,
+    candidate_ids: torch.Tensor,
+    unary_logits: torch.Tensor,
+    hidden: torch.Tensor,
+    anchor_token_ids: torch.Tensor,
+    top_k: int,
+) -> torch.Tensor:
+    successors = successor_table[candidate_ids]
+    predecessor_ids = torch.cat(
+        (
+            anchor_token_ids[:, None, None].expand(-1, 1, top_k),
+            candidate_ids[:, :-1],
+        ),
+        dim=1,
+    )
+    predecessors = predecessor_table[predecessor_ids]
+    return unary_logits[:, :, None] + torch.einsum(
+        "blpr,blcr->blpc", predecessors * hidden[:, :, None], successors
+    )
+
+
+@support_torch_compile
+class CandidateSelector(nn.Module):
+    def __init__(
+        self,
+        hidden_size: int,
+        vocab_size: int,
+        rank: int,
+        top_k: int,
+        params_dtype: torch.dtype,
+        prefix: str,
+    ) -> None:
+        super().__init__()
+        self.top_k = top_k
+        self.predecessor_codebook = nn.Parameter(
+            torch.empty(vocab_size, rank, dtype=params_dtype), requires_grad=False
+        )
+        self.successor_codebook = nn.Parameter(
+            torch.empty(vocab_size, rank, dtype=params_dtype), requires_grad=False
+        )
+        self.hidden_projection = ReplicatedLinear(
+            hidden_size,
+            rank,
+            bias=False,
+            params_dtype=params_dtype,
+            quant_config=None,
+            prefix=maybe_prefix(prefix, "hidden_projection"),
+            return_bias=False,
+        )
+
+    def forward(
+        self,
+        candidate_ids: torch.Tensor,
+        unary_logits: torch.Tensor,
+        hidden_states: torch.Tensor,
+        anchor_token_ids: torch.Tensor,
+    ) -> torch.Tensor:
+        hidden = self.hidden_projection(hidden_states)
+        return _score_edges(
+            self.predecessor_codebook,
+            self.successor_codebook,
+            candidate_ids,
+            unary_logits,
+            hidden,
+            anchor_token_ids,
+            self.top_k,
+        )
+
+
+class DFlash2Qwen3Model(DFlashQwen3Model):
+    decoder_layer_cls = DFlash2Qwen3DecoderLayer
+
+    def __init__(
+        self,
+        *,
+        vllm_config: VllmConfig,
+        start_layer_id: int = 0,
+        prefix: str = "",
+    ) -> None:
+        super().__init__(
+            vllm_config=vllm_config,
+            start_layer_id=start_layer_id,
+            prefix=prefix,
+        )
+        draft_config = self.config.dflash_config
+        self.input_embedding_scale = float(
+            draft_config.get("input_embedding_scale", 1.0)
+        )
+        # Without its own tag the selector shares the draft head's compile cache.
+        with set_model_tag("dflash2_candidate_selector"):
+            self.candidate_selector = CandidateSelector(
+                hidden_size=self.config.hidden_size,
+                vocab_size=self.config.vocab_size,
+                rank=int(draft_config["selector_rank"]),
+                top_k=int(draft_config["selector_top_k"]),
+                params_dtype=vllm_config.model_config.dtype,
+                prefix=maybe_prefix(prefix, "candidate_selector"),
+            )
+
+    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return super().embed_input_ids(input_ids) * self.input_embedding_scale
+
+
+class DFlash2Qwen3ForCausalLM(DFlashQwen3ForCausalLM):
+    model_cls = DFlash2Qwen3Model
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
+        super().__init__(vllm_config=vllm_config, prefix=prefix)
+        draft_config = self.config.dflash_config
+        softcap = float(draft_config.get("final_logit_softcapping") or 0.0)
+        self.candidate_logits_processor = LogitsProcessor(
+            vllm_config.model_config.get_vocab_size(),
+            scale=float(draft_config.get("output_multiplier", 1.0)),
+            soft_cap=softcap if softcap > 0 else None,
+        )
+
+    def compute_candidates(
+        self, hidden_states: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        logits = self.candidate_logits_processor(self.lm_head, hidden_states)
+        assert logits is not None
+        top_k = self.model.candidate_selector.top_k
+        unary_logits, candidate_ids = torch.topk(logits, top_k, dim=-1)
+        return candidate_ids, unary_logits
+
+
+EntryClass = DFlash2Qwen3ForCausalLM


### PR DESCRIPTION
Production-vs-repo audit (requested after the recent A/B windows). Four gaps found and fixed:

| File | Why |
|---|---|
| `local/prefill-probe.py` | Cold-prefill TTFT probe — the instrument behind the W2 dual-rail verdict (941 vs 917 tok/s) |
| `local/w2-nccl-allreduce.sh` | Prod-stopped NCCL all_reduce sweep (single- vs dual-rail legs, refuses to run while serving) |
| `local/w4-hol-probe.py` | Head-of-line TTFT probe — the instrument behind the W4 verdict (256 s → 7.9 s) |
| `overlay/qwen3_dflash2.py` | **Restored**: `Dockerfile:434` COPYs it, so its earlier removal broke `BUILD=1` image rebuilds. Runtime boots unaffected (baked into the pinned image). If you'd rather keep it deleted, the Dockerfile COPY must go with it — but that forfeits reproducible rebuilds of the DFlash2 draft path. |

Everything else that differs between repo and production is intentional repo-side cleanup (header neutralization, shellcheck if/else) — verified file-by-file, no production logic missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0169v6WmVciYA7Ea16n36CK7