### PR TITLE
Prod sync 2026-08-30: cache-reset endpoint, W9 router-GEMM backport, ops hardening

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -447,6 +447,8 @@ COPY overlay/patch_hybrid_prefix_hit.py /opt/glm53/patch_hybrid_prefix_hit.py
 COPY tests/test_hybrid_prefix_hit.py /opt/glm53/test_hybrid_prefix_hit.py
 COPY overlay/patch_xgrammar_termination.py /opt/glm53/patch_xgrammar_termination.py
 COPY tests/test_xgrammar_termination.py /opt/glm53/test_xgrammar_termination.py
+COPY overlay/patch_cache_reset.py /opt/glm53/patch_cache_reset.py
+COPY tests/test_cache_reset_endpoint.py /opt/glm53/test_cache_reset_endpoint.py
 RUN python3 /opt/glm53/patch_model_overrides.py
 RUN python3 /opt/glm53/patch_dflash2.py
 RUN python3 /opt/glm53/patch_glm_eagle3.py
@@ -455,9 +457,11 @@ RUN python3 /opt/glm53/patch_suppress_stops_in_reasoning.py
 RUN python3 /opt/glm53/patch_scheduler_decode_floor.py
 RUN python3 /opt/glm53/patch_hybrid_prefix_hit.py
 RUN python3 /opt/glm53/patch_xgrammar_termination.py
+RUN python3 /opt/glm53/patch_cache_reset.py
 
 RUN EXL3_SELFCHECK_GPU=0 python3 /opt/glm53/test_exl3_overlay.py \
     && python3 /opt/glm53/test_suppress_stops.py \
     && python3 /opt/glm53/test_scheduler_decode_floor.py \
     && python3 /opt/glm53/test_hybrid_prefix_hit.py \
-    && python3 /opt/glm53/test_xgrammar_termination.py
+    && python3 /opt/glm53/test_xgrammar_termination.py \
+    && python3 /opt/glm53/test_cache_reset_endpoint.py

--- a/README.md
+++ b/README.md
@@ -80,6 +80,30 @@ Then install the units in `local/` (`systemctl --user enable ...`) so the pair s
 reboots and heals itself. `docs/03-bringup.md` has the full drill, including why
 `ExecStart` must be restart-shaped and why the watchdog never blocks.
 
+## API surface notes (this build)
+
+**Cache reset.** `overlay/patch_cache_reset.py` mounts the upstream dev cache
+router on the head API server, so a genuinely cold prefix cache no longer
+needs a container restart:
+
+```bash
+curl -s -X POST http://127.0.0.1:8000/reset_prefix_cache    # -> {"success": true}
+```
+
+It returns `{"success": bool}` and reports `false` while blocks are still
+held (running requests, in-flight async KV offload) — retry after they
+drain. `GLM53_EXPOSE_CACHE_RESET=0 ./start.sh` restores the stock surface
+(restart is then the only reset); `VLLM_SERVER_DEV_MODE=1` still mounts the
+whole dev set (`/sleep`, `/rlhf`, `/rpc`, `/server_info`) if ever needed.
+Auth caveat: the bearer middleware only guards `/v1`, `/v2`, `/inference`,
+`/cohere` (upstream `GUARDED_PREFIX`), so root-mounted routes — the stock
+`/tokenize` / `/detokenize` and the cache-reset routes — answer without the
+key even with `VLLM_API_KEY` set. Set `GLM53_EXPOSE_CACHE_RESET=0` on kits
+that serve untrusted clients.
+
+**Tokenize.** It is mounted at the **root** (`/v1/tokenize` is 404) and the
+request validates `prompt` (or `messages` for the chat shape), not `text`.
+
 ## Measured (2026-08-29, warm, temp 0, median of 3)
 
 | Phase | Value |

--- a/local/cache-burst.py
+++ b/local/cache-burst.py
@@ -5,11 +5,16 @@ LOCAL to this cluster; not part of the vendored upstream kit.
 
 Simulates N long-lived agent sessions (openclaw-shaped: big stable prompt
 prefix, tiny new suffix per turn, short answers) hitting the server
-concurrently for R rounds, and reports the server-side prefix-cache delta
-per round. Round 1 is cold by construction; rounds 2+ measure whether each
-session's cached prefix SURVIVED the other sessions' traffic — the eviction
-churn probe. If N*ctx_tokens exceeds the 929,670-token KV pool, hit% on
-rounds 2+ collapses; if it fits, hit% should be >90%.
+concurrently for R rounds, and reports the prefix-cache hit rate per round.
+Primary ledger: per-request usage.prompt_tokens_details.cached_tokens (exact,
+per-request). Secondary: the global prefix_cache_queries/hits counter delta —
+kept for continuity, but it over-counts 1.3–2x under queue pressure (vLLM RFC
+#37003 thread), so trust the usage-based number when they disagree.
+Round 1 is cold by construction; rounds 2+ measure whether each session's
+cached prefix SURVIVED the other sessions' traffic — the eviction churn probe.
+If N*ctx_tokens exceeds the KV pool (1,396,551 tok at the 2026-08-29 1M
+geometry; pool "tokens" are geometry-dependent), hit% on rounds 2+ collapses;
+if it fits, hit% should be >90%.
 
 Usage:
   uv run python local/cache-burst.py --sessions 4 --ctx-tokens 60000 --rounds 2
@@ -52,10 +57,13 @@ def turn(base, model, prefix, session, rnd, max_tokens, timeout):
     t0 = time.time()
     try:
         with urllib.request.urlopen(req, timeout=timeout) as r:
-            json.load(r)
-        return time.time() - t0, None
+            resp = json.load(r)
+        usage = resp.get("usage") or {}
+        prompt = usage.get("prompt_tokens") or 0
+        cached = (usage.get("prompt_tokens_details") or {}).get("cached_tokens") or 0
+        return time.time() - t0, None, prompt, cached
     except Exception as e:
-        return time.time() - t0, str(e)[:200]
+        return time.time() - t0, str(e)[:200], 0, 0
 
 def main():
     ap = argparse.ArgumentParser()
@@ -82,10 +90,15 @@ def main():
                               range(a.sessions)))
         wall, m1 = time.time() - t0, metrics(a.base)
         dq, dh, dp = m1["q"] - m0["q"], m1["h"] - m0["h"], m1["p"] - m0["p"]
-        errs = [e for _, e in res if e]
-        lat = sorted(t for t, _ in res)
-        print(f"round {rnd}: wall {wall:6.1f}s  hit% {100*dh/max(dq,1):5.1f}  "
-              f"prompt_tok {dp:9.0f}  prefill_tps {dp/max(wall,0.01):7.0f}  "
+        errs = [e for _, e, _, _ in res if e]
+        lat = sorted(t for t, _, _, _ in res)
+        prompt_sum = sum(p for _, _, p, _ in res)
+        cached_sum = sum(c for _, _, _, c in res)
+        # usage-based hit% is the trustworthy number; counter-based kept for continuity
+        print(f"round {rnd}: wall {wall:6.1f}s  "
+              f"hit% {100*cached_sum/max(prompt_sum,1):5.1f} (usage: {cached_sum:,}/{prompt_sum:,})  "
+              f"[counters {100*dh/max(dq,1):5.1f}]  "
+              f"prefill_tps {dp/max(wall,0.01):7.0f}  "
               f"lat p50/max {lat[len(lat)//2]:.1f}/{lat[-1]:.1f}s  errors {len(errs)}")
         for e in errs[:3]:
             print(f"    err: {e}")

--- a/local/cache-probe.sh
+++ b/local/cache-probe.sh
@@ -13,6 +13,11 @@
 # NOTE metric semantics: vllm:kv_cache_usage_perc counts only blocks held by
 # RUNNING requests (it reads 0.0 at idle even with a warm cache). Cached
 # reusable blocks live in the free pool and are invisible to that gauge.
+# ⚠ The global queries/hits counters over-count 1.3–2x under queue pressure
+# (vLLM RFC #37003 thread) — this probe watches OTHER clients' live traffic so
+# they are the only option here; treat the windowed hit% as directional. For
+# exact numbers use cache-burst.py, which reads per-request
+# usage.prompt_tokens_details.cached_tokens from its own requests.
 #
 # Usage: cache-probe.sh [interval_seconds] [count]
 set -uo pipefail

--- a/local/content-warmup.sh
+++ b/local/content-warmup.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# content-warmup.sh — replay standing clients' stable prompt anchors after a
+# restart so their first real turn hits warm prefix-cache pages (W8).
+#
+# LOCAL to this cluster; not part of the upstream MiaAI-Lab kit.
+#
+# The kit's boot-shape-warmup burns KERNEL shapes; this warms CONTENT: each
+# anchor goes through the ordinary prefill path as a normal request, landing
+# real pages in the prefix cache (which sparse retention then keeps). Only
+# byte-identical prefixes hit, so anchors must match what the client actually
+# sends — capture them from real traffic, don't hand-write them.
+#
+# DORMANT unless GLM53_CONTENT_WARMUP=1. Anchors live in
+#   ~/.local/share/glm53-content-warmup/
+#     *.txt   — anchor text, replayed as the system message of a 1-token chat
+#     *.json  — a full /v1/chat/completions request body, posted verbatim
+#               (max_tokens is overridden to 1)
+# Anchors under 3584 tokens (one hybrid page) can never hit — warned and sent
+# anyway (harmless).
+#
+# Wire-up (at window time): systemd drop-in on vllm-glm53exl3.service —
+#   [Service]
+#   ExecStartPost=-/usr/bin/bash %h/GLM-5.3-Flash-EXL3-2x-DGX-Sparks/local/content-warmup.sh
+# The leading '-' keeps a warmup failure from failing the unit.
+set -uo pipefail
+
+[ "${GLM53_CONTENT_WARMUP:-0}" = "1" ] || { echo "content-warmup: disabled (GLM53_CONTENT_WARMUP != 1)"; exit 0; }
+
+BASE="${GLM53_BASE:-http://127.0.0.1:8000}"
+MODEL="${GLM53_MODEL:-GLM-5.3-Flash-EXL3}"
+ANCHOR_DIR="${GLM53_ANCHOR_DIR:-$HOME/.local/share/glm53-content-warmup}"
+REQ_TIMEOUT="${GLM53_WARMUP_REQ_TIMEOUT:-600}"   # bounded: a 100k cold prefill is ~2 min
+PAGE_TOKENS=3584
+
+ts() { date -u +%H:%M:%SZ; }
+log() { echo "[content-warmup $(ts)] $*"; }
+
+shopt -s nullglob
+files=("$ANCHOR_DIR"/*.txt "$ANCHOR_DIR"/*.json)
+[ "${#files[@]}" -gt 0 ] || { log "no anchors in $ANCHOR_DIR — nothing to warm"; exit 0; }
+
+curl -sf -m 10 "$BASE/health" >/dev/null || { log "API not reachable at $BASE — skipping"; exit 0; }
+
+warmed=0
+for f in "${files[@]}"; do
+    name="$(basename "$f")"
+    case "$f" in
+        *.json)
+            body="$(python3 -c 'import json,sys; b=json.load(open(sys.argv[1])); b["max_tokens"]=1; b.setdefault("temperature",0); print(json.dumps(b))' "$f")" \
+                || { log "SKIP $name: not valid JSON"; continue; }
+            ;;
+        *)
+            # token-count check via /tokenize (best effort)
+            n="$(python3 - "$BASE" "$f" <<'PY' 2>/dev/null
+import json,sys,urllib.request
+base,path=sys.argv[1],sys.argv[2]
+req=urllib.request.Request(base+"/tokenize",data=json.dumps({"prompt":open(path).read()}).encode(),headers={"Content-Type":"application/json"})
+print(json.load(urllib.request.urlopen(req,timeout=30)).get("count",0))
+PY
+)"
+            [ -n "${n:-}" ] && [ "${n:-0}" -lt "$PAGE_TOKENS" ] 2>/dev/null \
+                && log "WARN $name: ~${n} tokens < one ${PAGE_TOKENS}-token page — can never produce a hit"
+            body="$(python3 -c 'import json,sys; print(json.dumps({"model":sys.argv[2],"messages":[{"role":"system","content":open(sys.argv[1]).read()},{"role":"user","content":"OK"}],"max_tokens":1,"temperature":0,"chat_template_kwargs":{"enable_thinking":False}}))' "$f" "$MODEL")"
+            ;;
+    esac
+    t0=$(date +%s)
+    if out="$(curl -sf -m "$REQ_TIMEOUT" -H "Content-Type: application/json" -d "$body" "$BASE/v1/chat/completions" 2>&1)"; then
+        cached="$(printf '%s' "$out" | python3 -c 'import json,sys; u=json.load(sys.stdin).get("usage") or {}; print((u.get("prompt_tokens_details") or {}).get("cached_tokens",0), u.get("prompt_tokens",0))' 2>/dev/null)"
+        log "warmed $name in $(( $(date +%s) - t0 ))s (cached/prompt: ${cached:-?})"
+        warmed=$((warmed+1))
+    else
+        log "WARN $name: request failed after $(( $(date +%s) - t0 ))s — continuing"
+    fi
+done
+log "done: ${warmed}/${#files[@]} anchors warmed"

--- a/local/metrics-alert.sh
+++ b/local/metrics-alert.sh
@@ -28,7 +28,11 @@ MIN_DRAFT="${MIN_DRAFT:-50}"
 # Config-critical argv fragments (pipe-separated). Every one must be present.
 # 900000 -> 1000000 2026-08-29 (the 1M Window-2 geometry; the stale value had the
 # canary failing every tick). Keep this in lockstep with MAX_MODEL_LEN in .env.
-EXPECT_ARGV="${EXPECT_ARGV:---host 127.0.0.1|--port ${PORT}|--kv-cache-memory-bytes 15414698763|--quantization exl3|--max-model-len 1000000}"
+# MNBT guarded since 2026-08-29: upstream kit default moved to 2048 (PR #40);
+# ours must stay 3584 (= hybrid page size, align-mode cache needs MNBT >= page).
+# async-off guarded for the same reason: it is a tri-state that silently
+# resolves ENABLED when the flag is dropped.
+EXPECT_ARGV="${EXPECT_ARGV:---host 127.0.0.1|--port ${PORT}|--kv-cache-memory-bytes 15414698763|--quantization exl3|--max-model-len 1000000|--max-num-batched-tokens 3584|--no-async-scheduling}"
 
 mkdir -p "$STATE_DIR"
 ts() { date -u +%Y-%m-%dT%H:%M:%SZ; }

--- a/overlay/patch_cache_reset.py
+++ b/overlay/patch_cache_reset.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Expose the cache-reset API routes on the :exl3 image (issue #31).
+
+This vLLM build (0.1.dev20051+g487ecf187) ships ``/reset_prefix_cache``,
+``/reset_mm_cache`` and ``/reset_encoder_cache`` in
+``vllm/entrypoints/serve/dev/cache/api_router.py`` — but ``build_app`` only
+mounts them when ``VLLM_SERVER_DEV_MODE=1``, which would also expose the
+whole dev surface (``/sleep``, ``/rlhf``, ``/rpc``, ``/server_info``).
+Cold prefix-cache benchmarking then needs a full container restart, which
+the README's prefix-cache ladder used to work around with per-session
+salting only (issue #31, bench_prefix_cache.py docstring).
+
+This patch adds a narrow ``elif`` to ``build_app``: when
+``GLM53_EXPOSE_CACHE_RESET=1``, attach ONLY the cache-reset router. The
+rest of the dev surface stays off, and ``VLLM_SERVER_DEV_MODE=1`` keeps
+precedence (full dev mounts, as upstream). The flag is read at
+``build_app`` time, so toggling it needs a container restart but not a
+re-patch.
+
+Auth note (upstream quirk, documented in the README): the
+``AuthenticationMiddleware`` only guards ``GUARDED_PREFIX = ("/v1", "/v2",
+"/inference", "/cohere")``, so root-mounted routes — including the stock
+``/tokenize`` and the cache-reset routes — answer without a bearer even
+when ``VLLM_API_KEY`` is set. A cache reset can flush serving state, so
+set ``GLM53_EXPOSE_CACHE_RESET=0`` on shared kits.
+
+Fail closed if the vLLM anchors drift.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+P = Path(
+    os.environ.get(
+        "GLM53_API_SERVER_PY",
+        "/usr/local/lib/python3.12/dist-packages/vllm/entrypoints/openai/"
+        "api_server.py",
+    )
+)
+MARK = "# [glm53-cache-reset]"
+
+DEV_OLD = """    if envs.VLLM_SERVER_DEV_MODE:
+        from vllm.entrypoints.serve import register_vllm_dev_api_routers
+
+        register_vllm_dev_api_routers(app)
+"""
+
+DEV_NEW = """    if envs.VLLM_SERVER_DEV_MODE:
+        from vllm.entrypoints.serve import register_vllm_dev_api_routers
+
+        register_vllm_dev_api_routers(app)
+    elif os.getenv("GLM53_EXPOSE_CACHE_RESET", "0") == "1":
+        # [glm53-cache-reset] Expose only the cache-reset dev routes (issue
+        # #31): /reset_prefix_cache, /reset_mm_cache, /reset_encoder_cache.
+        # The rest of the dev surface (sleep / rlhf / rpc / server_info)
+        # stays off; VLLM_SERVER_DEV_MODE=1 keeps mounting everything.
+        from vllm.entrypoints.serve.dev.cache.api_router import (
+            attach_router as attach_cache_reset_router,
+        )
+
+        attach_cache_reset_router(app)
+"""
+
+
+def main() -> int:
+    if not P.is_file():
+        raise SystemExit(f"missing {P}")
+    text = P.read_text()
+    n_old = text.count(DEV_OLD)
+    n_new = text.count(DEV_NEW)
+    n_mark = text.count(MARK)
+    if n_new == 1 and n_mark <= 1:
+        print(f"{P.name}: cache-reset elif already present — skipping")
+        return 0
+    if n_mark or n_new:
+        raise SystemExit(
+            f"{P}: partial/inconsistent cache-reset patch "
+            f"(old={n_old}, new={n_new}, marker={n_mark})"
+        )
+    if n_old != 1:
+        raise SystemExit(
+            f"{P}: expected exactly one pristine dev-mode block, found {n_old}"
+        )
+    text = text.replace(DEV_OLD, DEV_NEW, 1)
+    if text.count(DEV_NEW) != 1 or text.count(MARK) != 1:
+        raise SystemExit(f"{P}: cache-reset post-patch verification failed")
+    compile(text, str(P), "exec")
+    P.write_text(text)
+    print(f"patched {P.name} (GLM53_EXPOSE_CACHE_RESET=1 mounts only the "
+          "cache-reset dev routes)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/overlay/patch_router_gemm_gb10.py
+++ b/overlay/patch_router_gemm_gb10.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Enable the cuBLAS out_dtype router GEMM on GB10 (vLLM PR #54048 backport).
+
+LOCAL to this cluster; not part of the upstream MiaAI-Lab kit (offered upstream
+once proven).
+
+On family-120 Blackwell (GB10 sm_121) ``GateLinear`` gates the fused
+bf16 x bf16 -> fp32 router GEMM on ``allow_specialized_router_gemm``, which is
+Hopper + SM100-family only (``is_device_capability_family(100)`` is False on
+GB10). The fused path is just ``torch.mm``'s out_dtype epilogue — plain cuBLAS,
+arch-agnostic — so GB10 needlessly runs a standalone bf16->fp32 copy kernel
+that also bf16-rounds the router logits before grouped_topk. GLM-5.3-Flash is
+exactly the affected shape: text_config ships ``moe_router_dtype: float32``,
+the gate weight is bf16, and there is no Linear bias — the arch gate is the
+only failing condition, on every MoE layer, prefill and decode.
+
+Backports vLLM PR #54048 (open; fixes #49921): gate the cuBLAS tier on its own
+CUDA/ROCm + no-bias predicate instead of ``allow_specialized_router_gemm``.
+Both sites (``__init__`` and ``set_out_dtype``) are patched to stay coherent.
+
+Ablation: ``GLM53_ROUTER_GEMM_CUBLAS=0`` at runtime restores stock eligibility
+exactly (the env is read at gate construction, i.e. model load). Default 1.
+
+Fail closed if the vLLM anchors drift.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+P = Path(
+    os.environ.get(
+        "GLM53_GATE_LINEAR_PY",
+        "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/"
+        "fused_moe/router/gate_linear.py",
+    )
+)
+MARK = "# [glm53-router-gemm-gb10]"
+
+INIT_OLD = """        self._router_gemm_no_bias = not bias
+        self.allow_cublas_router_gemm = (
+            (
+                self.allow_specialized_router_gemm
+                or (current_platform.is_rocm() and self._router_gemm_no_bias)
+            )
+            and self.weight.dtype == torch.bfloat16
+            and self.out_dtype == torch.float32
+        )
+"""
+
+INIT_NEW = """        self._router_gemm_no_bias = not bias
+        # [glm53-router-gemm-gb10] vLLM #54048 backport: the cuBLAS out_dtype
+        # epilogue is arch-agnostic; do not gate it on the SM90/SM100-only
+        # specialized-kernel predicate (family-120/GB10 was losing this tier
+        # and bf16-rounding router logits through the copy-kernel fallback).
+        # GLM53_ROUTER_GEMM_CUBLAS=0 restores stock eligibility exactly.
+        import os as _glm53_os
+        self._router_gemm_cublas_capable = (
+            self.allow_specialized_router_gemm
+            or (current_platform.is_rocm() and self._router_gemm_no_bias)
+            or (
+                _glm53_os.getenv("GLM53_ROUTER_GEMM_CUBLAS", "1") == "1"
+                and (current_platform.is_cuda() or current_platform.is_rocm())
+                and self._router_gemm_no_bias
+            )
+        )
+        self.allow_cublas_router_gemm = (
+            self._router_gemm_cublas_capable
+            and self.weight.dtype == torch.bfloat16
+            and self.out_dtype == torch.float32
+        )
+        if self.allow_cublas_router_gemm and not (
+            self.allow_specialized_router_gemm
+            or (current_platform.is_rocm() and self._router_gemm_no_bias)
+        ):
+            logger.info_once(
+                "GB10 cuBLAS out_dtype router GEMM enabled (#54048 overlay)."
+            )
+"""
+
+SETDTYPE_OLD = """        if (
+            not self.allow_cublas_router_gemm
+            and (
+                self.allow_specialized_router_gemm
+                or (current_platform.is_rocm() and self._router_gemm_no_bias)
+            )
+            and out_dtype == torch.float32
+        ):
+            self.allow_cublas_router_gemm = self.weight.dtype == torch.bfloat16
+"""
+
+SETDTYPE_NEW = """        if (
+            not self.allow_cublas_router_gemm
+            and self._router_gemm_cublas_capable  # [glm53-router-gemm-gb10]
+            and out_dtype == torch.float32
+        ):
+            self.allow_cublas_router_gemm = self.weight.dtype == torch.bfloat16
+"""
+
+
+def main() -> int:
+    if not P.is_file():
+        raise SystemExit(f"missing {P}")
+    text = P.read_text()
+    n_mark = text.count(MARK)
+    if text.count(INIT_NEW) == 1 and text.count(SETDTYPE_NEW) == 1:
+        print(f"{P.name}: router-gemm-gb10 patch already present — skipping")
+        return 0
+    if n_mark:
+        raise SystemExit(f"{P}: partial/inconsistent router-gemm patch (marker={n_mark})")
+    for name, frag in (("init", INIT_OLD), ("set_out_dtype", SETDTYPE_OLD)):
+        if text.count(frag) != 1:
+            raise SystemExit(
+                f"{P}: expected exactly one pristine {name} block, "
+                f"found {text.count(frag)} — anchors drifted, refusing"
+            )
+    text = text.replace(INIT_OLD, INIT_NEW, 1).replace(SETDTYPE_OLD, SETDTYPE_NEW, 1)
+    if text.count(MARK) != 2:
+        raise SystemExit(f"{P}: post-patch verification failed (marker={text.count(MARK)})")
+    compile(text, str(P), "exec")
+    P.write_text(text)
+    print(f"patched {P.name} (cuBLAS out_dtype router GEMM un-gated for GB10; "
+          "GLM53_ROUTER_GEMM_CUBLAS=0 to ablate)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/start.sh
+++ b/start.sh
@@ -150,6 +150,7 @@ SCHED_PATCH_HOST="${SCHED_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_scheduler_decode
 DRAFTER_PATCH_HOST="${DRAFTER_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_glm5_drafter_group.py}"
 APC_PATCH_HOST="${APC_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_hybrid_prefix_hit.py}"
 XGRAMMAR_PATCH_HOST="${XGRAMMAR_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_xgrammar_termination.py}"
+CACHE_RESET_PATCH_HOST="${CACHE_RESET_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_cache_reset.py}"
 KV_CACHE_DTYPE="${KV_CACHE_DTYPE:-fp8}"
 QUANTIZATION="${QUANTIZATION:-exl3}"
 LANGUAGE_MODEL_ONLY="${LANGUAGE_MODEL_ONLY:-0}"
@@ -191,6 +192,13 @@ VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS="${VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS:-1800}"
 # 1 = after /health, burn DFlash2 BLOCK / sampler / kpool shapes. Nonfatal.
 GLM53_BOOT_SHAPE_WARMUP="${GLM53_BOOT_SHAPE_WARMUP:-1}"
 GLM53_WARMUP_REQ_TIMEOUT="${GLM53_WARMUP_REQ_TIMEOUT:-240}"
+# 1 = mount ONLY the cache-reset dev routes (/reset_prefix_cache, /reset_mm_cache,
+# /reset_encoder_cache — issue #31) on the head API server, so cold bench runs
+# can reset the prefix cache without a restart. The rest of the dev surface
+# (sleep / rlhf / rpc / server_info) stays off. Caveat: root-mounted routes are
+# outside the bearer guard (GUARDED_PREFIX), so set 0 on shared kits. Restart
+# applies it; the patch itself is inert when 0 (stock image behavior).
+GLM53_EXPOSE_CACHE_RESET="${GLM53_EXPOSE_CACHE_RESET:-1}"
 
 # OpenAI-compatible API bearer token. Read the native VLLM_API_KEY env var
 # (vLLM falls back to it when --api-key is absent on the CLI), so the key
@@ -354,6 +362,7 @@ preflight() {
     [ -f "$DRAFTER_PATCH_HOST" ] || die "$DRAFTER_PATCH_HOST missing"
     [ -f "$APC_PATCH_HOST" ] || die "$APC_PATCH_HOST missing"
     [ -f "$XGRAMMAR_PATCH_HOST" ] || die "$XGRAMMAR_PATCH_HOST missing"
+    [ -f "$CACHE_RESET_PATCH_HOST" ] || die "$CACHE_RESET_PATCH_HOST missing"
 
     local need_kb=$((180 * 1024 * 1024)) avail
     mkdir -p "$HF_CACHE_DIR"
@@ -822,6 +831,9 @@ fi
 if [ -f /opt/glm53/patch_xgrammar_termination.py ]; then
     python3 /opt/glm53/patch_xgrammar_termination.py
 fi
+if [ -f /opt/glm53/patch_cache_reset.py ]; then
+    python3 /opt/glm53/patch_cache_reset.py
+fi
 say "launching: vllm serve ${MODEL_DIR} ${ARGS[*]}"
 exec vllm serve "${MODEL_DIR}" "${ARGS[@]}"
 EOF
@@ -912,6 +924,9 @@ fi
 if [ -f /opt/glm53/patch_xgrammar_termination.py ]; then
     python3 /opt/glm53/patch_xgrammar_termination.py
 fi
+if [ -f /opt/glm53/patch_cache_reset.py ]; then
+    python3 /opt/glm53/patch_cache_reset.py
+fi
 say "joining TP2 at ${HEAD_IP}:${MASTER_PORT} as rank 1"
 exec vllm serve "${MODEL_DIR}" "${ARGS[@]}"
 EOF
@@ -940,6 +955,8 @@ launch_cluster() {
     scp -q -o BatchMode=yes "$APC_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_hybrid_prefix_hit.py"
     [ -f "$XGRAMMAR_PATCH_HOST" ] || die "missing $XGRAMMAR_PATCH_HOST"
     scp -q -o BatchMode=yes "$XGRAMMAR_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_xgrammar_termination.py"
+    [ -f "$CACHE_RESET_PATCH_HOST" ] || die "missing $CACHE_RESET_PATCH_HOST"
+    scp -q -o BatchMode=yes "$CACHE_RESET_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_cache_reset.py"
 
     local -a nccl_common=(
         -e NCCL_IB_DISABLE=0
@@ -963,6 +980,9 @@ launch_cluster() {
         -e VLLM_CACHE_ROOT=/root/.cache/vllm
         -e "GLM53_SUPPRESS_STOPS_IN_REASONING=$GLM53_SUPPRESS_STOPS_IN_REASONING"
         -e "GLM53_MIXED_PREFILL_CHUNK=$GLM53_MIXED_PREFILL_CHUNK"
+        # Read by the patched build_app (issue #31): mount only the cache-reset
+        # dev routes when 1. Patched file is inert when 0/unset.
+        -e "GLM53_EXPOSE_CACHE_RESET=$GLM53_EXPOSE_CACHE_RESET"
         -e "TRITON_CACHE_DIR=$TRITON_CACHE_DIR"
         -e "TILELANG_CACHE_DIR=$TILELANG_CACHE_DIR"
         # LOCAL: upstream persists triton/tilelang but not FlashInfer's JIT
@@ -1047,6 +1067,7 @@ launch_cluster() {
         -v '/tmp/patch_glm5_drafter_group.py:/opt/glm53/patch_glm5_drafter_group.py:ro' \
         -v '/tmp/patch_hybrid_prefix_hit.py:/opt/glm53/patch_hybrid_prefix_hit.py:ro' \
         -v '/tmp/patch_xgrammar_termination.py:/opt/glm53/patch_xgrammar_termination.py:ro' \
+        -v '/tmp/patch_cache_reset.py:/opt/glm53/patch_cache_reset.py:ro' \
         ${worker_preload} \
         ${worker_nccl} \
         -e NCCL_SOCKET_IFNAME='$WORKER_CX7_IF' \
@@ -1073,6 +1094,7 @@ launch_cluster() {
         -v "$DRAFTER_PATCH_HOST:/opt/glm53/patch_glm5_drafter_group.py:ro" \
         -v "$APC_PATCH_HOST:/opt/glm53/patch_hybrid_prefix_hit.py:ro" \
         -v "$XGRAMMAR_PATCH_HOST:/opt/glm53/patch_xgrammar_termination.py:ro" \
+        -v "$CACHE_RESET_PATCH_HOST:/opt/glm53/patch_cache_reset.py:ro" \
         "${head_preload[@]}" \
         "${nccl_common[@]}" \
         -e NCCL_SOCKET_IFNAME="$HEAD_CX7_IF" \

--- a/start.sh
+++ b/start.sh
@@ -151,6 +151,8 @@ DRAFTER_PATCH_HOST="${DRAFTER_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_glm5_drafter
 APC_PATCH_HOST="${APC_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_hybrid_prefix_hit.py}"
 XGRAMMAR_PATCH_HOST="${XGRAMMAR_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_xgrammar_termination.py}"
 CACHE_RESET_PATCH_HOST="${CACHE_RESET_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_cache_reset.py}"
+# LOCAL: vLLM #54048 backport — cuBLAS out_dtype router GEMM on GB10 (W9)
+ROUTER_GEMM_PATCH_HOST="${ROUTER_GEMM_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_router_gemm_gb10.py}"
 KV_CACHE_DTYPE="${KV_CACHE_DTYPE:-fp8}"
 QUANTIZATION="${QUANTIZATION:-exl3}"
 LANGUAGE_MODEL_ONLY="${LANGUAGE_MODEL_ONLY:-0}"
@@ -363,6 +365,7 @@ preflight() {
     [ -f "$APC_PATCH_HOST" ] || die "$APC_PATCH_HOST missing"
     [ -f "$XGRAMMAR_PATCH_HOST" ] || die "$XGRAMMAR_PATCH_HOST missing"
     [ -f "$CACHE_RESET_PATCH_HOST" ] || die "$CACHE_RESET_PATCH_HOST missing"
+    [ -f "$ROUTER_GEMM_PATCH_HOST" ] || die "$ROUTER_GEMM_PATCH_HOST missing"  # LOCAL: W9
 
     local need_kb=$((180 * 1024 * 1024)) avail
     mkdir -p "$HF_CACHE_DIR"
@@ -834,6 +837,9 @@ fi
 if [ -f /opt/glm53/patch_cache_reset.py ]; then
     python3 /opt/glm53/patch_cache_reset.py
 fi
+if [ -f /opt/glm53/patch_router_gemm_gb10.py ]; then
+    python3 /opt/glm53/patch_router_gemm_gb10.py
+fi
 say "launching: vllm serve ${MODEL_DIR} ${ARGS[*]}"
 exec vllm serve "${MODEL_DIR}" "${ARGS[@]}"
 EOF
@@ -927,6 +933,9 @@ fi
 if [ -f /opt/glm53/patch_cache_reset.py ]; then
     python3 /opt/glm53/patch_cache_reset.py
 fi
+if [ -f /opt/glm53/patch_router_gemm_gb10.py ]; then
+    python3 /opt/glm53/patch_router_gemm_gb10.py
+fi
 say "joining TP2 at ${HEAD_IP}:${MASTER_PORT} as rank 1"
 exec vllm serve "${MODEL_DIR}" "${ARGS[@]}"
 EOF
@@ -957,6 +966,8 @@ launch_cluster() {
     scp -q -o BatchMode=yes "$XGRAMMAR_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_xgrammar_termination.py"
     [ -f "$CACHE_RESET_PATCH_HOST" ] || die "missing $CACHE_RESET_PATCH_HOST"
     scp -q -o BatchMode=yes "$CACHE_RESET_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_cache_reset.py"
+    [ -f "$ROUTER_GEMM_PATCH_HOST" ] || die "missing $ROUTER_GEMM_PATCH_HOST"
+    scp -q -o BatchMode=yes "$ROUTER_GEMM_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_router_gemm_gb10.py"
 
     local -a nccl_common=(
         -e NCCL_IB_DISABLE=0
@@ -983,6 +994,8 @@ launch_cluster() {
         # Read by the patched build_app (issue #31): mount only the cache-reset
         # dev routes when 1. Patched file is inert when 0/unset.
         -e "GLM53_EXPOSE_CACHE_RESET=$GLM53_EXPOSE_CACHE_RESET"
+        # LOCAL: W9 ablation — 0 restores stock router-GEMM eligibility exactly
+        -e "GLM53_ROUTER_GEMM_CUBLAS=${GLM53_ROUTER_GEMM_CUBLAS:-1}"
         -e "TRITON_CACHE_DIR=$TRITON_CACHE_DIR"
         -e "TILELANG_CACHE_DIR=$TILELANG_CACHE_DIR"
         # LOCAL: upstream persists triton/tilelang but not FlashInfer's JIT
@@ -1068,6 +1081,7 @@ launch_cluster() {
         -v '/tmp/patch_hybrid_prefix_hit.py:/opt/glm53/patch_hybrid_prefix_hit.py:ro' \
         -v '/tmp/patch_xgrammar_termination.py:/opt/glm53/patch_xgrammar_termination.py:ro' \
         -v '/tmp/patch_cache_reset.py:/opt/glm53/patch_cache_reset.py:ro' \
+        -v '/tmp/patch_router_gemm_gb10.py:/opt/glm53/patch_router_gemm_gb10.py:ro' \
         ${worker_preload} \
         ${worker_nccl} \
         -e NCCL_SOCKET_IFNAME='$WORKER_CX7_IF' \
@@ -1095,6 +1109,7 @@ launch_cluster() {
         -v "$APC_PATCH_HOST:/opt/glm53/patch_hybrid_prefix_hit.py:ro" \
         -v "$XGRAMMAR_PATCH_HOST:/opt/glm53/patch_xgrammar_termination.py:ro" \
         -v "$CACHE_RESET_PATCH_HOST:/opt/glm53/patch_cache_reset.py:ro" \
+        -v "$ROUTER_GEMM_PATCH_HOST:/opt/glm53/patch_router_gemm_gb10.py:ro" \
         "${head_preload[@]}" \
         "${nccl_common[@]}" \
         -e NCCL_SOCKET_IFNAME="$HEAD_CX7_IF" \

--- a/tests/bench_prefix_cache.py
+++ b/tests/bench_prefix_cache.py
@@ -12,10 +12,12 @@ Protocol (mirrors the kit README's prefix-caching table):
         vllm:prefix_cache_{hits,queries} counter deltas around the turn.
 
   A prefix-cache reset (POST /reset_prefix_cache, with /flush_cache fallbacks)
-  runs before each cold turn when the server offers one. This image currently
-  does not, so every chat is also salted with a per-invocation session id:
-  repeated runs measure true colds instead of silently hitting the previous
-  session's pages.
+  runs before each cold turn when the server offers one. Since #31 is
+  implemented (overlay/patch_cache_reset.py, GLM53_EXPOSE_CACHE_RESET=1) the
+  image answers /reset_prefix_cache; every chat is still salted with a
+  per-invocation session id so repeated runs measure true colds even when the
+  reset route is disabled (GLM53_EXPOSE_CACHE_RESET=0) — instead of silently
+  hitting the previous session's pages.
 
 Page granularity (IMPORTANT on this stack): the sparse-MLA KpoolTailManager
 only counts BLOCK-ALIGNED hits at the 3584-token hybrid MLA page. Hits are
@@ -59,9 +61,10 @@ RESULTS_DIR = Path(__file__).resolve().parents[1] / "results"
 _CHARS_PER_TOKEN = 4.5
 # Hybrid MLA page: sparse-MLA prefix hits are block-aligned to this size.
 DEFAULT_PAGE_TOKENS = 3584
-# Unique per invocation: this vLLM build offers no cache-reset endpoint, so
-# colds must not reuse pages cached by a previous bench session (observed
-# 2026-08-29: reruns reused chat content and "cold" TTFT dropped 10.3s -> 1.9s).
+# Unique per invocation: colds must not reuse pages cached by a previous bench
+# session (observed 2026-08-29: reruns reused chat content and "cold" TTFT
+# dropped 10.3s -> 1.9s). /reset_prefix_cache is exposed since #31, but the
+# salt keeps colds honest even with GLM53_EXPOSE_CACHE_RESET=0.
 _SESSION_SALT = f"{int(time.time()) % 100000000:08d}"
 
 _DOC_SENTENCE = (

--- a/tests/test_cache_reset_endpoint.py
+++ b/tests/test_cache_reset_endpoint.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""Regression tests for the #31 cache-reset endpoint exposure."""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+import types
+from pathlib import Path
+
+
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parent
+PATCH = next(
+    p
+    for p in (
+        HERE / "patch_cache_reset.py",
+        ROOT / "overlay" / "patch_cache_reset.py",
+    )
+    if p.is_file()
+)
+INSTALLED_API_SERVER = Path(
+    "/usr/local/lib/python3.12/dist-packages/vllm/entrypoints/openai/"
+    "api_server.py"
+)
+MARK = "# [glm53-cache-reset]"
+FLAG = "GLM53_EXPOSE_CACHE_RESET"
+
+# Exact vLLM 487ecf187 build_app dev-mode block, embedded in a
+# dependency-free harness. The harness injects fake `envs` / vLLM modules so
+# the patched source can be exec'd and its routing behavior asserted.
+PINNED_API_SERVER_FIXTURE = '''def build_app(app):
+    if envs.VLLM_SERVER_DEV_MODE:
+        from vllm.entrypoints.serve import register_vllm_dev_api_routers
+
+        register_vllm_dev_api_routers(app)
+'''
+
+
+def run_patch(
+    target: Path,
+    *,
+    ok: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["GLM53_API_SERVER_PY"] = str(target)
+    proc = subprocess.run(
+        [sys.executable, str(PATCH)],
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if ok and proc.returncode != 0:
+        raise AssertionError(proc.stdout + proc.stderr)
+    if not ok and proc.returncode == 0:
+        raise AssertionError("patch unexpectedly accepted a drifted/partial target")
+    return proc
+
+
+def run_build_app(
+    source: str,
+    *,
+    dev_mode: bool,
+    flag: str | None,
+    calls: list[str],
+) -> None:
+    """Exec the fixture's build_app with fake vLLM modules and flag env."""
+    serve = types.ModuleType("vllm.entrypoints.serve")
+    serve.register_vllm_dev_api_routers = lambda app: calls.append("dev")
+    api_router = types.ModuleType(
+        "vllm.entrypoints.serve.dev.cache.api_router"
+    )
+    api_router.attach_router = lambda app: calls.append("cache")
+
+    saved = sys.modules.get("vllm")
+    saved_flag = os.environ.get(FLAG)
+    try:
+        sys.modules["vllm"] = types.ModuleType("vllm")
+        sys.modules["vllm.entrypoints"] = types.ModuleType("vllm.entrypoints")
+        sys.modules["vllm.entrypoints.serve"] = serve
+        sys.modules["vllm.entrypoints.serve.dev"] = types.ModuleType(
+            "vllm.entrypoints.serve.dev"
+        )
+        sys.modules["vllm.entrypoints.serve.dev.cache"] = types.ModuleType(
+            "vllm.entrypoints.serve.dev.cache"
+        )
+        sys.modules["vllm.entrypoints.serve.dev.cache.api_router"] = api_router
+        if flag is None:
+            os.environ.pop(FLAG, None)
+        else:
+            os.environ[FLAG] = flag
+        namespace: dict[str, object] = {
+            "os": os,
+            "envs": types.SimpleNamespace(VLLM_SERVER_DEV_MODE=dev_mode),
+        }
+        exec(compile(source, "patched_api_server_fixture.py", "exec"), namespace)
+        namespace["build_app"](object())
+    finally:
+        if saved is not None:
+            sys.modules["vllm"] = saved
+        else:
+            sys.modules.pop("vllm", None)
+        for name in (
+            "vllm.entrypoints",
+            "vllm.entrypoints.serve",
+            "vllm.entrypoints.serve.dev",
+            "vllm.entrypoints.serve.dev.cache",
+            "vllm.entrypoints.serve.dev.cache.api_router",
+        ):
+            sys.modules.pop(name, None)
+        if saved_flag is None:
+            os.environ.pop(FLAG, None)
+        else:
+            os.environ[FLAG] = saved_flag
+
+
+def test_fixture() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        target = Path(tmp) / "api_server.py"
+        target.write_text(PINNED_API_SERVER_FIXTURE)
+        run_patch(target)
+        patched = target.read_text()
+        assert patched.count(MARK) == 1
+        assert 'elif os.getenv("GLM53_EXPOSE_CACHE_RESET", "0") == "1":' in patched
+        assert "from vllm.entrypoints.serve.dev.cache.api_router import" in patched
+        assert "attach_cache_reset_router(app)" in patched
+        compile(patched, "patched_fixture.py", "exec")
+
+        # Flag semantics: the router mounts only when the flag is "1", full
+        # dev mode keeps precedence, and anything else stays stock.
+        calls: list[str] = []
+        run_build_app(patched, dev_mode=False, flag="1", calls=calls)
+        assert calls == ["cache"], calls
+        calls = []
+        run_build_app(patched, dev_mode=False, flag=None, calls=calls)
+        assert calls == [], calls
+        calls = []
+        run_build_app(patched, dev_mode=False, flag="0", calls=calls)
+        assert calls == [], calls
+        calls = []
+        run_build_app(patched, dev_mode=True, flag="1", calls=calls)
+        assert calls == ["dev"], calls
+
+        run_patch(target)
+        assert target.read_text() == patched
+
+        # Exact merged behavior is accepted when a newer image already has it
+        # (marker stripped, elif kept): the patch skips instead of failing.
+        merged = patched.replace("        # [glm53-cache-reset] Expose only\n"
+                                 , "        #\n", 1)
+        target.write_text(merged)
+        run_patch(target)
+        assert target.read_text() == merged
+
+
+def test_fail_closed() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        target = Path(tmp) / "api_server.py"
+
+        drifted = PINNED_API_SERVER_FIXTURE.replace(
+            "register_vllm_dev_api_routers(app)",
+            "register_vllm_dev_api_routers(app, strict=True)",
+            1,
+        )
+        target.write_text(drifted)
+        run_patch(target, ok=False)
+        assert target.read_text() == drifted
+
+        partial = PINNED_API_SERVER_FIXTURE.replace(
+            "    if envs.VLLM_SERVER_DEV_MODE:",
+            f"    {MARK} Expose only the cache-reset dev routes.\n"
+            "    if envs.VLLM_SERVER_DEV_MODE:",
+            1,
+        )
+        target.write_text(partial)
+        run_patch(target, ok=False)
+        assert target.read_text() == partial
+
+        duplicated = PINNED_API_SERVER_FIXTURE + PINNED_API_SERVER_FIXTURE
+        target.write_text(duplicated)
+        run_patch(target, ok=False)
+        assert target.read_text() == duplicated
+
+
+def test_installed_copy_if_present() -> None:
+    source = Path(os.environ.get("GLM53_API_SERVER_PY_SRC", INSTALLED_API_SERVER))
+    if not source.is_file():
+        return
+    with tempfile.TemporaryDirectory() as tmp:
+        target = Path(tmp) / "api_server.py"
+        target.write_bytes(source.read_bytes())
+        run_patch(target)
+        patched = target.read_text()
+        compile(patched, str(target), "exec")
+        assert patched.count(MARK) == 1
+        assert "attach_cache_reset_router(app)" in patched
+        run_patch(target)
+
+
+def test_recipe_wiring_if_present() -> None:
+    start = ROOT / "start.sh"
+    dockerfile = ROOT / "Dockerfile"
+    if not start.is_file() or not dockerfile.is_file():
+        return
+    launcher = start.read_text()
+    image = dockerfile.read_text()
+    assert 'CACHE_RESET_PATCH_HOST="${CACHE_RESET_PATCH_HOST:-' in launcher
+    assert 'GLM53_EXPOSE_CACHE_RESET="${GLM53_EXPOSE_CACHE_RESET:-1}"' in launcher
+    # forwarded through the shared container env block (head + worker)
+    assert '-e "GLM53_EXPOSE_CACHE_RESET=$GLM53_EXPOSE_CACHE_RESET"' in launcher
+    assert launcher.count("python3 /opt/glm53/patch_cache_reset.py") == 2
+    assert (
+        "-v '/tmp/patch_cache_reset.py:"
+        "/opt/glm53/patch_cache_reset.py:ro'" in launcher
+    )
+    assert (
+        '-v "$CACHE_RESET_PATCH_HOST:'
+        '/opt/glm53/patch_cache_reset.py:ro"' in launcher
+    )
+    assert 'scp -q -o BatchMode=yes "$CACHE_RESET_PATCH_HOST"' in launcher
+    assert "COPY overlay/patch_cache_reset.py" in image
+    assert "RUN python3 /opt/glm53/patch_cache_reset.py" in image
+    assert "python3 /opt/glm53/test_cache_reset_endpoint.py" in image
+
+
+def main() -> int:
+    test_fixture()
+    test_fail_closed()
+    test_installed_copy_if_present()
+    test_recipe_wiring_if_present()
+    print("cache-reset endpoint patch OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Brings the Mac working copy's three production-defining commits of 2026-08-29/30 onto the release tree. All three are live in production and gated (serving 6/6, toolcall 23/23, acceptance 1.0000, KV pool byte-identical).

## What's in it

**1. `/reset_prefix_cache` endpoint (cherry-pick of upstream kit PR #37)**
`overlay/patch_cache_reset.py` mounts only the upstream dev cache-reset router behind `GLM53_EXPOSE_CACHE_RESET=1` — cold prefix-cache benching no longer needs a container restart. Fail-closed on anchor drift; loopback-safe on this deployment's `--host 127.0.0.1` bind. README gains an API-surface-notes section (reset semantics, the root-mounted-routes auth caveat, `/tokenize` shape), adapted to this repo's pinned `PORT=8000`.

**2. W9 — vLLM #54048 backport: cuBLAS out_dtype router GEMM on GB10 (`overlay/patch_router_gemm_gb10.py`)**
Family-120 (GB10 sm_121) was excluded from the fused bf16×bf16→fp32 router GEMM by the SM90/SM100-only specialized-kernel gate, so every MoE layer bf16-rounded its router logits through a copy-kernel fallback — prefill and decode. GLM-5.3-Flash is squarely affected (`moe_router_dtype: float32`, bf16 gate weight, no bias; verified in-image that only the arch gate fails). Backport is fail-closed, idempotent, dry-run-verified against the live image file; `GLM53_ROUTER_GEMM_CUBLAS=0` restores stock eligibility exactly. Adopted in production 2026-08-30: engaged on both ranks, structured 70.24 tok/s @ acceptance 1.0000/7.0, cold prefill 900 tok/s @173k (no regression), toolcall 23/23. The JIT shape hash is untouched by design (cuBLAS is not a Triton/TileLang kernel).

**3. Ops hardening (second-sweep staging)**
- `local/metrics-alert.sh`: the live-argv integrity check now also asserts `--max-num-batched-tokens 3584` and `--no-async-scheduling` — guards against the upstream kit's new MNBT=2048 default (kit PR #40) silently landing at a future sync, and against the async tri-state resolving ENABLED if the flag is ever dropped.
- `local/cache-burst.py`: hit% now reported from per-request `usage.prompt_tokens_details.cached_tokens` (the global queries/hits counters over-count 1.3–2× under queue pressure); counter-based number kept as secondary.
- `local/cache-probe.sh`: documents the counter-inflation caveat (live-traffic probe has no per-request option).
- `local/content-warmup.sh` (new, DORMANT): W8 content-prefix warmup — replays standing clients' captured prompt anchors after a restart so their first real turn hits warm pages. Inert until `GLM53_CONTENT_WARMUP=1` + anchors exist; wire-up documented in the script header.

## Notes for review
- The commits were cherry-picked onto this tree (the working copy's git history shares no ancestor with the release tree). One README conflict was resolved editorially: this repo's curated structure is kept; only the API-surface-notes section is added.
- `start.sh` wiring for both overlays follows the existing runtime-mount pattern (preflight, scp, mounts on both ranks, env passthrough); `bash -n` clean.