### PR TITLE
A/B window results 2026-08-30: concurrent-prefill study, baseline corrections, drafter-TP shape-hash guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ that serve untrusted clients.
 **Tokenize.** It is mounted at the **root** (`/v1/tokenize` is 404) and the
 request validates `prompt` (or `messages` for the chat shape), not `text`.
 
-## Measured (2026-08-29, warm, temp 0, median of 3)
+## Measured (2026-08-29 → 08-30, warm, temp 0, converged medians — run 3–4 passes before judging a boot)
 
 | Phase | Value |
 |---|---|

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This is the deployment I actually run, with every gotcha it cost to get here wri
   context window**, served from two consumer-purchasable Sparks — no rack, no cloud bill,
   loopback-only by default.
 - **Measured, not claimed.** Every number in this README comes off the running cluster:
-  **70.4 tok/s structured / 29.5 tok/s prose** decode, **~893 tok/s** cold prefill,
+  **71–73 tok/s structured / 27.9 tok/s prose** decode at the 1M window, **~893 tok/s** cold prefill,
   **1.0 speculative acceptance** on structured output (7 drafted tokens per step, zero
   wasted verifies), a 110k-token session re-prefilling in **~4 s** instead of 132 via
   prefix caching — and **multi-session caching that works**: two 68k sessions retain
@@ -108,9 +108,9 @@ request validates `prompt` (or `messages` for the chat shape), not `text`.
 
 | Phase | Value |
 |---|---|
-| Structured decode (count 1→200) | 70.4 tok/s (acceptance 1.0000, 7.0/step, all positions) |
-| Prose decode | 29.5 tok/s |
-| Production path (temp 1.0, thinking on) | ~30 tok/s |
+| Structured decode (count 1→200) | 71–73 tok/s across boots (best recorded 72.8; acceptance 1.0000, 7.0/step, all positions) |
+| Prose decode | **27.9 tok/s at the 1M window** — the earlier 29.5 was measured at a 262k window; the 1M window costs ~6% prose decode (29.5 × 0.94 ≈ 27.7), so 27.9 is the healthy number, not a regression. A 26.5 reading seen after restart churn was swap-depression noise, not real |
+| Production path (temp 1.0, thinking on) | ~28–30 tok/s |
 | Cold prefill (solo, ~133–240k) | **~893 tok/s** (941 with `LONG_PREFILL_TOKEN_THRESHOLD` unset — the −5% is the price of HOL relief) |
 | Short-request TTFT behind a 240k cold prefill | **7.9 s** (256 s without the threshold) |
 | 110k cached re-prefill | **~4 s** (vs 132 s cold; 98% hit) |

--- a/docs/06-improvement-plan.md
+++ b/docs/06-improvement-plan.md
@@ -119,3 +119,27 @@ active (the warmup sweep pollutes counters), keep other traffic off, log the ver
 
 - **Driver stays on the 580.x branch** — 590.x deadlocks CUDAGraph capture on GB10;
   `local/check-updates.sh` now warns on any 590.x driver and flags it in OTA planning.
+
+## 2026-08-30 window results (appended)
+
+Three windows ran on the production pair; full plain-language write-up of the
+concurrency work in [08-concurrent-prefill.md](08-concurrent-prefill.md).
+
+- **Baseline correction.** Prose decode at the 1M window converges at **27.9 tok/s** —
+  the earlier 29.5 was measured at a 262k window, and the 1M window's documented ~6%
+  prose cost lands exactly there (29.5 × 0.94 ≈ 27.7). A 26.5 reading after restart
+  churn was swap-depression, not real. Structured varies 71–73 across boots (best
+  72.8) at acceptance 1.0000 / 7.0 per step. Judge any boot only after 3–4 converged
+  bench passes.
+- **Kpool tail slot-map clamp: adopted.** Applied as a runtime overlay onto the pinned
+  image (no rebuild): patched on both ranks, idempotent, tests green. Evidence battery:
+  five solo 2,600-token generations and a 4-way concurrent 2,600-token burst past the
+  ~2.2k corruption line, zero NaN; acceptance 7/7; serving 6/6; pool byte-identical.
+- **Mixed-prefill cap: measured, not adopted.** Cap 896 halves concurrent prompt-read
+  waits (−46%) at the cost of halved decode during the read (−50%); cap 448 is strictly
+  worse; the trade is flat because fat-expert MoE streaming dominates any mixed step.
+  Left off; documented as a one-line operator option.
+- **MAX_NUM_BATCHED_TOKENS=7168: safe but useless.** Boots and survives a 266k-token
+  cold read (856–872 tok/s, no indexer smem failure), but concurrent aggregate moved
+  only +5% under the skip rule and solo reads ~2% slower. Reverted; 3584 stands (page
+  alignment unchanged).

--- a/docs/06-improvement-plan.md
+++ b/docs/06-improvement-plan.md
@@ -157,3 +157,11 @@ concurrency work in [08-concurrent-prefill.md](08-concurrent-prefill.md).
 - **Guard fix that rode along:** `DFLASH_DRAFT_TP` is now part of the JIT shape-hash
   guard in `local/prod-start.sh` — changing drafter tensor-parallelism changes drafter
   kernel shapes, the same stale-cache class that once collapsed acceptance 0.96 → 0.58.
+- **Drafter tensor-parallelism 2: rejected.** The upstream kit made `DFLASH_DRAFT_TP=2`
+  its default (sharding the ~2.3 GiB DFlash2 drafter across both ranks). Measured here:
+  the hoped-for head-node memory relief did not appear (spark1 idle-free actually read
+  ~0.4 GiB lower, worker ~0.5 GiB higher — the head keeps its working set either way),
+  and decode tracked 1–2% below the TP=1 band on both phases, consistent with the
+  upstream PR's own receipts (their structured 65.1 vs our 70+ at TP=1). Acceptance
+  held a perfect 1.0000 / 7.0 per step, so TP=2 is safe — just not better on a 2-node
+  pair. This deployment pins `DFLASH_DRAFT_TP=1`.

--- a/docs/06-improvement-plan.md
+++ b/docs/06-improvement-plan.md
@@ -80,11 +80,15 @@ active (the warmup sweep pollutes counters), keep other traffic off, log the ver
    1,396,551 (1.40×) at k=7 — the extra verify slot costs ~3% of pool accounting.
    k=7 stands for mixed traffic; a structured-only deployment could revisit. The real
    answer is adaptive draft length, which is upstream rebase material (item 5).
-5. **Image rebase adoption** (trigger-driven, not scheduled): the build is a fork tip
-   (`b908a21f9a` + 142 GLM5Next/EXL3 commits); upstream has moved 643 commits past the
-   base. A self-rebase is the highest-risk path available and buys nothing the kit's
-   next image rebase won't — the weekly check-updates timer diffs staged vs upstream
-   HEAD and the GHCR digest vs the pin, and a moved digest opens this window. Protocol:
+5. **Image rebase adoption** (trigger-driven, not scheduled — **this kit builds and
+   releases its own image**; see `07-rebase-plan.md` for the full plan): the build is a
+   fork tip (`b908a21f9a` + 142 GLM5Next/EXL3 commits); upstream vLLM has moved 643+
+   commits past the base. The trigger is *vLLM upstream*, not any vendor image: when
+   official GLM-5.3 support (#53906) lands, the 142 fork commits shrink to a thin
+   overlay set and we rebase our own Dockerfile onto that base, build under our own
+   tag, and release it as this kit's next major version. Other kits' repos remain
+   sources to cherry-pick from, nothing more. Do not blind-rebase before then — the
+   risk math (fork drift across EXL3/KDA/slot-share) is unchanged. Protocol:
    stage the new digest with the FULL battery (acceptance/serving/toolcall suites,
    decode gates vs standing baselines, the cache-burst control set, loopback-bind
    verify, KV-pool line read) and re-check every overlay — patches subsumed upstream
@@ -112,8 +116,10 @@ active (the warmup sweep pollutes counters), keep other traffic off, log the ver
   verify ceiling is arithmetic.
 - **Re-enabling async scheduling** — the #47728-class double-count still fails the
   admission check at this geometry; async was throughput-neutral here anyway.
-- **Self-rebasing the vLLM fork** — 600+ commits of drift against fork-only EXL3/KDA
-  code; the upstream kit's own rebase is the sane path.
+- **Self-rebasing the vLLM fork *today*** — 600+ commits of drift against fork-only
+  EXL3/KDA code. This kit will do its own rebase and release (item 5 above), but only
+  after official GLM-5.3 support lands upstream and shrinks the fork to a thin
+  overlay; rebasing before that is the highest-risk move available for no gain.
 
 ## Operational holds picked up in this review
 

--- a/docs/06-improvement-plan.md
+++ b/docs/06-improvement-plan.md
@@ -143,3 +143,17 @@ concurrency work in [08-concurrent-prefill.md](08-concurrent-prefill.md).
   cold read (856–872 tok/s, no indexer smem failure), but concurrent aggregate moved
   only +5% under the skip rule and solo reads ~2% slower. Reverted; 3584 stands (page
   alignment unchanged).
+- **Context window 1M → 500k: rejected with data.** The suggestion (upstream issue #43)
+  is that a smaller window relieves capacity queueing. Measured here with a matched
+  probe (five concurrent ~82k cold sessions, cache reset first) the admission behavior
+  is **identical at both windows** — peak 3 of 4 slots running, capacity-reason waits
+  in ~37% of samples, worst lane ~7 minutes, aggregate ~940 tok/s — because the
+  queueing is the in-flight prefills' own accounted footprint, not the window setting.
+  Meanwhile the smaller window *costs* real capacity: the same pinned KV bytes count
+  **1,065,789 pool tokens at 500k vs 1,396,551 at 1M** (−24% — pool tokens are
+  geometry-dependent and the 1M layout packs them best on this stack), and prose decode
+  did not recover (~27 vs 27.9). So 500k buys nothing and shrinks the cache. The 1M
+  window stays.
+- **Guard fix that rode along:** `DFLASH_DRAFT_TP` is now part of the JIT shape-hash
+  guard in `local/prod-start.sh` — changing drafter tensor-parallelism changes drafter
+  kernel shapes, the same stale-cache class that once collapsed acceptance 0.96 → 0.58.

--- a/docs/08-concurrent-prefill.md
+++ b/docs/08-concurrent-prefill.md
@@ -40,13 +40,19 @@ arriving five seconds later, prefix cache reset first. Three configurations:
 
 Three conclusions:
 
-1. **Allowing mixed reading is a pure trade, not a free win.** Waiting times nearly
-   halve, but whoever is receiving an answer slows to half speed while the reading
-   happens. Total wall time is identical either way.
+1. **Allowing mixed reading is a trade, not a free win.** Waiting times nearly halve,
+   but whoever is receiving an answer slows to half speed while the reading happens.
+   In this probe the total wall time came out the same either way (165–172 s — the
+   decoder was the last to finish in both runs), but that equality is
+   workload-specific: per-request end-to-end time depends on how much reading vs
+   answering each request does (see the worked example below, where mixing wins by
+   ~14%).
 2. **The trade cannot be tuned away with a smaller bite size.** Reading *any* amount
    of new text in a step forces the server to stream all 288 expert weight matrices
-   through memory (~63% of the step cost, nearly flat in chunk size — see
-   `docs/improve-prefill.md` §P0 in the upstream kit). A 448-token bite taxes the
+   through memory (~63% of the step cost, nearly flat in chunk size — profiled in the
+   vendored upstream kit's prefill study,
+   [MiaAI-Lab/GLM-5.3-Flash-EXL3-2x-DGX-Sparks `docs/improve-prefill.md` §P0](https://github.com/MiaAI-Lab/GLM-5.3-Flash-EXL3-2x-DGX-Sparks/blob/b5ab8091/docs/improve-prefill.md)).
+   A 448-token bite taxes the
    decoder just as much as an 896-token bite and reads slower. If you mix at all,
    use the biggest sensible cap.
 3. **A bigger step budget does not help while the skip rule stands.** Doubling
@@ -84,8 +90,10 @@ leave it off.
   request no longer waits behind a 240k read (7.9 s instead of 256 s).
 - **Client habits** (free): stagger agent launches by ~15 s so their cold reads don't
   collide; keep agent system prompts byte-identical so they share cache pages; avoid
-  many tiny (<3,584-token) requests — they are below the cache page size and can
-  never hit.
+  many tiny (<3,584-token) requests — 3,584 tokens is this stack's prefix-cache page
+  (block) size for the hybrid KDA model (which is also why `MAX_NUM_BATCHED_TOKENS`
+  is pinned to the same value — see `docs/04-prefix-caching.md`), so shorter prompts
+  can never produce a cache hit.
 - **Upstream watch**: vLLM #52789 (mid-forward mamba checkpoints, 9–25% faster
   prompt reading) and the kit's own P7 idea (co-scheduling a second prefill into a
   capped step) are the structural fixes; both arrive via a future image rebase, not

--- a/docs/08-concurrent-prefill.md
+++ b/docs/08-concurrent-prefill.md
@@ -1,0 +1,92 @@
+# Concurrent agents and slow prefill — the problem, in plain language
+
+*Written 2026-08-30, after a measured A/B window on the production pair. All numbers
+below come off the running cluster.*
+
+## The problem
+
+When several coding agents talk to the server at the same time, new requests wait a
+very long time before their first token — often 80 to 160 seconds. Live telemetry from
+a real 4-agent working session showed a mean time-to-first-token of **39 seconds**
+(11.6 s of queueing plus 27.6 s of prompt reading), and the effective prompt-reading
+speed collapsed from ~900 tokens/second (server free) to **~160 tokens/second**
+(agents busy).
+
+## Why it happens
+
+The server has a protection rule that was written for a different situation. The rule
+(`GLM53_MIXED_PREFILL_CHUNK=skip`, in `overlay/patch_scheduler_decode_floor.py`) says:
+
+> *If anyone is currently receiving an answer (decoding), don't spend this engine step
+> reading new prompts (prefill) — wait.*
+
+That rule keeps answers streaming smoothly when one person uses the server. But with
+four agents working at once, someone is **always** receiving an answer — so prompt
+reading only happens in the small gaps between answers. A context that takes ~30
+seconds to read on a free server takes over two minutes on a busy one. That is the
+entire mechanism; the cache, the network, and the GPU are all fine.
+
+## What we tested (and measured)
+
+The probe: one request decoding a long answer, plus three fresh ~27k-token prompts
+arriving five seconds later, prefix cache reset first. Three configurations:
+
+| Configuration | Prompt-read time per lane | Aggregate read speed | Decoder speed during |
+|---|---|---|---|
+| `skip` (production today) | 136–164 s | 486 tok/s | 18.3 tok/s |
+| Mixed cap `896` | **88 s (−46%)** | **907 tok/s** | 9.1 tok/s (−50%) |
+| Mixed cap `448` | 93 s | 856 tok/s | 8.7 tok/s |
+| `MAX_NUM_BATCHED_TOKENS=7168` (skip kept) | 157 s | 509 tok/s (+5%) | 19.1 tok/s |
+
+Three conclusions:
+
+1. **Allowing mixed reading is a pure trade, not a free win.** Waiting times nearly
+   halve, but whoever is receiving an answer slows to half speed while the reading
+   happens. Total wall time is identical either way.
+2. **The trade cannot be tuned away with a smaller bite size.** Reading *any* amount
+   of new text in a step forces the server to stream all 288 expert weight matrices
+   through memory (~63% of the step cost, nearly flat in chunk size — see
+   `docs/improve-prefill.md` §P0 in the upstream kit). A 448-token bite taxes the
+   decoder just as much as an 896-token bite and reads slower. If you mix at all,
+   use the biggest sensible cap.
+3. **A bigger step budget does not help while the skip rule stands.** Doubling
+   `MAX_NUM_BATCHED_TOKENS` to 7168 (two cache pages) let four prompts share each
+   reading step instead of two — but each step took proportionally longer, so the
+   aggregate speed moved only +5%, and the starvation rule was untouched. It also
+   read ~2% slower solo (266k-token stress read: 856–872 tok/s, no crash — so 7168
+   is *safe*, just not useful). Reverted; 3584 stands.
+
+## What is implemented
+
+**Nothing changed in production.** The skip rule stays, because the pre-registered
+gate said the decoder should not lose more than 15% and it lost 50%. The mitigation
+is documented and one line away for operators who prefer faster response starts over
+smooth streaming during busy moments:
+
+```bash
+# in .env, then restart (scheduler-only: no JIT cache wipe, instantly reversible)
+GLM53_MIXED_PREFILL_CHUNK=896
+```
+
+For an interactive multi-agent workload the end-to-end turn math slightly favors
+turning this on: a turn that pays a 26k-token read plus a 500-token answer completes
+in ~143 s mixed vs ~167 s under skip. For a workload that mostly streams long answers,
+leave it off.
+
+## What actually reduces the pain (already shipped or queued)
+
+- **Prefix-cache retention** (`VLLM_PREFIX_CACHE_RETENTION_INTERVAL=0`, shipped): most
+  of an agent's prompt is unchanged between turns, and 85–97% of it now hits the cache
+  instead of being re-read. The collapse above only applies to the *missed* portion.
+- **Content warmup** (shipped): the agents' shared system prompt is pre-read at boot,
+  so even the first turn after a restart hits the cache.
+- **Long-prefill chunking** (`LONG_PREFILL_TOKEN_THRESHOLD=1792`, shipped): a short
+  request no longer waits behind a 240k read (7.9 s instead of 256 s).
+- **Client habits** (free): stagger agent launches by ~15 s so their cold reads don't
+  collide; keep agent system prompts byte-identical so they share cache pages; avoid
+  many tiny (<3,584-token) requests — they are below the cache page size and can
+  never hit.
+- **Upstream watch**: vLLM #52789 (mid-forward mamba checkpoints, 9–25% faster
+  prompt reading) and the kit's own P7 idea (co-scheduling a second prefill into a
+  capped step) are the structural fixes; both arrive via a future image rebase, not
+  an overlay.

--- a/local/prod-start.sh
+++ b/local/prod-start.sh
@@ -80,7 +80,7 @@ log "starting pair"
 # and recovered only after wiping both caches on both nodes (upstream #41871
 # class). Hash the shape-affecting knobs; on change, wipe triton+tilelang on
 # BOTH nodes (via the image, as root — the container writes them as root).
-shape_hash="$(grep -E '^(DFLASH_TOKENS|MTP_TOKENS|SPEC_METHOD|MAX_NUM_BATCHED_TOKENS|MAX_NUM_SEQS|MAX_MODEL_LEN|IMAGE|EXTRA_ARGS)=' .env 2>/dev/null | sort | md5sum | cut -d' ' -f1)"
+shape_hash="$(grep -E '^(DFLASH_TOKENS|DFLASH_DRAFT_TP|MTP_TOKENS|SPEC_METHOD|MAX_NUM_BATCHED_TOKENS|MAX_NUM_SEQS|MAX_MODEL_LEN|IMAGE|EXTRA_ARGS)=' .env 2>/dev/null | sort | md5sum | cut -d' ' -f1)"
 stamp="$HOME/.cache/vllm-glm53-flash/.config-shape"
 if [ -n "$shape_hash" ] && [ "$(cat "$stamp" 2>/dev/null)" != "$shape_hash" ]; then
     echo "[prod-start] config shape changed — wiping Triton/TileLang JIT caches on both nodes"


### PR DESCRIPTION
Five A/B windows ran on the production pair on 2026-08-30, each with pre-registered gates. This PR lands the findings and the one guard fix that came out of them.

## New

- **`docs/08-concurrent-prefill.md`** — plain-language study of why concurrent agents wait 80–160 s for first token: the decode-floor overlay's `skip` policy defers all prompt reading while any peer decodes. Measured matrix (skip / mixed cap 896 / cap 448 / MNBT 7168): mixing halves waits (−46%) but halves decode during the read (−50%), the trade is flat in bite size because fat-expert MoE streaming dominates any mixed step, and a bigger step budget changes nothing under `skip`. Nothing changed in production; the one-line operator option is documented.

## Baseline corrections (README + docs/06)

- Prose decode at the 1M window converges at **27.9 tok/s** — the earlier 29.5 was measured at a 262k window (the 1M window's ~6% prose cost lands at 29.5 × 0.94 ≈ 27.7). A 26.5 reading after restart churn was swap-depression, not real. Structured varies 71–73 across boots (best 72.8) at acceptance 1.0000 / 7.0-per-step.

## Measured-and-rejected (docs/06, with data)

- **1M → 500k window**: matched 5-lane probe shows identical admission at both geometries while 500k loses 24% of pool tokens (1,065,789 vs 1,396,551 — pool tokens are geometry-dependent; 1M packs best).
- **`DFLASH_DRAFT_TP=2`**: no head-node memory relief, decode 1–2% lower, consistent with the upstream PR's own receipts. This kit pins 1.
- **`MAX_NUM_BATCHED_TOKENS=7168`**: safe (survives a 266k cold read, no indexer-smem failure) but concurrent prefill moved only +5%; 3584 stands.

## Guard fix

- `local/prod-start.sh`: `DFLASH_DRAFT_TP` joins the JIT shape-hash guard — drafter tensor-parallelism changes drafter kernel shapes, the stale-cache class that once collapsed acceptance 0.96 → 0.58. Expect one hash-change cache wipe on the first boot after upgrading.

Also records the adopted kpool tail slot-map clamp evidence battery and re-scopes the rebase plan: this kit builds and releases its own image when vLLM lands official GLM-5.3 support (#53906); other kits are cherry-pick sources.