### PR TITLE
overlay: backport vLLM #54282 draft-noise salt (DFlash2 selector walk)

### DIFF
--- a/overlay/dflash2_speculator.py
+++ b/overlay/dflash2_speculator.py
@@ -17,6 +17,17 @@ from vllm.v1.worker.gpu.sample.gumbel import tl_rand32, tl_rand64
 from vllm.v1.worker.gpu.spec_decode.dflash.speculator import DFlashSpeculator
 
 
+# LOCAL: W15a — vLLM #54282 backport. Verification is a probability-ratio
+# test, not a Gumbel coupling, so the draft's noise must not share a Philox
+# stream with the target sampler's (same per-request seed, overlapping pos):
+# shared noise under-weights the draft's high-q losers in the rejection
+# residual at temp>0 with probabilistic drafting. Every call site in this
+# file IS a draft site, so the salt is unconditional here (upstream plumbs
+# IS_DRAFTING because its helper also serves the target sampler). Positions
+# are int64 and never approach 2**30, so the streams cannot collide.
+_DRAFT_NOISE_SALT = tl.constexpr(1 << 30)
+
+
 @triton.jit
 def gumbel_noised_argmax(
     logits,
@@ -35,7 +46,7 @@ def gumbel_noised_argmax(
     if USE_FP64:
         logits = logits.to(tl.float64)
     if temp != 0.0:
-        gumbel_seed = tl.randint(seed, pos)
+        gumbel_seed = tl.randint(seed, pos + _DRAFT_NOISE_SALT)
         if USE_FP64:
             u = tl_rand64(gumbel_seed, keys, includes_zero=False)
             gumbel_noise = -tl.log(-tl.log(u))


### PR DESCRIPTION
Salts the Philox offset in `gumbel_noised_argmax` (`pos + (1<<30)`) so the draft's Gumbel noise never shares a stream with the target sampler's. At temp>0 with `draft_sample_method=probabilistic` — this kit's serving config — shared noise biases the rejection residual against the draft's high-probability losers (upstream vLLM #54282, merged fe755c88). Unconditional here because every call site in this file is draft-side; upstream plumbs `IS_DRAFTING` only because its helper also serves the target sampler.

Gated live on the 2x DGX Spark pair: acceptance suite 7/7; structured decode 69.7–70.2 tok/s @ 1.0000 acceptance / 7.0 per step across four passes (unchanged vs pre-salt baseline); prose within the ambient variance band.