### PR TITLE
v1.3.0: self-built production image — parity sync, cutover + A/B ledger docs, README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,11 +2,6 @@
 .glm53-exl3-*.inner.sh
 logs/
 tool-eval-bench/
-# Keep the published direction vectors; do not ship transplant dumps (~640 MiB).
-ablit/*
-!ablit/LAYER_MAP.json
-!ablit/refusal_direction_glm53_dealign_late.pt
-!ablit/refusal_direction_glm53_bf_oproj.pt
 __pycache__/
 *.py[cod]
 .pytest_cache/

--- a/Dockerfile
+++ b/Dockerfile
@@ -449,6 +449,8 @@ COPY overlay/patch_xgrammar_termination.py /opt/glm53/patch_xgrammar_termination
 COPY tests/test_xgrammar_termination.py /opt/glm53/test_xgrammar_termination.py
 COPY overlay/patch_cache_reset.py /opt/glm53/patch_cache_reset.py
 COPY tests/test_cache_reset_endpoint.py /opt/glm53/test_cache_reset_endpoint.py
+COPY overlay/patch_kpool_tail_slotmap.py /opt/glm53/patch_kpool_tail_slotmap.py
+COPY tests/test_kpool_tail_slotmap.py /opt/glm53/test_kpool_tail_slotmap.py
 RUN python3 /opt/glm53/patch_model_overrides.py
 RUN python3 /opt/glm53/patch_dflash2.py
 RUN python3 /opt/glm53/patch_glm_eagle3.py
@@ -458,10 +460,12 @@ RUN python3 /opt/glm53/patch_scheduler_decode_floor.py
 RUN python3 /opt/glm53/patch_hybrid_prefix_hit.py
 RUN python3 /opt/glm53/patch_xgrammar_termination.py
 RUN python3 /opt/glm53/patch_cache_reset.py
+RUN python3 /opt/glm53/patch_kpool_tail_slotmap.py
 
 RUN EXL3_SELFCHECK_GPU=0 python3 /opt/glm53/test_exl3_overlay.py \
     && python3 /opt/glm53/test_suppress_stops.py \
     && python3 /opt/glm53/test_scheduler_decode_floor.py \
     && python3 /opt/glm53/test_hybrid_prefix_hit.py \
     && python3 /opt/glm53/test_xgrammar_termination.py \
-    && python3 /opt/glm53/test_cache_reset_endpoint.py
+    && python3 /opt/glm53/test_cache_reset_endpoint.py \
+    && python3 /opt/glm53/test_kpool_tail_slotmap.py \

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ on two NVIDIA DGX Spark (GB10 Grace Blackwell, 121 GiB unified memory each), ser
 **1M context** with DFlash2 speculative decoding at TP=2 over a direct 200Gb QSFP link.
 
 This is the deployment I actually run, with every gotcha it cost to get here written down.
+Since 2026-08-30 the serving image is **built by this repo's `Dockerfile`** from the official
+day-0 GLM-5.3 arm64 base (digest-pinned `FROM`) — production runs the build, not a pull.
 
 ## Why this kit
 
@@ -12,21 +14,24 @@ This is the deployment I actually run, with every gotcha it cost to get here wri
   context window**, served from two consumer-purchasable Sparks — no rack, no cloud bill,
   loopback-only by default.
 - **Measured, not claimed.** Every number in this README comes off the running cluster:
-  **71–73 tok/s structured / 27.9 tok/s prose** decode at the 1M window, **~893 tok/s** cold prefill,
-  **1.0 speculative acceptance** on structured output (7 drafted tokens per step, zero
-  wasted verifies), a 110k-token session re-prefilling in **~4 s** instead of 132 via
-  prefix caching — and **multi-session caching that works**: two 68k sessions retain
+  **~70 tok/s structured / 27.9 tok/s prose** decode at the 1M window (best recorded 72.8),
+  **~893 tok/s** cold prefill, **1.0 speculative acceptance** on structured output (7 drafted
+  tokens per step, zero wasted verifies), a **500,000-token prompt prefilled at 854 tok/s with
+  the drafter active and replayed 111× faster** from cache, a 110k-token session re-prefilling
+  in **~4 s** instead of 132 — and **multi-session caching that works**: two 68k sessions retain
   97.8%, four concurrent 60k sessions retain 95%. The bench scripts ship in `tests/`
   and `local/` — reproduce them in minutes.
 - **Hardware-honest quantization.** GB10 lacks the `cvt.e2m1x2` instruction — NVFP4
   can never compile for this chip. EXL3's trellis kernels are Blackwell-native and keep
   the 320B experts packed at 82 GiB/node, which is what leaves room for the 1M-token KV
   pool. The full rationale: `docs/01-architecture.md`.
-- **Reproducible by construction — and reproduce-TESTED.** Runtime image pinned **by
-  digest**, weights pinned by revision, KV pool pinned to the byte (identical every
-  boot — no profiling variance), a config-shape hash that wipes stale JIT caches before
-  they poison your numbers. v1.0.2 was verified by booting the production cluster from
-  a fresh clone of the tag: acceptance 7/7, byte-identical pool, loopback bind held.
+- **Reproducible by construction — and reproduce-TESTED.** The serving image is built by
+  this repo's `Dockerfile` from the official day-0 arm64 base (pinned **by digest**), weights
+  pinned by revision, KV pool pinned to the byte (identical every boot — no profiling
+  variance), a config-shape hash that wipes stale JIT caches before they poison your numbers.
+  The 2026-08-30 cutover was gated by booting production on the fresh build: acceptance 7/7,
+  serving 6/6, byte-identical pool (1,396,551 tokens), loopback bind held, structured
+  acceptance 1.0000/7.0.
 - **Quality-gated like production, because it is production.** A 7-probe acceptance suite
   (tool calls, thinking, vision, 36k needle), a 6-probe serving suite (SSE, 4-way
   concurrency, sustained load), a 23-turn tool-call battery under concurrent cold-prefill
@@ -41,7 +46,7 @@ This is the deployment I actually run, with every gotcha it cost to get here wri
 | | |
 |---|---|
 | Weights | [`brandonmusic/GLM-5.3-Flash-tr3-4bpw`](https://huggingface.co/brandonmusic/GLM-5.3-Flash-tr3-4bpw) — uniform-K4 EXL3/TR3, ~164 GiB, pinned revision |
-| Runtime | Prebuilt serving image, **pinned by digest** in `env.example` (provenance and licenses: [NOTICE](NOTICE)) |
+| Runtime | **Built by `Dockerfile` in this repo** from `vllm/vllm-openai:glm53-flash-arm64-cu130` (digest-pinned `FROM`; provenance and licenses: [NOTICE](NOTICE)) |
 | Drafter | `incoai/GLM-5.3-Flash-DFlash2`, k=7 (structured accept 1.0 post-xgrammar-fix, ~70 tok/s structured) |
 | Base kit | Upstream serving recipe vendored at `0e2e78f`, with local commits on top (credited in [NOTICE](NOTICE)) |
 
@@ -71,6 +76,7 @@ needed on top — all changes are marked `# LOCAL:` in-file:
 # on the head node
 git clone <this repo> glm53 && cd glm53
 cp env.example .env         # read it top to bottom — every value is a decision
+docker build -t glm53-selfbuild .   # from the digest-pinned day-0 base; ship to the worker too
 bash download.sh            # ~164 GiB of weights, verified against the pinned revision
 local/prod-start.sh         # NOT start.sh directly — see docs/03-bringup.md
 local/acceptance.sh         # 7 checks: tools, thinking, vision, long-context needle
@@ -104,11 +110,11 @@ that serve untrusted clients.
 **Tokenize.** It is mounted at the **root** (`/v1/tokenize` is 404) and the
 request validates `prompt` (or `messages` for the chat shape), not `text`.
 
-## Measured (2026-08-29 → 08-30, warm, temp 0, converged medians — run 3–4 passes before judging a boot)
+## Measured (2026-08-29 → 08-30, warm, temp 0, converged medians — run 3–4 passes before judging a boot; decode rows re-measured on the 08-30 self-built image)
 
 | Phase | Value |
 |---|---|
-| Structured decode (count 1→200) | 71–73 tok/s across boots (best recorded 72.8; acceptance 1.0000, 7.0/step, all positions) |
+| Structured decode (count 1→200) | **69–70 tok/s on the self-built image** (fork-image boots read 70.2–72.8 — within the observed boot-to-boot band; acceptance 1.0000, 7.0/step, all positions, every converged pass) |
 | Prose decode | **27.9 tok/s at the 1M window** — the earlier 29.5 was measured at a 262k window; the 1M window costs ~6% prose decode (29.5 × 0.94 ≈ 27.7), so 27.9 is the healthy number, not a regression. A 26.5 reading seen after restart churn was swap-depression noise, not real |
 | Production path (temp 1.0, thinking on) | ~28–30 tok/s |
 | Cold prefill (solo, ~133–240k) | **~893 tok/s** (941 with `LONG_PREFILL_TOKEN_THRESHOLD` unset — the −5% is the price of HOL relief) |
@@ -116,6 +122,8 @@ request validates `prompt` (or `messages` for the chat shape), not `text`.
 | 110k cached re-prefill | **~4 s** (vs 132 s cold; 98% hit) |
 | 2×68k sessions, cross-session retention | **97.8%** (5.8 s re-prefill) |
 | 4×60k concurrent sessions ×3 rounds | **95.0%** (271k tokens re-prefilled in 17.4 s) |
+| 500k fill with the drafter active | **854 tok/s cold**, needle retrieved, warm replay **111×** (585.7 s → 5.3 s) |
+| 30k replay with the drafter active | **15–17×** (2.2–2.4 s warm) |
 | Bench-convergence caveat | first passes after a restart read low (prose −17%) from parked-swap fault-in — run 3–4 passes |
 
 The 2026-08-29 numbers include the xgrammar termination backports (structured
@@ -124,22 +132,30 @@ retention fix (the multi-session rows above were an exact 0% before it), and the
 long-prefill chunk cap — `docs/06-improvement-plan.md` documents the full program,
 including the experiments that measured *worse* and were reverted.
 
-## Rebase track
+## Rebase track — executed
 
-Upstream vLLM is actively landing official GLM-5.3-Flash support (#53906, #53969,
-`FLASHINFER_MLA_SPARSE_SM120` auto-selection, native DFlash2, sparse mamba
-retention). `docs/07-rebase-plan.md` is the researched plan for moving this kit
-onto that base and shrinking the fork delta to an EXL3 plugin + thin GLM ports.
+The plan in `docs/07-rebase-plan.md` was carried out on 2026-08-30 and the results are
+written down: `docs/09-rebase-draft-test.md` is the field report of testing the official
+day-0 base + an out-of-tree EXL3 plugin + a DFlash2 port on the real pair (with the boot
+traps that cost nine rounds), and `docs/10-selfbuild-production.md` is the production
+cutover to the self-built image plus the A/B ledger — including the upstream #54282
+draft-noise-salt backport this kit now ships, and the experiments that measured *worse*
+and were reverted with numbers (the community LPTT/MNBT prefill config, FlashInfer's
+radix top-k at draft-batch sizes). What still separates this kit from vanilla upstream:
+the EXL3 kernels, the DFlash2 KV slot-share, the spec×prefix-cache fixes (upstream
+#54163 is the designated successor), and the xgrammar termination backports —
+each one measured load-bearing.
 
 ## Layout
 
 ```
 env.example        the deployment's configuration, annotated (start here)
+Dockerfile         builds the serving image from the digest-pinned day-0 base
 start.sh stop.sh   vendored launcher (LOCAL-patched: loopback bind, single env example)
 overlay/           runtime patches applied to the pinned image at container start
 local/             production ops: prod-start, watchdog, monitors, tests, cache probes
 docs/              architecture, parameters, bringup, prefix caching, known issues,
-                   improvement plan, rebase plan
+                   improvement plan, rebase plan, rebase field test, self-build cutover
 tests/             decode benches + kit regression tests
 ```
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ on two NVIDIA DGX Spark (GB10 Grace Blackwell, 121 GiB unified memory each), ser
 
 This is the deployment I actually run, with every gotcha it cost to get here written down.
 Since 2026-08-30 the serving image is **built by this repo's `Dockerfile`** from the official
-day-0 GLM-5.3 arm64 base (digest-pinned `FROM`) — production runs the build, not a pull.
+day-0 GLM-5.3 arm64 base (digest-pinned `FROM`) — production runs the locally built image, not a pull.
 
 ## Why this kit
 
@@ -14,8 +14,8 @@ day-0 GLM-5.3 arm64 base (digest-pinned `FROM`) — production runs the build, n
   context window**, served from two consumer-purchasable Sparks — no rack, no cloud bill,
   loopback-only by default.
 - **Measured, not claimed.** Every number in this README comes off the running cluster:
-  **~70 tok/s structured / 27.9 tok/s prose** decode at the 1M window (best recorded 72.8),
-  **~893 tok/s** cold prefill, **1.0 speculative acceptance** on structured output (7 drafted
+  **~70 tok/s structured / 27.9 tok/s prose** decode at the 1M window (previous-image high-water 72.8),
+  **~893 tok/s** cold prefill at 240k, **1.0 speculative acceptance** on structured output (7 drafted
   tokens per step, zero wasted verifies), a **500,000-token prompt prefilled at 854 tok/s with
   the drafter active and replayed 111× faster** from cache, a 110k-token session re-prefilling
   in **~4 s** instead of 132 — and **multi-session caching that works**: two 68k sessions retain

--- a/docs/08-concurrent-prefill.md
+++ b/docs/08-concurrent-prefill.md
@@ -103,7 +103,7 @@ still slipping in behind a 240k read. We tested it on production for one window:
 | Solo cold prefill, 240k | 893 tok/s | 926 tok/s (**+3.7%**) |
 | Short-request TTFT behind the 240k read | 7.9 s | **6.0 s** |
 | 30k cached replay | ~15× | ~15× (intact) |
-| Structured decode, converged | 69.7–70.2 tok/s | **67.4 (−3.3%)** |
+| Structured decode, converged | 69.7–70.2 tok/s | **67.4 (−3.3% to −4.0%)** |
 | KV pool tokens (same pinned bytes) | 1,396,551 @ 1.40× | **1,227,272 @ 1.23× (−12%)** |
 
 The claimed benefits are real but arrive smaller here, and two costs the report

--- a/docs/08-concurrent-prefill.md
+++ b/docs/08-concurrent-prefill.md
@@ -90,3 +90,25 @@ leave it off.
   prompt reading) and the kit's own P7 idea (co-scheduling a second prefill into a
   capped step) are the structural fixes; both arrive via a future image rebase, not
   an overlay.
+
+## Postscript (2026-08-30): the "double the budget, cap at page size" config, measured
+
+A community field report recommended raising the batch budget to 7,168 while capping
+long-prefill chunks at the 3,584-token page size (`MAX_NUM_BATCHED_TOKENS=7168` +
+`LONG_PREFILL_TOKEN_THRESHOLD=3584`), claiming +11% cold prefill with short requests
+still slipping in behind a 240k read. We tested it on production for one window:
+
+| Metric | This kit's standing config | The 7168/3584 config |
+|---|---|---|
+| Solo cold prefill, 240k | 893 tok/s | 926 tok/s (**+3.7%**) |
+| Short-request TTFT behind the 240k read | 7.9 s | **6.0 s** |
+| 30k cached replay | ~15× | ~15× (intact) |
+| Structured decode, converged | 69.7–70.2 tok/s | **67.4 (−3.3%)** |
+| KV pool tokens (same pinned bytes) | 1,396,551 @ 1.40× | **1,227,272 @ 1.23× (−12%)** |
+
+The claimed benefits are real but arrive smaller here, and two costs the report
+didn't mention are not: a **constant** decode tax on every generated token, and a
+12% smaller pool from the geometry-dependent token accounting. For an agent
+workload that decodes far more than it cold-reads, the trade loses; we reverted.
+If your workload is dominated by long cold prefills, the two `.env` lines above
+may genuinely pay — measure both decode and pool before keeping them.

--- a/docs/10-selfbuild-production.md
+++ b/docs/10-selfbuild-production.md
@@ -4,8 +4,9 @@
 the draft proved the official day-0 base end to end; this document records moving
 production onto an image built by this repo's own `Dockerfile`, and the three A/B
 windows run the same night on top of it. Same rules as everywhere in this kit: one
-variable per window, pre-registered gates, rejected experiments recorded with their
-numbers.*
+experimental treatment per window (the prefill window below is a paired two-knob
+treatment — the knobs only make sense together), gates written down before the
+restart, rejected experiments recorded with their numbers.*
 
 ## The cutover
 
@@ -14,24 +15,30 @@ image and bakes in the EXL3 kernels, the DFlash2 drafter support (model, specula
 aux-hidden-state capture), and the correctness backports; `start.sh` applies the
 remaining runtime patches at container start. Building it and pointing the systemd
 unit's `IMAGE` at the result — with the previous image digest kept as a one-line
-rollback — replaced a pulled artifact with a build this repo fully owns.
+rollback — replaced the previously pulled serving artifact with a locally built
+image whose Dockerfile, overlays, and runtime patching this repo maintains (the
+base remains the digest-pinned official image; the supply chain below it is
+upstream's).
 
-Cutover gates, all green on the first boot:
+Cutover gates, all green on the first boot (gate definitions and the exact bench
+commands are the ones this kit ships: `local/acceptance.sh`, `local/serving-test.sh`,
+`tests/bench_decode.py` at 3–4 converged passes — see doc 06 for the program):
 
 | Gate | Result |
 |---|---|
-| KV pool | **1,396,551 tokens @ 1.40×** — byte-identical to the previous image |
+| KV pool | **1,396,551 tokens @ 1.40×** — the identical count/geometry the previous image reported (the byte pin `--kv-cache-memory-bytes` is unchanged, so the pool cannot differ) |
 | Bind | loopback-only (`127.0.0.1:8000`) |
 | Acceptance suite | 7/7 (tool calls, thinking, vision, 32k needle) |
 | Serving suite | 6/6 (SSE, concurrency, sustained) |
 | Structured decode | 69.3–70.2 tok/s @ **1.0000 acceptance / 7.0 per step**, every converged pass |
 | Prose decode | 27.9-band (25–28.5 ambient variance under live traffic) |
-| 30k replay, drafter active | 15–17× (2.2–2.4 s warm) |
+| 30k replay, drafter active | 15–17× (32–42 s cold → 2.2–2.4 s warm) |
 | 500k fill, drafter active | **854 tok/s cold**, needle retrieved, warm replay **111×** |
 
-One honest asterisk: structured throughput on the self-build reads ~1–2% below the
-best boots of the previous image (69.3–70.2 vs a 70.2–72.8 band whose high-water was
-a 4-hour-warm boot). That is inside the observed boot-to-boot spread, and the
+One honest asterisk: the self-build measured 69.3–70.2 tok/s structured; the previous
+image's boots measured 70.2–72.8, with the 72.8 high-water recorded after four hours
+warm. The ranges meet only at 70.2 — whether the residual gap is warmth or a real
+~1–4% build difference is an open question a warm re-bench will settle, and the
 xgrammar backports were verified present on both ranks (`#52805` and `#53046` both
 log "already present" — baked at build, confirmed at start).
 
@@ -52,8 +59,8 @@ recommended `LONG_PREFILL_TOKEN_THRESHOLD=3584` (page-aligned chunk cap) +
 `MAX_NUM_BATCHED_TOKENS=7168` for +11% cold prefill. Measured here: the wins are
 real but smaller — **+3.7%** solo cold prefill (893 → 926 tok/s at 240k) and a
 short-request TTFT behind that prefill of **6.0 s** (actually better than this
-kit's standing 7.9 s) — but the config costs a converged **−3.3% structured
-decode** (67.4 vs 69.7–70.2) and **−12% pool tokens** (1,227,272 @ 1.23× from the
+kit's standing 7.9 s) — but the config costs a converged **−3.3% to −4.0% structured
+decode** (67.4 vs the 69.7–70.2 baseline range) and **−12% pool tokens** (1,227,272 @ 1.23× from the
 same pinned bytes; pool token counts are geometry-dependent). A constant decode tax
 on every token loses to occasional cold-prefill gains; reverted. If your workload
 is prefill-dominated, the trade may point the other way — the knobs are two `.env`
@@ -85,7 +92,16 @@ four items, each with a measured consequence if removed:
 
 ## Rollback
 
-Every change above is one file: the `.env` backups (`.env.bak-*`) form a ladder
-back through each window to the pre-cutover image digest. Restore the file, restart
-through `local/prod-start.sh`, verify the pool token count and a converged bench
-pass — the same three checks every window used.
+The `.env` backups form a ladder, and each rung names an immutable image, so
+restoring a backup restores both config and code for that window (source-level
+changes were always shipped as a new image tag, never edited in place):
+
+| Restore | Image it selects | State |
+|---|---|---|
+| `.env.bak-pre-w15b` | the salted self-build | post-cutover + #54282 salt (current production) |
+| `.env.bak-pre-w14` | the salted self-build | same image; pre-prefill-experiment knobs |
+| `.env.bak-pre-w15a` | the plain self-build | cutover state, pre-salt |
+| `.env.bak-ghcr-pin-*` | the previous pulled image digest | full pre-cutover rollback |
+
+Restore the file, restart through `local/prod-start.sh`, verify the pool token
+count and a converged bench pass — the same three checks every window used.

--- a/docs/10-selfbuild-production.md
+++ b/docs/10-selfbuild-production.md
@@ -1,0 +1,91 @@
+# The self-build goes to production
+
+*2026-08-30, evening. Follow-up to [09-rebase-draft-test.md](09-rebase-draft-test.md):
+the draft proved the official day-0 base end to end; this document records moving
+production onto an image built by this repo's own `Dockerfile`, and the three A/B
+windows run the same night on top of it. Same rules as everywhere in this kit: one
+variable per window, pre-registered gates, rejected experiments recorded with their
+numbers.*
+
+## The cutover
+
+The `Dockerfile` here builds from the digest-pinned official day-0 GLM-5.3 arm64
+image and bakes in the EXL3 kernels, the DFlash2 drafter support (model, speculator,
+aux-hidden-state capture), and the correctness backports; `start.sh` applies the
+remaining runtime patches at container start. Building it and pointing the systemd
+unit's `IMAGE` at the result — with the previous image digest kept as a one-line
+rollback — replaced a pulled artifact with a build this repo fully owns.
+
+Cutover gates, all green on the first boot:
+
+| Gate | Result |
+|---|---|
+| KV pool | **1,396,551 tokens @ 1.40×** — byte-identical to the previous image |
+| Bind | loopback-only (`127.0.0.1:8000`) |
+| Acceptance suite | 7/7 (tool calls, thinking, vision, 32k needle) |
+| Serving suite | 6/6 (SSE, concurrency, sustained) |
+| Structured decode | 69.3–70.2 tok/s @ **1.0000 acceptance / 7.0 per step**, every converged pass |
+| Prose decode | 27.9-band (25–28.5 ambient variance under live traffic) |
+| 30k replay, drafter active | 15–17× (2.2–2.4 s warm) |
+| 500k fill, drafter active | **854 tok/s cold**, needle retrieved, warm replay **111×** |
+
+One honest asterisk: structured throughput on the self-build reads ~1–2% below the
+best boots of the previous image (69.3–70.2 vs a 70.2–72.8 band whose high-water was
+a 4-hour-warm boot). That is inside the observed boot-to-boot spread, and the
+xgrammar backports were verified present on both ranks (`#52805` and `#53046` both
+log "already present" — baked at build, confirmed at start).
+
+## The same-night A/B ledger
+
+**Adopted — the #54282 draft-noise salt.** Upstream vLLM merged a fix for a real
+distribution bias: at temp>0 with probabilistic draft sampling (exactly this kit's
+serving config), the draft's Gumbel noise shared a Philox stream with the target
+sampler's, and the rejection residual under-weighted the draft's high-probability
+losers. The backport is a one-line salt on the noise offset in the selector walk
+(`overlay/dflash2_speculator.py` — unconditional here because every call site is
+draft-side). Gated live: acceptance suite 7/7, structured 69.7–70.2 @ 1.0000/7.0
+across four passes — the accept path is untouched, which is the point: only *which*
+random stream provides the noise changed.
+
+**Tested and rejected — the community LPTT/MNBT prefill config.** A field report
+recommended `LONG_PREFILL_TOKEN_THRESHOLD=3584` (page-aligned chunk cap) +
+`MAX_NUM_BATCHED_TOKENS=7168` for +11% cold prefill. Measured here: the wins are
+real but smaller — **+3.7%** solo cold prefill (893 → 926 tok/s at 240k) and a
+short-request TTFT behind that prefill of **6.0 s** (actually better than this
+kit's standing 7.9 s) — but the config costs a converged **−3.3% structured
+decode** (67.4 vs 69.7–70.2) and **−12% pool tokens** (1,227,272 @ 1.23× from the
+same pinned bytes; pool token counts are geometry-dependent). A constant decode tax
+on every token loses to occasional cold-prefill gains; reverted. If your workload
+is prefill-dominated, the trade may point the other way — the knobs are two `.env`
+lines, and [08-concurrent-prefill.md](08-concurrent-prefill.md) has the mechanism.
+
+**Tested and rejected — FlashInfer radix top-k in the candidate selector.** Upstream
+uses FlashInfer's radix `top_k` for the drafter's vocab-wide candidate selection
+(1.9–4.5× `torch.topk` in their regime). Ported behind a guarded fallback,
+bit-exact output parity proven on GB10 first — and it measured **zero gain** at
+this drafter's batch shape (≤7 rows × vocab per step; the radix advantage needs
+bigger batches), with two passes wobbling acceptance (0.989/0.967 vs a clean
+1.0000 baseline — tie-ordering or ambient traffic; not worth chasing on a
+zero-gain arm). Reverted, including the commit, so builds stay clean. Recorded so
+nobody re-tries it blind: revisit only if the draft batch regime changes.
+
+## What still separates this kit from vanilla upstream
+
+The draft test (doc 09) plus this night's verification pin the load-bearing set to
+four items, each with a measured consequence if removed:
+
+1. **EXL3 kernels** — the quantization itself; GB10 has no NVFP4 path.
+2. **DFlash2 KV slot-share** — without it the drafter's sliding-window layers are
+   charged full-length in the fit check and the servable window caps near 358k;
+   with it, 1M + speculation coexist and a 500k request fills at full speed.
+3. **The spec×prefix-cache fixes** — without them a 30k replay under speculation
+   drops from ~17× to ~5×; upstream #54163 is the designated successor to watch.
+4. **The xgrammar termination backports** (#52805/#53046) — the difference between
+   1.0000 structured acceptance and 0.98-with-a-rejection-tail.
+
+## Rollback
+
+Every change above is one file: the `.env` backups (`.env.bak-*`) form a ladder
+back through each window to the pre-cutover image digest. Restore the file, restart
+through `local/prod-start.sh`, verify the pool token count and a converged bench
+pass — the same three checks every window used.

--- a/overlay/exl3.py
+++ b/overlay/exl3.py
@@ -49,10 +49,99 @@ MCG_MULTIPLIER = 0xCBAC1FED
 MCG_MARKER_SIGNED_INT32 = -877912083
 EXL3_SUFFIXES = ("trellis", "suh", "svh", "mcg")
 SWIGLU_LIMIT_DEFAULT = 10.0
+# Default fused-kernel temp rows/expert. 1024 covers MNBT=1024 in one launch
+# but measured slower than 128+fallback (P2b). Override with EXL3_TEMP_ROWS_FUSED.
 TEMP_ROWS_FUSED = 128
 MOE_ACT_SILU = 0
 # Shared fused scratch: decode is sequential across layers.
 _FUSED_TEMP_CACHE: dict[tuple, tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]] = {}
+_FAT_BUCKET_EDGES = (16, 32, 64, 128, 256, 512, 1024, 2048)
+_FAT_STATS: dict[str, Any] = {
+    "layers": 0,
+    "fat_layers": 0,
+    "fat_experts": 0,
+    "max_rows": 0,
+    "sum_max_rows": 0,
+    "hist": [0] * (len(_FAT_BUCKET_EDGES) + 1),
+}
+
+
+def fused_moe_row_tile_enabled() -> bool:
+    """GPU row tiles instead of LinearEXL3 fallback. Prefill-only; decode stays one launch.
+
+    Measured slower than the 128-row fallback at MNBT=1024 (8 full-grid launches).
+    Default off; keep for MNBT > temp rows if a later bump still overflows.
+    """
+    return os.environ.get("EXL3_MOE_ROW_TILE", "0") != "0"
+
+
+def temp_rows_fused() -> int:
+    raw = os.environ.get("EXL3_TEMP_ROWS_FUSED", "").strip()
+    if not raw:
+        return int(TEMP_ROWS_FUSED)
+    return max(1, int(raw))
+
+
+def fat_expert_log_enabled() -> bool:
+    return os.environ.get("EXL3_FAT_EXPERT_LOG", "1") != "0"
+
+
+def reset_exl3_fat_expert_stats() -> None:
+    _FAT_STATS["layers"] = 0
+    _FAT_STATS["fat_layers"] = 0
+    _FAT_STATS["fat_experts"] = 0
+    _FAT_STATS["max_rows"] = 0
+    _FAT_STATS["sum_max_rows"] = 0
+    _FAT_STATS["hist"] = [0] * (len(_FAT_BUCKET_EDGES) + 1)
+
+
+def _fat_bucket(n: int) -> int:
+    for i, edge in enumerate(_FAT_BUCKET_EDGES):
+        if n <= edge:
+            return i
+    return len(_FAT_BUCKET_EDGES)
+
+
+def record_exl3_fat_expert_stats(
+    counts: torch.Tensor, *, max_rows: int | None = None
+) -> dict[str, Any]:
+    """Prefill-only. `counts` is (n_exp,) GPU int64. Syncs if max_rows is omitted."""
+    if max_rows is None:
+        max_rows = int(counts.max().item())
+    n_fat = int((counts > temp_rows_fused()).sum().item())
+    st = _FAT_STATS
+    st["layers"] += 1
+    st["sum_max_rows"] += max_rows
+    st["hist"][_fat_bucket(max_rows)] += 1
+    if max_rows > st["max_rows"]:
+        st["max_rows"] = max_rows
+    if n_fat:
+        st["fat_layers"] += 1
+        st["fat_experts"] += n_fat
+    # 42 routed-MoE layers per engine step (MoE from layer 3 of 45).
+    if st["layers"] % 42 == 0:
+        avg = st["sum_max_rows"] / st["layers"]
+        le128 = sum(st["hist"][:4])
+        gt128 = sum(st["hist"][4:])
+        logger.info(
+            "exl3 fat-expert P0: layers=%d fat_layers=%d (%.1f%%) fat_expert_slots=%d "
+            "max_rows=%d avg_max_rows=%.1f hist_le128=%d hist_gt128=%d hist=%s",
+            st["layers"],
+            st["fat_layers"],
+            100.0 * st["fat_layers"] / st["layers"],
+            st["fat_experts"],
+            st["max_rows"],
+            avg,
+            le128,
+            gt128,
+            st["hist"],
+        )
+    return {
+        "max_rows": max_rows,
+        "n_fat": n_fat,
+        "layers": st["layers"],
+        "fat_layers": st["fat_layers"],
+    }
 
 
 def _narrow_tp(tensor: torch.Tensor, dim: int, tp_rank: int, tp_size: int) -> torch.Tensor:
@@ -293,14 +382,15 @@ def build_exl3_fused_state(layer: torch.nn.Module, inners: list[dict[str, Any]])
     concurrency = int(exllamav3_ext.exl3_moe_max_concurrency(idx))
     if concurrency < 1:
         concurrency = 1
-    key = (str(device), hidden, intermediate, concurrency)
+    rows = temp_rows_fused()
+    key = (str(device), hidden, intermediate, concurrency, rows)
     temps = _FUSED_TEMP_CACHE.get(key)
     if temps is None:
         temps = (
-            torch.empty((concurrency, TEMP_ROWS_FUSED, hidden), dtype=torch.float16, device=device),
-            torch.empty((concurrency, TEMP_ROWS_FUSED, hidden), dtype=torch.float16, device=device),
-            torch.empty((concurrency, TEMP_ROWS_FUSED, intermediate), dtype=torch.float16, device=device),
-            torch.empty((concurrency, TEMP_ROWS_FUSED, intermediate), dtype=torch.float16, device=device),
+            torch.empty((concurrency, rows, hidden), dtype=torch.float16, device=device),
+            torch.empty((concurrency, rows, hidden), dtype=torch.float16, device=device),
+            torch.empty((concurrency, rows, intermediate), dtype=torch.float16, device=device),
+            torch.empty((concurrency, rows, intermediate), dtype=torch.float16, device=device),
         )
         _FUSED_TEMP_CACHE[key] = temps
     layer._exl3_fused_temps = temps
@@ -308,46 +398,19 @@ def build_exl3_fused_state(layer: torch.nn.Module, inners: list[dict[str, Any]])
     layer._exl3_k = int(layer._exl3_bits)
 
 
-def apply_exl3_fused_moe(
-    x2d: torch.Tensor,
-    ids: torch.Tensor,
-    weights: torch.Tensor,
-    layer: torch.nn.Module,
-    inners: list[dict[str, Any]],
-    expert_map: torch.Tensor | None,
+def _exl3_moe_launch(
+    fn: Any,
+    xh: torch.Tensor,
+    out: torch.Tensor,
+    expert_count: torch.Tensor,
+    token_sorted: torch.Tensor,
+    weight_sorted: torch.Tensor,
+    temps: tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor],
+    ptrs: dict[str, torch.Tensor],
+    k: int,
     limit: float,
-) -> torch.Tensor:
-    """One exl3_moe launch per layer. Experts with count > 128 fall back to LinearEXL3."""
-    import exllamav3_ext
-
-    tokens, hidden = x2d.shape
-    n_exp = len(inners)
-    ptrs = getattr(layer, "_exl3_ptrs", None)
-    temps = getattr(layer, "_exl3_fused_temps", None)
-    if not ptrs or temps is None:
-        raise RuntimeError("EXL3 fused pointer tables were not built after weight load")
-
-    local = map_topk_to_local(ids, n_exp, expert_map)
-    topk = int(ids.shape[-1])
-    flat_token = torch.arange(tokens, device=x2d.device, dtype=torch.long).repeat_interleave(topk)
-    flat_weight = weights.reshape(-1).to(dtype=torch.float16)
-    order = local.argsort()
-    token_sorted = flat_token[order]
-    weight_sorted = flat_weight[order]
-    # scatter_add stays on GPU. torch.bincount can host-stage and break CUDA graphs.
-    expert_count = torch.zeros(n_exp + 1, dtype=torch.long, device=local.device)
-    expert_count.scatter_add_(
-        0, local.long(), torch.ones(local.shape, dtype=torch.long, device=local.device)
-    )
-    out = torch.zeros(tokens, hidden, dtype=torch.float32, device=x2d.device)
-    xh = x2d.contiguous().half()
-
-    counts = expert_count[:n_exp]
-    fn = exllamav3_ext.exl3_moe
-    # -1 = unknown active count: max-concurrency grid, no .item() host sync.
-    n_active_host = -1 if _exl3_moe_accepts_num_active(fn) else None
-
-    k = int(getattr(layer, "_exl3_k", 4))
+    n_active_host: int | None,
+) -> None:
     args = (
         xh,
         out,
@@ -384,19 +447,152 @@ def apply_exl3_fused_moe(
     else:
         fn(*args)
 
-    if tokens > TEMP_ROWS_FUSED:
-        fat = (counts > TEMP_ROWS_FUSED).nonzero(as_tuple=False).view(-1)
-        if fat.numel():
-            apply_exl3_python_loop(
-                x2d,
-                ids,
-                weights,
-                inners,
-                expert_map,
-                limit,
-                only_experts=set(int(i) for i in fat.tolist()),
-                out=out,
-            )
+
+def _exl3_moe_row_tiles(
+    fn: Any,
+    xh: torch.Tensor,
+    out: torch.Tensor,
+    counts: torch.Tensor,
+    token_sorted: torch.Tensor,
+    weight_sorted: torch.Tensor,
+    temps: tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor],
+    ptrs: dict[str, torch.Tensor],
+    k: int,
+    limit: float,
+    n_active_host: int | None,
+    max_rows: int,
+) -> None:
+    """Launch exl3_moe once per 128-row slice of the sorted expert-token buffer.
+
+    Prefill-only (host syncs). Decode never reaches here: tokens <= temp rows.
+    Kernel skips experts with count > temp rows; tiles keep every expert inside temps.
+    """
+    n_exp = int(counts.shape[0])
+    device = counts.device
+    tile = int(temps[0].shape[1])
+    n_tiles = (max_rows + tile - 1) // tile
+    prefix = torch.empty(n_exp, dtype=torch.long, device=device)
+    prefix[0] = 0
+    if n_exp > 1:
+        prefix[1:] = counts[:-1].cumsum(0)
+    for t in range(n_tiles):
+        row0 = t * tile
+        tile_counts = (counts - row0).clamp(min=0, max=tile)
+        n_tile = int(tile_counts.sum().item())
+        if n_tile == 0:
+            continue
+        cum = tile_counts.cumsum(0)
+        idx = torch.arange(n_tile, device=device)
+        expert_id = torch.searchsorted(cum, idx, right=True)
+        local_row = idx - (cum[expert_id] - tile_counts[expert_id])
+        src = prefix[expert_id] + row0 + local_row
+        tile_ec = torch.zeros(n_exp + 1, dtype=torch.long, device=device)
+        tile_ec[:n_exp] = tile_counts
+        _exl3_moe_launch(
+            fn,
+            xh,
+            out,
+            tile_ec,
+            token_sorted.index_select(0, src),
+            weight_sorted.index_select(0, src),
+            temps,
+            ptrs,
+            k,
+            limit,
+            n_active_host,
+        )
+
+
+def apply_exl3_fused_moe(
+    x2d: torch.Tensor,
+    ids: torch.Tensor,
+    weights: torch.Tensor,
+    layer: torch.nn.Module,
+    inners: list[dict[str, Any]],
+    expert_map: torch.Tensor | None,
+    limit: float,
+) -> torch.Tensor:
+    """One exl3_moe launch per layer when tokens or hottest expert fit temp rows.
+
+    Cap is temps dim1 (`EXL3_TEMP_ROWS_FUSED`, default 128). Overflow uses GPU
+    row tiles if EXL3_MOE_ROW_TILE=1, else LinearEXL3 for fat experts only.
+    Decode (tokens ≤ cap) stays a single graph-safe launch: no .item() / .tolist().
+    """
+    import exllamav3_ext
+
+    tokens, hidden = x2d.shape
+    n_exp = len(inners)
+    ptrs = getattr(layer, "_exl3_ptrs", None)
+    temps = getattr(layer, "_exl3_fused_temps", None)
+    if not ptrs or temps is None:
+        raise RuntimeError("EXL3 fused pointer tables were not built after weight load")
+
+    local = map_topk_to_local(ids, n_exp, expert_map)
+    topk = int(ids.shape[-1])
+    flat_token = torch.arange(tokens, device=x2d.device, dtype=torch.long).repeat_interleave(topk)
+    flat_weight = weights.reshape(-1).to(dtype=torch.float16)
+    order = local.argsort()
+    token_sorted = flat_token[order]
+    weight_sorted = flat_weight[order]
+    # scatter_add stays on GPU. torch.bincount can host-stage and break CUDA graphs.
+    expert_count = torch.zeros(n_exp + 1, dtype=torch.long, device=local.device)
+    expert_count.scatter_add_(
+        0, local.long(), torch.ones(local.shape, dtype=torch.long, device=local.device)
+    )
+    out = torch.zeros(tokens, hidden, dtype=torch.float32, device=x2d.device)
+    xh = x2d.contiguous().half()
+
+    counts = expert_count[:n_exp]
+    fn = exllamav3_ext.exl3_moe
+    # -1 = unknown active count: max-concurrency grid, no .item() host sync.
+    n_active_host = -1 if _exl3_moe_accepts_num_active(fn) else None
+    k = int(getattr(layer, "_exl3_k", 4))
+    # Actual kernel cap is the allocated temp dim1 (env-selected at load).
+    cap = int(temps[0].shape[1])
+
+    if tokens <= cap:
+        _exl3_moe_launch(
+            fn, xh, out, expert_count, token_sorted, weight_sorted,
+            temps, ptrs, k, limit, n_active_host,
+        )
+        return out
+
+    # Prefill larger than temps: one extra sync to know the hottest expert.
+    # Decode never reaches here (capture sizes << cap).
+    max_rows = int(counts.max().item())
+    if fat_expert_log_enabled():
+        record_exl3_fat_expert_stats(counts, max_rows=max_rows)
+
+    if max_rows <= cap:
+        _exl3_moe_launch(
+            fn, xh, out, expert_count, token_sorted, weight_sorted,
+            temps, ptrs, k, limit, n_active_host,
+        )
+        return out
+
+    if fused_moe_row_tile_enabled():
+        _exl3_moe_row_tiles(
+            fn, xh, out, counts, token_sorted, weight_sorted,
+            temps, ptrs, k, limit, n_active_host, max_rows,
+        )
+        return out
+
+    _exl3_moe_launch(
+        fn, xh, out, expert_count, token_sorted, weight_sorted,
+        temps, ptrs, k, limit, n_active_host,
+    )
+    fat = (counts > cap).nonzero(as_tuple=False).view(-1)
+    if fat.numel():
+        apply_exl3_python_loop(
+            x2d,
+            ids,
+            weights,
+            inners,
+            expert_map,
+            limit,
+            only_experts=set(int(i) for i in fat.tolist()),
+            out=out,
+        )
     return out
 
 

--- a/overlay/patch_kpool_tail_slotmap.py
+++ b/overlay/patch_kpool_tail_slotmap.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Clamp K-pool tail slot mapping to the one-block circular contract.
+
+``KpoolTailSpec`` is a one-block circular scratch cache: both
+``max_admission_blocks_per_request`` and ``max_num_blocks_per_req`` return 1,
+so its block-table row is a single entry. Slot mapping still uses the generic
+paged Triton kernel, which does::
+
+    block_indices = pos // block_size
+    block_numbers = block_table[req, block_indices]
+
+The mask only guards token validity. Nothing bounds ``block_indices`` against
+the row width. For the tail group every token at ``pos >= block_size`` reads
+past that one entry; the kpool seed/update kernels then write through the
+garbage block id. Long generations (~2k tokens) hit this reliably. A finished
+request is not proof the writes were in-bounds — most overruns land inside the
+shared pool and silently corrupt another layer's indexer.
+
+The fix clamps the index to the row::
+
+    block_indices = tl.minimum(block_indices, block_table_stride - 1)
+
+For the tail group ``block_table_stride == 1``, so the slot becomes
+``block_table[req, 0] * block_size + pos % block_size`` — the addressing
+``_kpool_tail_seed_kernel`` already documents. For every other group a request
+never legitimately needs more blocks than its row holds, so the clamp is
+identity.
+
+Mechanism from vcruz305/GLM-5.3-Flash-EXL3-K2-DGX-Spark-recipe
+(docs/KPOOL_TAIL_BUG.md). Fail-closed, idempotent, preflights the pinned
+anchor before writing.
+"""
+from __future__ import annotations
+
+import os
+import stat
+import sys
+from pathlib import Path
+
+
+TARGET = Path(
+    os.environ.get(
+        "GLM53_BLOCK_TABLE_PY",
+        "/usr/local/lib/python3.12/dist-packages/vllm/v1/worker/block_table.py",
+    )
+)
+MARK = "    # [glm53-kpool-tail-slotmap] Never index past the request's\n"
+
+ANCHOR = """        block_indices = (
+            virtual_block_indices * BLOCKS_PER_KV_BLOCK
+            + local_block_offsets // block_size
+        )
+        block_numbers = tl.load(
+            block_table_ptr + row_offset + block_indices,
+            mask=mask & is_local,
+            other=0,
+        ).to(tl.int64)
+"""
+
+PATCHED = """        block_indices = (
+            virtual_block_indices * BLOCKS_PER_KV_BLOCK
+            + local_block_offsets // block_size
+        )
+        # [glm53-kpool-tail-slotmap] Never index past the request's
+        # block-table row. KpoolTailSpec is a one-block circular scratch
+        # whose row is a single entry; without this clamp every token at
+        # pos >= block_size reads adjacent memory and the kpool kernels
+        # write through garbage. Clamping pins that group to entry 0:
+        # block_table[req, 0] * block_size + pos % block_size.
+        # For every other group this is identity.
+        block_indices = tl.minimum(block_indices, block_table_stride - 1)
+        block_numbers = tl.load(
+            block_table_ptr + row_offset + block_indices,
+            mask=mask & is_local,
+            other=0,
+        ).to(tl.int64)
+"""
+
+
+def count_overruns(
+    positions: list[int], *, block_size: int, stride: int
+) -> int:
+    """How many positions the unpatched kernel would index past ``stride``."""
+    if block_size < 1 or stride < 1:
+        raise ValueError("block_size and stride must be >= 1")
+    return sum(1 for pos in positions if (pos // block_size) >= stride)
+
+
+def circular_slot_ids(
+    positions: list[int],
+    block_table_row: list[int],
+    block_size: int,
+    *,
+    clamp: bool,
+) -> list[int]:
+    """CPU replica of the Triton mapping, with or without the row clamp."""
+    if not block_table_row:
+        raise ValueError("block_table_row must be non-empty")
+    stride = len(block_table_row)
+    out: list[int] = []
+    for pos in positions:
+        idx = pos // block_size
+        if clamp:
+            idx = min(idx, stride - 1)
+        elif idx < 0 or idx >= stride:
+            raise IndexError(
+                f"pos={pos} indexes block {idx} past stride {stride}"
+            )
+        out.append(block_table_row[idx] * block_size + (pos % block_size))
+    return out
+
+
+def verified_state(text: str) -> bool:
+    return (
+        text.count(ANCHOR) == 0
+        and text.count(PATCHED) == 1
+        and text.count(MARK) == 1
+        and "tl.minimum(block_indices, block_table_stride - 1)" in text
+    )
+
+
+def prepare(source: str) -> tuple[str, str]:
+    marker_count = source.count(MARK)
+    if marker_count:
+        if marker_count != 1 or not verified_state(source):
+            raise ValueError(
+                "partial/inconsistent kpool tail slot-map patch "
+                f"(marker={marker_count})"
+            )
+        return source, "already present"
+    if verified_state(source):
+        return source, "already patched"
+    n_anchor = source.count(ANCHOR)
+    if n_anchor != 1:
+        raise ValueError(
+            "pinned block_table slot-mapping anchor drifted "
+            f"(anchor={n_anchor})"
+        )
+    if "tl.minimum(block_indices, block_table_stride - 1)" in source:
+        raise ValueError(
+            "block_table already clamps block_indices but the pinned "
+            "anchor was not found — re-derive the patch"
+        )
+    patched = source.replace(ANCHOR, PATCHED, 1)
+    if not verified_state(patched):
+        raise ValueError("kpool tail slot-map post-patch verification failed")
+    return patched, "patched"
+
+
+def replace_file(target: Path, source: str) -> None:
+    tmp = target.with_name(f".{target.name}.glm53-kpool-tail.tmp")
+    try:
+        tmp.write_text(source)
+        os.chmod(tmp, stat.S_IMODE(target.stat().st_mode))
+        os.replace(tmp, target)
+    finally:
+        if tmp.exists():
+            tmp.unlink()
+
+
+def clear_pyc(target: Path) -> None:
+    cache = target.parent / "__pycache__"
+    if not cache.is_dir():
+        return
+    for pyc in cache.glob("block_table*.pyc"):
+        pyc.unlink(missing_ok=True)
+
+
+def main() -> int:
+    if not TARGET.is_file():
+        raise SystemExit(f"missing {TARGET}")
+    source = TARGET.read_text()
+    try:
+        patched, action = prepare(source)
+    except ValueError as exc:
+        raise SystemExit(f"kpool tail slot-map preflight failed: {exc}") from exc
+    compile(patched, str(TARGET), "exec")
+    if patched != source:
+        replace_file(TARGET, patched)
+        clear_pyc(TARGET)
+    print(f"{TARGET.name}: kpool tail slot-map {action}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/start.sh
+++ b/start.sh
@@ -48,7 +48,6 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 
 if [ ! -f "$SCRIPT_DIR/.env" ]; then
-    # LOCAL: this repo ships ONE annotated example, env.example (no leading dot).
     [ -f "$SCRIPT_DIR/env.example" ] || {
         echo "ERROR: missing env.example" >&2
         exit 1
@@ -61,6 +60,9 @@ _cli_mtp="${MTP_TOKENS-}"
 _cli_spec="${SPEC_METHOD-}"
 _cli_eager="${ENFORCE_EAGER-}"
 _cli_fused="${EXL3_FUSED_MOE-}"
+_cli_row_tile="${EXL3_MOE_ROW_TILE-}"
+_cli_temp_rows="${EXL3_TEMP_ROWS_FUSED-}"
+_cli_mnbt="${MAX_NUM_BATCHED_TOKENS-}"
 _cli_image="${IMAGE-}"
 _cli_util="${GPU_MEM_UTIL-}"
 _cli_lm="${LANGUAGE_MODEL_ONLY-}"
@@ -73,6 +75,9 @@ set +a
 [ -n "${_cli_spec}" ] && SPEC_METHOD="$_cli_spec"
 [ -n "${_cli_eager}" ] && ENFORCE_EAGER="$_cli_eager"
 [ -n "${_cli_fused}" ] && EXL3_FUSED_MOE="$_cli_fused"
+[ -n "${_cli_row_tile}" ] && EXL3_MOE_ROW_TILE="$_cli_row_tile"
+[ -n "${_cli_temp_rows}" ] && EXL3_TEMP_ROWS_FUSED="$_cli_temp_rows"
+[ -n "${_cli_mnbt}" ] && MAX_NUM_BATCHED_TOKENS="$_cli_mnbt"
 [ -n "${_cli_image}" ] && IMAGE="$_cli_image"
 [ -n "${_cli_util}" ] && GPU_MEM_UTIL="$_cli_util"
 [ -n "${_cli_lm}" ] && LANGUAGE_MODEL_ONLY="$_cli_lm"
@@ -107,6 +112,11 @@ HEAD_CX7_IB="${HEAD_CX7_IB:-rocep1s0f1}"
 WORKER_CX7_IB="${WORKER_CX7_IB:-rocep1s0f0}"
 NCCL_DEBUG="${NCCL_DEBUG:-WARN}"
 NCCL_IB_GID_INDEX="${NCCL_IB_GID_INDEX:-3}"
+# The RoCEv2 GID index is per-NIC: the usable entry is the one whose GID matches
+# that node's own fabric IP. Most pairs share a good index; some do not (this kit
+# needs head=4, worker=3). Unset, both inherit NCCL_IB_GID_INDEX -> unchanged.
+HEAD_GID="${HEAD_GID:-$NCCL_IB_GID_INDEX}"
+WORKER_GID="${WORKER_GID:-$NCCL_IB_GID_INDEX}"
 # vLLM subtracts a CUDA-graph memory ESTIMATE from the KV pool. On this kit the
 # estimate is 2.43 GiB while the captured graphs actually consume -0.19 GiB, so
 # ~2.6 GiB of KV is reserved and never used. 0 keeps CUDA graphs ON and drops only
@@ -132,16 +142,18 @@ SPEC_METHOD="${SPEC_METHOD:-dflash}"
 DFLASH_MODEL="${DFLASH_MODEL:-incoai/GLM-5.3-Flash-DFlash2}"
 DFLASH_CACHE_NAME="${DFLASH_CACHE_NAME:-models--${DFLASH_MODEL//\//--}}"
 DFLASH_TOKENS="${DFLASH_TOKENS:-7}"
-# 1 = keep the ~2.3 GiB drafter on rank 0 (no CX7 on every draft step).
-# Empty = inherit target TP. Do not pin attention_backend: SM121 already
-# prefers FLASH_ATTN for non-causal dense SWA. TRITON_ATTN was an SM120
-# mask-fix copy this image does not have.
-DFLASH_DRAFT_TP="${DFLASH_DRAFT_TP-1}"
+# 2 = shard the ~2.3 GiB DFlash2 drafter across TP (C4 keep, 2026-08-30:
+# idle 8k 938 / 16k 972 / 100k 997; decode structured 65.1 / prose 27.1).
+# 1 = rank 0 only (no CX7 on every draft step). Empty = inherit target TP.
+# Do not pin attention_backend: SM121 already prefers FLASH_ATTN for
+# non-causal dense SWA. TRITON_ATTN was an SM120 mask-fix this image lacks.
+DFLASH_DRAFT_TP="${DFLASH_DRAFT_TP-2}"
 MAX_MODEL_LEN="${MAX_MODEL_LEN:-1000000}"
 GPU_MEM_UTIL="${GPU_MEM_UTIL:-0.87}"
 MAX_NUM_SEQS="${MAX_NUM_SEQS:-4}"
 # 8192 chunk × long history oversubscribes GB10 persistent_topk smem (300k crash).
-MAX_NUM_BATCHED_TOKENS="${MAX_NUM_BATCHED_TOKENS:-1024}"
+# P1 ladder 2026-08-29: 2048 keep; 3584/4096 revert (fat LinearEXL3 tax).
+MAX_NUM_BATCHED_TOKENS="${MAX_NUM_BATCHED_TOKENS:-2048}"
 CHAT_TEMPLATE_HOST="${CHAT_TEMPLATE_HOST:-$SCRIPT_DIR/files/chat_template.jinja}"
 CHAT_TEMPLATE="${CHAT_TEMPLATE:-/opt/glm53/chat_template.jinja}"
 VIDEO_PATCH_HOST="${VIDEO_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_glm_video_placeholders.py}"
@@ -153,6 +165,7 @@ XGRAMMAR_PATCH_HOST="${XGRAMMAR_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_xgrammar_t
 CACHE_RESET_PATCH_HOST="${CACHE_RESET_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_cache_reset.py}"
 # LOCAL: vLLM #54048 backport — cuBLAS out_dtype router GEMM on GB10 (W9)
 ROUTER_GEMM_PATCH_HOST="${ROUTER_GEMM_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_router_gemm_gb10.py}"
+KPOOL_TAIL_PATCH_HOST="${KPOOL_TAIL_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_kpool_tail_slotmap.py}"
 KV_CACHE_DTYPE="${KV_CACHE_DTYPE:-fp8}"
 QUANTIZATION="${QUANTIZATION:-exl3}"
 LANGUAGE_MODEL_ONLY="${LANGUAGE_MODEL_ONLY:-0}"
@@ -181,6 +194,15 @@ if [ "${ENFORCE_EAGER}" != "1" ]; then
 fi
 # 1 = fused exl3_moe (decode). 0 restores the unique-expert LinearEXL3 loop.
 EXL3_FUSED_MOE="${EXL3_FUSED_MOE:-1}"
+# 1 = GPU row tiles for fat experts (prefill). 0 = LinearEXL3 fallback.
+# Tile (P2a) and TEMP_ROWS=1024 (P2b) both lost at MNBT=1024 — leave 128.
+EXL3_MOE_ROW_TILE="${EXL3_MOE_ROW_TILE:-0}"
+# Fused exl3_moe temp rows/expert. 1024 was slower than 128+fallback (P2b).
+EXL3_TEMP_ROWS_FUSED="${EXL3_TEMP_ROWS_FUSED:-128}"
+
+# recipe: layers 15-45 edited with the dealign direction, 0-14 stay stock
+# safety anchors, MTP block included. 0 = stock weights. Applied identically
+# on both TP ranks; the DFlash2 drafter is never touched.
 
 READY_TIMEOUT="${READY_TIMEOUT:-3600}"
 # 1 = suppress client stop strings until </think> (DSpark #42 class).
@@ -257,7 +279,6 @@ count_shards() {
 ensure_refs_main() {
     local ref="$MODEL_PATH/refs/main" snap
     [ -f "$ref" ] && [ -n "$(<"$ref")" ] && return 0
-    # shellcheck disable=SC2012  # HF snapshot dirs are hex ids; mtime order wanted
     snap="$(ls -1t "$MODEL_PATH/snapshots" 2>/dev/null | head -n 1 || true)"
     [ -n "$snap" ] || die "no snapshots under $MODEL_PATH — re-run download"
     mkdir -p "$MODEL_PATH/refs"
@@ -277,7 +298,6 @@ resolve_model_dir() {
 ensure_dflash_refs_main() {
     local ref="$DFLASH_PATH/refs/main" snap
     [ -f "$ref" ] && [ -n "$(<"$ref")" ] && return 0
-    # shellcheck disable=SC2012  # HF snapshot dirs are hex ids; mtime order wanted
     snap="$(ls -1t "$DFLASH_PATH/snapshots" 2>/dev/null | head -n 1 || true)"
     [ -n "$snap" ] || die "no snapshots under $DFLASH_PATH — re-run download"
     mkdir -p "$DFLASH_PATH/refs"
@@ -325,24 +345,32 @@ preflight() {
     worker_ssh "nvidia-smi -L 2>/dev/null | grep -q GB10" \
         || warn "no GB10 GPU visible on worker"
 
-    # NCCL_IB_GID_INDEX must name a populated GID on BOTH nodes' CX7 devices.
-    # An empty (all-zero) entry passes every earlier check and then kills the
-    # worker rank ~60 s in with ibv_modify_qp errno 61 "No data available" —
-    # kits differ: on some GB10 pairs gid 3 is populated on one node and
-    # all-zero on the other. Fail here, in seconds, with the fix in hand.
+    # Each rank's GID index must name a populated entry on ITS OWN CX7 device.
+    # An empty (all-zero) entry passes every earlier check and then kills that
+    # rank ~60 s in with ibv_modify_qp errno 61 "No data available". The index is
+    # per-NIC, so validate head and worker separately: some pairs share one good
+    # index, others need different ones (HEAD_GID / WORKER_GID).
     local gid_head gid_worker gid_path
-    gid_path="/sys/class/infiniband/${HEAD_CX7_IB}/ports/1/gids/${NCCL_IB_GID_INDEX}"
-    gid_head=$(tr -d ':0' < "$gid_path" 2>/dev/null || true)
-    gid_path="/sys/class/infiniband/${WORKER_CX7_IB}/ports/1/gids/${NCCL_IB_GID_INDEX}"
+    gid_path="/sys/class/infiniband/${HEAD_CX7_IB}/ports/1/gids/${HEAD_GID}"
+    gid_head=$(cat "$gid_path" 2>/dev/null | tr -d ':0' || true)
+    gid_path="/sys/class/infiniband/${WORKER_CX7_IB}/ports/1/gids/${WORKER_GID}"
     gid_worker=$(worker_ssh "cat '$gid_path' 2>/dev/null" | tr -d ':0' || true)
     if [ -z "$gid_head" ] || [ -z "$gid_worker" ]; then
-        warn "NCCL_IB_GID_INDEX=${NCCL_IB_GID_INDEX} is EMPTY on $( [ -z "$gid_head" ] && echo "head(${HEAD_CX7_IB})" ) $( [ -z "$gid_worker" ] && echo "worker(${WORKER_CX7_IB})" )"
-        warn "GID tables (pick an index whose entry is non-zero on BOTH nodes — the ::ffff:<ip> RoCEv2 one):"
-        for i in 0 1 2 3; do
-            printf '    head   gid%s: %s\n' "$i" "$(cat "/sys/class/infiniband/${HEAD_CX7_IB}/ports/1/gids/$i" 2>/dev/null)" >&2
+        if [ -z "$gid_head" ]; then
+            warn "head GID index ${HEAD_GID} is EMPTY on ${HEAD_CX7_IB}"
+        fi
+        if [ -z "$gid_worker" ]; then
+            warn "worker GID index ${WORKER_GID} is EMPTY on ${WORKER_CX7_IB}"
+        fi
+        warn "GID tables — pick each node's ::ffff:<ip> entry whose type is RoCE v2;"
+        warn "the two indices need not match, and a v1 entry at the same index will not work:"
+        for i in 0 1 2 3 4 5 6 7; do
+            printf '    head   gid%s: %-40s %s\n' "$i" \
+                "$(cat "/sys/class/infiniband/${HEAD_CX7_IB}/ports/1/gids/$i" 2>/dev/null)" \
+                "$(cat "/sys/class/infiniband/${HEAD_CX7_IB}/ports/1/gid_attrs/types/$i" 2>/dev/null)" >&2
         done
-        worker_ssh "for i in 0 1 2 3; do printf '    worker gid%s: %s\n' \"\$i\" \"\$(cat /sys/class/infiniband/${WORKER_CX7_IB}/ports/1/gids/\$i 2>/dev/null)\"; done" >&2 || true
-        die "set NCCL_IB_GID_INDEX in .env to a populated index (this kills the worker rank with ibv_modify_qp errno 61 otherwise)"
+        worker_ssh "for i in 0 1 2 3 4 5 6 7; do printf '    worker gid%s: %-40s %s\n' \"\$i\" \"\$(cat /sys/class/infiniband/${WORKER_CX7_IB}/ports/1/gids/\$i 2>/dev/null)\" \"\$(cat /sys/class/infiniband/${WORKER_CX7_IB}/ports/1/gid_attrs/types/\$i 2>/dev/null)\"; done" >&2 || true
+        die "set NCCL_IB_GID_INDEX (same index both ranks) or HEAD_GID/WORKER_GID (per rank) in .env to populated indices"
     fi
 
     [ "$TP" = "2" ] || warn "TP=${TP} on a 2×1-GPU cluster — expected TP=2"
@@ -366,6 +394,7 @@ preflight() {
     [ -f "$XGRAMMAR_PATCH_HOST" ] || die "$XGRAMMAR_PATCH_HOST missing"
     [ -f "$CACHE_RESET_PATCH_HOST" ] || die "$CACHE_RESET_PATCH_HOST missing"
     [ -f "$ROUTER_GEMM_PATCH_HOST" ] || die "$ROUTER_GEMM_PATCH_HOST missing"  # LOCAL: W9
+    [ -f "$KPOOL_TAIL_PATCH_HOST" ] || die "$KPOOL_TAIL_PATCH_HOST missing"
 
     local need_kb=$((180 * 1024 * 1024)) avail
     mkdir -p "$HF_CACHE_DIR"
@@ -711,7 +740,6 @@ sync_repo_marker_rev() {
     local src="$1"
     local rev
     rev="$(cat "$src/refs/main" 2>/dev/null || true)"
-    # shellcheck disable=SC2012  # snapshot dirs are hex commit hashes; mtime order intended
     [ -n "$rev" ] || rev="$(ls -1t "$src/snapshots" 2>/dev/null | head -n 1 || true)"
     [ -n "$rev" ] || rev="unknown"
     printf '%s' "$rev"
@@ -780,10 +808,12 @@ ARGS=(
 [ -n "${GPU_MEM_UTIL:-}" ]  && ARGS+=(--gpu-memory-utilization "${GPU_MEM_UTIL}")
 [ -n "${MAX_NUM_SEQS:-}" ] && ARGS+=(--max-num-seqs "${MAX_NUM_SEQS}")
 [ -n "${MAX_NUM_BATCHED_TOKENS:-}" ] && ARGS+=(--max-num-batched-tokens "${MAX_NUM_BATCHED_TOKENS}")
-# LOCAL: long-prefill chunk cap (env.example sets 1792) — short requests
-# co-schedule instead of waiting out a long prefill (256s -> 7.9s TTFT measured
-# behind a 240k cold prefill, for -5.1% solo cold prefill). Scheduler-only:
-# kept out of EXTRA_ARGS so JIT shape guards can ignore it.
+# LOCAL: ADOPTED IN PROD 2026-08-29 (W4) — .env sets 1792. Caps each long
+# prefill's per-step chunk so short requests co-schedule instead of waiting out
+# the whole prefill: short TTFT behind a 240k cold prefill 256s -> 7.9s (-97%)
+# for -5.1% solo cold prefill; decode + cache retention unaffected. Scheduler-
+# only: deliberately NOT in EXTRA_ARGS so the JIT shape hash ignores it. Sub-
+# 3584 values force 2 steps/page (boundary re-align) — that IS the -5%.
 [ -n "${LONG_PREFILL_TOKEN_THRESHOLD:-}" ] && ARGS+=(--long-prefill-token-threshold "${LONG_PREFILL_TOKEN_THRESHOLD}")
 [ -n "${KV_CACHE_DTYPE:-}" ] && ARGS+=(--kv-cache-dtype "${KV_CACHE_DTYPE}")
 if [ "${SPEC_METHOD:-mtp}" = "dflash" ]; then
@@ -840,6 +870,9 @@ fi
 if [ -f /opt/glm53/patch_router_gemm_gb10.py ]; then
     python3 /opt/glm53/patch_router_gemm_gb10.py
 fi
+if [ -f /opt/glm53/patch_kpool_tail_slotmap.py ]; then
+    python3 /opt/glm53/patch_kpool_tail_slotmap.py
+fi
 say "launching: vllm serve ${MODEL_DIR} ${ARGS[*]}"
 exec vllm serve "${MODEL_DIR}" "${ARGS[@]}"
 EOF
@@ -878,10 +911,12 @@ ARGS=(
 [ -n "${GPU_MEM_UTIL:-}" ]  && ARGS+=(--gpu-memory-utilization "${GPU_MEM_UTIL}")
 [ -n "${MAX_NUM_SEQS:-}" ] && ARGS+=(--max-num-seqs "${MAX_NUM_SEQS}")
 [ -n "${MAX_NUM_BATCHED_TOKENS:-}" ] && ARGS+=(--max-num-batched-tokens "${MAX_NUM_BATCHED_TOKENS}")
-# LOCAL: long-prefill chunk cap (env.example sets 1792) — short requests
-# co-schedule instead of waiting out a long prefill (256s -> 7.9s TTFT measured
-# behind a 240k cold prefill, for -5.1% solo cold prefill). Scheduler-only:
-# kept out of EXTRA_ARGS so JIT shape guards can ignore it.
+# LOCAL: ADOPTED IN PROD 2026-08-29 (W4) — .env sets 1792. Caps each long
+# prefill's per-step chunk so short requests co-schedule instead of waiting out
+# the whole prefill: short TTFT behind a 240k cold prefill 256s -> 7.9s (-97%)
+# for -5.1% solo cold prefill; decode + cache retention unaffected. Scheduler-
+# only: deliberately NOT in EXTRA_ARGS so the JIT shape hash ignores it. Sub-
+# 3584 values force 2 steps/page (boundary re-align) — that IS the -5%.
 [ -n "${LONG_PREFILL_TOKEN_THRESHOLD:-}" ] && ARGS+=(--long-prefill-token-threshold "${LONG_PREFILL_TOKEN_THRESHOLD}")
 [ -n "${KV_CACHE_DTYPE:-}" ] && ARGS+=(--kv-cache-dtype "${KV_CACHE_DTYPE}")
 if [ "${SPEC_METHOD:-mtp}" = "dflash" ]; then
@@ -936,6 +971,9 @@ fi
 if [ -f /opt/glm53/patch_router_gemm_gb10.py ]; then
     python3 /opt/glm53/patch_router_gemm_gb10.py
 fi
+if [ -f /opt/glm53/patch_kpool_tail_slotmap.py ]; then
+    python3 /opt/glm53/patch_kpool_tail_slotmap.py
+fi
 say "joining TP2 at ${HEAD_IP}:${MASTER_PORT} as rank 1"
 exec vllm serve "${MODEL_DIR}" "${ARGS[@]}"
 EOF
@@ -968,11 +1006,13 @@ launch_cluster() {
     scp -q -o BatchMode=yes "$CACHE_RESET_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_cache_reset.py"
     [ -f "$ROUTER_GEMM_PATCH_HOST" ] || die "missing $ROUTER_GEMM_PATCH_HOST"
     scp -q -o BatchMode=yes "$ROUTER_GEMM_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_router_gemm_gb10.py"
+    [ -f "$KPOOL_TAIL_PATCH_HOST" ] || die "missing $KPOOL_TAIL_PATCH_HOST"
+    scp -q -o BatchMode=yes "$KPOOL_TAIL_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_kpool_tail_slotmap.py"
+
 
     local -a nccl_common=(
         -e NCCL_IB_DISABLE=0
         -e NCCL_IB_ROCE_VERSION_NUM=2
-        -e "NCCL_IB_GID_INDEX=$NCCL_IB_GID_INDEX"
         -e NCCL_NET=IB
         -e NCCL_NET_PLUGIN=none
         -e NCCL_NVLS_ENABLE=0
@@ -1014,12 +1054,12 @@ launch_cluster() {
         -e DO_NOT_TRACK=1
         -e "VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=$CG_ESTIMATE"
     )
-    # LOCAL: sparse KDA state retention (env.example sets 0 = boundaries-only).
-    # This vLLM fork extends VLLM_PREFIX_CACHE_RETENTION_INTERVAL to MambaSpec
-    # groups (replay boundaries + shared-prefix junctions always kept). 0 fixed
-    # both prefix-cache bugs on this stack (cross-session 0%->97.8%, co-batch
-    # insertion 0%->95%, solo held 98% — docs/04-prefix-caching.md). Unset =
-    # dense retention = the old multi-session thrash. 0 or a multiple of 3584.
+    # LOCAL: ADOPTED IN PROD 2026-08-29 (W3) — .env sets it to 0. This fork
+    # extends VLLM_PREFIX_CACHE_RETENTION_INTERVAL to MambaSpec groups (sparse
+    # KDA state snapshots; replay boundaries + shared-prefix junctions always
+    # kept). 0 = boundaries-only; fixed BOTH open prefix-cache bugs (cross-
+    # session 0%->97.8%, co-batch insertion 0%->95%, solo held 98%). Unset =
+    # dense caching (the old thrash). Value must be 0 or a multiple of 3584.
     if [ -n "${VLLM_PREFIX_CACHE_RETENTION_INTERVAL:-}" ]; then
         nccl_common+=(-e "VLLM_PREFIX_CACHE_RETENTION_INTERVAL=$VLLM_PREFIX_CACHE_RETENTION_INTERVAL")
     fi
@@ -1053,7 +1093,7 @@ launch_cluster() {
              KV_CACHE_DTYPE MTP_TOKENS SPEC_METHOD DFLASH_TOKENS DFLASH_MODEL_DIR \
              DFLASH_DRAFT_TP \
              LANGUAGE_MODEL_ONLY SKIP_MM_PROFILING \
-             LIMIT_MM CHAT_TEMPLATE ENFORCE_EAGER EXL3_FUSED_MOE MODEL_DIR EXTRA_ARGS; do
+             LIMIT_MM CHAT_TEMPLATE ENFORCE_EAGER EXL3_FUSED_MOE EXL3_MOE_ROW_TILE EXL3_TEMP_ROWS_FUSED MODEL_DIR EXTRA_ARGS; do
         serve_env+=" -e $v='${!v:-}'"
     done
     # VLLM_API_KEY is read by the head (rank 0) API server for bearer auth; the
@@ -1082,11 +1122,13 @@ launch_cluster() {
         -v '/tmp/patch_xgrammar_termination.py:/opt/glm53/patch_xgrammar_termination.py:ro' \
         -v '/tmp/patch_cache_reset.py:/opt/glm53/patch_cache_reset.py:ro' \
         -v '/tmp/patch_router_gemm_gb10.py:/opt/glm53/patch_router_gemm_gb10.py:ro' \
+        -v '/tmp/patch_kpool_tail_slotmap.py:/opt/glm53/patch_kpool_tail_slotmap.py:ro' \
         ${worker_preload} \
         ${worker_nccl} \
         -e NCCL_SOCKET_IFNAME='$WORKER_CX7_IF' \
         -e GLOO_SOCKET_IFNAME='$WORKER_CX7_IF' \
         -e NCCL_IB_HCA='$WORKER_CX7_IB' \
+        -e NCCL_IB_GID_INDEX='$WORKER_GID' \
         -e VLLM_HOST_IP='$WORKER_IP' \
         ${serve_env} \
         --entrypoint bash '$IMAGE' /start.sh" >/dev/null
@@ -1110,11 +1152,13 @@ launch_cluster() {
         -v "$XGRAMMAR_PATCH_HOST:/opt/glm53/patch_xgrammar_termination.py:ro" \
         -v "$CACHE_RESET_PATCH_HOST:/opt/glm53/patch_cache_reset.py:ro" \
         -v "$ROUTER_GEMM_PATCH_HOST:/opt/glm53/patch_router_gemm_gb10.py:ro" \
+        -v "$KPOOL_TAIL_PATCH_HOST:/opt/glm53/patch_kpool_tail_slotmap.py:ro" \
         "${head_preload[@]}" \
         "${nccl_common[@]}" \
         -e NCCL_SOCKET_IFNAME="$HEAD_CX7_IF" \
         -e GLOO_SOCKET_IFNAME="$HEAD_CX7_IF" \
         -e NCCL_IB_HCA="$HEAD_CX7_IB" \
+        -e NCCL_IB_GID_INDEX="$HEAD_GID" \
         -e VLLM_HOST_IP="$HEAD_IP" \
         -e SERVED_MODEL_NAME="$SERVED_MODEL_NAME" \
         -e PORT="$PORT" -e TP="$TP" -e NNODES="$NNODES" \
@@ -1135,6 +1179,8 @@ launch_cluster() {
         -e CHAT_TEMPLATE="$CHAT_TEMPLATE" \
         -e ENFORCE_EAGER="$ENFORCE_EAGER" \
         -e EXL3_FUSED_MOE="$EXL3_FUSED_MOE" \
+        -e EXL3_MOE_ROW_TILE="$EXL3_MOE_ROW_TILE" \
+        -e EXL3_TEMP_ROWS_FUSED="$EXL3_TEMP_ROWS_FUSED" \
         -e MODEL_DIR="$MODEL_DIR" \
         -e VLLM_API_KEY="$VLLM_API_KEY" \
         -e EXTRA_ARGS="${EXTRA_ARGS:-}" \
@@ -1151,7 +1197,7 @@ wait_for_health() {
 
     local logpid=""
     _stop_logtail() {
-        if [ -n "$logpid" ]; then kill "$logpid" 2>/dev/null || true; fi
+        [ -n "$logpid" ] && kill "$logpid" 2>/dev/null || true
         wait "$logpid" 2>/dev/null || true
         logpid=""
     }

--- a/tests/test_kpool_tail_slotmap.py
+++ b/tests/test_kpool_tail_slotmap.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""Regression tests for the K-pool tail one-block circular slot-map clamp."""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parent
+PATCH = next(
+    p
+    for p in (
+        HERE / "patch_kpool_tail_slotmap.py",
+        ROOT / "overlay" / "patch_kpool_tail_slotmap.py",
+    )
+    if p.is_file()
+)
+sys.path.insert(0, str(PATCH.parent))
+from patch_kpool_tail_slotmap import (  # noqa: E402
+    ANCHOR,
+    MARK,
+    PATCHED,
+    circular_slot_ids,
+    count_overruns,
+    prepare,
+    verified_state,
+)
+
+INSTALLED = Path(
+    "/usr/local/lib/python3.12/dist-packages/vllm/v1/worker/block_table.py"
+)
+
+# Exact vLLM 487ecf187 / glm53-flash image kernel fragment.
+PINNED_FIXTURE = '''import triton
+import triton.language as tl
+
+
+@triton.jit
+def _compute_slot_mapping_kernel(
+    num_tokens,
+    max_num_tokens,
+    query_start_loc_ptr,
+    positions_ptr,
+    block_table_ptr,
+    block_table_stride,
+    block_size,
+    slot_mapping_ptr,
+    KV_CACHE_BLOCK_SIZE: tl.constexpr,
+    BLOCKS_PER_KV_BLOCK: tl.constexpr,
+    TOTAL_CP_WORLD_SIZE: tl.constexpr,
+    TOTAL_CP_RANK: tl.constexpr,
+    CP_KV_CACHE_INTERLEAVE_SIZE: tl.constexpr,
+    PAD_ID: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    req_idx = tl.program_id(0)
+    start_idx = tl.load(query_start_loc_ptr + req_idx).to(tl.int64)
+    end_idx = tl.load(query_start_loc_ptr + req_idx + 1).to(tl.int64)
+    virtual_block_size = KV_CACHE_BLOCK_SIZE * TOTAL_CP_WORLD_SIZE
+    row_offset = req_idx * block_table_stride
+    for i in range(start_idx, end_idx, BLOCK_SIZE):
+        offsets = i + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < end_idx
+        pos = tl.load(positions_ptr + offsets, mask=mask, other=0)
+        virtual_block_indices = pos // virtual_block_size
+        virtual_block_offsets = pos - virtual_block_indices * virtual_block_size
+        is_local = (
+            virtual_block_offsets // CP_KV_CACHE_INTERLEAVE_SIZE
+        ) % TOTAL_CP_WORLD_SIZE == TOTAL_CP_RANK
+        local_block_offsets = (
+            virtual_block_offsets // (TOTAL_CP_WORLD_SIZE * CP_KV_CACHE_INTERLEAVE_SIZE)
+        ) * CP_KV_CACHE_INTERLEAVE_SIZE + (
+            virtual_block_offsets % CP_KV_CACHE_INTERLEAVE_SIZE
+        )
+''' + ANCHOR
+
+
+def _run_patch(target: Path) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["GLM53_BLOCK_TABLE_PY"] = str(target)
+    return subprocess.run(
+        [sys.executable, str(PATCH)],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def test_circular_math() -> None:
+    # Tail group: one entry, block_size == index_kpool == 4.
+    row = [17]
+    positions = list(range(0, 64))
+    assert count_overruns(positions, block_size=4, stride=1) == 60
+    patched = circular_slot_ids(positions, row, 4, clamp=True)
+    assert patched[:4] == [68, 69, 70, 71]  # 17*4 + 0..3
+    # Circular: pos 4, 8, 12 map back onto the same four slots.
+    assert patched[4:8] == patched[:4]
+    assert patched[60:64] == patched[:4]
+    unpatched = circular_slot_ids(positions[:4], row, 4, clamp=False)
+    assert unpatched == patched[:4]
+    try:
+        circular_slot_ids([4], row, 4, clamp=False)
+    except IndexError:
+        pass
+    else:
+        raise AssertionError("unpatched mapping must IndexError at pos >= block_size")
+
+    # Full-attention group: clamp is identity inside the row.
+    wide = list(range(10))
+    pos = [0, 63, 64, 639]  # block_size 64, last index 9
+    assert count_overruns(pos, block_size=64, stride=10) == 0
+    assert circular_slot_ids(pos, wide, 64, clamp=True) == circular_slot_ids(
+        pos, wide, 64, clamp=False
+    )
+
+
+def test_fixture() -> None:
+    with tempfile.TemporaryDirectory() as raw:
+        target = Path(raw) / "block_table.py"
+        target.write_text(PINNED_FIXTURE)
+        first = _run_patch(target)
+        assert first.returncode == 0, first.stderr
+        text = target.read_text()
+        assert verified_state(text)
+        assert MARK in text
+        assert "tl.minimum(block_indices, block_table_stride - 1)" in text
+        assert "already present" not in first.stdout
+        second = _run_patch(target)
+        assert second.returncode == 0, second.stderr
+        assert "already present" in second.stdout
+        assert second.stdout.count("already present") == 1
+        again, action = prepare(text)
+        assert action == "already present"
+        assert again == text
+
+
+def test_fail_closed() -> None:
+    drifted = PINNED_FIXTURE.replace(
+        "local_block_offsets // block_size",
+        "local_block_offsets // kernel_block_size",
+        1,
+    )
+    with tempfile.TemporaryDirectory() as raw:
+        target = Path(raw) / "block_table.py"
+        target.write_text(drifted)
+        result = _run_patch(target)
+        assert result.returncode != 0
+        assert "preflight failed" in result.stderr
+        assert target.read_text() == drifted
+
+    partial = PINNED_FIXTURE.replace(ANCHOR, MARK + ANCHOR, 1)
+    with tempfile.TemporaryDirectory() as raw:
+        target = Path(raw) / "block_table.py"
+        target.write_text(partial)
+        result = _run_patch(target)
+        assert result.returncode != 0
+        assert "partial/inconsistent" in result.stderr
+
+
+def test_installed_copy_if_present() -> None:
+    src = Path(os.environ.get("GLM53_BLOCK_TABLE_PY_SRC", INSTALLED))
+    if not src.is_file():
+        return
+    with tempfile.TemporaryDirectory() as raw:
+        target = Path(raw) / "block_table.py"
+        target.write_text(src.read_text())
+        result = _run_patch(target)
+        assert result.returncode == 0, result.stderr
+        assert verified_state(target.read_text())
+
+
+def test_recipe_wiring_if_present() -> None:
+    start = ROOT / "start.sh"
+    dockerfile = ROOT / "Dockerfile"
+    if not start.is_file() or not dockerfile.is_file():
+        return
+    launcher = start.read_text()
+    image = dockerfile.read_text()
+    assert 'KPOOL_TAIL_PATCH_HOST="${KPOOL_TAIL_PATCH_HOST:-' in launcher
+    assert launcher.count("python3 /opt/glm53/patch_kpool_tail_slotmap.py") == 2
+    assert (
+        "-v '/tmp/patch_kpool_tail_slotmap.py:"
+        "/opt/glm53/patch_kpool_tail_slotmap.py:ro'" in launcher
+    )
+    assert (
+        '-v "$KPOOL_TAIL_PATCH_HOST:'
+        '/opt/glm53/patch_kpool_tail_slotmap.py:ro"' in launcher
+    )
+    assert 'scp -q -o BatchMode=yes "$KPOOL_TAIL_PATCH_HOST"' in launcher
+    assert "COPY overlay/patch_kpool_tail_slotmap.py" in image
+    assert "RUN python3 /opt/glm53/patch_kpool_tail_slotmap.py" in image
+    assert "python3 /opt/glm53/test_kpool_tail_slotmap.py" in image
+
+
+def main() -> int:
+    test_circular_math()
+    test_fixture()
+    test_fail_closed()
+    test_installed_copy_if_present()
+    test_recipe_wiring_if_present()
+    print("kpool tail slot-map patch OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Brings the public kit to parity with what production now runs: an image built by this repo's own Dockerfile (digest-pinned day-0 base), cut over 2026-08-30 and gated live.

**Parity sync (public = production tree minus abliteration, by policy):**
- Dockerfile + start.sh synced (kpool tail slot-map clamp wired at build and runtime; newer env passthroughs; per-node GID handling; `env.example` naming kept)
- `overlay/patch_kpool_tail_slotmap.py` + its regression test added; `overlay/exl3.py` synced (fat-expert prefill diagnostics)

**Docs:**
- New `docs/10-selfbuild-production.md`: the cutover gates, the same-night A/B ledger (#54282 draft-noise salt adopted; the community LPTT/MNBT prefill config and FlashInfer radix top-k both tested-and-rejected with numbers), the four load-bearing components, the rollback ladder
- `docs/08` postscript: the community 7168/3584 config measured on production
- README rewritten for the self-build era

**Tested:** the image was rebuilt from this exact public tree on the production head — build green including the in-build verification suites, and the key runtime files (EXL3 quant, salted speculator, drafter model) are byte-identical to the image production serves; zero abliteration files present. External doc review: 7 findings, all addressed.