### PR TITLE
docs: align all docs with the self-built setup; explicit rebase-image spec sheet

### DIFF
--- a/docs/02-parameters.md
+++ b/docs/02-parameters.md
@@ -65,6 +65,6 @@ cache is invisible to it). 0.87 demands 105.87 GiB free against boots measured a
 - `READY_TIMEOUT=4800` / `VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=1800` — a cold JIT rebuild
   after a cache wipe is slow, not dead. Timeouts that "look generous" prevent the
   watchdog from shooting a booting engine.
-- `IMAGE` pinned **by digest** + `SKIP_PULL=1` — a restart must never silently upgrade
+- `IMAGE` names an **immutable** artifact + `SKIP_PULL=1` — since 2026-08-30 that is a local build tag produced by this repo's `Dockerfile` (previously a registry digest); either way, a restart must never silently upgrade
   the runtime. The weekly check-updates timer diffs the registry digest against the pin
   so upgrades are deliberate.

--- a/docs/03-bringup.md
+++ b/docs/03-bringup.md
@@ -1,5 +1,9 @@
 # Bring-up and operations
 
+> Since 2026-08-30 bringup starts one step earlier: `docker build` the serving
+> image from this repo (see the README quickstart) and load it on both nodes
+> before anything below. `IMAGE` in `.env` names that build.
+
 ## First start
 
 ```bash

--- a/docs/05-known-issues.md
+++ b/docs/05-known-issues.md
@@ -2,8 +2,10 @@
 
 ## 1. Co-batched prefill inserts nothing into the prefix cache — FIXED 2026-08-29
 
-**Image:** `ghcr.io/miaai-lab/glm-5.3-flash-2x-dgx-sparks@sha256:9bb1557a…`
-(vLLM `0.1.dev20051+g487ecf187`). **Status: RESOLVED by
+**Measured on:** the previously pulled image
+(`ghcr.io/miaai-lab/…@sha256:9bb1557a…`, vLLM `0.1.dev20051+g487ecf187`); the
+self-built image production runs since 2026-08-30 is the same lineage and vLLM
+build, so every issue and fix here carries over unchanged. **Status: RESOLVED by
 `VLLM_PREFIX_CACHE_RETENTION_INTERVAL=0`** (see `04-prefix-caching.md`, "The
 retention fix") — the zero-insertion was a side effect of dense KDA retention
 making cached pages unaffordable, not a scheduler defect. The isolation data below

--- a/docs/06-improvement-plan.md
+++ b/docs/06-improvement-plan.md
@@ -171,3 +171,17 @@ concurrency work in [08-concurrent-prefill.md](08-concurrent-prefill.md).
   upstream PR's own receipts (their structured 65.1 vs our 70+ at TP=1). Acceptance
   held a perfect 1.0000 / 7.0 per step, so TP=2 is safe — just not better on a 2-node
   pair. This deployment pins `DFLASH_DRAFT_TP=1`.
+
+## Addendum, 2026-08-30 evening: the program moved onto a self-built image
+
+Production cut over to the image this repo's `Dockerfile` builds (gates and specs:
+`10-selfbuild-production.md`). Three windows ran the same night on the new
+baseline, same method as everything above: the vLLM #54282 draft-noise salt was
+**adopted** (acceptance held 1.0000/7.0 — the fix changes which random stream
+feeds the draft, not the accept path); a community prefill config (batch budget
+7168 + chunk cap 3584) was **tested and rejected** (+3.7% cold prefill and better
+short-request TTFT, but −3.3 to −4% on every decoded token and −12% pool tokens);
+FlashInfer's radix top-k in the candidate selector was **tested and rejected**
+(bit-exact but zero gain at ≤7-row draft batches). Open follow-ups: a long-warm
+re-bench of the self-build's structured decode, and upstream #54163 as a future
+window with cache-battery gates.

--- a/docs/07-rebase-plan.md
+++ b/docs/07-rebase-plan.md
@@ -1,5 +1,11 @@
 # Rebase plan — riding GLM-5.3-Flash into vLLM mainline
 
+> **Status (2026-08-30): the first stage of this plan was executed.** The day-0
+> base was field-tested on the pair (`09-rebase-draft-test.md`) and production now
+> runs an image this repo builds from it (`10-selfbuild-production.md`). What
+> remains of this plan is the *forward* rebase — moving onto vLLM main once
+> #53906 merges — for which the survey below is the map.
+
 Researched 2026-08-29 (web survey + a full inventory of a current vllm-project/vllm
 main checkout, `cacc429f62`). Goal: the next major release of this kit sits on
 **official upstream GLM-5.3-Flash support** and carries only the layers upstream

--- a/docs/10-selfbuild-production.md
+++ b/docs/10-selfbuild-production.md
@@ -20,6 +20,21 @@ image whose Dockerfile, overlays, and runtime patching this repo maintains (the
 base remains the digest-pinned official image; the supply chain below it is
 upstream's).
 
+## The image, spec'd
+
+| Spec | Value |
+|---|---|
+| Base image | `vllm/vllm-openai:glm53-flash-arm64-cu130` @ `sha256:905c0293…` (day-0 GLM-5.3 **preview** image, digest-pinned `FROM`) |
+| vLLM inside | `0.1.dev20051+g487ecf187` — pre-release dev build from the official enablement lineage, cut **before** #53906 merged and before vLLM's native DFlash2 |
+| Attention/CUDA stack | FlashInfer 0.6.17 (`FLASHINFER_MLA_SPARSE_SM120`), CUDA 13, CUDA graphs on (token-batch capture sizes 1–32 to cover k=7 verify) |
+| Quantization | EXL3 4 bpw (`--quantization exl3`, fused `exl3_moe`), `exllamav3` built in-image at commit `c5d9c657` for aarch64/sm_121 — weights load **82 GiB/node packed** |
+| Weights | `brandonmusic/GLM-5.3-Flash-tr3-4bpw`, snapshot `1ae6d704…` (~164 GiB, 120 shards) |
+| Drafter | `incoai/GLM-5.3-Flash-DFlash2`, snapshot `7d74cdd8…`, BF16, k=7, draft TP=1, **#54282 noise salt applied** |
+| Topology | TP=2 across two GB10 nodes (`--nnodes 2`), single RoCE rail, MTU 9000 |
+| KV cache | `fp8_ds_mla` packed, pool **pinned to 15,414,698,763 bytes** → 1,396,551 tokens @ the 1M geometry (1.40× concurrency), profiling skipped |
+| Scheduler | `MAX_NUM_BATCHED_TOKENS=3584` (= the KDA page size), async scheduling **off**, long-prefill chunk cap 1,792, sparse retention on |
+| Window / bind | 1,000,000-token context, API on `127.0.0.1:8000` only |
+
 Cutover gates, all green on the first boot (gate definitions and the exact bench
 commands are the ones this kit ships: `local/acceptance.sh`, `local/serving-test.sh`,
 `tests/bench_decode.py` at 3–4 converged passes — see doc 06 for the program):


### PR DESCRIPTION
Full docs-folder review against the current production setup. Doc 10 gains an explicit spec table for the rebased image (base digest, pre-release vLLM build provenance, EXL3 build commit, weight/drafter snapshots, KV byte pin and geometry, scheduler invariants). Docs 02/03/05/06/07 updated for the local-build era (IMAGE invariant, bringup build step, measurement provenance in known-issues, executed-status banner on the rebase plan, improvement-plan addendum for the 08-30 windows). Docs 01/04/08/09 reviewed and left unchanged — timeless or already current.