### PR TITLE
W16–W18 staging + two hygiene fixes: drafter revision pin, JIT-wipe guard, opt-in spinwait/fine-grained-APC overlays, unconditional Reasoning-Effort line

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,13 @@ this tree from the recipe it started from:
 |---|---|---|
 | Hits read 0% at upstream `MNBT=1024` (chunk ends miss the page boundary) | `MAX_NUM_BATCHED_TOKENS` = the 3,584 page size, async scheduling OFF | solo 110k replay **97–98%** |
 | Every hit lost its last page (N−1 of N) | `overlay/patch_hybrid_prefix_hit.py` — prune scoped to the drafter's own group | full-N-page hits |
-| Multi-session retention collapse — 2×68k sessions **0%** (163 s) | `VLLM_PREFIX_CACHE_RETENTION_INTERVAL=0` (sparse KDA retention, extended to the mamba groups) | **97.8%** (5.8 s) |
-| Co-batch zero-insertion — 4×60k concurrent **0%** (288 s) | same knob | **95.0%** (17.4 s) |
-| Short request stuck behind a 240k read — **256 s** TTFT | `LONG_PREFILL_TOKEN_THRESHOLD=1792` fairness cap | **7.9 s** |
+| Multi-session retention collapse — 2×68k sessions **0%** (163 s) | `VLLM_PREFIX_CACHE_RETENTION_INTERVAL=0` (sparse KDA retention, extended to the mamba groups) | **100%** (1.3 s) |
+| Co-batch zero-insertion — 4×60k concurrent **0%** (288 s) | same knob | **98.7%** (16.5 s) |
+| Prompts under ~3.6k could never hit, and every follow-up re-read up to a page | `overlay/patch_fine_grained_apc.py` — hits reconcile at the 64-token hash grain instead of the 3,584-token page | a 2.6k prompt reuses **2,816** tokens; follow-ups reuse **96–99%** (~4.1 s → ~1.0 s per turn) |
+| Toggling thinking on/off threw the whole prefix away (50k prompt: 56.8 s re-read) | chat template emits the `Reasoning Effort` line unconditionally — the off-shape is a strict extension of the on-shape | toggle hits **100%** (0.26 s) |
+| Short request stuck behind a 240k read — **256 s** TTFT | `LONG_PREFILL_TOKEN_THRESHOLD=1792` fairness cap | **5.3–7.0 s** |
 | First turn after every restart cold | `local/content-warmup.sh` pre-reads the shared system prompt at boot | warm on turn 1 |
+| Two CPU cores spinning flat-out during every decode (SoC heat, no work) | `overlay/patch_spinwait_gb10.py` — vLLM's 1 s reader spin cut to 2 ms | spinning core freed, head hot zones **−5 °C**, throughput unchanged (same-day control) |
 
 Mechanism, the remaining cautions, and how to verify on your own pair (a lifetime
 hit-rate on a dashboard hides all of this): `docs/04-prefix-caching.md`,
@@ -44,12 +47,13 @@ The headline figures, same pair:
 | | |
 |---|---|
 | Context window | **1,000,000 tokens**, with speculation active — on two desk machines |
-| Structured decode | **~70 tok/s** at speculative acceptance **1.0000** (7/7 drafted tokens accepted, every converged pass) |
-| Prose decode | **27.9 tok/s** at the 1M window |
-| Cold prefill | **~893 tok/s** solo (133–240k prompts) |
+| Structured decode | **~67 tok/s** at speculative acceptance **1.0000** (7/7 drafted tokens accepted, every converged pass; ~70 with fine-grained caching off — the ~3% is the price of sub-page cache hits, and worth it) |
+| Prose decode | **~28–31 tok/s** at the 1M window |
+| Cold prefill | **~860–870 tok/s** solo (178–240k prompts) |
 | 500k prompt, drafter on | **854 tok/s** cold; same prompt replayed from cache **111× faster** (5.3 s) |
 | Short request behind a 240k read | **7.9 s** to first token (256 s without this kit's fairness cap) |
-| Multi-session caching | 2×68k sessions retain **97.8%**; 4×60k concurrent retain **95%** |
+| Multi-session caching | 2×68k sessions retain **100%**; 4×60k concurrent retain **98.7%** |
+| Follow-up turns | reuse **96–99%** of the prompt at 64-token grain — even prompts under one 3,584-token page |
 
 No other public recipe serves this model on this hardware with all four of: EXL3
 (the only quantization GB10 can actually run — it lacks the instruction NVFP4
@@ -58,14 +62,13 @@ that survives the hybrid-KDA architecture and the drafter, and perfect structure
 acceptance. Each of those is a specific fix in this tree, and removing any one of
 them has a measured cost (`docs/10-selfbuild-production.md`, "load-bearing set").
 
-Metric provenance, honestly: decode figures are medians of 3–4 converged temp-0
-passes; the ~70 structured is the 2026-08-30 self-built image (the earlier pulled
-image read 70.2–72.8 across boots, its 72.8 high-water after four hours warm — a
-long-warm re-bench of the self-build is the open follow-up); 27.9 prose and the
-caching rows were measured 08-29 on the previous image, whose cache mechanisms are
-baked into this build and spot-verified by the 500k/30k replay runs (15–17× at 30k);
-prefill and replay figures are single timed runs. Every bench script ships in
-`tests/` and `local/` — reproduce any row in minutes.
+Metric provenance, honestly: every figure above was re-measured on 2026-08-31 on the
+self-built image with all of this repo's fixes active (decode = medians of 3+ converged
+temp-0 passes; prefill and latency rows are matched same-day probe runs — we learned the
+hard way that a reference from another day or image drifts by a few percent, so every
+A/B here runs its control arm the same day). The 500k/111× replay row is from the
+2026-08-30 cutover battery on the same image. Every bench and probe ships in `tests/`
+and `local/` — reproduce any row in minutes.
 
 ## The serving image: preview vLLM, pinned and completed
 
@@ -97,7 +100,7 @@ known landmine flagged (upstream's Aug-22 refactor broke DFlash2 loading on main
 |---|---|
 | Weights | [`brandonmusic/GLM-5.3-Flash-tr3-4bpw`](https://huggingface.co/brandonmusic/GLM-5.3-Flash-tr3-4bpw) — uniform-K4 EXL3/TR3, ~164 GiB, pinned revision |
 | Runtime | **Built by `Dockerfile` here** from the digest-pinned preview base ([NOTICE](NOTICE)) |
-| Drafter | `incoai/GLM-5.3-Flash-DFlash2`, k=7, BF16 (keep it BF16 — quantized-drafter handling is broken upstream) |
+| Drafter | `incoai/GLM-5.3-Flash-DFlash2`, k=7, BF16, **pinned to commit `7d74cdd`** — the Hub repo has shipped three different weights under the same name; the two newer ones were A/B-tested here and won nothing (one loses 6% on prose) |
 | Ops | memory-gated restarts, crash/wedge/stop-aware watchdog, acceptance alerting, Xid monitoring, systemd units |
 
 Key local hardening, all marked `# LOCAL:` in-file: **loopback bind hardcoded**
@@ -143,8 +146,13 @@ change, including the rejections — with numbers, so you don't re-pay for them:
 a community-recommended prefill config (+3.7% cold prefill, but −3.3–4% on every
 decoded token and −12% pool); FlashInfer's radix top-k (zero gain at draft-batch
 sizes); a bigger draft length (k=8: prose −9%); dual-rail NCCL (loses at production
-geometry). If a knob isn't set the way upstream defaults it, there's a measured
-reason in those three docs.
+geometry); both newer DFlash2 drafter checkpoints (no win, one −6% prose — the pin
+stays on `7d74cdd`); sharding the drafter across ranks (`DFLASH_DRAFT_TP=2` — tested
+twice, single-stream *and* at 4-way concurrency: a wash here, and the head node's
+memory gets slightly worse). We also chased the reported long-context decode collapse
+(acceptance falling to 16% past 100k) and could not reproduce it on this stack —
+structured acceptance stays 0.93–0.98 per position out to ~195k tokens. If a knob
+isn't set the way upstream defaults it, there's a measured reason in those docs.
 
 ## Layout
 

--- a/docs/02-parameters.md
+++ b/docs/02-parameters.md
@@ -68,3 +68,23 @@ cache is invisible to it). 0.87 demands 105.87 GiB free against boots measured a
 - `IMAGE` names an **immutable** artifact + `SKIP_PULL=1` — since 2026-08-30 that is a local build tag produced by this repo's `Dockerfile` (previously a registry digest); either way, a restart must never silently upgrade
   the runtime. The weekly check-updates timer diffs the registry digest against the pin
   so upgrades are deliberate.
+
+## Added 2026-08-31
+
+- `DFLASH_REVISION=7d74cdd…` — the drafter checkpoint, pinned. The Hub repo mutates
+  under a fixed name; without the pin, a re-download quietly swaps drafter weights,
+  which is the same stale-kernel hazard as changing `DFLASH_TOKENS` (it is in the JIT
+  shape hash for that reason). The newer checkpoints were benched and rejected.
+- `DEFAULT_MAX_NEW_TOKENS=65536` — server-side ceiling for requests that omit
+  `max_tokens`. Without it, one forgetful client can decode toward a million tokens
+  and starve everyone. Passed as its own `--override-generation-config` argument so
+  the JIT shape hash ignores it; the model's own sampling defaults (temperature 1.0)
+  survive the merge — verify the boot log line says so.
+- `GLM53_SPINWAIT_2MS=1` — cuts vLLM's shared-memory reader spin from 1 s to 2 ms.
+  On a 20-core GB10 the default keeps two threads busy-spinning at ~90% through every
+  decode; with the patch the spinner parks and the head's hot zones drop ~5 °C.
+  Throughput measured unchanged against a same-day control.
+- `GLM53_FINE_GRAINED_APC=1` — lets prefix-cache hits land on 64-token boundaries
+  instead of full 3,584-token pages (the coordinator's veto came from a scratch
+  buffer that never caches anyway — `docs/04`). This is what makes small prompts and
+  follow-up turns cache; it costs ~3% structured decode, accepted deliberately.

--- a/docs/04-prefix-caching.md
+++ b/docs/04-prefix-caching.md
@@ -87,7 +87,9 @@ never prefix-caches at all (its lookup returns 0). The boot log says so verbatim
 `Disabling fine-grained prefix-cache hits because these KV cache managers require
 block-aligned lookups: KpoolTailManager.` Upstream kit PR #59 exempts that manager
 from the veto so MLA + mamba(align) hits reconcile at the hash grain (64 tokens).
-Ported here as `overlay/patch_fine_grained_apc.py` behind `GLM53_FINE_GRAINED_APC=1`
-(default off) for the W18 window — expected gain is bounded by where mamba
-checkpoints exist under `VLLM_PREFIX_CACHE_RETENTION_INTERVAL=0`, so it is a
-hypothesis to measure, not a promise. See `06-improvement-plan.md`.
+Ported here as `overlay/patch_fine_grained_apc.py` behind `GLM53_FINE_GRAINED_APC=1`.
+**ADOPTED in production 2026-08-31 (W18):** follow-ups reuse at grain 64 — a 6.5k
+prompt goes 3,584 → 6,464 reused tokens (96.2%), a 2.6k prompt 0 → 2,816; follow-up
+wall ~4.1 s → ~1.0 s; 2×68k retention 100%, 4×60k concurrent 98.7%, zero IMA in the
+soak. Cost: −2.7% structured decode (66.5–66.7 vs 68.4–68.7), accepted for agentic
+traffic. Details + gates: `06-improvement-plan.md` (W18).

--- a/docs/04-prefix-caching.md
+++ b/docs/04-prefix-caching.md
@@ -76,3 +76,18 @@ local/cache-probe.sh 30
 
 Round 1 is cold by construction; rounds 2+ are the verdict. A healthy config shows
 >90% on round 2 sequential and the same sessions re-prefilling in seconds.
+
+## 2026-08-31 addendum: the sub-page floor has a candidate fix (W18)
+
+The "hits align to 3584-token pages" rule above is not a property of the model —
+it is the coordinator's *partial-hash veto*: fine-grained hits are disabled when
+any KV-cache manager lacks `supports_fine_grained_hash_lookup`, and on this hybrid
+the only such manager is `KpoolTailManager`, the 4-token indexer tail scratch that
+never prefix-caches at all (its lookup returns 0). The boot log says so verbatim:
+`Disabling fine-grained prefix-cache hits because these KV cache managers require
+block-aligned lookups: KpoolTailManager.` Upstream kit PR #59 exempts that manager
+from the veto so MLA + mamba(align) hits reconcile at the hash grain (64 tokens).
+Ported here as `overlay/patch_fine_grained_apc.py` behind `GLM53_FINE_GRAINED_APC=1`
+(default off) for the W18 window — expected gain is bounded by where mamba
+checkpoints exist under `VLLM_PREFIX_CACHE_RETENTION_INTERVAL=0`, so it is a
+hypothesis to measure, not a promise. See `06-improvement-plan.md`.

--- a/docs/06-improvement-plan.md
+++ b/docs/06-improvement-plan.md
@@ -225,7 +225,7 @@ so the two shapes diverge at token ~2); toggle back on 99.6%.
 | W17 | `GLM53_SPINWAIT_2MS=1` — vLLM `SpinCondition` reader spin 1 s → 2 ms (kit PR #69; frees 3–4 spinning P-cores on GB10) | reader-thread CPU < 50% of prior; decode in band; TTFT-behind-240k ≤ 7.9 s; **re-baseline after** | **ADOPTED 2026-08-31** — see below |
 | W18 | `GLM53_FINE_GRAINED_APC=1` — exempt `KpoolTailManager` from the partial-hash veto so hits reconcile at hash grain 64 instead of the 3584 page (kit PR #59) | sub-page follow-ups hit; output-stability control; zero IMA; universal gates | **ADOPTED 2026-08-31 (owner call on a −2.7% structured tax)** — see below |
 | W19 | Drafter `dc77ff1` then `bf582e4` (shape hash → JIT wipe) | accept ≥ 1.0000/7.0 structured and prose ≥ 27.9 | **TESTED 2026-08-31 — `7d74cdd` pin stands** (below) |
-| W20 | `DFLASH_DRAFT_TP=2` measured at **C4** (kit issue #56: +37% per-stream at C4; our earlier rejection was single-stream) | pool ≥ 1.0× 1M; C4 per-stream ≥ +15% and single-stream ≥ −3% | queued |
+| W20 | `DFLASH_DRAFT_TP=2` measured at **C4** (kit issue #56: +37% per-stream at C4; our earlier rejection was single-stream) | pool ≥ 1.0× 1M; C4 per-stream ≥ +15% and single-stream ≥ −3% | **TESTED 2026-08-31 — REJECTED, TP=1 stands** (below) |
 | W21 | KV offload to per-node NVMe (kit PR #58 port) — own go/no-go, last | universal + zero corruption + pool unmoved; kill on rank death / MemFree < 2.5 GiB / any output diff | queued |
 | W22+ | Long-context draft-length ladder (k∈{5,3} at 50k/150k, capture sizes re-picked per k+1) | informational | **CLOSED 2026-08-31 by F0** — no long-context decay to fix (below) |
 
@@ -343,3 +343,22 @@ reads a real prose loss. Adopt-only-on-measurable-win applies: reverted to `7d74
 The A/B also live-verified the repaired wipe guard three times (stamp advanced only
 after both node wipes). Both alternate snapshots stay in the HF caches on both nodes
 for future re-tests; acceptance 7/7 on every arm.
+
+### W20 result — draft TP=2 re-tested at C4: the +37% does not reproduce, TP=1 stands
+
+Kit issue #56 reported +37% per-stream at C4 for `DFLASH_DRAFT_TP=2`; our earlier
+rejection had only measured single-stream, so the window re-opened with a C4
+protocol (issue #56's shape: 4 threads, unique ~8k prompts, decode timed
+first-token-to-last). Same day, same image, wipe-verified flips both ways:
+
+| | C1 per-stream | C4 per-stream mean (2 samples) | pool | head MemFree |
+|---|---|---|---|---|
+| TP=1 (baseline) | 18.9 | 20.1 / 21.2 | 1,396,551 | ~3.3 GiB idle |
+| TP=2 (arm) | 18.0 | 19.8 / 21.6 | 1,396,551 (byte-pinned) | 3.10 idle → 2.57 after |
+
+A wash everywhere (gate was C4 ≥ +15%), and the head's memory got slightly worse —
+the same direction as the first rejection. Issue #56's win was measured on an
+unpinned pool at MNBT 2048 / util 0.87; it does not transfer to this pinned
+geometry. Note the byte-pinned pool also makes their −18% pool cost a non-event
+here (token count unchanged). Reverted; `DFLASH_DRAFT_TP=1` pinned, hash guard
+wiped correctly on both flips.

--- a/docs/06-improvement-plan.md
+++ b/docs/06-improvement-plan.md
@@ -221,7 +221,7 @@ so the two shapes diverge at token ~2); toggle back on 99.6%.
 
 | Window | Change (knob) | Gate | Status |
 |---|---|---|---|
-| W16 | Template emits the effort line unconditionally (off-shape = on-shape + `</think>`) + `DEFAULT_MAX_NEW_TOKENS=65536` (own `--override-generation-config` arg, hash-neutral) | toggle hits ≥ 95%; boot log shows the override; universal gates | queued |
+| W16 | Template emits the effort line unconditionally (off-shape = on-shape + `</think>`) + `DEFAULT_MAX_NEW_TOKENS=65536` (own `--override-generation-config` arg, hash-neutral) | toggle hits ≥ 95%; boot log shows the override; universal gates | **ADOPTED 2026-08-31** — see below |
 | W17 | `GLM53_SPINWAIT_2MS=1` — vLLM `SpinCondition` reader spin 1 s → 2 ms (kit PR #69; frees 3–4 spinning P-cores on GB10) | reader-thread CPU < 50% of prior; decode in band; TTFT-behind-240k ≤ 7.9 s; **re-baseline after** | queued |
 | W18 | `GLM53_FINE_GRAINED_APC=1` — exempt `KpoolTailManager` from the partial-hash veto so hits reconcile at hash grain 64 instead of the 3584 page (kit PR #59; the boot log today says `Disabling fine-grained prefix-cache hits … KpoolTailManager`) | sub-page follow-ups hit; temp-0 byte-identical cold vs replay; zero IMA; universal gates | queued |
 | W19 | Drafter `dc77ff1` then `bf582e4` (shape hash → JIT wipe) | accept ≥ 1.0000/7.0 structured and prose ≥ 27.9 | queued |
@@ -236,3 +236,24 @@ signature is mean-accept-length 1.00 = zero drafts accepted — ours is 7.0/step
 PR #66 (no `VLLM_API_KEY` here). vLLM upstream items (#54373 draft RoPE layout,
 #53802 hit boundaries, #52495 SWA accounting, #53426 K=0 skip) are rebase-time
 carries, not overlays.
+
+### W16 result — ADOPTED (2026-08-31, boot 11:26Z, one-time JIT wipe by the repaired guard)
+
+Same probe, same shape, after the change: thinking-on cold 58.9 s → warm 100% / 0.38 s →
+**thinking-off toggle 100% hits / 0.26 s** (was 0% / 56.8 s) → toggle back 100% / 0.26 s.
+The one remaining fork is deliberate and documented: a *different* `reasoning_effort`
+(turn 5, `low` vs the default `max`) renders a different head line and misses (0%,
+56.9 s) — clients must keep the effort constant within a session, exactly as upstream
+zai's template behaves. `DEFAULT_MAX_NEW_TOKENS`: the boot log shows the override
+merged **on top of** the model's `generation_config` (`{'temperature': 1.0,
+'top_p': 0.95, 'max_tokens': 65536}`), so production sampling is unchanged; a
+request omitting `max_tokens` ends `finish_reason=stop`.
+
+Gates, all green: pool byte-identical **1,396,551 / 1.40×**; loopback-only bind;
+acceptance **7/7**; serving **6/6**; toolcall **23/23, 0 blank args** (incl. two
+concurrent 60k cold-pad waves); structured converged **68.3–68.5 tok/s @
+1.0000 / 7.0** (pass 1 read 59.6 — cold JIT after the wipe, then flat; −1.2% vs the
+69.3 band floor, within boot-to-boot variance — the change touches no decode kernel);
+prose **30.3–31.2** (above the 27.9 baseline); `cache-burst` 2×68k round-2 **97.8%**
+(5.1 s), cold prefill 892 tok/s; 0 FSM errors, 0 ERROR lines, no Xid; MemFree idle
+3.3 / 4.0 GiB. Rollback: `.env.bak-pre-w16` + the pre-change template.

--- a/docs/06-improvement-plan.md
+++ b/docs/06-improvement-plan.md
@@ -227,7 +227,7 @@ so the two shapes diverge at token ~2); toggle back on 99.6%.
 | W19 | Drafter `dc77ff1` then `bf582e4` (shape hash → JIT wipe) | accept ≥ 1.0000/7.0 structured and prose ≥ 27.9 | queued |
 | W20 | `DFLASH_DRAFT_TP=2` measured at **C4** (kit issue #56: +37% per-stream at C4; our earlier rejection was single-stream) | pool ≥ 1.0× 1M; C4 per-stream ≥ +15% and single-stream ≥ −3% | queued |
 | W21 | KV offload to per-node NVMe (kit PR #58 port) — own go/no-go, last | universal + zero corruption + pool unmoved; kill on rank death / MemFree < 2.5 GiB / any output diff | queued |
-| W22+ | Long-context draft-length ladder (k∈{5,3} at 50k/150k, capture sizes re-picked per k+1) | informational | queued |
+| W22+ | Long-context draft-length ladder (k∈{5,3} at 50k/150k, capture sizes re-picked per k+1) | informational | **CLOSED 2026-08-31 by F0** — no long-context decay to fix (below) |
 
 Skipped with reasons: #65 indexer top-k backports (MNBT 3584 already holds; 7168
 measured useless); PR #39 (`MemAvailable` gate — wrong signal here); PR #72
@@ -310,3 +310,17 @@ correctness gate on this stack — cold-vs-cold with a cache reset between is al
 cache change (prime suspect: DFlash2 probabilistic draft sampling); filed as its own
 open item. Output *quality* gates (needle, acceptance, coherent summaries) all hold.
 Rollback: `.env.bak-pre-w18` (env-only, no JIT wipe).
+
+### F0 result — the issue-#73 long-context decode collapse does NOT reproduce here
+
+Ladder (`local/f0-longctx-probe.py`, unique docs, warm prefix, temp 0, SSE-timed
+decode, spec counters per request), run **in both orders** to separate warm-in from
+context effects: structured decode is flat **56–65 tok/s @ acceptance 0.93–0.98 per
+position** from 0 through ~195k prompt tokens; prose bounces 15–28 tok/s with **no
+monotone context trend** (acceptance 0.15–0.36 — its usual short-context band; the
+forward run's scary "rises with context" pattern was warm-in order, and the reversed
+run inverted it). Issue #73's 70% → 16% decay (measured on ABLIT=1 / MNBT 2048 /
+draft TP=2) is absent on this stack at k=7. The W22 draft-length ladder is closed
+unless a real workload shows long-context pain; adaptive-K remains a rebase-era item
+(#51303). Probe caveat: the ctx≈0 rows under-read (37-token prompts, SSE timing) —
+use `tests/bench_decode.py` for short-context absolutes.

--- a/docs/06-improvement-plan.md
+++ b/docs/06-improvement-plan.md
@@ -222,7 +222,7 @@ so the two shapes diverge at token ~2); toggle back on 99.6%.
 | Window | Change (knob) | Gate | Status |
 |---|---|---|---|
 | W16 | Template emits the effort line unconditionally (off-shape = on-shape + `</think>`) + `DEFAULT_MAX_NEW_TOKENS=65536` (own `--override-generation-config` arg, hash-neutral) | toggle hits ≥ 95%; boot log shows the override; universal gates | **ADOPTED 2026-08-31** — see below |
-| W17 | `GLM53_SPINWAIT_2MS=1` — vLLM `SpinCondition` reader spin 1 s → 2 ms (kit PR #69; frees 3–4 spinning P-cores on GB10) | reader-thread CPU < 50% of prior; decode in band; TTFT-behind-240k ≤ 7.9 s; **re-baseline after** | queued |
+| W17 | `GLM53_SPINWAIT_2MS=1` — vLLM `SpinCondition` reader spin 1 s → 2 ms (kit PR #69; frees 3–4 spinning P-cores on GB10) | reader-thread CPU < 50% of prior; decode in band; TTFT-behind-240k ≤ 7.9 s; **re-baseline after** | **ADOPTED 2026-08-31** — see below |
 | W18 | `GLM53_FINE_GRAINED_APC=1` — exempt `KpoolTailManager` from the partial-hash veto so hits reconcile at hash grain 64 instead of the 3584 page (kit PR #59; the boot log today says `Disabling fine-grained prefix-cache hits … KpoolTailManager`) | sub-page follow-ups hit; temp-0 byte-identical cold vs replay; zero IMA; universal gates | queued |
 | W19 | Drafter `dc77ff1` then `bf582e4` (shape hash → JIT wipe) | accept ≥ 1.0000/7.0 structured and prose ≥ 27.9 | queued |
 | W20 | `DFLASH_DRAFT_TP=2` measured at **C4** (kit issue #56: +37% per-stream at C4; our earlier rejection was single-stream) | pool ≥ 1.0× 1M; C4 per-stream ≥ +15% and single-stream ≥ −3% | queued |
@@ -257,3 +257,28 @@ concurrent 60k cold-pad waves); structured converged **68.3–68.5 tok/s @
 prose **30.3–31.2** (above the 27.9 baseline); `cache-burst` 2×68k round-2 **97.8%**
 (5.1 s), cold prefill 892 tok/s; 0 FSM errors, 0 ERROR lines, no Xid; MemFree idle
 3.3 / 4.0 GiB. Rollback: `.env.bak-pre-w16` + the pre-change template.
+
+### W17 result — ADOPTED (2026-08-31; arm boot 11:54Z, matched control 12:32Z, arm re-applied)
+
+**Mechanism confirmed on this pair.** Under a single decode, the head ran two threads
+pinned at 92% / 85% (`VLLM::EngineCore`, `VLLM::Worker_TP`) — the `sched_yield` spin
+that `busy_loop_s = 1 s` guarantees during decode (messages arrive every few ms, so
+the park path never triggers). With the 2 ms window the `EngineCore` spinner is gone
+(only the GPU-driving `Worker_TP` stays busy, as it should); head hot zones read
+**83 → 78 °C** in the same 10-s sample (worker unchanged: its busy thread *is* the
+GPU driver). No NCCL / shm / timeout warnings on either rank across the boot.
+
+**Cost: none measurable — but only a same-day matched control could show that.**
+The arm's first read looked like a −4% cold-prefill tax against the standing 893 tok/s
+reference (857 / 860 at 240k, 836 at 178k). Reverting to the pre-W17 `.env` on the
+same image and re-running the identical probes gave **860 / 871 at 240k and 862 at
+178k** — the reference had drifted, the arm is a wash (−0.5%). Short-request TTFT
+behind the 240k read: arm 6.5 / 6.0 s vs control 7.0 / 5.3 s (equal within noise, both
+under the 7.9 s W4 gate). Decode on the arm boot converged to structured **68.4–68.7 @
+1.0000/7.0** and prose **28.2–31.2** — identical to the W16 boot (passes 1–4 read
+~1% low while warming, the usual post-restart curve). Acceptance 7/7, serving 6/6,
+toolcall 23/23 / 0 blank, pool byte-identical, no wipe (env-only knob).
+
+**Re-baseline for W18+ (post-C, same image, converged):** structured 68.4–68.7 @
+1.0000/7.0 · prose 28.2–31.2 · solo cold prefill 857–871 tok/s @ 240k · short-TTFT-
+behind-240k 5.3–7.0 s · retention 2×68k 97.8%. Rollback: `.env.bak-pre-w17`.

--- a/docs/06-improvement-plan.md
+++ b/docs/06-improvement-plan.md
@@ -226,7 +226,7 @@ so the two shapes diverge at token ~2); toggle back on 99.6%.
 | W18 | `GLM53_FINE_GRAINED_APC=1` — exempt `KpoolTailManager` from the partial-hash veto so hits reconcile at hash grain 64 instead of the 3584 page (kit PR #59) | sub-page follow-ups hit; output-stability control; zero IMA; universal gates | **ADOPTED 2026-08-31 (owner call on a −2.7% structured tax)** — see below |
 | W19 | Drafter `dc77ff1` then `bf582e4` (shape hash → JIT wipe) | accept ≥ 1.0000/7.0 structured and prose ≥ 27.9 | **TESTED 2026-08-31 — `7d74cdd` pin stands** (below) |
 | W20 | `DFLASH_DRAFT_TP=2` measured at **C4** (kit issue #56: +37% per-stream at C4; our earlier rejection was single-stream) | pool ≥ 1.0× 1M; C4 per-stream ≥ +15% and single-stream ≥ −3% | **TESTED 2026-08-31 — REJECTED, TP=1 stands** (below) |
-| W21 | KV offload to per-node NVMe (kit PR #58 port) — own go/no-go, last | universal + zero corruption + pool unmoved; kill on rank death / MemFree < 2.5 GiB / any output diff | queued |
+| W21 | KV offload to per-node NVMe (kit PR #58 port) — own go/no-go, last | universal + zero corruption + pool unmoved; kill on rank death / MemFree < 2.5 GiB / any output diff | **PARKED 2026-08-31 (owner call)** — take it on a fresh session after a soak of W16–W18; track upstream #54413/#54414/#54415 meanwhile |
 | W22+ | Long-context draft-length ladder (k∈{5,3} at 50k/150k, capture sizes re-picked per k+1) | informational | **CLOSED 2026-08-31 by F0** — no long-context decay to fix (below) |
 
 Skipped with reasons: #65 indexer top-k backports (MNBT 3584 already holds; 7168

--- a/docs/06-improvement-plan.md
+++ b/docs/06-improvement-plan.md
@@ -223,7 +223,7 @@ so the two shapes diverge at token ~2); toggle back on 99.6%.
 |---|---|---|---|
 | W16 | Template emits the effort line unconditionally (off-shape = on-shape + `</think>`) + `DEFAULT_MAX_NEW_TOKENS=65536` (own `--override-generation-config` arg, hash-neutral) | toggle hits ≥ 95%; boot log shows the override; universal gates | **ADOPTED 2026-08-31** — see below |
 | W17 | `GLM53_SPINWAIT_2MS=1` — vLLM `SpinCondition` reader spin 1 s → 2 ms (kit PR #69; frees 3–4 spinning P-cores on GB10) | reader-thread CPU < 50% of prior; decode in band; TTFT-behind-240k ≤ 7.9 s; **re-baseline after** | **ADOPTED 2026-08-31** — see below |
-| W18 | `GLM53_FINE_GRAINED_APC=1` — exempt `KpoolTailManager` from the partial-hash veto so hits reconcile at hash grain 64 instead of the 3584 page (kit PR #59; the boot log today says `Disabling fine-grained prefix-cache hits … KpoolTailManager`) | sub-page follow-ups hit; temp-0 byte-identical cold vs replay; zero IMA; universal gates | queued |
+| W18 | `GLM53_FINE_GRAINED_APC=1` — exempt `KpoolTailManager` from the partial-hash veto so hits reconcile at hash grain 64 instead of the 3584 page (kit PR #59) | sub-page follow-ups hit; output-stability control; zero IMA; universal gates | **ADOPTED 2026-08-31 (owner call on a −2.7% structured tax)** — see below |
 | W19 | Drafter `dc77ff1` then `bf582e4` (shape hash → JIT wipe) | accept ≥ 1.0000/7.0 structured and prose ≥ 27.9 | queued |
 | W20 | `DFLASH_DRAFT_TP=2` measured at **C4** (kit issue #56: +37% per-stream at C4; our earlier rejection was single-stream) | pool ≥ 1.0× 1M; C4 per-stream ≥ +15% and single-stream ≥ −3% | queued |
 | W21 | KV offload to per-node NVMe (kit PR #58 port) — own go/no-go, last | universal + zero corruption + pool unmoved; kill on rank death / MemFree < 2.5 GiB / any output diff | queued |
@@ -282,3 +282,31 @@ toolcall 23/23 / 0 blank, pool byte-identical, no wipe (env-only knob).
 **Re-baseline for W18+ (post-C, same image, converged):** structured 68.4–68.7 @
 1.0000/7.0 · prose 28.2–31.2 · solo cold prefill 857–871 tok/s @ 240k · short-TTFT-
 behind-240k 5.3–7.0 s · retention 2×68k 97.8%. Rollback: `.env.bak-pre-w17`.
+
+### W18 result — ADOPTED (2026-08-31, boot 13:11Z; owner accepted a −2.7% structured-decode tax)
+
+**The sub-page floor is gone.** Same follow-up ladder, control (page-aligned) → arm
+(hash grain 64): 2.6k-token prompt **0 → 2,816 reused tokens**; 6.5k **3,584 → 6,464**
+(52.7% → 96.2% of the prompt); 10.4k 7,168 → 10,368; 39k 35,840 → 39,040. Follow-up
+wall time **~4.1 s → ~1.0 s** — that saving lands on *every* agent turn. Multi-session:
+2×68k round-2 **97.8% → 100%** (5.1 s → 1.3 s); 4×60k × 3 rounds concurrent
+**95.0% → 98.7%** with **0 errors, 0 illegal-memory-access, 0 Xid, 0 preemptions**
+(the #54199-class concurrent-hit risk did not fire in this soak). Boot log:
+`[glm53-fgapc] partial_hash=True hash_block=64` and the veto warning gone; pool
+byte-identical; acceptance 7/7; serving 6/6; toolcall 23/23.
+
+**Cost, measured and accepted:** structured decode converged at **66.5–66.7 tok/s
+@ 1.0000/7.0** vs the same-day W17 re-baseline 68.4–68.7 (−2.7%, 6 flat passes,
+si/so≈0 — real, not warm-up; prose unchanged at 28.3–30.0). Prime suspect: with
+partial hits enabled `_align_cacheable()` stops rounding, so decode registers cache
+state at finer granularity every step. For agentic traffic the trade is lopsided —
++0.17 s on a 400-token reply vs −3 s on the preceding follow-up prefill — and the
+owner adopted on that calculus. **Standing structured gate is now 66.5–66.7.**
+Open research item: whether the per-step registration cost can be reduced.
+
+**Gate lesson (measured):** "temp-0 byte-identical cold vs replay" is NOT a usable
+correctness gate on this stack — cold-vs-cold with a cache reset between is already
+**0/3 identical** (and was 1/3 before W18). Temp-0 nondeterminism pre-exists the
+cache change (prime suspect: DFlash2 probabilistic draft sampling); filed as its own
+open item. Output *quality* gates (needle, acceptance, coherent summaries) all hold.
+Rollback: `.env.bak-pre-w18` (env-only, no JIT wipe).

--- a/docs/06-improvement-plan.md
+++ b/docs/06-improvement-plan.md
@@ -185,3 +185,54 @@ FlashInfer's radix top-k in the candidate selector was **tested and rejected**
 (bit-exact but zero gain at ≤7-row draft batches). Open follow-ups: a long-warm
 re-bench of the self-build's structured decode, and upstream #54163 as a future
 window with cache-battery gates.
+
+## 2026-08-31: fourth sweep — two hygiene bugs, then W16–W22 (queued, one per restart)
+
+A full re-survey of the upstream kit (20 open issues, 17 open PRs; nothing
+runtime-affecting merged since our base) and vLLM upstream, qualified against
+this production. Every candidate below is an *open* proposal: each is ported
+behind an opt-in knob, Codex-reviewed, then measured in its own window against
+the standing gates (pool byte-identical 1,396,551; acceptance 7/7; serving 6/6;
+toolcall 23/23; structured ≥ 68.5 @ 1.0000/7.0; prose ≥ 27.0; cache-burst 2×68k
+≥ 95% / 4×60k ≥ 90%; no Xid; loopback-only bind).
+
+**Found on our side first (fixed in this tree, no restart):**
+
+- **The JIT-wipe guard had been a silent no-op since the self-build cutover.**
+  `local/prod-start.sh` resolved the wipe container by grepping a `ghcr.io…sha256:`
+  digest out of `.env`; `IMAGE=glm53-selfbuild:…` matches nothing, so the wipe
+  skipped while the stamp still advanced — the exact stale-JIT class (acceptance
+  0.96 → 0.58) the guard exists for. Now it reads `IMAGE=` verbatim (digest as
+  fallback) and never advances the stamp on a missed wipe.
+- **The DFlash2 drafter was unpinned and off the shape hash.** `incoai/GLM-5.3-Flash-DFlash2`
+  has shipped three different `model.safetensors` under `main` (08-27 `7d74cdd`,
+  08-28 `dc77ff1`, 08-31 `bf582e4`); production runs `7d74cdd` (sha256 `8931dc52…`)
+  only because nothing ever re-downloaded. `DFLASH_REVISION` (default = that sha)
+  is now threaded through download / resolve / worker sync-marker (kit PR #67
+  shape, also closes the stale-`refs/main` boot failure from issue #52), and
+  `DFLASH_MODEL|DFLASH_REVISION` join the hash — a drafter swap is the same
+  kernel-shape class as `DFLASH_TOKENS`.
+
+**Pre-W16 baseline for the template fix (kit PR #63), measured on production
+with `local/w16-toggle-probe.py`, one unique 50k-token prompt:** thinking-on
+warm replay 99.6% hits / 1.3 s; **thinking-off toggle 0% hits / 56.8 s** (full
+re-prefill — the `Reasoning Effort` head line was gated on `thinking_enabled`,
+so the two shapes diverge at token ~2); toggle back on 99.6%.
+
+| Window | Change (knob) | Gate | Status |
+|---|---|---|---|
+| W16 | Template emits the effort line unconditionally (off-shape = on-shape + `</think>`) + `DEFAULT_MAX_NEW_TOKENS=65536` (own `--override-generation-config` arg, hash-neutral) | toggle hits ≥ 95%; boot log shows the override; universal gates | queued |
+| W17 | `GLM53_SPINWAIT_2MS=1` — vLLM `SpinCondition` reader spin 1 s → 2 ms (kit PR #69; frees 3–4 spinning P-cores on GB10) | reader-thread CPU < 50% of prior; decode in band; TTFT-behind-240k ≤ 7.9 s; **re-baseline after** | queued |
+| W18 | `GLM53_FINE_GRAINED_APC=1` — exempt `KpoolTailManager` from the partial-hash veto so hits reconcile at hash grain 64 instead of the 3584 page (kit PR #59; the boot log today says `Disabling fine-grained prefix-cache hits … KpoolTailManager`) | sub-page follow-ups hit; temp-0 byte-identical cold vs replay; zero IMA; universal gates | queued |
+| W19 | Drafter `dc77ff1` then `bf582e4` (shape hash → JIT wipe) | accept ≥ 1.0000/7.0 structured and prose ≥ 27.9 | queued |
+| W20 | `DFLASH_DRAFT_TP=2` measured at **C4** (kit issue #56: +37% per-stream at C4; our earlier rejection was single-stream) | pool ≥ 1.0× 1M; C4 per-stream ≥ +15% and single-stream ≥ −3% | queued |
+| W21 | KV offload to per-node NVMe (kit PR #58 port) — own go/no-go, last | universal + zero corruption + pool unmoved; kill on rank death / MemFree < 2.5 GiB / any output diff | queued |
+| W22+ | Long-context draft-length ladder (k∈{5,3} at 50k/150k, capture sizes re-picked per k+1) | informational | queued |
+
+Skipped with reasons: #65 indexer top-k backports (MNBT 3584 already holds; 7168
+measured useless); PR #39 (`MemAvailable` gate — wrong signal here); PR #72
+dual-rail (closed earlier: loses at prod geometry); PR #70 (vllm#53030's
+signature is mean-accept-length 1.00 = zero drafts accepted — ours is 7.0/step);
+PR #66 (no `VLLM_API_KEY` here). vLLM upstream items (#54373 draft RoPE layout,
+#53802 hit boundaries, #52495 SWA accounting, #53426 K=0 skip) are rebase-time
+carries, not overlays.

--- a/docs/06-improvement-plan.md
+++ b/docs/06-improvement-plan.md
@@ -224,7 +224,7 @@ so the two shapes diverge at token ~2); toggle back on 99.6%.
 | W16 | Template emits the effort line unconditionally (off-shape = on-shape + `</think>`) + `DEFAULT_MAX_NEW_TOKENS=65536` (own `--override-generation-config` arg, hash-neutral) | toggle hits ≥ 95%; boot log shows the override; universal gates | **ADOPTED 2026-08-31** — see below |
 | W17 | `GLM53_SPINWAIT_2MS=1` — vLLM `SpinCondition` reader spin 1 s → 2 ms (kit PR #69; frees 3–4 spinning P-cores on GB10) | reader-thread CPU < 50% of prior; decode in band; TTFT-behind-240k ≤ 7.9 s; **re-baseline after** | **ADOPTED 2026-08-31** — see below |
 | W18 | `GLM53_FINE_GRAINED_APC=1` — exempt `KpoolTailManager` from the partial-hash veto so hits reconcile at hash grain 64 instead of the 3584 page (kit PR #59) | sub-page follow-ups hit; output-stability control; zero IMA; universal gates | **ADOPTED 2026-08-31 (owner call on a −2.7% structured tax)** — see below |
-| W19 | Drafter `dc77ff1` then `bf582e4` (shape hash → JIT wipe) | accept ≥ 1.0000/7.0 structured and prose ≥ 27.9 | queued |
+| W19 | Drafter `dc77ff1` then `bf582e4` (shape hash → JIT wipe) | accept ≥ 1.0000/7.0 structured and prose ≥ 27.9 | **TESTED 2026-08-31 — `7d74cdd` pin stands** (below) |
 | W20 | `DFLASH_DRAFT_TP=2` measured at **C4** (kit issue #56: +37% per-stream at C4; our earlier rejection was single-stream) | pool ≥ 1.0× 1M; C4 per-stream ≥ +15% and single-stream ≥ −3% | queued |
 | W21 | KV offload to per-node NVMe (kit PR #58 port) — own go/no-go, last | universal + zero corruption + pool unmoved; kill on rank death / MemFree < 2.5 GiB / any output diff | queued |
 | W22+ | Long-context draft-length ladder (k∈{5,3} at 50k/150k, capture sizes re-picked per k+1) | informational | **CLOSED 2026-08-31 by F0** — no long-context decay to fix (below) |
@@ -324,3 +324,22 @@ draft TP=2) is absent on this stack at k=7. The W22 draft-length ladder is close
 unless a real workload shows long-context pain; adaptive-K remains a rebase-era item
 (#51303). Probe caveat: the ctx≈0 rows under-read (37-token prompts, SSE timing) —
 use `tests/bench_decode.py` for short-context absolutes.
+
+### W19 result — both newer drafter checkpoints tested, the `7d74cdd` pin stands
+
+incoai has shipped three `model.safetensors` under `main`; with the pin machinery in
+place this was a clean three-way A/B (each arm: `.env` pin flip → verified JIT wipe on
+both nodes → restart → 3+ converged passes per phase, same day, same image):
+
+| checkpoint | structured (tok/s @ accept) | prose (tok/s) | verdict |
+|---|---|---|---|
+| `7d74cdd` (08-27, production) | 66.5–66.7 @ 1.0000/7.0 | 28.3–30.0 | **KEEP** |
+| `dc77ff1` (08-28) | 66.7–66.9 @ 1.0000/7.0 | **26.3–29.4** (4 of 5 passes below band, median ≈26.6) | reject (−6% prose median) |
+| `bf582e4` (08-31) | 66.3–66.5 @ 1.0000/7.0 | 28.1–28.8 | reject (wash — no win) |
+
+Acceptance stayed a perfect 1.0000 / 7.0-per-step structured on every arm and the 50k
+spot was unchanged — the newer checkpoints buy nothing on this stack, and `dc77ff1`
+reads a real prose loss. Adopt-only-on-measurable-win applies: reverted to `7d74cdd`.
+The A/B also live-verified the repaired wipe guard three times (stamp advanced only
+after both node wipes). Both alternate snapshots stay in the HF caches on both nodes
+for future re-tests; acceptance 7/7 on every arm.

--- a/docs/10-selfbuild-production.md
+++ b/docs/10-selfbuild-production.md
@@ -120,3 +120,15 @@ changes were always shipped as a new image tag, never edited in place):
 
 Restore the file, restart through `local/prod-start.sh`, verify the pool token
 count and a converged bench pass — the same three checks every window used.
+
+## 2026-08-31 addendum — the config this doc describes gained four adopted changes
+
+The same-day A/B program (`docs/06`, W16–W20) landed on top of the cutover state:
+the chat template's effort line is unconditional (thinking toggles keep the cache),
+`DEFAULT_MAX_NEW_TOKENS=65536`, `GLM53_SPINWAIT_2MS=1`, `GLM53_FINE_GRAINED_APC=1`,
+and the drafter is pinned (`DFLASH_REVISION=7d74cdd…`). Standing gates moved
+accordingly: structured 66.5–66.7 @ 1.0000/7.0 (the fine-grained-cache trade),
+prose 28.2–31.2, solo cold prefill 857–871 @ 240k, 2×68k retention 100%.
+The JIT-wipe guard in `local/prod-start.sh` was also repaired (it had been a silent
+no-op since the image cutover — it now resolves the wipe container from `IMAGE=`
+verbatim and only advances its stamp when both nodes actually wiped).

--- a/env.example
+++ b/env.example
@@ -64,6 +64,15 @@ MAX_NUM_SEQS=4
 # 1792 = clean half-page alternation). Unset to disable. Decode and prefix-cache
 # retention are unaffected.
 LONG_PREFILL_TOKEN_THRESHOLD=1792
+# Server-side default for requests that omit max_tokens (W16). Empty = stock
+# unbounded fallback (max_model_len - prompt). Own --override-generation-config
+# arg, hash-neutral; the model's generation_config temperature 1.0 is kept.
+# DEFAULT_MAX_NEW_TOKENS=65536
+# W17 opt-in: shrink vLLM SpinCondition reader spin 1 s -> 2 ms (GB10 core relief).
+# GLM53_SPINWAIT_2MS=1
+# W18 opt-in: exempt KpoolTailManager from the partial-hash veto -> prefix hits at
+# hash grain 64 instead of the 3584-token page. 0 reverts without a JIT wipe.
+# GLM53_FINE_GRAINED_APC=1
 KV_CACHE_DTYPE=fp8                  # packed fp8_ds_mla
 GPU_MEM_UTIL=0.85                   # BOOT GATE ONLY under the KV pin; 0.87 crash-loops
 # KV pool pinned: profiling skipped, pool byte-identical every boot. Suggested by
@@ -87,6 +96,11 @@ VLLM_PREFIX_CACHE_RETENTION_INTERVAL=0
 # --- speculative decoding -----------------------------------------------------
 SPEC_METHOD=dflash
 DFLASH_MODEL=incoai/GLM-5.3-Flash-DFlash2
+# Pinned drafter checkpoint. incoai has shipped three different model.safetensors
+# under Hub main (08-27 7d74cdd, 08-28 dc77ff1, 08-31 bf582e4); every receipt in
+# this repo was taken on 7d74cdd. A drafter swap is a JIT-shape change (hashed by
+# local/prod-start.sh). Empty = track main deliberately.
+DFLASH_REVISION=7d74cdd881ed7e32c31175984a67823127b66cfe
 DFLASH_TOKENS=7                     # k=7; verify batch = 8 tokens/seq — cudagraph capture
                                     # sizes 1 2 4 8 16 24 32 are TOKEN batches for 1-4 seqs
 

--- a/files/chat_template.jinja
+++ b/files/chat_template.jinja
@@ -5,7 +5,8 @@
 {%- set thinking_enabled = true -%}
 {%- endif -%}
 {%- set effective_reasoning_effort = reasoning_effort if reasoning_effort is defined and reasoning_effort in ['low', 'high'] else 'max' -%}
-{%- if thinking_enabled and effective_reasoning_effort is not none -%}<|system|>Reasoning Effort: {{ effective_reasoning_effort | capitalize }}{%- endif -%}
+{#- LOCAL (W16, kit PR #63): emit the effort line unconditionally so a thinking on/off toggle keeps the prefix cache — the off-shape is a strict extension of the on-shape (upstream zai template also emits it unconditionally) -#}
+{%- if effective_reasoning_effort is not none -%}<|system|>Reasoning Effort: {{ effective_reasoning_effort | capitalize }}{%- endif -%}
 {%- set clear_thinking = clear_thinking if clear_thinking is defined else false -%}
 {%- if tools -%}
 {%- macro tool_to_json(tool) -%}

--- a/local/f0-longctx-probe.py
+++ b/local/f0-longctx-probe.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""F0: long-context decode + DFlash2 acceptance ladder (kit issue #73 shape).
+
+For each context size, build a unique ~N-token document, warm it once
+(max_tokens=1, so the follow-up generation hits the prefix cache and the
+measurement is decode-dominated), then run one generation per phase:
+
+  prose      "Continue the analysis..." (free-form, 300 tokens, temp 0)
+  structured "Count from 1 to 120, comma-separated." (300 tokens, temp 0)
+
+Reports decode tok/s (completion_tokens / (wall - TTFT), TTFT from SSE first
+token) and the spec-decode acceptance over the request from the
+vllm:spec_decode_num_{drafts,draft_tokens,accepted_tokens}_total deltas, plus
+per-position acceptance from vllm:spec_decode_num_accepted_tokens_per_pos.
+
+  uv run python local/f0-longctx-probe.py [--ctx 0 50000 150000] [--base ...]
+"""
+import argparse, json, random, re, time, urllib.request
+
+MODEL = "GLM-5.3-Flash-EXL3"
+WORDS = ["alpha", "beam", "cache", "delta", "ember", "fjord", "glyph", "hinge", "ionic",
+         "joule", "kelvin", "lumen", "matrix", "nadir", "orbit", "prism", "quartz", "rotor",
+         "sigma", "torus", "umbra", "vector", "wafer", "xenon", "yield", "zenith"]
+
+
+def spec_metrics(base):
+    with urllib.request.urlopen(f"{base}/metrics", timeout=15) as r:
+        txt = r.read().decode()
+    def g(pat):
+        m = re.search(pat, txt, re.M)
+        return float(m.group(1)) if m else 0.0
+    pos = {}
+    for m in re.finditer(r'^vllm:spec_decode_num_accepted_tokens_per_pos_total\{[^}]*position="(\d+)"[^}]*\} (\S+)', txt, re.M):
+        pos[int(m.group(1))] = float(m.group(2))
+    return {"drafts": g(r'^vllm:spec_decode_num_drafts_total\{[^}]*\} (\S+)'),
+            "draft_tok": g(r'^vllm:spec_decode_num_draft_tokens_total\{[^}]*\} (\S+)'),
+            "acc": g(r'^vllm:spec_decode_num_accepted_tokens_total\{[^}]*\} (\S+)'),
+            "pos": pos}
+
+
+def doc(seed, n):
+    r = random.Random(seed)
+    return f"[doc {seed}]\n" + " ".join(f"{r.choice(WORDS)}{r.randint(0, 999)}" for _ in range(int(n / 2.4))) + "\n[end doc]"
+
+
+def stream_chat(base, messages, max_tokens, timeout=1800):
+    body = {"model": MODEL, "messages": messages, "temperature": 0, "max_tokens": max_tokens,
+            "stream": True, "stream_options": {"include_usage": True},
+            "chat_template_kwargs": {"enable_thinking": False}}
+    req = urllib.request.Request(f"{base}/v1/chat/completions", data=json.dumps(body).encode(),
+                                 headers={"Content-Type": "application/json"})
+    t0 = time.time(); ttft = None; usage = {}
+    with urllib.request.urlopen(req, timeout=timeout) as r:
+        for raw in r:
+            line = raw.decode().strip()
+            if not line.startswith("data: ") or line == "data: [DONE]":
+                continue
+            chunk = json.loads(line[6:])
+            if ttft is None and chunk.get("choices") and chunk["choices"][0].get("delta", {}).get("content"):
+                ttft = time.time() - t0
+            if chunk.get("usage"):
+                usage = chunk["usage"]
+    return (ttft or 0.0), time.time() - t0, usage
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--base", default="http://127.0.0.1:18000")
+    ap.add_argument("--ctx", type=int, nargs="+", default=[0, 50000, 150000])
+    ap.add_argument("--gen-tokens", type=int, default=300)
+    ap.add_argument("--seed", type=int, default=int(time.time()))
+    a = ap.parse_args()
+
+    print(f"{'ctx~':>7} {'phase':<10} {'prompt':>8} {'decode tok/s':>12} {'accept':>7} {'per-step':>8}  per-position")
+    for i, n in enumerate(a.ctx):
+        d = doc(a.seed * 10 + i, n) if n else "You are analysing token statistics."
+        tasks = [("prose", "Continue with a 250-word free-form analysis of patterns you notice in the document."),
+                 ("structured", "Count from 1 to 120 as a comma-separated list. Output only the numbers.")]
+        # warm the shared prefix once so generation measures decode, not prefill
+        stream_chat(a.base, [{"role": "user", "content": d + "\n\nReply with one word: ok."}], 1)
+        for phase, task in tasks:
+            msgs = [{"role": "user", "content": d + "\n\n" + task}]
+            s0 = spec_metrics(a.base)
+            ttft, wall, usage = stream_chat(a.base, msgs, a.gen_tokens)
+            s1 = spec_metrics(a.base)
+            ct = usage.get("completion_tokens", 0); pt = usage.get("prompt_tokens", 0)
+            dec = ct / (wall - ttft) if wall > ttft and ct else 0.0
+            drafts = s1["drafts"] - s0["drafts"]; dtok = s1["draft_tok"] - s0["draft_tok"]
+            acc = s1["acc"] - s0["acc"]
+            ratio = acc / dtok if dtok else 0.0
+            per_step = acc / drafts if drafts else 0.0
+            pos = " ".join(f"{(s1['pos'].get(k,0)-s0['pos'].get(k,0))/drafts:.2f}" if drafts else "-" for k in sorted(set(s0["pos"]) | set(s1["pos"])))
+            print(f"{n:>7} {phase:<10} {pt:>8} {dec:>12.1f} {ratio:>7.3f} {per_step:>8.2f}  {pos}")
+
+
+if __name__ == "__main__":
+    main()

--- a/local/prod-start.sh
+++ b/local/prod-start.sh
@@ -18,7 +18,7 @@
 # The wait cannot live in ExecStartPre: that runs BEFORE ExecStart, i.e. before
 # the stop that frees the memory. It has to sit between stop and start.
 set -uo pipefail
-cd "$(dirname "${BASH_SOURCE[0]}")/.."
+cd "$(dirname "${BASH_SOURCE[0]}")/.." || exit 1
 
 WORKER_SSH="${WORKER_SSH:-nvidia@192.168.177.11}"
 # Gate = GPU_MEM_UTIL x total. Wait for a little more than vLLM will demand.

--- a/local/prod-start.sh
+++ b/local/prod-start.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # prod-start.sh — production entrypoint: stop, WAIT FOR MEMORY TO SETTLE, start.
 #
-# LOCAL to this cluster; not part of the vendored upstream kit.
+# LOCAL to this cluster; not part of the upstream MiaAI-Lab kit.
 #
 # WHY THIS EXISTS (measured 2026-08-28): `start.sh restart` tears the pair down
 # and starts the new one immediately. The kernel has not yet returned the old
@@ -18,7 +18,7 @@
 # The wait cannot live in ExecStartPre: that runs BEFORE ExecStart, i.e. before
 # the stop that frees the memory. It has to sit between stop and start.
 set -uo pipefail
-cd "$(dirname "${BASH_SOURCE[0]}")/.." || exit 1
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
 WORKER_SSH="${WORKER_SSH:-nvidia@192.168.177.11}"
 # Gate = GPU_MEM_UTIL x total. Wait for a little more than vLLM will demand.
@@ -80,16 +80,35 @@ log "starting pair"
 # and recovered only after wiping both caches on both nodes (upstream #41871
 # class). Hash the shape-affecting knobs; on change, wipe triton+tilelang on
 # BOTH nodes (via the image, as root — the container writes them as root).
-shape_hash="$(grep -E '^(DFLASH_TOKENS|DFLASH_DRAFT_TP|MTP_TOKENS|SPEC_METHOD|MAX_NUM_BATCHED_TOKENS|MAX_NUM_SEQS|MAX_MODEL_LEN|IMAGE|EXTRA_ARGS)=' .env 2>/dev/null | sort | md5sum | cut -d' ' -f1)"
+# DFLASH_MODEL/DFLASH_REVISION are in the hash too: a drafter checkpoint swap
+# changes the drafter kernel shapes — same wipe class as DFLASH_TOKENS.
+# The launcher's own default pin line is hashed too, so a default change in
+# start.sh still wipes even when .env carries no DFLASH_REVISION= line.
+shape_hash="$( { grep -E '^(DFLASH_TOKENS|DFLASH_DRAFT_TP|DFLASH_MODEL|DFLASH_REVISION|MTP_TOKENS|SPEC_METHOD|MAX_NUM_BATCHED_TOKENS|MAX_NUM_SEQS|MAX_MODEL_LEN|IMAGE|EXTRA_ARGS)=' .env 2>/dev/null; grep -E '^DFLASH_REVISION=' start.sh 2>/dev/null; } | sort | md5sum | cut -d' ' -f1)"
 stamp="$HOME/.cache/vllm-glm53-flash/.config-shape"
 if [ -n "$shape_hash" ] && [ "$(cat "$stamp" 2>/dev/null)" != "$shape_hash" ]; then
     echo "[prod-start] config shape changed — wiping Triton/TileLang JIT caches on both nodes"
-    img="$(grep -oE 'ghcr.io[^"'"'"']*sha256:[0-9a-f]{64}' .env | head -1)"
+    # Resolve the wipe container from the IMAGE= line verbatim (the self-built
+    # image has no ghcr digest — the old digest-only grep matched nothing and
+    # the wipe silently no-op'd while the stamp still advanced). Fallback: any
+    # ghcr digest pin in .env.
+    img="$(sed -n 's/^IMAGE=//p' .env | tail -1 | tr -d '"'"'"'"' | tr -d '[:space:]')"
+    [ -n "$img" ] || img="$(grep -oE 'ghcr.io[^"'"'"']*sha256:[0-9a-f]{64}' .env | head -1)"
     if [ -n "$img" ]; then
-        docker run --rm --entrypoint /bin/bash -v "$HOME/.cache/vllm-glm53-flash:/c" "$img"             -c 'rm -rf /c/triton /c/tilelang' || echo "[prod-start] WARN: head cache wipe failed"
-        ssh -o BatchMode=yes -o ConnectTimeout=10 "$WORKER_SSH"             "docker run --rm --entrypoint /bin/bash -v \$HOME/.cache/vllm-glm53-flash:/c '$img' -c 'rm -rf /c/triton /c/tilelang'"             || echo "[prod-start] WARN: worker cache wipe failed"
+        wipe_ok=1
+        docker run --rm --entrypoint /bin/bash -v "$HOME/.cache/vllm-glm53-flash:/c" "$img"             -c 'rm -rf /c/triton /c/tilelang' || { echo "[prod-start] WARN: head cache wipe failed"; wipe_ok=0; }
+        ssh -o BatchMode=yes -o ConnectTimeout=10 "$WORKER_SSH"             "docker run --rm --entrypoint /bin/bash -v \$HOME/.cache/vllm-glm53-flash:/c '$img' -c 'rm -rf /c/triton /c/tilelang'"             || { echo "[prod-start] WARN: worker cache wipe failed"; wipe_ok=0; }
+        # Advance the stamp ONLY when both nodes were wiped; a half-wipe must
+        # retry on the next start (one rank on stale kernels is the 0.96->0.58 class).
+        if [ "$wipe_ok" = 1 ]; then
+            mkdir -p "$(dirname "$stamp")" && printf '%s\n' "$shape_hash" > "$stamp"
+        else
+            echo "[prod-start] WARN: JIT cache wipe incomplete — stamp left unchanged, will retry next start"
+        fi
+    else
+        # Do NOT advance the stamp: a missed wipe must retry on the next start.
+        echo "[prod-start] WARN: could not resolve IMAGE from .env — JIT caches NOT wiped, stamp left unchanged"
     fi
-    mkdir -p "$(dirname "$stamp")" && printf '%s\n' "$shape_hash" > "$stamp"
 fi
 
 exec ./start.sh start

--- a/local/w16-toggle-probe.py
+++ b/local/w16-toggle-probe.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""W16 probe: does a thinking on/off toggle keep the prefix cache?
+
+Sends ONE unique ~N-token prompt through a fixed turn sequence and reads the
+vllm:prefix_cache_{queries,hits}_total counter deltas per turn (the operative
+ledger on this fork — usage.prompt_tokens_details is null). Before W16 the
+`Reasoning Effort` head line was gated on thinking_enabled, so turns 3/4
+(toggle off / on) diverged at token ~2 and re-prefilled the whole prompt.
+
+  turn 1  thinking ON   cold        expect hits ~0
+  turn 2  thinking ON   warm        expect hits ~ prompt (page-aligned pre-W18)
+  turn 3  thinking OFF  toggle      W16 pass = hits ~ prompt (was ~0)
+  turn 4  thinking ON   toggle back W16 pass = hits ~ prompt
+  turn 5  thinking OFF  effort=low  documented fork: a DIFFERENT effort still misses
+
+Run from the Mac through the tunnel:
+  uv run python local/w16-toggle-probe.py --tokens 21000 [--base http://127.0.0.1:18000]
+Also checks (--check-max-tokens) that a request omitting max_tokens ends with
+finish_reason=stop and reports the server-side default (W16 G).
+"""
+import argparse, json, random, re, time, urllib.request
+
+MODEL = "GLM-5.3-Flash-EXL3"
+
+
+def metrics(base):
+    with urllib.request.urlopen(f"{base}/metrics", timeout=15) as r:
+        txt = r.read().decode()
+    def g(pat):
+        m = re.search(pat, txt, re.M)
+        return float(m.group(1)) if m else 0.0
+    return {"q": g(r'^vllm:prefix_cache_queries_total\{[^}]*\} (\S+)'),
+            "h": g(r'^vllm:prefix_cache_hits_total\{[^}]*\} (\S+)')}
+
+
+def make_doc(seed, approx_tokens):
+    rnd = random.Random(seed)
+    words = ["alpha", "beam", "cache", "delta", "ember", "fjord", "glyph", "hinge", "ionic",
+             "joule", "kelvin", "lumen", "matrix", "nadir", "orbit", "prism", "quartz", "rotor",
+             "sigma", "torus", "umbra", "vector", "wafer", "xenon", "yield", "zenith"]
+    # ~1.3 tokens/word on this tokenizer for plain words with numbers mixed in
+    n = int(approx_tokens / 1.3)
+    body = " ".join(f"{rnd.choice(words)}{rnd.randint(0, 999)}" for _ in range(n))
+    return f"[doc {seed}]\n{body}\n[end doc]"
+
+
+def chat(base, messages, enable_thinking, effort=None, max_tokens=1, timeout=900):
+    body = {"model": MODEL, "messages": messages, "temperature": 0,
+            "chat_template_kwargs": {"enable_thinking": enable_thinking}}
+    if max_tokens is not None:
+        body["max_tokens"] = max_tokens
+    if effort is not None:
+        body["chat_template_kwargs"]["reasoning_effort"] = effort
+    req = urllib.request.Request(f"{base}/v1/chat/completions",
+                                 data=json.dumps(body).encode(),
+                                 headers={"Content-Type": "application/json"})
+    t0 = time.time()
+    with urllib.request.urlopen(req, timeout=timeout) as r:
+        out = json.loads(r.read().decode())
+    return time.time() - t0, out
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--base", default="http://127.0.0.1:18000")
+    ap.add_argument("--tokens", type=int, default=21000)
+    ap.add_argument("--seed", type=int, default=int(time.time()))
+    ap.add_argument("--check-max-tokens", action="store_true")
+    a = ap.parse_args()
+
+    doc = make_doc(a.seed, a.tokens)
+    msgs = [{"role": "system", "content": "You are a careful assistant. Answer in one word."},
+            {"role": "user", "content": doc + "\n\nWhat is the first word after '[doc'? One word."}]
+    plan = [("1 thinking ON  cold", True, None),
+            ("2 thinking ON  warm", True, None),
+            ("3 thinking OFF toggle", False, None),
+            ("4 thinking ON  toggle back", True, None),
+            ("5 thinking OFF effort=low", False, "low")]
+    rows = []
+    for label, think, effort in plan:
+        m0 = metrics(a.base)
+        dt, out = chat(a.base, msgs, think, effort)
+        m1 = metrics(a.base)
+        q, h = m1["q"] - m0["q"], m1["h"] - m0["h"]
+        pt = out.get("usage", {}).get("prompt_tokens", 0)
+        rows.append((label, pt, int(q), int(h), (h / q * 100 if q else 0.0), dt))
+        print(f"{label:28s} prompt={pt:6d} queries={int(q):6d} hits={int(h):6d} "
+              f"hit%={(h / q * 100 if q else 0):6.1f} wall={dt:6.2f}s")
+    t2, t3, t4 = rows[1][4], rows[2][4], rows[3][4]
+    verdict = "PASS" if (t3 >= 95 and t4 >= 95) else "FAIL"
+    print(f"\nW16 toggle verdict: {verdict} (warm {t2:.1f}% / off-toggle {t3:.1f}% / on-toggle {t4:.1f}%); "
+          f"turn 5 (different effort) {rows[4][4]:.1f}% — expected to miss on this fork")
+    if a.check_max_tokens:
+        dt, out = chat(a.base, [{"role": "user", "content": "Reply with the single word: ready"}],
+                       False, max_tokens=None)
+        ch = out["choices"][0]
+        print(f"\nno-max_tokens request: finish_reason={ch.get('finish_reason')} "
+              f"completion_tokens={out.get('usage', {}).get('completion_tokens')} wall={dt:.2f}s")
+
+
+if __name__ == "__main__":
+    main()

--- a/local/w18-fgapc-probe.py
+++ b/local/w18-fgapc-probe.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""W18 probe: prefix-cache hit granularity + cold-vs-replay output stability.
+
+Part A — follow-up ladder. For each prompt size N, send a unique document twice:
+turn 1 cold, turn 2 = the same messages + a ~200-token appended user turn (the
+agentic follow-up shape). Reads vllm:prefix_cache_{queries,hits}_total deltas.
+Pre-W18 (page-aligned hits) turn 2 can reuse at most floor(N/3584)*3584 tokens
+— and NOTHING for N < 3584. Post-W18 (hash grain 64) it should reuse ~N.
+
+Part B — output stability. Three unique prompts, temp 0, thinking off,
+max_tokens 48: cold completion vs immediate replay. Reports whether the two
+completions are byte-identical (a hybrid KDA model may legitimately differ on
+cached-vs-recomputed state; the control run on the pre-W18 boot is the reference).
+
+  uv run python local/w18-fgapc-probe.py [--base http://127.0.0.1:18000]
+"""
+import argparse, json, random, re, time, urllib.request
+
+MODEL = "GLM-5.3-Flash-EXL3"
+PAGE = 3584
+
+
+def metrics(base):
+    with urllib.request.urlopen(f"{base}/metrics", timeout=15) as r:
+        txt = r.read().decode()
+    def g(pat):
+        m = re.search(pat, txt, re.M)
+        return float(m.group(1)) if m else 0.0
+    return {"q": g(r'^vllm:prefix_cache_queries_total\{[^}]*\} (\S+)'),
+            "h": g(r'^vllm:prefix_cache_hits_total\{[^}]*\} (\S+)')}
+
+
+WORDS = ["alpha", "beam", "cache", "delta", "ember", "fjord", "glyph", "hinge", "ionic",
+         "joule", "kelvin", "lumen", "matrix", "nadir", "orbit", "prism", "quartz", "rotor",
+         "sigma", "torus", "umbra", "vector", "wafer", "xenon", "yield", "zenith"]
+
+
+def doc(seed, approx_tokens):
+    rnd = random.Random(seed)
+    n = max(8, int(approx_tokens / 2.4))  # measured ~2.4 tok per "word123 " unit
+    return f"[doc {seed}]\n" + " ".join(f"{rnd.choice(WORDS)}{rnd.randint(0, 999)}" for _ in range(n)) + "\n[end doc]"
+
+
+def chat(base, messages, max_tokens=1, timeout=900):
+    body = {"model": MODEL, "messages": messages, "temperature": 0, "max_tokens": max_tokens,
+            "chat_template_kwargs": {"enable_thinking": False}}
+    req = urllib.request.Request(f"{base}/v1/chat/completions", data=json.dumps(body).encode(),
+                                 headers={"Content-Type": "application/json"})
+    t0 = time.time()
+    with urllib.request.urlopen(req, timeout=timeout) as r:
+        out = json.loads(r.read().decode())
+    return time.time() - t0, out
+
+
+def timed_turn(base, messages, max_tokens=1):
+    m0 = metrics(base); dt, out = chat(base, messages, max_tokens); m1 = metrics(base)
+    return dt, out, int(m1["q"] - m0["q"]), int(m1["h"] - m0["h"])
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--base", default="http://127.0.0.1:18000")
+    ap.add_argument("--seed", type=int, default=int(time.time()))
+    a = ap.parse_args()
+
+    print("== Part A: follow-up ladder (turn 2 = same prompt + ~200-token follow-up)")
+    print(f"{'N~':>7} {'prompt1':>8} {'prompt2':>8} {'hits2':>7} {'page-floor':>10} {'hit%':>6} {'wall1':>7} {'wall2':>7}")
+    for i, n in enumerate((2000, 5000, 8000, 30000)):
+        d = doc(a.seed * 10 + i, n)
+        m1 = [{"role": "user", "content": d + "\n\nReply with one word: ok."}]
+        w1, o1, q1, h1 = timed_turn(a.base, m1)
+        follow = " ".join(f"{WORDS[(i * 7 + k) % len(WORDS)]}{k}" for k in range(85))
+        m2 = m1 + [{"role": "assistant", "content": "ok"},
+                   {"role": "user", "content": follow + "\n\nReply with one word: done."}]
+        w2, o2, q2, h2 = timed_turn(a.base, m2)
+        p1 = o1["usage"]["prompt_tokens"]; p2 = o2["usage"]["prompt_tokens"]
+        floor = (p1 // PAGE) * PAGE
+        print(f"{n:>7} {p1:>8} {p2:>8} {h2:>7} {floor:>10} {(h2 / q2 * 100 if q2 else 0):>6.1f} {w1:>7.2f} {w2:>7.2f}")
+
+    print("\n== Part B: temp-0 cold vs replay, 3 unique prompts, max_tokens 48")
+    same = 0
+    for i in range(3):
+        d = doc(a.seed * 100 + i, 6000)
+        m = [{"role": "user", "content": d + "\n\nSummarize the document in one sentence."}]
+        _, o1, _, _ = timed_turn(a.base, m, 48)
+        _, o2, _, h2 = timed_turn(a.base, m, 48)
+        c1 = o1["choices"][0]["message"]["content"]; c2 = o2["choices"][0]["message"]["content"]
+        ident = c1 == c2; same += ident
+        print(f"prompt {i}: replay hits={h2} identical={ident}" + ("" if ident else f"\n   cold:   {c1[:120]!r}\n   replay: {c2[:120]!r}"))
+    print(f"\nPart B: {same}/3 byte-identical")
+
+
+if __name__ == "__main__":
+    main()

--- a/local/w20-concurrency-probe.py
+++ b/local/w20-concurrency-probe.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""W20 probe: per-stream decode at C1 vs C4 (kit issue #56 protocol).
+
+N threads, one unique ~8k-token prompt each (unique salt so APC cannot serve one
+stream from another), 400-token generations at temp 0, thinking off. Decode rate
+is measured first-token-to-last from the SSE stream (prefill excluded). Prints
+per-stream tok/s, the aggregate, and TTFT spread.
+
+  uv run python local/w20-concurrency-probe.py --concurrency 1
+  uv run python local/w20-concurrency-probe.py --concurrency 4
+"""
+import argparse, json, random, threading, time, urllib.request
+
+MODEL = "GLM-5.3-Flash-EXL3"
+WORDS = ["alpha", "beam", "cache", "delta", "ember", "fjord", "glyph", "hinge", "ionic",
+         "joule", "kelvin", "lumen", "matrix", "nadir", "orbit", "prism", "quartz", "rotor",
+         "sigma", "torus", "umbra", "vector", "wafer", "xenon", "yield", "zenith"]
+
+
+def doc(seed, n):
+    r = random.Random(seed)
+    return f"[doc {seed}]\n" + " ".join(f"{r.choice(WORDS)}{r.randint(0, 999)}" for _ in range(int(n / 2.4))) + "\n[end doc]"
+
+
+def stream_one(base, seed, n_ctx, gen_tokens, out, idx):
+    msgs = [{"role": "user", "content": doc(seed, n_ctx) + "\n\nWrite a 300-word free-form analysis of the document."}]
+    body = {"model": MODEL, "messages": msgs, "temperature": 0, "max_tokens": gen_tokens,
+            "stream": True, "stream_options": {"include_usage": True},
+            "chat_template_kwargs": {"enable_thinking": False}}
+    req = urllib.request.Request(f"{base}/v1/chat/completions", data=json.dumps(body).encode(),
+                                 headers={"Content-Type": "application/json"})
+    t0 = time.time(); first = None; usage = {}
+    with urllib.request.urlopen(req, timeout=1800) as r:
+        for raw in r:
+            line = raw.decode().strip()
+            if not line.startswith("data: ") or line == "data: [DONE]":
+                continue
+            chunk = json.loads(line[6:])
+            if first is None and chunk.get("choices") and chunk["choices"][0].get("delta", {}).get("content"):
+                first = time.time()
+            if chunk.get("usage"):
+                usage = chunk["usage"]
+    last = time.time()
+    ct = usage.get("completion_tokens", 0)
+    dec = ct / (last - first) if first and last > first and ct else 0.0
+    out[idx] = {"ttft": (first - t0) if first else 0.0, "decode": dec, "ct": ct}
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--base", default="http://127.0.0.1:18000")
+    ap.add_argument("--concurrency", type=int, default=4)
+    ap.add_argument("--ctx-tokens", type=int, default=8000)
+    ap.add_argument("--gen-tokens", type=int, default=400)
+    ap.add_argument("--seed", type=int, default=int(time.time()))
+    a = ap.parse_args()
+
+    out = [None] * a.concurrency
+    threads = [threading.Thread(target=stream_one, args=(a.base, a.seed * 100 + i, a.ctx_tokens, a.gen_tokens, out, i))
+               for i in range(a.concurrency)]
+    t0 = time.time()
+    for t in threads: t.start()
+    for t in threads: t.join()
+    wall = time.time() - t0
+    decs = [o["decode"] for o in out if o]
+    print(f"C{a.concurrency} ctx~{a.ctx_tokens}: per-stream decode " +
+          " ".join(f"{d:.1f}" for d in decs) +
+          f" | mean {sum(decs)/len(decs):.1f} | aggregate {sum(decs):.1f} tok/s | "
+          f"ttft {min(o['ttft'] for o in out):.1f}-{max(o['ttft'] for o in out):.1f}s | wall {wall:.1f}s")
+
+
+if __name__ == "__main__":
+    main()

--- a/overlay/patch_fine_grained_apc.py
+++ b/overlay/patch_fine_grained_apc.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""[glm53-fgapc] Fine-grained APC for the GLM-5.3 hybrid: exempt the KpoolTail
+scratch manager from the partial-hash-hit veto.
+
+LOCAL: ported from upstream kit PR #59 (W18 A/B window). Upstream disables
+fine-grained prefix-cache hits whenever ANY cache manager lacks
+`supports_fine_grained_hash_lookup` and is not already hash-grained. On this
+hybrid the only such manager is KpoolTailManager — a one-block circular
+scratch per request that (a) never has block hashes computed, (b) already
+opts out of the hybrid hit min (its find_longest_cache_hit returns 0), and
+(c) whose group is reseeded fresh when the cached window does not cover the
+hit. Its veto therefore zeroes a capability the MLA + mamba(align) managers
+do support (hash grain = gcd of participating groups = 64 here), and every
+follow-up re-prefills up to a full 3584-token hybrid block. Exempting it
+lets the MLA/mamba hit reconcile at hash granularity.
+
+Gated by GLM53_FINE_GRAINED_APC (start.sh default 0 here — flipped to 1 for
+the window; env-only, not in the JIT shape hash). Idempotent via the
+[glm53-fgapc] marker; ast.parse-validated after edit; fails closed on
+anchor drift.
+"""
+
+import ast
+import os
+import sys
+
+MARKER = "[glm53-fgapc]"
+
+VETO_OLD = """            unsupported_partial_hit_managers = {
+                type(manager).__name__
+                for manager in self.single_type_managers
+                if not manager.supports_fine_grained_hash_lookup
+                and manager.block_size != hash_block_size
+            }"""
+
+VETO_NEW = """            unsupported_partial_hit_managers = {
+                type(manager).__name__
+                for manager in self.single_type_managers
+                if not manager.supports_fine_grained_hash_lookup
+                and manager.block_size != hash_block_size
+                # [glm53-fgapc] KpoolTail is a 1-block/req scratch: it never
+                # sees block hashes and already opts out of the hybrid hit
+                # min, so its block-aligned-only lookup must not veto
+                # fine-grained hits for the managers that do participate.
+                and type(manager).__name__ != "KpoolTailManager"
+            }"""
+
+DIAG_OLD = """        self.verify_and_split_kv_cache_groups()"""
+
+DIAG_NEW = """        logger.info(
+            # [glm53-fgapc]
+            "[glm53-fgapc] partial_hash=%s hash_block=%s managers=%s",
+            self.enable_partial_hash_hits,
+            hash_block_size,
+            sorted(
+                (
+                    type(manager).__name__,
+                    manager.block_size,
+                    bool(
+                        getattr(
+                            manager, "supports_fine_grained_hash_lookup", False
+                        )
+                    ),
+                )
+                for manager in self.single_type_managers
+            ),
+        )
+        self.verify_and_split_kv_cache_groups()"""
+
+
+def patch_file(path: str, dry_run: bool = False) -> int:
+    with open(path, encoding="utf-8") as f:
+        text = f.read()
+
+    if MARKER in text:
+        # Idempotency must mean "both edits fully present", not "marker seen".
+        if VETO_NEW in text and DIAG_NEW in text:
+            ast.parse(text, filename=path)
+            print(f"[patch_fine_grained_apc] {path}: already patched; no-op.")
+            return 0
+        raise AssertionError(
+            f"{path}: marker present but the patched forms are incomplete "
+            "(partial/interrupted earlier edit?); refusing to touch it."
+        )
+
+    if VETO_OLD not in text:
+        raise AssertionError(
+            f"{path}: partial-hash veto block not found (upstream layout "
+            "changed?); refusing to guess."
+        )
+    text = text.replace(VETO_OLD, VETO_NEW, 1)
+
+    if text.count(DIAG_OLD) != 1:
+        raise AssertionError(
+            f"{path}: expected exactly one verify_and_split call site, "
+            f"found {text.count(DIAG_OLD)}."
+        )
+    text = text.replace(DIAG_OLD, DIAG_NEW, 1)
+
+    try:
+        ast.parse(text, filename=path)
+    except SyntaxError as e:
+        raise AssertionError(f"POST-EDIT ast.parse FAILED for {path}: {e}") from e
+
+    if dry_run:
+        print(f"[patch_fine_grained_apc] DRY RUN -- {path} not written.")
+    else:
+        tmp = path + ".glm53-fgapc.tmp"
+        with open(tmp, "w", encoding="utf-8") as f:
+            f.write(text)
+        os.replace(tmp, path)  # atomic: never leave a marker-bearing partial file
+        print(f"[patch_fine_grained_apc] {path}: fine-grained APC exemption applied.")
+    return 1
+
+
+def main() -> int:
+    # LOCAL: default OFF until the W18 window adopts it (upstream PR #59 ships
+    # it on). GLM53_FINE_GRAINED_APC=1 applies; anything else leaves the
+    # block-aligned-only upstream behaviour.
+    if os.environ.get("GLM53_FINE_GRAINED_APC", "0") != "1":
+        print(
+            "[patch_fine_grained_apc] GLM53_FINE_GRAINED_APC!=1 — "
+            "skipping (block-aligned-only upstream behavior)."
+        )
+        return 0
+
+    # GLM53_FGAPC_TARGET is a test hook only (synthetic source files).
+    path = os.environ.get(
+        "GLM53_FGAPC_TARGET",
+        "/usr/local/lib/python3.12/dist-packages/vllm/v1/core/kv_cache_coordinator.py",
+    )
+    if not os.path.isfile(path):
+        # Enabled but nothing to patch: fail closed — start.sh's set -e stops the
+        # rank before `exec vllm serve` instead of booting silently unpatched.
+        print(f"[patch_fine_grained_apc] FATAL: target not found: {path}", file=sys.stderr)
+        return 1
+    patch_file(path, dry_run=os.environ.get("DRY_RUN") == "1")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/overlay/patch_spinwait_gb10.py
+++ b/overlay/patch_spinwait_gb10.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""GB10: shrink SpinCondition busy_loop_s 1 s -> 2 ms (opt-in via GLM53_SPINWAIT_2MS=1).
+
+LOCAL: ported from upstream kit PR #69 (W17 A/B window). The vLLM build in
+this image ships shm_broadcast.py with SpinCondition busy_loop_s defaulting
+to 1 second: after every read, each reader thread sched_yield()-spins for a
+full second before falling back to the zmq notify socket. On GB10 (20-core
+Grace, unified memory) those spinning readers compete with NCCL proxy threads
+and the engine loop for cores.
+
+Precedent on the same silicon: the DeepSeek-V4-Flash DSpark image was patched
+from 1 s to 2 ms in 2026-08 and validated on four Sparks (analysis:
+https://nacyot.github.io/artifacts/vllm-spin-wait-gb10/). SpinCondition here
+keeps a zmq wake-up path, so shrinking the spin window is safe: readers just
+park on the poller 2 ms after the last read instead of 1 s, and the writer's
+notify ping wakes them.
+
+Default OFF (no behavior change unless GLM53_SPINWAIT_2MS=1).
+Anchor drift fails closed so a vLLM bump cannot silently half-apply.
+"""
+import os
+import sys
+
+PATH = ("/usr/local/lib/python3.12/dist-packages/vllm/distributed/"
+        "device_communicators/shm_broadcast.py")
+OLD = "busy_loop_s: float = 1,"
+NEW = "busy_loop_s: float = 0.002,"
+
+if os.environ.get("GLM53_SPINWAIT_2MS", "0") != "1":
+    print("spinwait: GLM53_SPINWAIT_2MS!=1, leaving busy_loop_s as-is")
+    sys.exit(0)
+
+with open(PATH, encoding="utf-8") as f:
+    src = f.read()
+
+if NEW in src:
+    print("spinwait: already patched (busy_loop_s=0.002)")
+    sys.exit(0)
+
+n = src.count(OLD)
+if n != 1:
+    print(f"spinwait FATAL: anchor {OLD!r} found {n} times (expected 1)",
+          file=sys.stderr)
+    sys.exit(1)
+
+with open(PATH, "w", encoding="utf-8") as f:
+    f.write(src.replace(OLD, NEW))
+print("spinwait: busy_loop_s 1 -> 0.002 patched")

--- a/start.sh
+++ b/start.sh
@@ -141,6 +141,18 @@ MTP_TOKENS="${MTP_TOKENS:-2}"
 SPEC_METHOD="${SPEC_METHOD:-dflash}"
 DFLASH_MODEL="${DFLASH_MODEL:-incoai/GLM-5.3-Flash-DFlash2}"
 DFLASH_CACHE_NAME="${DFLASH_CACHE_NAME:-models--${DFLASH_MODEL//\//--}}"
+# LOCAL: pin the drafter checkpoint (upstream kit PR #67 shape). incoai has
+# shipped three different model.safetensors under Hub main (08-27 7d74cdd,
+# 08-28 dc77ff1, 08-31 bf582e4); this deployment's receipts were all taken
+# on 7d74cdd (sha256 8931dc52…). Empty = track main deliberately. A drafter
+# swap is a JIT-shape change: prod-start.sh hashes DFLASH_REVISION too.
+DFLASH_REVISION="${DFLASH_REVISION-7d74cdd881ed7e32c31175984a67823127b66cfe}"
+# Only immutable full commit hashes are accepted (a tag/branch would resolve to a
+# differently-named snapshot dir and silently fall back to refs/main).
+if [ -n "${DFLASH_REVISION:-}" ] && ! [[ "$DFLASH_REVISION" =~ ^[0-9a-f]{40}$ ]]; then
+    printf '\033[1;31m[glm53-exl3]\033[0m ERROR: DFLASH_REVISION must be a 40-hex commit sha or empty (got: %s)\n' "$DFLASH_REVISION" >&2
+    exit 1
+fi
 DFLASH_TOKENS="${DFLASH_TOKENS:-7}"
 # 2 = shard the ~2.3 GiB DFlash2 drafter across TP (C4 keep, 2026-08-30:
 # idle 8k 938 / 16k 972 / 100k 997; decode structured 65.1 / prose 27.1).
@@ -154,6 +166,12 @@ MAX_NUM_SEQS="${MAX_NUM_SEQS:-4}"
 # 8192 chunk × long history oversubscribes GB10 persistent_topk smem (300k crash).
 # P1 ladder 2026-08-29: 2048 keep; 3584/4096 revert (fat LinearEXL3 tax).
 MAX_NUM_BATCHED_TOKENS="${MAX_NUM_BATCHED_TOKENS:-2048}"
+# LOCAL: server-side default for requests that omit max_tokens (upstream kit
+# PR #51 shape, W16). Empty = stock unbounded fallback (max_model_len-prompt).
+# Wired as its own --override-generation-config arg, NOT via EXTRA_ARGS, so
+# prod-start.sh's JIT shape hash ignores it (merge semantics: config.update,
+# the model's generation_config temperature 1.0 is kept).
+DEFAULT_MAX_NEW_TOKENS="${DEFAULT_MAX_NEW_TOKENS:-}"
 CHAT_TEMPLATE_HOST="${CHAT_TEMPLATE_HOST:-$SCRIPT_DIR/files/chat_template.jinja}"
 CHAT_TEMPLATE="${CHAT_TEMPLATE:-/opt/glm53/chat_template.jinja}"
 VIDEO_PATCH_HOST="${VIDEO_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_glm_video_placeholders.py}"
@@ -166,6 +184,10 @@ CACHE_RESET_PATCH_HOST="${CACHE_RESET_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_cach
 # LOCAL: vLLM #54048 backport — cuBLAS out_dtype router GEMM on GB10 (W9)
 ROUTER_GEMM_PATCH_HOST="${ROUTER_GEMM_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_router_gemm_gb10.py}"
 KPOOL_TAIL_PATCH_HOST="${KPOOL_TAIL_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_kpool_tail_slotmap.py}"
+# LOCAL: W17 (kit PR #69) SpinCondition 1 s -> 2 ms, opt-in GLM53_SPINWAIT_2MS=1
+SPINWAIT_PATCH_HOST="${SPINWAIT_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_spinwait_gb10.py}"
+# LOCAL: W18 (kit PR #59) fine-grained APC (KpoolTail veto exemption), opt-in GLM53_FINE_GRAINED_APC=1
+FGAPC_PATCH_HOST="${FGAPC_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_fine_grained_apc.py}"
 KV_CACHE_DTYPE="${KV_CACHE_DTYPE:-fp8}"
 QUANTIZATION="${QUANTIZATION:-exl3}"
 LANGUAGE_MODEL_ONLY="${LANGUAGE_MODEL_ONLY:-0}"
@@ -210,6 +232,10 @@ GLM53_SUPPRESS_STOPS_IN_REASONING="${GLM53_SUPPRESS_STOPS_IN_REASONING:-1}"
 # Mixed-step prefill policy when a peer is already decoding (issue #6).
 # skip = do not mix; N>0 = cap tokens; 0 = off.
 GLM53_MIXED_PREFILL_CHUNK="${GLM53_MIXED_PREFILL_CHUNK:-skip}"
+# LOCAL: 1 = shrink vLLM SpinCondition busy_loop_s 1 s -> 2 ms (GB10 core relief, W17). Off by default.
+GLM53_SPINWAIT_2MS="${GLM53_SPINWAIT_2MS:-0}"
+# LOCAL: 1 = exempt KpoolTailManager from the partial-hash veto -> hash-grain (64) prefix hits (W18). Off by default.
+GLM53_FINE_GRAINED_APC="${GLM53_FINE_GRAINED_APC:-0}"
 # EngineCore stock timeout is 300s; mid-serve Triton/TileLang JIT on TP=2 can
 # exceed that without being a true hang. NCCL watchdog is still 600s.
 VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS="${VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS:-1800}"
@@ -259,6 +285,44 @@ log()  { printf '\033[1;36m[glm53-exl3]\033[0m %s\n' "$*"; }
 warn() { printf '\033[1;33m[glm53-exl3]\033[0m %s\n' "$*" >&2; }
 die()  { printf '\033[1;31m[glm53-exl3]\033[0m ERROR: %s\n' "$*" >&2; exit 1; }
 
+# GLM53 numeric config guard (begin)
+_glm53_canonical_positive_int() {
+    local name="$1" value="$2" maximum="$3" canonical
+    if ! [[ "$value" =~ ^[0-9]+$ ]]; then
+        echo "$name must be a positive base-10 integer (got: $value)" >&2
+        return 2
+    fi
+    canonical="$value"
+    while [ "${canonical#0}" != "$canonical" ]; do canonical="${canonical#0}"; done
+    [ -n "$canonical" ] || canonical=0
+    if [ "$canonical" = 0 ] \
+       || [ "${#canonical}" -gt "${#maximum}" ] \
+       || [ "$canonical" -gt "$maximum" ]; then
+        echo "$name must be between 1 and $maximum (got: $value)" >&2
+        return 2
+    fi
+    printf -v "$name" '%s' "$canonical"
+    # $name is one of three fixed names below.
+    # shellcheck disable=SC2163
+    export "$name"
+}
+
+validate_numeric_config() {
+    if ! [[ "$GPU_MEM_UTIL" =~ ^(0([.][0-9]+)?|[.][0-9]+|1([.]0+)?)$ ]] \
+       || ! awk -v u="$GPU_MEM_UTIL" 'BEGIN { exit !(u > 0 && u <= 1) }'; then
+        echo "GPU_MEM_UTIL must be greater than 0 and at most 1 (got: $GPU_MEM_UTIL)" >&2
+        return 2
+    fi
+    _glm53_canonical_positive_int MAX_MODEL_LEN "$MAX_MODEL_LEN" 1000000 || return
+    _glm53_canonical_positive_int MAX_NUM_SEQS "$MAX_NUM_SEQS" 4096 || return
+    _glm53_canonical_positive_int MAX_NUM_BATCHED_TOKENS "$MAX_NUM_BATCHED_TOKENS" 8388608 || return
+    # LOCAL: DEFAULT_MAX_NEW_TOKENS is spliced into generated shell + JSON; empty = off.
+    if [ -n "${DEFAULT_MAX_NEW_TOKENS:-}" ]; then
+        _glm53_canonical_positive_int DEFAULT_MAX_NEW_TOKENS "$DEFAULT_MAX_NEW_TOKENS" 1000000 || return
+    fi
+}
+# GLM53 numeric config guard (end)
+
 banner() {
     local label="${1:-start.sh}"
     printf '\n'
@@ -273,7 +337,15 @@ worker_ssh() { ssh -T -o BatchMode=yes -o ConnectTimeout=15 "$WORKER_SSH" "$@"; 
 usage() { sed -n '2,40p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; }
 
 count_shards() {
-    find "$1/snapshots" -name '*.safetensors' 2>/dev/null | wc -l | tr -d '[:space:]' || true
+    local repo_path="$1" ref
+    ref="$(cat "$repo_path/refs/main" 2>/dev/null || true)"
+    [ -n "$ref" ] || ref="$(ls -1t "$repo_path/snapshots" 2>/dev/null | head -n 1 || true)"
+    if [ -z "$ref" ]; then
+        printf '0'
+        return
+    fi
+    find "$repo_path/snapshots/$ref" -maxdepth 1 -type f -name '*.safetensors' 2>/dev/null \
+        | wc -l | tr -d '[:space:]' || true
 }
 
 ensure_refs_main() {
@@ -307,10 +379,17 @@ ensure_dflash_refs_main() {
 
 resolve_dflash_dir() {
     local ref="$DFLASH_PATH/refs/main" hash dir
-    ensure_dflash_refs_main
-    hash="$(<"$ref")"
+    # LOCAL: prefer the pinned snapshot even if refs/main points elsewhere (PR #67)
+    if [ -n "${DFLASH_REVISION:-}" ]; then
+        hash="$DFLASH_REVISION"
+        [ -d "$DFLASH_PATH/snapshots/$hash" ] || die "DFlash2 pinned snapshot $hash missing under $DFLASH_PATH/snapshots — run without SKIP_DOWNLOAD (or REFRESH_WEIGHTS=1)"
+    else
+        ensure_dflash_refs_main
+        hash="$(<"$ref")"
+    fi
     dir="$DFLASH_PATH/snapshots/$hash"
     [ -f "$dir/config.json" ] || die "DFlash2 config.json missing in $dir"
+    [ -f "$dir/model.safetensors" ] || die "DFlash2 model.safetensors missing in $dir"
     printf '/root/.cache/huggingface/hub/%s/snapshots/%s' "$DFLASH_CACHE_NAME" "$hash"
 }
 
@@ -395,6 +474,8 @@ preflight() {
     [ -f "$CACHE_RESET_PATCH_HOST" ] || die "$CACHE_RESET_PATCH_HOST missing"
     [ -f "$ROUTER_GEMM_PATCH_HOST" ] || die "$ROUTER_GEMM_PATCH_HOST missing"  # LOCAL: W9
     [ -f "$KPOOL_TAIL_PATCH_HOST" ] || die "$KPOOL_TAIL_PATCH_HOST missing"
+    [ -f "$SPINWAIT_PATCH_HOST" ] || die "$SPINWAIT_PATCH_HOST missing"  # LOCAL: W17
+    [ -f "$FGAPC_PATCH_HOST" ] || die "$FGAPC_PATCH_HOST missing"  # LOCAL: W18
 
     local need_kb=$((180 * 1024 * 1024)) avail
     mkdir -p "$HF_CACHE_DIR"
@@ -682,8 +763,14 @@ download_weights() {
 download_dflash() {
     [ "$SPEC_METHOD" = "dflash" ] || return 0
     [ "${SKIP_DOWNLOAD:-0}" = "1" ] && { log "SKIP_DOWNLOAD=1 — skipping DFlash2 download check"; return; }
-    local have
-    have="$(find "$DFLASH_PATH/snapshots" -name 'model.safetensors' 2>/dev/null | wc -l | tr -d '[:space:]' || true)"
+    local have=0 selected=""
+    # LOCAL: completeness is judged on the SELECTED snapshot (pin, else refs/main), not any snapshot (PR #67/#68)
+    if [ -n "${DFLASH_REVISION:-}" ]; then
+        selected="$DFLASH_PATH/snapshots/$DFLASH_REVISION"
+    elif [ -s "$DFLASH_PATH/refs/main" ]; then
+        selected="$DFLASH_PATH/snapshots/$(<"$DFLASH_PATH/refs/main")"
+    fi
+    [ -n "$selected" ] && [ -f "$selected/model.safetensors" ] && have=1
     if [ "${have:-0}" -ge 1 ] && [ "${REFRESH_WEIGHTS:-0}" != "1" ]; then
         log "DFlash2 already present: $DFLASH_PATH"
         ensure_dflash_refs_main
@@ -692,9 +779,11 @@ download_dflash() {
     resolve_hf_bin || die "no 'hf' / 'huggingface-cli' on PATH and no python huggingface_hub — pip install --user -U 'huggingface_hub[cli]' (or set HF_BIN=/path/to/hf)"
     mkdir -p "$HF_CACHE_DIR"
     log "downloading ${DFLASH_MODEL} (~2.3 GiB) into ${HF_CACHE_DIR} ..."
-    HF_HOME="$HF_CACHE_DIR" "${HF_BIN_CMD[@]}" download "$DFLASH_MODEL"
-    ensure_dflash_refs_main
-    have="$(find "$DFLASH_PATH/snapshots" -name 'model.safetensors' 2>/dev/null | wc -l | tr -d '[:space:]' || true)"
+    local -a dflash_args=("$DFLASH_MODEL")
+    [ -n "${DFLASH_REVISION:-}" ] && dflash_args+=(--revision "$DFLASH_REVISION")
+    HF_HOME="$HF_CACHE_DIR" "${HF_BIN_CMD[@]}" download "${dflash_args[@]}"
+    selected="$(resolve_dflash_dir)"
+    have=1
     [ "${have:-0}" -ge 1 ] || die "DFlash2 download finished without model.safetensors"
     log "DFlash2 download complete"
 }
@@ -737,20 +826,26 @@ download_only() {
 # (issue #22, item 2). FORCE_SYNC=1 bypasses the marker; deleting the
 # marker file on the worker has the same effect.
 sync_repo_marker_rev() {
-    local src="$1"
+    local src="$1" preferred="${2:-}"
     local rev
-    rev="$(cat "$src/refs/main" 2>/dev/null || true)"
+    if [ -n "$preferred" ] && [ -d "$src/snapshots/$preferred" ]; then
+        rev="$preferred"
+    else
+        rev="$(cat "$src/refs/main" 2>/dev/null || true)"
+    fi
     [ -n "$rev" ] || rev="$(ls -1t "$src/snapshots" 2>/dev/null | head -n 1 || true)"
     [ -n "$rev" ] || rev="unknown"
     printf '%s' "$rev"
 }
 
 sync_repo_to_worker() {
-    local src="$1" cache_name="$2" label="$3"
+    local src="$1" cache_name="$2" label="$3" preferred="${4:-}"
     local marker rev
     marker="${WORKER_CACHE_DIR}/hub/${cache_name}/.glm53-exl3-synced"
-    rev="$(sync_repo_marker_rev "$src")"
-    if [ "${FORCE_SYNC:-0}" != "1" ] \
+    rev="$(sync_repo_marker_rev "$src" "$preferred")"
+    # LOCAL: REFRESH_WEIGHTS=1 re-downloaded locally — the worker must not keep a
+    # stale copy behind an unchanged revision marker.
+    if [ "${FORCE_SYNC:-0}" != "1" ] && [ "${REFRESH_WEIGHTS:-0}" != "1" ] \
        && [ "$(worker_ssh "cat '$marker' 2>/dev/null" || true)" = "$rev" ]; then
         log "worker ${cache_name} already at ${rev} — rsync skipped (FORCE_SYNC=1 to force)"
         return 0
@@ -768,7 +863,7 @@ sync_weights() {
     sync_repo_to_worker "$MODEL_PATH" "$MODEL_CACHE_NAME" "weights"
     if [ "$SPEC_METHOD" = "dflash" ]; then
         [ -d "$DFLASH_PATH" ] || die "DFlash2 weights missing at $DFLASH_PATH"
-        sync_repo_to_worker "$DFLASH_PATH" "$DFLASH_CACHE_NAME" "DFlash2 draft"
+        sync_repo_to_worker "$DFLASH_PATH" "$DFLASH_CACHE_NAME" "DFlash2 draft" "$DFLASH_REVISION"
     fi
     log "worker weights in sync"
 }
@@ -808,6 +903,7 @@ ARGS=(
 [ -n "${GPU_MEM_UTIL:-}" ]  && ARGS+=(--gpu-memory-utilization "${GPU_MEM_UTIL}")
 [ -n "${MAX_NUM_SEQS:-}" ] && ARGS+=(--max-num-seqs "${MAX_NUM_SEQS}")
 [ -n "${MAX_NUM_BATCHED_TOKENS:-}" ] && ARGS+=(--max-num-batched-tokens "${MAX_NUM_BATCHED_TOKENS}")
+[ -n "${DEFAULT_MAX_NEW_TOKENS:-}" ] && ARGS+=(--override-generation-config "{\"max_new_tokens\": ${DEFAULT_MAX_NEW_TOKENS}}")
 # LOCAL: ADOPTED IN PROD 2026-08-29 (W4) — .env sets 1792. Caps each long
 # prefill's per-step chunk so short requests co-schedule instead of waiting out
 # the whole prefill: short TTFT behind a 240k cold prefill 256s -> 7.9s (-97%)
@@ -873,6 +969,12 @@ fi
 if [ -f /opt/glm53/patch_kpool_tail_slotmap.py ]; then
     python3 /opt/glm53/patch_kpool_tail_slotmap.py
 fi
+if [ -f /opt/glm53/patch_spinwait_gb10.py ]; then
+    python3 /opt/glm53/patch_spinwait_gb10.py
+fi
+if [ -f /opt/glm53/patch_fine_grained_apc.py ]; then
+    python3 /opt/glm53/patch_fine_grained_apc.py
+fi
 say "launching: vllm serve ${MODEL_DIR} ${ARGS[*]}"
 exec vllm serve "${MODEL_DIR}" "${ARGS[@]}"
 EOF
@@ -911,6 +1013,7 @@ ARGS=(
 [ -n "${GPU_MEM_UTIL:-}" ]  && ARGS+=(--gpu-memory-utilization "${GPU_MEM_UTIL}")
 [ -n "${MAX_NUM_SEQS:-}" ] && ARGS+=(--max-num-seqs "${MAX_NUM_SEQS}")
 [ -n "${MAX_NUM_BATCHED_TOKENS:-}" ] && ARGS+=(--max-num-batched-tokens "${MAX_NUM_BATCHED_TOKENS}")
+[ -n "${DEFAULT_MAX_NEW_TOKENS:-}" ] && ARGS+=(--override-generation-config "{\"max_new_tokens\": ${DEFAULT_MAX_NEW_TOKENS}}")
 # LOCAL: ADOPTED IN PROD 2026-08-29 (W4) — .env sets 1792. Caps each long
 # prefill's per-step chunk so short requests co-schedule instead of waiting out
 # the whole prefill: short TTFT behind a 240k cold prefill 256s -> 7.9s (-97%)
@@ -974,6 +1077,12 @@ fi
 if [ -f /opt/glm53/patch_kpool_tail_slotmap.py ]; then
     python3 /opt/glm53/patch_kpool_tail_slotmap.py
 fi
+if [ -f /opt/glm53/patch_spinwait_gb10.py ]; then
+    python3 /opt/glm53/patch_spinwait_gb10.py
+fi
+if [ -f /opt/glm53/patch_fine_grained_apc.py ]; then
+    python3 /opt/glm53/patch_fine_grained_apc.py
+fi
 say "joining TP2 at ${HEAD_IP}:${MASTER_PORT} as rank 1"
 exec vllm serve "${MODEL_DIR}" "${ARGS[@]}"
 EOF
@@ -1008,6 +1117,10 @@ launch_cluster() {
     scp -q -o BatchMode=yes "$ROUTER_GEMM_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_router_gemm_gb10.py"
     [ -f "$KPOOL_TAIL_PATCH_HOST" ] || die "missing $KPOOL_TAIL_PATCH_HOST"
     scp -q -o BatchMode=yes "$KPOOL_TAIL_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_kpool_tail_slotmap.py"
+    [ -f "$SPINWAIT_PATCH_HOST" ] || die "missing $SPINWAIT_PATCH_HOST"
+    scp -q -o BatchMode=yes "$SPINWAIT_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_spinwait_gb10.py"
+    [ -f "$FGAPC_PATCH_HOST" ] || die "missing $FGAPC_PATCH_HOST"
+    scp -q -o BatchMode=yes "$FGAPC_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_fine_grained_apc.py"
 
 
     local -a nccl_common=(
@@ -1036,6 +1149,10 @@ launch_cluster() {
         -e "GLM53_EXPOSE_CACHE_RESET=$GLM53_EXPOSE_CACHE_RESET"
         # LOCAL: W9 ablation — 0 restores stock router-GEMM eligibility exactly
         -e "GLM53_ROUTER_GEMM_CUBLAS=${GLM53_ROUTER_GEMM_CUBLAS:-1}"
+        # LOCAL: W17/W18 opt-in overlays (both ranks read these at patch time)
+        -e "GLM53_SPINWAIT_2MS=$GLM53_SPINWAIT_2MS"
+        -e "GLM53_FINE_GRAINED_APC=$GLM53_FINE_GRAINED_APC"
+        -e "DEFAULT_MAX_NEW_TOKENS=$DEFAULT_MAX_NEW_TOKENS"
         -e "TRITON_CACHE_DIR=$TRITON_CACHE_DIR"
         -e "TILELANG_CACHE_DIR=$TILELANG_CACHE_DIR"
         # LOCAL: upstream persists triton/tilelang but not FlashInfer's JIT
@@ -1123,6 +1240,8 @@ launch_cluster() {
         -v '/tmp/patch_cache_reset.py:/opt/glm53/patch_cache_reset.py:ro' \
         -v '/tmp/patch_router_gemm_gb10.py:/opt/glm53/patch_router_gemm_gb10.py:ro' \
         -v '/tmp/patch_kpool_tail_slotmap.py:/opt/glm53/patch_kpool_tail_slotmap.py:ro' \
+        -v '/tmp/patch_spinwait_gb10.py:/opt/glm53/patch_spinwait_gb10.py:ro' \
+        -v '/tmp/patch_fine_grained_apc.py:/opt/glm53/patch_fine_grained_apc.py:ro' \
         ${worker_preload} \
         ${worker_nccl} \
         -e NCCL_SOCKET_IFNAME='$WORKER_CX7_IF' \
@@ -1153,6 +1272,8 @@ launch_cluster() {
         -v "$CACHE_RESET_PATCH_HOST:/opt/glm53/patch_cache_reset.py:ro" \
         -v "$ROUTER_GEMM_PATCH_HOST:/opt/glm53/patch_router_gemm_gb10.py:ro" \
         -v "$KPOOL_TAIL_PATCH_HOST:/opt/glm53/patch_kpool_tail_slotmap.py:ro" \
+        -v "$SPINWAIT_PATCH_HOST:/opt/glm53/patch_spinwait_gb10.py:ro" \
+        -v "$FGAPC_PATCH_HOST:/opt/glm53/patch_fine_grained_apc.py:ro" \
         "${head_preload[@]}" \
         "${nccl_common[@]}" \
         -e NCCL_SOCKET_IFNAME="$HEAD_CX7_IF" \
@@ -1278,7 +1399,9 @@ on_ready() {
     local spec="MTP k=${MTP_TOKENS}"
     [ "$SPEC_METHOD" = "dflash" ] && spec="DFlash2 k=${DFLASH_TOKENS} (${DFLASH_MODEL})"
     [ "$SPEC_METHOD" = "none" ] && spec=off
-    log "  features   : tools=glm47+auto, reasoning=glm45, spec=${spec}, vision=${vision}"
+    local mt_line="mt_default=off (omitted max_tokens unbounded)"
+    [ -n "${DEFAULT_MAX_NEW_TOKENS:-}" ] && mt_line="mt_default=${DEFAULT_MAX_NEW_TOKENS}"
+    log "  features   : tools=glm47+auto, reasoning=glm45, spec=${spec}, vision=${vision}, ${mt_line}, spinwait2ms=${GLM53_SPINWAIT_2MS}, fgapc=${GLM53_FINE_GRAINED_APC}"
     local auth_line="none (VLLM_API_KEY empty)"
     if [ -n "${VLLM_API_KEY:-}" ]; then
         auth_line="bearer token set (VLLM_API_KEY) — send Authorization: Bearer <key> on /v1 requests"
@@ -1378,6 +1501,9 @@ logs() {
 # ------------------------------- main --------------------------------------
 main() {
     local cmd="${1:-start}"
+    case "$cmd" in
+        start|restart) validate_numeric_config ;;
+    esac
     case "$cmd" in
         stop)     banner stop.sh ;;
         download) banner download.sh ;;

--- a/start.sh
+++ b/start.sh
@@ -339,6 +339,7 @@ usage() { sed -n '2,40p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; }
 count_shards() {
     local repo_path="$1" ref
     ref="$(cat "$repo_path/refs/main" 2>/dev/null || true)"
+    # shellcheck disable=SC2012  # newest-snapshot fallback; snapshot dirnames are hex shas
     [ -n "$ref" ] || ref="$(ls -1t "$repo_path/snapshots" 2>/dev/null | head -n 1 || true)"
     if [ -z "$ref" ]; then
         printf '0'
@@ -351,6 +352,7 @@ count_shards() {
 ensure_refs_main() {
     local ref="$MODEL_PATH/refs/main" snap
     [ -f "$ref" ] && [ -n "$(<"$ref")" ] && return 0
+    # shellcheck disable=SC2012  # newest-snapshot fallback; snapshot dirnames are hex shas
     snap="$(ls -1t "$MODEL_PATH/snapshots" 2>/dev/null | head -n 1 || true)"
     [ -n "$snap" ] || die "no snapshots under $MODEL_PATH — re-run download"
     mkdir -p "$MODEL_PATH/refs"
@@ -370,6 +372,7 @@ resolve_model_dir() {
 ensure_dflash_refs_main() {
     local ref="$DFLASH_PATH/refs/main" snap
     [ -f "$ref" ] && [ -n "$(<"$ref")" ] && return 0
+    # shellcheck disable=SC2012  # newest-snapshot fallback; snapshot dirnames are hex shas
     snap="$(ls -1t "$DFLASH_PATH/snapshots" 2>/dev/null | head -n 1 || true)"
     [ -n "$snap" ] || die "no snapshots under $DFLASH_PATH — re-run download"
     mkdir -p "$DFLASH_PATH/refs"
@@ -431,7 +434,7 @@ preflight() {
     # index, others need different ones (HEAD_GID / WORKER_GID).
     local gid_head gid_worker gid_path
     gid_path="/sys/class/infiniband/${HEAD_CX7_IB}/ports/1/gids/${HEAD_GID}"
-    gid_head=$(cat "$gid_path" 2>/dev/null | tr -d ':0' || true)
+    gid_head=$(tr -d ':0' < "$gid_path" 2>/dev/null || true)
     gid_path="/sys/class/infiniband/${WORKER_CX7_IB}/ports/1/gids/${WORKER_GID}"
     gid_worker=$(worker_ssh "cat '$gid_path' 2>/dev/null" | tr -d ':0' || true)
     if [ -z "$gid_head" ] || [ -z "$gid_worker" ]; then
@@ -833,6 +836,7 @@ sync_repo_marker_rev() {
     else
         rev="$(cat "$src/refs/main" 2>/dev/null || true)"
     fi
+    # shellcheck disable=SC2012  # newest-snapshot fallback; snapshot dirnames are hex shas
     [ -n "$rev" ] || rev="$(ls -1t "$src/snapshots" 2>/dev/null | head -n 1 || true)"
     [ -n "$rev" ] || rev="unknown"
     printf '%s' "$rev"
@@ -1318,7 +1322,7 @@ wait_for_health() {
 
     local logpid=""
     _stop_logtail() {
-        [ -n "$logpid" ] && kill "$logpid" 2>/dev/null || true
+        if [ -n "$logpid" ]; then kill "$logpid" 2>/dev/null || true; fi
         wait "$logpid" 2>/dev/null || true
         logpid=""
     }

--- a/tests/_run_cold_prefill.py
+++ b/tests/_run_cold_prefill.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+"""Live cold-prefill ladder for GLM-5.3-Flash-EXL3 on :8888.
+
+Protocol matches the published kit receipts: temp 0, thinking off via
+top-level chat_template_kwargs, stream + include_usage, max_tokens=8,
+unique salt per cold request, one-at-a-time, TTFT = first content token.
+"""
+from __future__ import annotations
+
+import json
+import secrets
+import time
+import urllib.error
+import urllib.request
+import uuid
+from pathlib import Path
+
+BASE = "http://127.0.0.1:8888"
+SERVED = "GLM-5.3-Flash-EXL3"
+FILLER = "the "
+TASK = "Reply with OK."
+OUT_JSON = Path("/home/mia/NewModels/glm-5.3-flash-sm120/docs/_cold_prefill_raw.json")
+
+# target prompt_tokens, http timeout seconds
+LADDER = [
+    ("~8k", 8_000, 180),
+    ("~12k", 12_000, 180),
+    ("~16k", 16_000, 180),
+    ("~100k", 100_000, 600),
+    ("~256k", 256_000, 1_200),
+    ("~300k", 300_000, 1_200),
+]
+
+
+def http_get(path: str, timeout: float = 15.0):
+    req = urllib.request.Request(BASE + path)
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return resp.status, resp.read().decode("utf-8", "replace")
+
+
+def http_post(path: str, body: dict, timeout: float, stream: bool = False):
+    data = json.dumps(body).encode()
+    req = urllib.request.Request(
+        BASE + path,
+        data=data,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    return urllib.request.urlopen(req, timeout=timeout)
+
+
+def tokenize_messages(messages: list[dict], timeout: float = 180.0) -> int:
+    body = {"model": SERVED, "messages": messages}
+    with http_post("/tokenize", body, timeout=timeout) as resp:
+        obj = json.loads(resp.read().decode())
+    return int(obj["count"])
+
+
+def parse_metrics(raw: str) -> dict[str, float]:
+    out: dict[str, float] = {}
+    for line in raw.splitlines():
+        if not line or line.startswith("#"):
+            continue
+        # drop labels for the counters we care about
+        if line.startswith("vllm:prefix_cache_hits_total{"):
+            out["prefix_cache_hits_total"] = float(line.rsplit(" ", 1)[1])
+        elif line.startswith("vllm:prefix_cache_queries_total{"):
+            out["prefix_cache_queries_total"] = float(line.rsplit(" ", 1)[1])
+        elif line.startswith("vllm:prompt_tokens_total{"):
+            out["prompt_tokens_total"] = float(line.rsplit(" ", 1)[1])
+        elif 'source="local_compute"' in line and line.startswith(
+            "vllm:prompt_tokens_by_source_total{"
+        ):
+            out["local_compute"] = float(line.rsplit(" ", 1)[1])
+        elif 'source="local_cache_hit"' in line and line.startswith(
+            "vllm:prompt_tokens_by_source_total{"
+        ):
+            out["local_cache_hit"] = float(line.rsplit(" ", 1)[1])
+        elif line.startswith("vllm:gpu_cache_usage_perc{"):
+            out["gpu_cache_usage_perc"] = float(line.rsplit(" ", 1)[1])
+        elif line.startswith("vllm:num_requests_running{"):
+            out["num_requests_running"] = float(line.rsplit(" ", 1)[1])
+    return out
+
+
+def metrics_snapshot() -> dict[str, float]:
+    _, raw = http_get("/metrics")
+    return parse_metrics(raw)
+
+
+def unique_salt() -> str:
+    return f"COLD-PREFILL salt={uuid.uuid4()} pad={secrets.token_hex(24)}"
+
+
+def build_user_text(n_filler: int, salt: str) -> str:
+    return f"{salt}\n{FILLER * n_filler}\n{TASK}"
+
+
+def chat_messages(user_text: str, extra: list[dict] | None = None) -> list[dict]:
+    msgs = [{"role": "user", "content": user_text}]
+    if extra:
+        msgs.extend(extra)
+    return msgs
+
+
+def calibrate(target: int, salt: str, timeout: float = 180.0) -> tuple[int, int, str]:
+    """Pick filler count so tokenize(messages) is within ~2% of target."""
+    # overhead: salt + task + chat template, filler ≈ 1 token per "the "
+    overhead_text = build_user_text(0, salt)
+    overhead = tokenize_messages(chat_messages(overhead_text), timeout=timeout)
+    n = max(target - overhead, 1)
+    text = build_user_text(n, salt)
+    got = tokenize_messages(chat_messages(text), timeout=timeout)
+    # one correction step using measured ratio
+    if got > 0 and abs(got - target) / target > 0.005:
+        per = (got - overhead) / n if n else 1.0
+        if per <= 0:
+            per = 1.0
+        n = max(int(round((target - overhead) / per)), 1)
+        text = build_user_text(n, salt)
+        got = tokenize_messages(chat_messages(text), timeout=timeout)
+    # fine adjust by token delta (each filler ~1 token)
+    if abs(got - target) / target > 0.005:
+        n = max(n + (target - got), 1)
+        text = build_user_text(n, salt)
+        got = tokenize_messages(chat_messages(text), timeout=timeout)
+    rel = abs(got - target) / target
+    print(f"  calibrated tokenize={got} target={target} filler={n} rel={rel:.3%}", flush=True)
+    if rel > 0.02:
+        print("  WARNING: tokenize still >2% off target", flush=True)
+    return n, got, text
+
+
+def stream_chat(messages: list[dict], timeout: float) -> dict:
+    body = {
+        "model": SERVED,
+        "messages": messages,
+        "temperature": 0,
+        "max_tokens": 8,
+        "stream": True,
+        "stream_options": {"include_usage": True},
+        "chat_template_kwargs": {"enable_thinking": False},
+    }
+    t0 = time.perf_counter()
+    first_content = None
+    chunks: list[str] = []
+    reasoning: list[str] = []
+    usage = None
+    finish = None
+    http = None
+    err = None
+    try:
+        with http_post("/v1/chat/completions", body, timeout=timeout) as resp:
+            http = resp.status
+            buf = b""
+            while True:
+                piece = resp.read(4096)
+                if not piece:
+                    break
+                buf += piece
+                while b"\n" in buf:
+                    line, buf = buf.split(b"\n", 1)
+                    line = line.strip()
+                    if not line.startswith(b"data:"):
+                        continue
+                    payload = line[5:].strip()
+                    if payload == b"[DONE]":
+                        continue
+                    try:
+                        obj = json.loads(payload)
+                    except json.JSONDecodeError:
+                        continue
+                    if obj.get("usage"):
+                        usage = obj["usage"]
+                    choices = obj.get("choices") or []
+                    if not choices:
+                        continue
+                    delta = choices[0].get("delta") or {}
+                    content = delta.get("content") or ""
+                    reason = delta.get("reasoning") or delta.get("reasoning_content") or ""
+                    if reason:
+                        reasoning.append(reason)
+                    if content:
+                        if first_content is None:
+                            first_content = time.perf_counter()
+                        chunks.append(content)
+                    fr = choices[0].get("finish_reason")
+                    if fr:
+                        finish = fr
+    except Exception as exc:
+        err = f"{type(exc).__name__}: {exc}"
+    t1 = time.perf_counter()
+    text = "".join(chunks)
+    reason_text = "".join(reasoning)
+    prompt_tokens = int((usage or {}).get("prompt_tokens") or 0)
+    completion_tokens = int((usage or {}).get("completion_tokens") or 0)
+    ttft = None if first_content is None else (first_content - t0)
+    prefill = None
+    if ttft and ttft > 0 and prompt_tokens > 0:
+        prefill = prompt_tokens / ttft
+    gen_ok = bool(text) and ("ok" in text.lower()) and ("nan" not in text.lower())
+    cached = None
+    details = (usage or {}).get("prompt_tokens_details") or {}
+    if isinstance(details, dict) and details.get("cached_tokens") is not None:
+        cached = details.get("cached_tokens")
+    return {
+        "http": http,
+        "error": err,
+        "finish_reason": finish,
+        "prompt_tokens": prompt_tokens,
+        "completion_tokens": completion_tokens,
+        "cached_tokens": cached,
+        "ttft_s": ttft,
+        "wall_s": t1 - t0,
+        "prefill_tok_s": prefill,
+        "gen": text,
+        "reasoning": reason_text,
+        "gen_ok": gen_ok,
+        "usage": usage,
+    }
+
+
+def delta_metrics(before: dict, after: dict) -> dict:
+    keys = (
+        "prefix_cache_hits_total",
+        "prefix_cache_queries_total",
+        "prompt_tokens_total",
+        "local_compute",
+        "local_cache_hit",
+    )
+    return {k: after.get(k, 0.0) - before.get(k, 0.0) for k in keys}
+
+
+def main() -> int:
+    st, body = http_get("/health")
+    print(f"GET /health -> {st} {body!r}", flush=True)
+    if st != 200:
+        print("STOP: health failed", flush=True)
+        return 1
+    global SERVED
+    st, raw = http_get("/v1/models")
+    models = json.loads(raw)
+    served = models["data"][0]["id"]
+    max_len = models["data"][0].get("max_model_len")
+    print(f"GET /v1/models -> {st} id={served} max_model_len={max_len}", flush=True)
+    if served != SERVED:
+        print(f"NOTE: using served id {served} (not {SERVED})", flush=True)
+    SERVED = served
+
+    m0 = metrics_snapshot()
+    print(f"metrics at start: {json.dumps(m0)}", flush=True)
+
+    results: list[dict] = []
+    eightk_user = None
+    eightk_assistant = None
+
+    for i, (name, target, timeout) in enumerate(LADDER):
+        salt = unique_salt()
+        print(f"\n=== {name} cold target={target} timeout={timeout}s ===", flush=True)
+        n, tok_est, user_text = calibrate(target, salt, timeout=min(timeout, 180))
+        msgs = chat_messages(user_text)
+        before = metrics_snapshot()
+        rec = stream_chat(msgs, timeout=timeout)
+        after = metrics_snapshot()
+        rec["name"] = name
+        rec["kind"] = "cold"
+        rec["target"] = target
+        rec["filler_count"] = n
+        rec["tokenize_est"] = tok_est
+        rec["salt"] = salt
+        rec["metrics_delta"] = delta_metrics(before, after)
+        rec["gpu_cache_usage_perc"] = after.get("gpu_cache_usage_perc")
+        results.append(rec)
+        print(json.dumps({k: rec[k] for k in rec if k not in ("usage", "salt")}, default=str), flush=True)
+
+        if i == 0:
+            eightk_user = user_text
+            eightk_assistant = rec.get("gen") or ""
+            print("\n=== ~8k APC follow-up (same user text + assistant + short user turn) ===", flush=True)
+            follow_msgs = chat_messages(
+                eightk_user,
+                extra=[
+                    {"role": "assistant", "content": eightk_assistant},
+                    {"role": "user", "content": "Confirm with OK."},
+                ],
+            )
+            before = metrics_snapshot()
+            follow = stream_chat(follow_msgs, timeout=timeout)
+            after = metrics_snapshot()
+            follow["name"] = "~8k follow-up"
+            follow["kind"] = "apc"
+            follow["target"] = target
+            follow["metrics_delta"] = delta_metrics(before, after)
+            follow["gpu_cache_usage_perc"] = after.get("gpu_cache_usage_perc")
+            follow["assistant_echo"] = eightk_assistant
+            results.append(follow)
+            print(json.dumps({k: follow[k] for k in follow if k not in ("usage",)}, default=str), flush=True)
+
+    payload = {
+        "served_model": SERVED,
+        "max_model_len": max_len,
+        "started_metrics": m0,
+        "ended_metrics": metrics_snapshot(),
+        "results": results,
+        "wall_clock": time.strftime("%Y-%m-%d %H:%M:%S %z"),
+    }
+    OUT_JSON.write_text(json.dumps(payload, indent=2) + "\n")
+    print(f"\nWrote {OUT_JSON}", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_chat_template.py
+++ b/tests/test_chat_template.py
@@ -29,14 +29,24 @@ class ChatTemplateTests(unittest.TestCase):
         self.assertTrue(rendered.endswith("<|assistant|><think>"), rendered)
 
     def test_thinking_can_be_disabled(self) -> None:
+        # LOCAL (W16): the effort line is emitted unconditionally so the
+        # thinking toggle never invalidates the prefix cache at token ~2.
         rendered = render_generation_prompt(enable_thinking=False)
-        self.assertNotIn("Reasoning Effort:", rendered)
+        self.assertIn("<|system|>Reasoning Effort: Max", rendered)
         self.assertTrue(rendered.endswith("<|assistant|><think></think>"), rendered)
 
     def test_thinking_alias_matches_parser_behavior(self) -> None:
         rendered = render_generation_prompt(thinking=False)
-        self.assertNotIn("Reasoning Effort:", rendered)
+        self.assertIn("<|system|>Reasoning Effort: Max", rendered)
         self.assertTrue(rendered.endswith("<|assistant|><think></think>"), rendered)
+
+    def test_thinking_off_is_strict_extension_of_on(self) -> None:
+        # Prefix stability: the off-shape must equal the on-shape plus the
+        # closed think block, so the two share the whole cached prefix.
+        on = render_generation_prompt(enable_thinking=True)
+        off = render_generation_prompt(enable_thinking=False)
+        self.assertTrue(on.endswith("<|assistant|><think>"), on)
+        self.assertEqual(off, on + "</think>")
 
     def test_explicit_thinking_preserves_reasoning_effort(self) -> None:
         rendered = render_generation_prompt(

--- a/tests/test_dflash_revision_pin.py
+++ b/tests/test_dflash_revision_pin.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Regression guard: the DFlash2 drafter resolves a pinned revision (kit PR #67 shape).
+
+incoai/GLM-5.3-Flash-DFlash2 has shipped three different model.safetensors under
+the same model ID (7d74cdd -> dc77ff1 -> bf582e4). Without a pin, a REFRESH_WEIGHTS
+or fresh node silently pulls whatever Hub main means that day. This deployment's
+receipts were all taken on 7d74cdd (sha256 8931dc52...), so that is the default.
+"""
+from __future__ import annotations
+
+import re
+import shlex
+import subprocess
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+START = ROOT / "start.sh"
+PIN = "7d74cdd881ed7e32c31175984a67823127b66cfe"
+
+
+def source() -> str:
+    return START.read_text(encoding="utf-8")
+
+
+def function(name: str) -> str:
+    match = re.search(rf"(?ms)^{re.escape(name)}\(\) \{{\n.*?^\}}\n", source())
+    assert match, f"missing function {name}"
+    return match.group(0)
+
+
+def test_pin_is_declared_and_threaded_through() -> None:
+    text = source()
+    assert f'DFLASH_REVISION="${{DFLASH_REVISION-{PIN}}}"' in text
+    assert 'dflash_args+=(--revision "$DFLASH_REVISION")' in text
+    assert '[ -f "$dir/model.safetensors" ]' in function("resolve_dflash_dir")
+    assert ('sync_repo_to_worker "$DFLASH_PATH" "$DFLASH_CACHE_NAME" '
+            '"DFlash2 draft" "$DFLASH_REVISION"') in text
+
+
+def test_download_and_resolution_use_the_pin() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        args_file = Path(tmp) / "hf-args"
+        script = f"""
+set -euo pipefail
+log() {{ :; }}
+die() {{ printf 'DIE:%s\\n' "$*" >&2; exit 97; }}
+{function("ensure_dflash_refs_main")}
+{function("resolve_dflash_dir")}
+{function("download_dflash")}
+resolve_hf_bin() {{ HF_BIN_CMD=(mock_hf); }}
+mock_hf() {{
+    printf '%s\\n' "$@" > "$ARGS_FILE"
+    mkdir -p "$DFLASH_PATH/snapshots/$DFLASH_REVISION"
+    touch "$DFLASH_PATH/snapshots/$DFLASH_REVISION/config.json"
+    touch "$DFLASH_PATH/snapshots/$DFLASH_REVISION/model.safetensors"
+}}
+ARGS_FILE={shlex.quote(str(args_file))}
+DFLASH_PATH={shlex.quote(str(Path(tmp) / "dflash"))}
+DFLASH_CACHE_NAME=models--incoai--DFlash
+DFLASH_MODEL=incoai/DFlash
+DFLASH_REVISION={PIN}
+HF_CACHE_DIR={shlex.quote(tmp)}
+SPEC_METHOD=dflash
+SKIP_DOWNLOAD=0
+REFRESH_WEIGHTS=0
+download_dflash
+printf 'resolved=%s\\n' "$(resolve_dflash_dir)"
+"""
+        result = subprocess.run(["bash", "-c", script], capture_output=True, text=True)
+        assert result.returncode == 0, result.stderr
+        assert args_file.read_text(encoding="utf-8").splitlines() == [
+            "download", "incoai/DFlash", "--revision", PIN]
+        assert result.stdout.strip().endswith(f"/snapshots/{PIN}")
+
+
+def test_pinned_snapshot_wins_over_stale_refs_main() -> None:
+    """refs/main pointing at a never-materialised newer commit must not break boot (issue #52 shape)."""
+    with tempfile.TemporaryDirectory() as tmp:
+        script = f"""
+set -euo pipefail
+log() {{ :; }}
+die() {{ printf 'DIE:%s\\n' "$*" >&2; exit 97; }}
+{function("ensure_dflash_refs_main")}
+{function("resolve_dflash_dir")}
+DFLASH_PATH={shlex.quote(str(Path(tmp) / "dflash"))}
+DFLASH_CACHE_NAME=models--incoai--DFlash
+DFLASH_REVISION={PIN}
+mkdir -p "$DFLASH_PATH/snapshots/$DFLASH_REVISION" "$DFLASH_PATH/refs"
+touch "$DFLASH_PATH/snapshots/$DFLASH_REVISION/config.json" "$DFLASH_PATH/snapshots/$DFLASH_REVISION/model.safetensors"
+printf 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef' > "$DFLASH_PATH/refs/main"
+resolve_dflash_dir
+"""
+        result = subprocess.run(["bash", "-c", script], capture_output=True, text=True)
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.strip().endswith(f"/snapshots/{PIN}")
+
+
+if __name__ == "__main__":
+    test_pin_is_declared_and_threaded_through()
+    test_download_and_resolution_use_the_pin()
+    test_pinned_snapshot_wins_over_stale_refs_main()
+    print("dflash revision-pin guard OK")

--- a/tests/test_fine_grained_apc_overlay.py
+++ b/tests/test_fine_grained_apc_overlay.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Unit tests for overlay/patch_fine_grained_apc.py against synthetic source.
+
+Covers: disabled = no-op exit 0; enabled + missing target = exit 1 (fail closed);
+first application rewrites both anchors and parses; re-application is a no-op;
+a marker-bearing partial file is refused; a drifted anchor is refused.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+OVERLAY = ROOT / "overlay" / "patch_fine_grained_apc.py"
+
+SYNTHETIC = '''import logging
+logger = logging.getLogger(__name__)
+
+class HybridKVCacheCoordinator:
+    def __init__(self, hash_block_size):
+        self.single_type_managers = []
+        self.enable_partial_hash_hits = True
+        if self.enable_partial_hash_hits:
+            unsupported_partial_hit_managers = {
+                type(manager).__name__
+                for manager in self.single_type_managers
+                if not manager.supports_fine_grained_hash_lookup
+                and manager.block_size != hash_block_size
+            }
+            if unsupported_partial_hit_managers:
+                self.enable_partial_hash_hits = False
+        self.verify_and_split_kv_cache_groups()
+
+    def verify_and_split_kv_cache_groups(self):
+        pass
+'''
+
+
+def run(env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    e = os.environ.copy()
+    e.update(env)
+    return subprocess.run([sys.executable, str(OVERLAY)], env=e, capture_output=True, text=True)
+
+
+def test_disabled_is_noop() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        target = Path(tmp) / "kv.py"
+        target.write_text(SYNTHETIC)
+        r = run({"GLM53_FINE_GRAINED_APC": "0", "GLM53_FGAPC_TARGET": str(target)})
+        assert r.returncode == 0 and "skipping" in r.stdout
+        assert target.read_text() == SYNTHETIC
+
+
+def test_enabled_missing_target_fails_closed() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        r = run({"GLM53_FINE_GRAINED_APC": "1", "GLM53_FGAPC_TARGET": str(Path(tmp) / "absent.py")})
+        assert r.returncode == 1 and "FATAL: target not found" in r.stderr
+
+
+def test_apply_then_idempotent() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        target = Path(tmp) / "kv.py"
+        target.write_text(SYNTHETIC)
+        env = {"GLM53_FINE_GRAINED_APC": "1", "GLM53_FGAPC_TARGET": str(target)}
+        r = run(env)
+        assert r.returncode == 0, r.stderr
+        text = target.read_text()
+        assert 'and type(manager).__name__ != "KpoolTailManager"' in text
+        assert '"[glm53-fgapc] partial_hash=%s hash_block=%s managers=%s"' in text
+        assert text.count("[glm53-fgapc]") >= 2
+        compile(text, "kv.py", "exec")
+        assert not list(Path(tmp).glob("*.tmp"))
+        r2 = run(env)
+        assert r2.returncode == 0 and "already patched" in r2.stdout
+        assert target.read_text() == text
+
+
+def test_partial_marker_is_refused() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        target = Path(tmp) / "kv.py"
+        target.write_text(SYNTHETIC.replace("import logging", "# [glm53-fgapc] stray marker\nimport logging"))
+        r = run({"GLM53_FINE_GRAINED_APC": "1", "GLM53_FGAPC_TARGET": str(target)})
+        assert r.returncode != 0 and "incomplete" in (r.stderr + r.stdout)
+
+
+def test_drifted_anchor_is_refused() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        target = Path(tmp) / "kv.py"
+        target.write_text(SYNTHETIC.replace("and manager.block_size != hash_block_size", "and manager.block_size > hash_block_size"))
+        r = run({"GLM53_FINE_GRAINED_APC": "1", "GLM53_FGAPC_TARGET": str(target)})
+        assert r.returncode != 0 and "veto block not found" in (r.stderr + r.stdout)
+        assert "[glm53-fgapc]" not in target.read_text()
+
+
+if __name__ == "__main__":
+    for t in (test_disabled_is_noop, test_enabled_missing_target_fails_closed,
+              test_apply_then_idempotent, test_partial_marker_is_refused, test_drifted_anchor_is_refused):
+        t()
+    print("fine-grained APC overlay tests OK")

--- a/tests/test_numeric_config.py
+++ b/tests/test_numeric_config.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""CPU-only tests for launcher numeric type/range validation."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+START = ROOT / "start.sh"
+
+
+def guard_source() -> str:
+    source = START.read_text()
+    begin = source.index("# GLM53 numeric config guard (begin)")
+    end_marker = "# GLM53 numeric config guard (end)"
+    end = source.index(end_marker, begin) + len(end_marker)
+    return source[begin:end]
+
+
+def validate(util: str, model: str, seqs: str, batch: str) -> subprocess.CompletedProcess[str]:
+    script = (
+        guard_source()
+        + '\nGPU_MEM_UTIL="$1"; MAX_MODEL_LEN="$2"; MAX_NUM_SEQS="$3"; '
+        + 'MAX_NUM_BATCHED_TOKENS="$4"\n'
+        + 'validate_numeric_config || exit $?\n'
+        + 'printf "%s|%s|%s|%s\\n" "$GPU_MEM_UTIL" "$MAX_MODEL_LEN" '
+        + '"$MAX_NUM_SEQS" "$MAX_NUM_BATCHED_TOKENS"\n'
+    )
+    return subprocess.run(
+        ["bash", "-c", script, "test", util, model, seqs, batch],
+        text=True,
+        capture_output=True,
+        check=False,
+        env={**os.environ, "LC_ALL": "C"},
+    )
+
+
+def expect_rc(values: tuple[str, str, str, str], expected: int) -> None:
+    result = validate(*values)
+    assert result.returncode == expected, (values, result.returncode, result.stdout, result.stderr)
+
+
+def test_matrix() -> None:
+    expect_rc(("0.87", "1000000", "4", "1024"), 0)
+    expect_rc((".87", "01000000", "0004", "01024"), 0)
+    expect_rc(("1.0", "1000000", "4096", "8388608"), 0)
+    expect_rc(("0", "1000000", "4", "1024"), 2)
+    expect_rc(("8.7", "1000000", "4", "1024"), 2)
+    expect_rc(("nope", "1000000", "4", "1024"), 2)
+    expect_rc(("0.87", "0", "4", "1024"), 2)
+    expect_rc(("0.87", "1000001", "4", "1024"), 2)
+    expect_rc(("0.87", "1000000", "O4", "1024"), 2)
+    expect_rc(("0.87", "1000000", "4097", "1024"), 2)
+    expect_rc(("0.87", "1000000", "4", "1024\r"), 2)
+    expect_rc(("0.87", "1000000", "4", "18446744073709551615"), 2)
+
+
+def test_decimal_normalization() -> None:
+    result = validate(".87", "01000000", "0004", "01024")
+    assert result.returncode == 0
+    assert result.stdout.strip() == ".87|1000000|4|1024"
+
+
+def test_restart_validates_before_stop() -> None:
+    source = START.read_text()
+    main = source.index("main() {")
+    validation = source.index("start|restart) validate_numeric_config", main)
+    restart = source.index("restart)  stop; start", main)
+    assert validation < restart
+
+
+if __name__ == "__main__":
+    test_matrix()
+    test_decimal_normalization()
+    test_restart_validates_before_stop()
+    print("numeric config tests: PASS")

--- a/tests/test_prod_start_guard.py
+++ b/tests/test_prod_start_guard.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""The JIT shape guard in local/prod-start.sh, run standalone with mocked docker/ssh.
+
+Asserts: the wipe container is resolved from IMAGE= (self-built tag, no ghcr
+digest); the stamp advances only when BOTH node wipes succeed; a failed wipe
+on either node leaves the stamp unchanged; an unresolvable IMAGE leaves it
+unchanged; the hash covers DFLASH_REVISION (from .env or the launcher default).
+"""
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PROD_START = (ROOT / "local" / "prod-start.sh").read_text(encoding="utf-8")
+
+
+def guard_block() -> str:
+    begin = PROD_START.index("# --- JIT-cache config-shape guard")
+    end = PROD_START.index("exec ./start.sh start")
+    return PROD_START[begin:end]
+
+
+def make_shim(bindir: Path, name: str, body: str) -> None:
+    p = bindir / name
+    p.write_text("#!/usr/bin/env bash\n" + body)
+    p.chmod(p.stat().st_mode | stat.S_IEXEC)
+
+
+def run_guard(tmp: Path, env_text: str, docker_rc: int, ssh_rc: int, stamp: str | None = None,
+              start_sh_default: str = 'DFLASH_REVISION="${DFLASH_REVISION-abc}"\n') -> tuple[subprocess.CompletedProcess[str], Path, Path]:
+    work = tmp / "kit"; work.mkdir(exist_ok=True)
+    (work / ".env").write_text(env_text)
+    (work / "start.sh").write_text(start_sh_default)
+    home = tmp / "home"; (home / ".cache" / "vllm-glm53-flash").mkdir(parents=True, exist_ok=True)
+    stamp_path = home / ".cache" / "vllm-glm53-flash" / ".config-shape"
+    if stamp is not None:
+        stamp_path.write_text(stamp)
+    bindir = tmp / "bin"; bindir.mkdir(exist_ok=True)
+    log = tmp / "calls.log"
+    make_shim(bindir, "docker", f'echo "docker $*" >> {log}\nexit {docker_rc}\n')
+    make_shim(bindir, "ssh", f'echo "ssh $*" >> {log}\nexit {ssh_rc}\n')
+    script = "set -uo pipefail\nWORKER_SSH=nvidia@worker\n" + guard_block()
+    env = {"PATH": f"{bindir}:{os.environ['PATH']}", "HOME": str(home)}
+    r = subprocess.run(["bash", "-c", script], cwd=work, env=env, capture_output=True, text=True)
+    return r, stamp_path, log
+
+
+ENV = "IMAGE=glm53-selfbuild:b5ab8091-w15a\nDFLASH_TOKENS=7\nDFLASH_REVISION=abc\n"
+
+
+def test_image_resolved_from_IMAGE_line_and_stamp_written_on_success() -> None:
+    with tempfile.TemporaryDirectory() as t:
+        r, stamp, log = run_guard(Path(t), ENV, 0, 0, stamp="stale")
+        assert r.returncode == 0, r.stderr
+        calls = log.read_text()
+        lines = calls.splitlines()
+        assert "glm53-selfbuild:b5ab8091-w15a" in calls
+        assert sum(l.startswith("docker ") for l in lines) == 1 and sum(l.startswith("ssh ") for l in lines) == 1
+        assert stamp.read_text().strip() != "stale" and len(stamp.read_text().strip()) == 32
+
+
+def test_head_wipe_failure_leaves_stamp() -> None:
+    with tempfile.TemporaryDirectory() as t:
+        r, stamp, _ = run_guard(Path(t), ENV, 1, 0, stamp="stale")
+        assert stamp.read_text() == "stale" and "incomplete" in r.stdout
+
+
+def test_worker_wipe_failure_leaves_stamp() -> None:
+    with tempfile.TemporaryDirectory() as t:
+        r, stamp, _ = run_guard(Path(t), ENV, 0, 1, stamp="stale")
+        assert stamp.read_text() == "stale" and "incomplete" in r.stdout
+
+
+def test_unresolvable_image_leaves_stamp_and_skips_wipe() -> None:
+    with tempfile.TemporaryDirectory() as t:
+        r, stamp, log = run_guard(Path(t), "DFLASH_TOKENS=7\n", 0, 0, stamp="stale")
+        assert stamp.read_text() == "stale" and "could not resolve IMAGE" in r.stdout
+        assert not log.exists()
+
+
+def test_hash_tracks_revision_and_launcher_default() -> None:
+    with tempfile.TemporaryDirectory() as t:
+        _, s1, _ = run_guard(Path(t), ENV, 0, 0)
+        h1 = s1.read_text()
+    with tempfile.TemporaryDirectory() as t:
+        _, s2, _ = run_guard(Path(t), ENV.replace("DFLASH_REVISION=abc", "DFLASH_REVISION=def"), 0, 0)
+        h2 = s2.read_text()
+    with tempfile.TemporaryDirectory() as t:
+        _, s3, _ = run_guard(Path(t), ENV, 0, 0, start_sh_default='DFLASH_REVISION="${DFLASH_REVISION-zzz}"\n')
+        h3 = s3.read_text()
+    assert h1 != h2 and h1 != h3
+
+
+if __name__ == "__main__":
+    test_image_resolved_from_IMAGE_line_and_stamp_written_on_success()
+    test_head_wipe_failure_leaves_stamp()
+    test_worker_wipe_failure_leaves_stamp()
+    test_unresolvable_image_leaves_stamp_and_skips_wipe()
+    test_hash_tracks_revision_and_launcher_default()
+    print("prod-start guard tests OK")

--- a/tests/test_w16_w18_wiring.py
+++ b/tests/test_w16_w18_wiring.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Static wiring guards for the W16-W18 ports (kit PRs #51, #59, #69).
+
+Each overlay must be wired six ways (host var, preflight, worker scp, both
+container mounts, both patch-exec blocks) and its env must reach both ranks.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+START = (ROOT / "start.sh").read_text(encoding="utf-8")
+PROD_START = (ROOT / "local" / "prod-start.sh").read_text(encoding="utf-8")
+
+
+def _count(s: str) -> int:
+    return START.count(s)
+
+
+def test_overlays_wired_six_ways() -> None:
+    for host_var, fname in (("SPINWAIT_PATCH_HOST", "patch_spinwait_gb10.py"),
+                            ("FGAPC_PATCH_HOST", "patch_fine_grained_apc.py")):
+        assert (ROOT / "overlay" / fname).is_file()
+        assert f'{host_var}="${{{host_var}:-$SCRIPT_DIR/overlay/{fname}}}"' in START
+        assert f'[ -f "${host_var}" ] || die "${host_var} missing"' in START
+        assert f'scp -q -o BatchMode=yes "${host_var}" "${{WORKER_SSH}}:/tmp/{fname}"' in START
+        assert f"-v '/tmp/{fname}:/opt/glm53/{fname}:ro'" in START  # worker
+        assert f'-v "${host_var}:/opt/glm53/{fname}:ro"' in START  # head
+        assert _count(f"python3 /opt/glm53/{fname}") == 2  # both ranks
+
+
+def test_env_defaults_off_and_reach_both_ranks() -> None:
+    assert 'GLM53_SPINWAIT_2MS="${GLM53_SPINWAIT_2MS:-0}"' in START
+    assert 'GLM53_FINE_GRAINED_APC="${GLM53_FINE_GRAINED_APC:-0}"' in START
+    # shared nccl_common array is expanded into BOTH docker runs
+    assert '-e "GLM53_SPINWAIT_2MS=$GLM53_SPINWAIT_2MS"' in START
+    assert '-e "GLM53_FINE_GRAINED_APC=$GLM53_FINE_GRAINED_APC"' in START
+    assert '"${nccl_common[@]}"' in START and 'for e in "${nccl_common[@]}"' in START
+
+
+def test_default_max_new_tokens_is_hash_neutral() -> None:
+    assert 'DEFAULT_MAX_NEW_TOKENS="${DEFAULT_MAX_NEW_TOKENS:-}"' in START  # empty = unchanged
+    line = ('[ -n "${DEFAULT_MAX_NEW_TOKENS:-}" ] && ARGS+=(--override-generation-config '
+            '"{\\"max_new_tokens\\": ${DEFAULT_MAX_NEW_TOKENS}}")')
+    assert _count(line) == 2  # head + worker
+    hash_line = re.search(r'^shape_hash=.*$', PROD_START, re.M).group(0)
+    assert "DEFAULT_MAX_NEW_TOKENS" not in hash_line
+    assert "LONG_PREFILL_TOKEN_THRESHOLD" not in hash_line
+
+
+def test_prod_start_hash_and_wipe_image() -> None:
+    hash_line = re.search(r'^shape_hash=.*$', PROD_START, re.M).group(0)
+    for k in ("DFLASH_MODEL", "DFLASH_REVISION", "DFLASH_TOKENS", "DFLASH_DRAFT_TP", "IMAGE"):
+        assert k in hash_line, k
+    # wipe container resolved from IMAGE= verbatim (self-built images have no ghcr digest)
+    assert "sed -n 's/^IMAGE=//p' .env" in PROD_START
+    # a missed wipe must not advance the stamp
+    assert "stamp left unchanged" in PROD_START
+
+
+if __name__ == "__main__":
+    test_overlays_wired_six_ways()
+    test_env_defaults_off_and_reach_both_ranks()
+    test_default_max_new_tokens_is_hash_neutral()
+    test_prod_start_hash_and_wipe_image()
+    print("W16-W18 wiring guards OK")


### PR DESCRIPTION
## Summary

Fourth upstream sweep (2026-08-31) — hygiene fixes plus opt-in ports, **all windows now resolved on production**: W16 + W17 + W18 ADOPTED (measured below), W19 + W20 tested-and-rejected with receipts, F0 closed the long-context question, W21 (NVMe offload) parked by owner call. Production runs `7d74cdd` pin + spinwait 2 ms + fine-grained APC; standing gates in `docs/06-improvement-plan.md`. Ready to merge.

### Hygiene (fixes real bugs found in this tree)
- **`local/prod-start.sh` JIT-wipe guard was a silent no-op since the self-build cutover** — it grepped a `ghcr.io…sha256:` digest out of `.env`; `IMAGE=glm53-selfbuild:…` matches nothing, so the wipe skipped while the stamp still advanced. Now: image from `IMAGE=` verbatim (digest fallback), stamp written **only when both node wipes succeed**, hash covers `DFLASH_MODEL|DFLASH_REVISION` and the launcher's default pin line. **Verified live at the W16 boot:** the guard fired, both nodes wiped, stamp advanced.
- **DFlash2 drafter pinned** (`DFLASH_REVISION`, kit PR #67 shape): `incoai/GLM-5.3-Flash-DFlash2` has shipped three different `model.safetensors` under `main` (08-27 `7d74cdd` / 08-28 `dc77ff1` / 08-31 `bf582e4`); every receipt here is on `7d74cdd` (sha256 `8931dc52…`) — now the default. Full-sha only; pinned snapshot preferred over a stale `refs/main` (closes the issue-#52 boot failure); worker sync marker keyed on the pin; `REFRESH_WEIGHTS=1` forces the worker rsync too.
- Upstream merged #38 (numeric-knob validation, extended to `DEFAULT_MAX_NEW_TOKENS`), #71 (cold-prefill harness), PR #68 (snapshot-scoped shard count).

### W16 — ADOPTED
- `files/chat_template.jinja`: `Reasoning Effort` line emitted unconditionally (kit PR #63); off-shape is a strict extension of the on-shape.
- `DEFAULT_MAX_NEW_TOKENS=65536` (kit PR #51) as its own hash-neutral `--override-generation-config` arg; boot log shows it merged on top of the model's `temperature 1.0 / top_p 0.95`.
- **Measured** (`local/w16-toggle-probe.py`, one unique 50k prompt, production): thinking-off toggle **0% hits / 56.8 s → 100% / 0.26 s**; toggle back 100%. A *different* `reasoning_effort` still forks (documented client rule).
- Gates: pool byte-identical 1,396,551; acceptance 7/7; serving 6/6; toolcall 23/23 / 0 blank; structured 68.3–68.5 @ 1.0000/7.0 (converged after the cold-JIT first pass; within boot variance); prose 30.3–31.2; cache-burst 2×68k 97.8%; 0 FSM / 0 ERROR / no Xid.

### W17 — ADOPTED (matched same-day control)
- `overlay/patch_spinwait_gb10.py` — `SpinCondition.busy_loop_s` 1 s → 2 ms, `GLM53_SPINWAIT_2MS=1` now in production `.env`.
- Under one decode the head ran `VLLM::EngineCore` 92% + `Worker_TP` 85% (1-s `sched_yield` spin); arm: the EngineCore spinner is gone, head hot zones 83 → 78 °C, 0 NCCL/shm warnings on either rank.
- Cost: none — arm cold prefill 857/860 @240k vs **same-day control 860/871**; short-TTFT-behind-240k 6.0–6.5 s vs control 5.3–7.0 s; decode identical (structured 68.4–68.7 @ 1.0000/7.0, prose 28.2–31.2). Standing 893 reference had drifted → lesson: always run the control arm the same day.
- Re-baseline for W18+: structured 68.4–68.7, prose 28.2–31.2, cold prefill 857–871 @240k.

### W18 — ADOPTED (owner call on a −2.7% structured tax)
- `overlay/patch_fine_grained_apc.py`, `GLM53_FINE_GRAINED_APC=1` now in production `.env`. Boot: `[glm53-fgapc] partial_hash=True hash_block=64`, veto warning gone, both ranks.
- Follow-up ladder control → arm: 2.6k prompt 0 → 2,816 reused tokens; 6.5k 3,584 → 6,464 (96.2%); 39k 35,840 → 39,040; follow-up wall ~4.1 s → ~1.0 s. 2×68k retention 97.8% → 100%; 4×60k×3 concurrent 95.0% → 98.7%; **0 IMA / 0 Xid / 0 preemptions** in the soak.
- Cost: structured 68.5 → 66.5–66.7 (−2.7%, converged; prose unchanged) — accepted for agentic traffic; standing gate updated.
- Finding: temp-0 output is cold-vs-cold nondeterministic on this stack (pre-existing, 0/3 with cache resets; DFlash2 probabilistic drafting suspected) — byte-identity gates are void here.

### W19 — tested, the `7d74cdd` pin stands
- Three-way drafter A/B (pin flip → verified JIT wipe → converged passes, same day/image): `dc77ff1` −6% prose median, `bf582e4` a wash; structured acceptance 1.0000/7.0 on all three. Reverted to `7d74cdd`; adopt-only-on-measurable-win.
- F0 side result: issue #73's long-context decode collapse does **not** reproduce here (structured 56–65 tok/s @ 0.93–0.98 acceptance flat to ~195k, both ladder orders) — the W22 k-ladder is closed.

### W20 — rejected again, now with the C4 protocol
- `DFLASH_DRAFT_TP=2` at C4 (issue #56's own shape): C4 per-stream 19.8/21.6 vs TP=1 baseline 20.1/21.2, C1 18.0 vs 18.9, head MemFree slightly worse; pool unchanged (byte-pinned). The +37% does not transfer to a pinned pool at MNBT 3584. TP=1 pinned.

### Staged, dormant (default OFF)
- **W18** `overlay/patch_fine_grained_apc.py` — exempt `KpoolTailManager` from the partial-hash veto behind `GLM53_FINE_GRAINED_APC=1` (kit PR #59); fails closed on missing target / partial marker / drifted anchor; atomic write. The W16 boot log still shows the veto (`Disabling fine-grained prefix-cache hits … KpoolTailManager`), as expected with the knob off.

### Review
Codex (gpt-5.6-sol): 1 High (stamp advanced on a failed wipe) + 4 Medium (REFRESH_WEIGHTS worker sync, empty/non-sha pin semantics, overlay exit-0 on missing target, hash blind to a changed default) + 2 Low — all fixed; Kpool exemption judged safe from the lineage facts; template change judged correct.

### Test plan
- [x] `tests/` 47/47 (new: `test_dflash_revision_pin`, `test_w16_w18_wiring`, `test_fine_grained_apc_overlay`, `test_prod_start_guard` with mocked docker/ssh, `test_numeric_config`)
- [x] `bash -n start.sh local/prod-start.sh`
- [x] Synced to spark1; W16 boot clean (750 s incl. the one-time wipe)
- [x] W16 window gates (above) — results in `docs/06-improvement-plan.md`





