### PR TITLE
W41+W42: KV-capacity boot log + per-request APC no-store overlays

### DIFF
--- a/docs/06-improvement-plan.md
+++ b/docs/06-improvement-plan.md
@@ -953,6 +953,77 @@ absent → template renders Max), `.env.bak-pre-w27`, `start.sh.bak-pre-w27` on 
   8 tokens per sequence). `MAX_NUM_SEQS=4` is a hard admission cap today and is the
   cheapest concurrency lever left; it is in the JIT shape hash (one-time wipe) and needs
   the both-node memory tripwire from W38.
-- W41 + W42 (kit PR #94 KV-capacity log, PR #95 `APC_NO_STORE`) stay next, one restart,
-  Codex pre-ship first; A3 after them; the W29 confirming repeat whenever the box is
-  idle.
+- W43 is next; A3 after it; the W29 confirming repeat whenever the box is idle.
+
+### W41 + W42 — KV-capacity boot log + per-request APC no-store, ADOPTED (2026-09-01, boot 21:16Z, active 21:19Z)
+
+**Why they exist.** W41 (kit PR #94, `overlay/patch_kv_capacity_log.py`): the stock
+`GPU KV cache size` line is, for a multi-group hybrid, a *concurrency* figure in
+token units — two reviewers independently misread "1,553,140 tokens" as a prefix
+cache while the pool is 566 usable block ids and one cached 3584-token segment
+costs 38 of them (upstream feature request vllm-project/vllm#54662). W42 (kit PR
+#95, `overlay/patch_apc_no_store.py`): vLLM has a read-side prefix-cache opt-out
+but no write-side one, so a one-off batch/eval request's blocks get hashed, queue
+behind other sessions' cached prefixes in `BlockPool.free_blocks`' LRU, and evict
+them; no-store blocks stay unhashed and recycle LIFO from the front.
+
+**What shipped.** Both overlays are log/mechanism-only and knob-guarded
+(`GLM53_KV_CAPACITY_LOG`, `GLM53_APC_NO_STORE`; exactly 0/1, unset → 1, not in
+the JIT shape hash). W41 injects per-group lines + an honest capacity summary
+after the byte-identical stock line; any derivation error is a `warning_once`,
+never boot-fatal. W42 adds `SamplingParams.skip_writing_prefix_cache` (typed or
+`vllm_xargs`), suppressing only the two request-driven hash-insertion sites in
+`block_pool.py`; `num_cached_block` sentinel accounting, lookups, and the
+reader-side partial-hit CoW are untouched; malformed values are an HTTP 400 at
+the API boundary, the engine-side resolver never raises. Launcher: the two knobs
+default at top level (cannot exit) and are strictly validated inside
+`validate_numeric_config` (start/restart only — a bad value can never block
+stop/status/logs), with setness-aware caller-wins capture/restore so caller
+exports (including explicitly empty) beat `.env`. No `.env` change, no image
+rebuild, one restart. Rollback: `start.sh.bak-pre-w41w42` on spark1, knob-level
+`GLM53_KV_CAPACITY_LOG=0` / `GLM53_APC_NO_STORE=0`, or removing the two overlays.
+
+**Pre-ship review — final-reviewer subagent (GPT-5.6 Sol), three rounds.**
+Round 1 CHANGES-REQUIRED: (1) the top-level bool guard would have blocked
+stop/status/logs on a malformed value — fixed by moving strict validation into
+`validate_numeric_config` (the W27 finding-1 class, recaught here because the
+staged tests had deliberately pinned the top-level placement); (2) `.env`
+silently overrode caller knob exports (`GLM53_APC_NO_STORE=0 ./start.sh restart`
+resolved back to 1, reproduced) — fixed with setness-aware capture/restore plus
+a behavioral test against a fake `.env`; (3, recorded) review-staging layout.
+Round 2 CHANGES-REQUIRED: (1) the review staging had drifted from the ship
+copies and the render log recorded permission failures — staging resynced,
+render script fixed, all diffs + log regenerated clean; (2, recorded) the
+passthrough assertions stripped both sides, which could hide whitespace-only
+alteration — now byte-exact (`length|value`, binary-safe capture). Round 3:
+**APPROVED, no required or recorded findings.** Reviewer-verified: overlays
+byte-identical between staging and ship, rendered diffs match the ship overlays
+(290/152/31/66 lines), all four W41/W42 launcher regions identical across both
+start.sh copies, tests 159 + 140 checks, `bash -n` clean. Receipts from the
+digest: rendered diffs produced by actually applying the overlays to the pinned
+image's pristine sources (throwaway containers), idempotent re-run clean, all
+patched files parse inside the image.
+
+**Gates (boot 21:16:08Z → active 21:19Z; prod-start MemFree guard passed).**
+Pool byte-identical: stock line unchanged at **1,396,551** tokens / 1.40x.
+Shape stamp untouched (no JIT wipe). Loopback bind `127.0.0.1:8000` only. Both
+ranks report the overlays applied. W41 receipts (head): 7 group lines (MLA 3584,
+KpoolTail scratch no-cache, 4× Mamba align, drafter SWA window=2048 eagle=yes),
+then `usable block ids: 566 (num_blocks=567 incl. the null block; 406 ids per
+1,000,000-token request => 1.40x); ids per 3584-token cached segment across
+groups: 38 (per group: [1, 0, 1, 1, 1, 1, 33]); cached-conversation capacity ≈
+50,176 tokens = 14 segments` — the honest figure the stock line cannot express.
+W42 functional gate: valid `vllm_xargs {"skip_writing_prefix_cache": 1}` request
+→ HTTP 200 + resolution receipt; a large cold no-store request (>3584 tokens)
+produced BOTH store-suppression receipts (`full site` and `partial site`);
+malformed value `"yes"` → **HTTP 400** with the exact named error; cached-peer
+eviction check: 6,000-token peer prompt 6.68 s cold → 0.27 s warm → **0.26 s
+after two no-store requests** (no eviction). Acceptance **7/7**; serving **6/6**
+through the tunnel. Structured: accept **1.0000 / 7.0, all seven positions 1.00**,
+9 runs no-NaN, tok/s 66.6–69.2 on 7 of 9 runs (two ~25 tok/s outliers are a
+documented self-contention confound: the bench ran while the owner's coding
+session — which runs on this server — was generating). Prose: 28.2–34.1 tok/s
+on 8 of 9 runs (one 17.0 outlier, same confound), in-to-above the 28.6–31.0
+band; acceptance ratios 0.34–0.44 / 2.4–3.1, normal. Standing baselines
+unthreatened; re-bench on an idle box is folded into the already-queued W29
+repeat.

--- a/env.example
+++ b/env.example
@@ -83,6 +83,22 @@ GLM53_FINE_GRAINED_APC=1
 # never reached); required before any LPTT >= 3584 arm. Read once at import: flipping
 # it needs a restart. Not in the JIT shape hash. Rollback GLM53_ALIGN_FLOOR=0.
 GLM53_ALIGN_FLOOR=1
+# W41 KV-capacity boot log (overlay/patch_kv_capacity_log.py, kit PR #94): log-only.
+# After the stock "GPU KV cache size" line, prints one line per KV-cache group
+# (spec, block_size, page bytes, ids per 1M request, prefix-cacheable, eagle/mamba
+# mode) plus the usable-block-id count and an aligned dense-retention
+# cached-conversation upper bound. Diagnostic only: exceptions are caught and logged,
+# never raised. Exactly 0 or 1; validated on start/restart, so a bad value
+# never blocks stop/status/logs on a running pair. Not in the JIT hash.
+GLM53_KV_CAPACITY_LOG=1
+# W42 per-request prefix-cache no-store (overlay/patch_apc_no_store.py, kit PR #95).
+# A request sent with vllm_xargs {"skip_writing_prefix_cache": 1} (or the typed
+# SamplingParams field) never inserts its blocks into the GPU prefix cache; lookups
+# are unaffected. Its blocks stay unhashed and recycle LIFO from the front of the free
+# queue, so a one-off batch lane no longer evicts other sessions' cached prefixes.
+# 0 = kill switch: a valid 1 becomes a logged no-op (malformed values are still
+# rejected with HTTP 400 at the API boundary). Exactly 0 or 1. Not in the JIT hash.
+GLM53_APC_NO_STORE=1
 # W23 mixed-prefill gate v2 (defaults shown; MAX_WAIT_MS=0 restores the v1 hold-forever gate).
 # Cached follow-ups whose uncached remainder is <= WARM_TOKENS skip the mixing hold entirely;
 # a cold prefill held while others decode proceeds after MAX_WAIT_MS at LATE_CAP tokens/step.

--- a/overlay/patch_apc_no_store.py
+++ b/overlay/patch_apc_no_store.py
@@ -1,0 +1,493 @@
+#!/usr/bin/env python3
+"""Per-request GPU prefix-cache "no-store" (``skip_writing_prefix_cache``).
+
+Recipe-overlay style: fail-closed, idempotent, transactional, MARK/anchor,
+matching overlay/patch_apc_per_group_retention.py. See
+docs/DESIGN-apc-no-store.md for the analysis and the receipts protocol.
+
+Problem (all line refs = the live fork, read-only):
+
+  vLLM has a READ-side opt-out (``SamplingParams.skip_reading_prefix_cache`` ->
+  ``Request.skip_reading_prefix_cache`` -> ``KVCacheManager.get_computed_blocks``)
+  but no WRITE-side one. ``cache_salt`` namespaces and still stores;
+  ``delay_cache_blocks`` (kv_cache_manager.py:552) is a one-step P/D defer.
+  ``BlockPool.free_blocks`` (block_pool.py:719-743) appends HASHED blocks to the
+  back of the free queue (LRU) and prepends UNHASHED ones (LIFO);
+  ``get_new_blocks`` pops from the front. A one-off batch/eval request's blocks
+  are therefore hashed, queue behind the owner's idle 80K conversation, and the
+  owner's blocks are what gets evicted next: the batch job re-orders the LRU in
+  its own favour. With a no-store flag its blocks carry no hash, go to the
+  FRONT, and are the very next ids recycled.
+
+Mechanism: suppress the HASH INSERTION, keep every piece of bookkeeping.
+
+  The two request-driven ``_insert_block_hash`` sites in block_pool.py --
+  ``cache_full_blocks`` (:293) and ``cache_partial_block`` (:508) -- return early
+  for a no-store request. NOT the obvious ``allocate_slots`` one-liner
+  (``if not self.enable_caching or delay_cache_blocks``): skipping
+  ``coordinator.cache_blocks`` skips ``SingleTypeKVCacheManager.cache_blocks``'
+  last line ``self.num_cached_block[request_id] = num_full_blocks``, and
+  membership in ``num_cached_block`` is the running-request sentinel read by
+  ``get_num_blocks_to_allocate`` (:196, fast path asserting no new computed
+  blocks) and ``KVCacheCoordinator.allocate_new_computed_blocks`` (:241). With
+  the block_pool placement ``num_cached_block`` advances identically for every
+  manager on every step; ``MambaManager._cache_partial_tail_block`` gets
+  ``None`` back so the request is never registered as a partial-tail PRODUCER
+  in ``_partial_hit_reqs`` (:1865, gated on ``partial_hash is not None``); the
+  READER-side partial-hit CoW (``add_local_computed_blocks`` :285-291) is
+  untouched; ``MambaManager.cache_blocks``' ``cached_blocks_this_step`` loop
+  already ``continue``s on ``block.block_hash is None`` (:1825). Every consumer
+  already tolerates an allocated full block without a hash: that is exactly
+  what the fork's sparse retention (``reachable_block_mask``) produces.
+  ``move_block_hashes`` is deliberately NOT guarded: it relocates hashes that
+  already exist and normal requests need it; for a no-store request the only
+  path into it (a running request with a registered partial hit) requires the
+  producer registration this overlay suppresses (test C3a/C3e).
+
+Semantics (write-only, GPU prefix cache only):
+  * lookups stay enabled: a no-store request may still read-hit, and reading
+    touches blocks (refreshes their LRU position). Combine with
+    ``skip_reading_prefix_cache`` for zero cache interaction.
+  * a no-store request that is preempted resumes from whatever it could READ
+    (nothing, if its prefix was cold) -- the --no-enable-prefix-caching resume
+    path; prefer it for short lanes, ideally with a low ``priority``.
+  * KV connectors / CPU offload are not touched (none active on this kit).
+
+Surface:
+  ``SamplingParams.skip_writing_prefix_cache: bool | None`` (typed) or
+  ``vllm_xargs: {"skip_writing_prefix_cache": 1}`` on /v1/chat/completions,
+  /v1/completions, /v1/responses (already forwarded to
+  ``SamplingParams.extra_args`` by the fork; zero entrypoint edits). Values are
+  STRICT -- bool, int 0/1, str "0"/"1" -- and validated in
+  ``SamplingParams.__post_init__`` (API-server side; a bad value is an HTTP 400
+  via the ValueError handler, never a silent no-op). ``vllm_xargs`` is typed
+  ``dict[str, str|int|float|list]``; pydantic v2 coerces JSON ``true``/``false``
+  to ``1``/``0`` there (verified, pydantic 2.13), which is exactly the intended
+  meaning, so booleans work too. ``Request`` is materialised in the engine-core input
+  thread, so its resolver never raises; an unparseable value there (unreachable
+  through the API) logs once and stores normally.
+
+Kill switch: ``GLM53_APC_NO_STORE`` exactly ``0`` or ``1`` (unset = 1). ``0``
+  = a valid ``1`` from the client is ignored (logged once); malformed values
+  are still rejected. Anything else fails closed at import (boot failure; the
+  launcher refuses it before the pair is stopped).
+
+Receipts in the server log (both ``logger.info_once``):
+  ``[glm53-apc-no-store] first request resolved skip_writing_prefix_cache=1``
+      the flag reached the engine (emitted at resolution, so a warm request
+      that never stores anything still leaves proof);
+  ``[glm53-apc-no-store] suppressing prefix-cache store (full site)`` /
+  ``(partial site)`` -- the store path was actually cut.
+
+Fail closed if any anchor drifts: every anchor in every file is checked
+BEFORE anything is written; a file that already carries the MARK must carry
+every generated snippet verbatim and still parse (else refuse); complete files
+are skipped; each write is a temp-file + os.replace (never a truncated target).
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+MARK = "# [glm53-apc-no-store]"
+NO_STORE_KEY = "skip_writing_prefix_cache"
+
+_VLLM = "/usr/local/lib/python3.12/dist-packages/vllm"
+SAMPLING_PARAMS_PY = Path(
+    os.environ.get("GLM53_SAMPLING_PARAMS_PY", f"{_VLLM}/sampling_params.py")
+)
+REQUEST_PY = Path(os.environ.get("GLM53_REQUEST_PY", f"{_VLLM}/v1/request.py"))
+BLOCK_POOL_PY = Path(
+    os.environ.get("GLM53_BLOCK_POOL_PY", f"{_VLLM}/v1/core/block_pool.py")
+)
+
+# ---------------------------------------------------------------- anchors ----
+
+# sampling_params.py ----------------------------------------------------------
+
+# 1. the read-side field (sampling_params.py:364): add its write-side sibling.
+SP_FIELD_OLD = "    skip_reading_prefix_cache: bool | None = None\n"
+SP_FIELD_NEW = '''    skip_reading_prefix_cache: bool | None = None
+    skip_writing_prefix_cache: bool | None = None  # [glm53-apc-no-store]
+    """If True, this request's KV blocks are never inserted into the GPU
+    prefix cache (overlay/patch_apc_no_store.py). Lookups are unaffected: the
+    request may still read-hit. Its blocks stay unhashed, so
+    ``BlockPool.free_blocks`` recycles them LIFO from the front of the free
+    queue instead of queueing them behind -- and thereby evicting -- other
+    sessions' cached blocks. For one-off batch lanes whose prefix will never be
+    reused. Also reachable as ``vllm_xargs: {"skip_writing_prefix_cache": 1}``
+    (``extra_args``); accepted values are bool, int 0/1 and str "0"/"1"
+    (pydantic coerces a JSON boolean in ``vllm_xargs`` to 1/0)."""
+'''
+
+# 2. module-level helpers, inserted before the SamplingParams class.
+SP_CLASS_ANCHOR = "\nclass SamplingParams(\n"
+SP_HELPERS = '''
+# [glm53-apc-no-store] helper-begin
+_GLM53_NO_STORE_KEY = "skip_writing_prefix_cache"
+_GLM53_NO_STORE_ENV = "GLM53_APC_NO_STORE"
+
+
+def _glm53_parse_no_store(value, where):  # [glm53-apc-no-store]
+    """Strict 0/1 parser for the per-request no-store flag.
+
+    Accepts bool, int 0/1 and str "0"/"1" -- nothing else. ``bool("0")`` is
+    True, floats are ambiguous, "yes"/"true" are not part of the contract, so
+    all of those raise ValueError (an HTTP 400 through the OpenAI server's
+    ValueError handler when raised from SamplingParams.__post_init__).
+    """
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int) and value in (0, 1):
+        return bool(value)
+    if isinstance(value, str) and value in ("0", "1"):
+        return value == "1"
+    raise ValueError(
+        f"{where} must be 0 or 1 (int), \\"0\\"/\\"1\\" (str) or a JSON boolean; "
+        f"got {value!r}."
+    )
+
+
+def _glm53_no_store_env():  # [glm53-apc-no-store]
+    """GLM53_APC_NO_STORE: unset -> enabled; exactly "0"/"1"; else fail closed."""
+    import os as _os
+
+    raw = _os.environ.get(_GLM53_NO_STORE_ENV)
+    if raw is None:
+        return True
+    if raw in ("0", "1"):
+        return raw == "1"
+    raise ValueError(
+        f"{_GLM53_NO_STORE_ENV} must be exactly 0 or 1 (got {raw!r}); "
+        "unset it to keep the per-request no-store flag honoured."
+    )
+
+
+_GLM53_NO_STORE_ENABLED = _glm53_no_store_env()
+
+
+def _glm53_validate_no_store_params(params):  # [glm53-apc-no-store]
+    """Reject a malformed flag where the request is still the client's.
+
+    Runs from ``SamplingParams.__post_init__`` -- i.e. in the API-server
+    process for /v1/chat/completions etc. (``to_sampling_params`` ->
+    ``from_optional``) and in the caller's process for the offline ``LLM``
+    API -- BEFORE the kill switch is consulted, so ``GLM53_APC_NO_STORE=0``
+    never turns a typo into a silent no-op. The typed field is normalised to
+    a bool; ``extra_args`` is left as sent.
+    """
+    typed = params.skip_writing_prefix_cache
+    if typed is not None:
+        params.skip_writing_prefix_cache = _glm53_parse_no_store(
+            typed, "SamplingParams.skip_writing_prefix_cache"
+        )
+    extra = params.extra_args
+    if extra and _GLM53_NO_STORE_KEY in extra:
+        _glm53_parse_no_store(
+            extra[_GLM53_NO_STORE_KEY], 'vllm_xargs["skip_writing_prefix_cache"]'
+        )
+
+
+def _glm53_resolve_no_store(sampling_params, request_id):  # [glm53-apc-no-store]
+    """Engine-side resolution: typed field first, then ``extra_args``.
+
+    Never raises: ``Request`` is materialised in the engine-core input thread
+    (``EngineCore.preprocess_add_request``), where an exception is not a
+    request-scoped error. A value that fails the strict parser here is
+    unreachable through the OpenAI API (``_glm53_validate_no_store_params``
+    already rejected it with a 400); if it happens anyway it is logged once and
+    the request stores normally. Malformed values are rejected BEFORE the kill
+    switch is applied; the switch only decides whether a valid 1 is honoured.
+    """
+    if sampling_params is None:
+        return False
+    raw = getattr(sampling_params, _GLM53_NO_STORE_KEY, None)
+    where = "SamplingParams.skip_writing_prefix_cache"
+    if raw is None:
+        extra = getattr(sampling_params, "extra_args", None)
+        if not extra or _GLM53_NO_STORE_KEY not in extra:
+            return False
+        raw = extra[_GLM53_NO_STORE_KEY]
+        where = 'vllm_xargs["skip_writing_prefix_cache"]'
+    try:
+        value = _glm53_parse_no_store(raw, where)
+    except ValueError as exc:
+        logger.warning(
+            "[glm53-apc-no-store] %s -- request %s stores normally "
+            "(this value should have been rejected at the API boundary)",
+            exc,
+            request_id,
+        )
+        return False
+    if not value:
+        return False
+    # ``*_once`` is keyed on (msg, args): keep the request id OUT of the args
+    # so these really are one line per process; the per-request id is a debug
+    # line.
+    if not _GLM53_NO_STORE_ENABLED:
+        logger.info_once(
+            "[glm53-apc-no-store] ignoring skip_writing_prefix_cache=1: "
+            "GLM53_APC_NO_STORE=0 (first occurrence; later ones not logged)"
+        )
+        logger.debug("[glm53-apc-no-store] ignored for request %s", request_id)
+        return False
+    logger.info_once(
+        "[glm53-apc-no-store] first request resolved skip_writing_prefix_cache=1 "
+        "(lookups unaffected, prefix-cache stores suppressed; later "
+        "occurrences not logged)"
+    )
+    logger.debug("[glm53-apc-no-store] request %s is no-store", request_id)
+    return True
+# [glm53-apc-no-store] helper-end
+
+'''
+
+# 3. the tail of SamplingParams.__post_init__ (:529-533): validate after the
+#    read-side auto-set so a bad value is a 400, not a silent no-op.
+SP_POST_OLD = (
+    "            self.skip_reading_prefix_cache = self.prompt_logprobs is not None\n"
+)
+SP_POST_NEW = (
+    "            self.skip_reading_prefix_cache = self.prompt_logprobs is not None\n"
+    "        _glm53_validate_no_store_params(self)  # [glm53-apc-no-store]\n"
+)
+
+# v1/request.py ---------------------------------------------------------------
+
+# 4. resolve the flag once, next to the read-side one (request.py:213).
+REQ_RESOLVE_OLD = (
+    "        self.skip_reading_prefix_cache = self.get_skip_reading_prefix_cache()\n"
+)
+REQ_RESOLVE_NEW = (
+    "        self.skip_reading_prefix_cache = self.get_skip_reading_prefix_cache()\n"
+    "        # [glm53-apc-no-store] write-side sibling; resolved once, never raises\n"
+    "        self.skip_writing_prefix_cache = self.get_skip_writing_prefix_cache()\n"
+)
+
+# 5. the resolver, after get_skip_reading_prefix_cache (request.py:294-305).
+REQ_METHOD_OLD = """        return False
+
+    def is_finished(self) -> bool:
+"""
+REQ_METHOD_NEW = '''        return False
+
+    def get_skip_writing_prefix_cache(self) -> bool:  # [glm53-apc-no-store]
+        """Whether this request's blocks must never enter the prefix cache.
+
+        Typed ``SamplingParams.skip_writing_prefix_cache`` first, then
+        ``SamplingParams.extra_args`` (the ``vllm_xargs`` route). Strict 0/1
+        values; the kill switch GLM53_APC_NO_STORE=0 makes a valid 1 a logged
+        no-op. Never raises (see _glm53_resolve_no_store). PoolingParams are
+        out of scope (chat/completions only).
+        """
+        from vllm.sampling_params import _glm53_resolve_no_store
+
+        return _glm53_resolve_no_store(self.sampling_params, self.request_id)
+
+    def is_finished(self) -> bool:
+'''
+
+# v1/core/block_pool.py -------------------------------------------------------
+
+# 6. proof-of-life helper above the class (module logger exists at :30).
+BP_CLASS_ANCHOR = "\nclass BlockPool:\n"
+BP_HELPER = '''
+def _glm53_log_nostore(request, site) -> None:  # [glm53-apc-no-store]
+    """Proof-of-life: log the first time a no-store request suppresses a store.
+
+    Pair with the resolution receipt logged by Request: that one proves the
+    flag reached the engine, this one proves the store path was cut. A warm
+    no-store request that has nothing new to store legitimately emits only
+    the first.
+    """
+    # ``info_once`` is keyed on (msg, args): the site is a bounded set (two
+    # values), the request id is deliberately not an arg.
+    logger.info_once(
+        "[glm53-apc-no-store] suppressing prefix-cache store (%s site); "
+        "lookups still enabled; later occurrences not logged",
+        site,
+    )
+    logger.debug(
+        "[glm53-apc-no-store] %s store suppressed for request %s",
+        site,
+        getattr(request, "request_id", "<unknown>"),
+    )
+
+'''
+
+# 7. cache_full_blocks (:259-261): the first request-driven _insert_block_hash
+#    site. Returning here also skips the BlockStored event: nothing was stored.
+BP_FULL_OLD = """        if num_cached_blocks >= num_full_blocks:
+            return
+        new_full_blocks = blocks[num_cached_blocks:num_full_blocks]
+"""
+BP_FULL_NEW = """        if num_cached_blocks >= num_full_blocks:
+            return
+        if getattr(request, "skip_writing_prefix_cache", False):  # [glm53-apc-no-store]
+            # No-store request: insert no hash, emit no BlockStored event.
+            # The caller (SingleTypeKVCacheManager.cache_blocks) still advances
+            # ``num_cached_block`` -- the running-request sentinel read at
+            # single_type_kv_cache_manager.py:196 and kv_cache_coordinator.py:241
+            # -- so allocation accounting is unchanged. These blocks keep
+            # ``block_hash is None`` and are recycled LIFO from the front of the
+            # free queue by ``free_blocks`` below, ahead of anything cached.
+            _glm53_log_nostore(request, "full")
+            return
+        new_full_blocks = blocks[num_cached_blocks:num_full_blocks]
+"""
+
+# 8. cache_partial_block (:484-487): the second site (fine-grained partial tail).
+#    Returning None also stops MambaManager._cache_partial_tail_block from
+#    registering this request as a partial-tail *producer* (:1865-1866).
+BP_PARTIAL_OLD = """        if block.is_null:
+            return None
+
+        assert block_size > self.hash_block_size
+"""
+BP_PARTIAL_NEW = """        if block.is_null:
+            return None
+        if getattr(request, "skip_writing_prefix_cache", False):  # [glm53-apc-no-store]
+            # No-store request: no partial entry. Returning None also stops
+            # MambaManager._cache_partial_tail_block from registering this
+            # request in ``_partial_hit_reqs`` as a partial-tail *producer*
+            # (single_type_kv_cache_manager.py:1865), which keeps
+            # get_num_blocks_to_allocate and allocate_new_blocks in agreement
+            # and keeps move_block_hashes unreachable for it. The *reader* side
+            # of the partial-hit CoW (add_local_computed_blocks:285-291) is
+            # untouched: lookups remain enabled for no-store requests.
+            _glm53_log_nostore(request, "partial")
+            return None
+
+        assert block_size > self.hash_block_size
+"""
+
+# (label, old, new) per file, applied in order. ``old`` must occur exactly once
+# in the pristine text; the helper anchors are re-inserted in front of their
+# anchor line.
+PLAN = {
+    "sampling_params.py": (
+        SAMPLING_PARAMS_PY,
+        (
+            ("sampling-field", SP_FIELD_OLD, SP_FIELD_NEW),
+            ("sampling-helpers", SP_CLASS_ANCHOR, SP_HELPERS + SP_CLASS_ANCHOR),
+            ("sampling-post-init", SP_POST_OLD, SP_POST_NEW),
+        ),
+        ("logger = init_logger(__name__)\n",),
+    ),
+    "request.py": (
+        REQUEST_PY,
+        (
+            ("request-resolve", REQ_RESOLVE_OLD, REQ_RESOLVE_NEW),
+            ("request-method", REQ_METHOD_OLD, REQ_METHOD_NEW),
+        ),
+        (),
+    ),
+    "block_pool.py": (
+        BLOCK_POOL_PY,
+        (
+            ("block-pool-helper", BP_CLASS_ANCHOR, BP_HELPER + BP_CLASS_ANCHOR),
+            ("block-pool-full", BP_FULL_OLD, BP_FULL_NEW),
+            ("block-pool-partial", BP_PARTIAL_OLD, BP_PARTIAL_NEW),
+        ),
+        ("logger = init_logger(__name__)\n",),
+    ),
+}
+
+
+def expected_marks(edits) -> int:
+    """How many MARK occurrences a completely patched file carries."""
+    return sum(new.count(MARK) - old.count(MARK) for _, old, new in edits)
+
+
+# ------------------------------------------------------------------ apply ----
+
+
+def _parses(text: str, path: Path) -> None:
+    try:
+        ast.parse(text, str(path))
+    except SyntaxError as exc:
+        raise SystemExit(f"{path}: does not parse: {exc}") from None
+
+
+def preflight(name: str, path: Path, edits, requires) -> str | None:
+    """Return the patched text, or None if the file is already complete.
+
+    Raises SystemExit on a missing file, a drifted anchor, or a file that
+    carries the MARK without every one of this overlay's generated snippets
+    (verbatim, exactly once) -- a partially applied, edited or truncated
+    target is refused rather than skipped as "already done".
+    """
+    if not path.is_file():
+        raise SystemExit(f"missing {path}")
+    text = path.read_text()
+    have = text.count(MARK)
+    want = expected_marks(edits)
+    if have:
+        missing = [label for label, _old, new in edits if text.count(new) != 1]
+        if have != want or missing:
+            raise SystemExit(
+                f"{path}: carries {have} '{MARK}' marker(s) (complete = {want}) "
+                f"and lacks the verbatim snippet(s) {missing}; refusing to patch "
+                "a partially modified file (restore the pristine file first)"
+            )
+        _parses(text, path)
+        return None
+    for needle in requires:
+        if text.count(needle) != 1:
+            raise SystemExit(f"{path}: prerequisite {needle.strip()!r} not unique")
+    for label, old, new in edits:
+        n = text.count(old)
+        if n != 1:
+            raise SystemExit(f"{path}: expected one {label} target, found {n}")
+        text = text.replace(old, new, 1)
+    if text.count(MARK) != want:
+        raise SystemExit(f"{path}: internal error, marker count after apply")
+    _parses(text, path)
+    return text
+
+
+def atomic_write(path: Path, text: str) -> None:
+    """Write via a sibling temp file + os.replace: the target is never left
+    truncated, even if this process dies mid-write."""
+    fd, tmp = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".glm53", dir=path.parent)
+    try:
+        with os.fdopen(fd, "w") as fh:
+            fh.write(text)
+        os.replace(tmp, path)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def main() -> int:
+    staged: dict[str, tuple[Path, str]] = {}
+    for name, (path, edits, requires) in PLAN.items():
+        patched = preflight(name, path, edits, requires)
+        if patched is None:
+            print(f"{path.name}: {MARK} already present - skipping")
+        else:
+            staged[name] = (path, patched)
+    # Every anchor in every file has been verified; only now write anything.
+    for name, (path, patched) in staged.items():
+        atomic_write(path, patched)
+        print(f"patched {path.name} ({name}: {expected_marks(PLAN[name][1])} marks)")
+    if staged:
+        print(
+            "patched no-store overlay (per-request GPU prefix-cache no-store via "
+            f"SamplingParams.{NO_STORE_KEY} / vllm_xargs; kill switch "
+            "GLM53_APC_NO_STORE)"
+        )
+    else:
+        print("no-store overlay: already applied, nothing to do")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/overlay/patch_kv_capacity_log.py
+++ b/overlay/patch_kv_capacity_log.py
@@ -1,0 +1,584 @@
+#!/usr/bin/env python3
+"""Honest KV-capacity boot log for the hybrid model (log-only overlay).
+
+The problem
+-----------
+``update_kv_cache_capacity`` (``v1/core/kv_cache_utils.py``) logs, once per
+boot::
+
+    GPU KV cache size: 1,553,140 tokens, Maximum concurrency for 1,000,000 tokens per request: 1.55x
+
+The first number is ``int(max_concurrency * max_model_len)`` where
+``max_concurrency = num_blocks / num_blocks_per_request`` and
+``num_blocks_per_request`` is a SUM OVER KV-CACHE GROUPS of
+``cdiv(spec.max_memory_usage_bytes(cfg), spec.page_size_bytes)``
+(``get_max_concurrency_for_kv_cache_config``). For a single-group model that
+is the pool's token capacity up to rounding, which is what the label suggests.
+For this hybrid model (MLA + kpool tail + 4 mamba + DFlash2 drafter SWA, one
+shared BlockPool with globally unique block ids) it is a concurrency figure in
+token units: neither ``num_blocks`` nor ``num_blocks_per_request`` is logged,
+``max_concurrency`` is printed to two decimals, and only their ratio can be
+recovered. On this kit the line read 1.5M tokens while the pool was 643 block
+ids (642 usable) and one cached 3584-token segment cost 38 of them
+(1 MLA + 4 mamba + 33 drafter) -- about 57K tokens of cached conversation with
+nothing running. Two reviewers independently read the line as a 1.5M-token
+prefix cache. Upstream feature request: vllm-project/vllm#54662.
+
+What this overlay does
+----------------------
+Immediately after the existing line (kept byte-identical) it logs, from the
+SAME config objects the existing line is computed from:
+
+* one line per KV-cache group: index, spec type, block_size, page size, blocks
+  per ``max_model_len`` request (the same ``cdiv`` expression as
+  ``get_max_concurrency_for_kv_cache_config``, so the two cannot drift), and
+  whether the group takes part in prefix caching;
+* one summary line: usable block ids (``num_blocks - 1``: ``BlockPool``
+  permanently holds back block id 0 as the null block), the ids one aligned
+  cached segment costs across groups (per group), and the resulting
+  cached-conversation capacity at that alignment.
+
+Log-only. No control flow, no allocation, no config mutation, runs once in the
+engine core at boot. Knob ``GLM53_KV_CAPACITY_LOG``: unset or ``1`` = log,
+``0`` = one line saying it is disabled, anything else = ``ValueError`` (a
+typo'd knob must not silently pick a mode; the launcher validates it on
+start/restart and the helper re-validates in-process).
+Any failure inside the derivation itself is a ``warning_once`` naming the
+exception, and boot proceeds: the feature is diagnostic and must never take
+the server down.
+
+What the summary models (and what it does not)
+----------------------------------------------
+"Ids per cached segment" is the DENSE-retention cost with block-aligned hits,
+i.e. what the managers' ``reachable_block_mask`` hashes when no retention
+interval is set and hits end on scheduler-block boundaries:
+
+* exactly ``FullAttentionSpec`` / ``MLAAttentionSpec``: every block is hashed
+  -> ``alignment / block_size`` ids (1 here);
+* exactly ``MambaSpec`` in ``align`` / ``all`` cache mode (read from the spec
+  the manager acts on): one state per block -> ``alignment / block_size`` ids
+  per group (1 each here);
+* exactly ``SlidingWindowSpec`` / ``SlidingWindowMLASpec``:
+  ``min(need, alignment / block_size)`` with
+  ``need = cdiv(window - 1, block_size) + (1 if EAGLE group)`` -- the
+  contiguous run a hit needs (``SlidingWindowManager._contiguous_blocks_for_hit``;
+  33 of 56 here);
+* groups that opt out of prefix caching (``KpoolTailSpec``): 0 -- a live block
+  per request, never a cached one.
+
+Alignment is the lcm of every group's block size, which is what the
+coordinator asserts its scheduler block size to be (3584 here) when no
+context parallelism rescales block sizes; under DCP/PCP > 1 the figure is
+withheld. Any other spec class -- subclasses included, because a subclass
+may come with its own manager and reservation rule (``SinkFullAttentionSpec``
+keeps permanent sink blocks; ``KpoolTailSpec`` is scratch) -- and mamba cache
+mode ``none`` / a mixed uniform group are reported as UNMODELLED and the
+capacity figure is withheld rather than guessed. Not modelled on purpose: the
+per-group retention overlay (#83) makes the drafter cost boundary tails only,
+and fine-grained hits (#84) change where a segment may end; both are decided
+later, in the coordinator, and the summary says which policy it assumes.
+
+EAGLE detection mirrors the coordinator exactly: ``group.is_eagle_group`` when
+any group carries it, else -- when ``speculative_config.use_eagle()`` -- the
+groups whose unwrapped spec is an exact ``SlidingWindowSpec``
+(``patch_hybrid_prefix_hit.py``'s ``_glm53_is_draft_swa_spec``), else every
+group (the upstream fallback).
+
+Conventions follow ``overlay/patch_indexer_workspace.py`` /
+``patch_kpool_tail_slotmap.py``: pinned ANCHOR, MARK sentinel,
+``verified_state``, ``prepare``, idempotent, atomic replace, pyc clear, drift
+=> nonzero exit. Both sites are preflighted before either is written. Must be
+applied AFTER ``patch_glm5_drafter_group.py`` (same file); it has no anchors
+in common with any other overlay.
+
+Usage::
+
+    python3 patch_kv_capacity_log.py              # apply
+    python3 patch_kv_capacity_log.py --preflight  # validate anchors only
+"""
+from __future__ import annotations
+
+import math
+import os
+import stat
+import sys
+from pathlib import Path
+
+
+TARGET = Path(
+    os.environ.get(
+        "GLM53_KV_CACHE_UTILS_PY",
+        "/usr/local/lib/python3.12/dist-packages/vllm/v1/core/kv_cache_utils.py",
+    )
+)
+
+ENV_NAME = "GLM53_KV_CAPACITY_LOG"
+TAG = "[glm53-kv-capacity-log]"
+
+
+# ---------------------------------------------------------------------------
+# The injected helpers, as source.
+#
+# This string is BOTH what gets written into kv_cache_utils.py AND what the
+# host tests exercise: it is exec'd below to produce module-level callables.
+# One implementation of the derivation, so a test can never pass against a
+# replica that has drifted from the shipped code. Inside kv_cache_utils.py the
+# names it relies on (``cdiv``, ``math``, ``os``, ``logger``) are all bound
+# above the insert point; ``prepare`` checks that.
+# ---------------------------------------------------------------------------
+HELPERS_SRC = '''# [glm53-kv-capacity-log] helpers -- log-only; see overlay/patch_kv_capacity_log.py
+_GLM53_KV_CAPACITY_ENV = "GLM53_KV_CAPACITY_LOG"
+_GLM53_KV_CAPACITY_TAG = "[glm53-kv-capacity-log]"
+
+
+def _glm53_kv_capacity_log_enabled() -> bool:
+    """Exactly "0" or "1"; an UNSET var means "1" (log).
+
+    Same contract as the launcher's start/restart validation: no strip,
+    no lower, "" is a value and not an absence. A typo'd knob raises rather
+    than silently choosing.
+    """
+    raw = os.environ.get(_GLM53_KV_CAPACITY_ENV)
+    if raw is None or raw == "1":
+        return True
+    if raw == "0":
+        return False
+    raise ValueError(
+        f"{_GLM53_KV_CAPACITY_ENV} must be exactly 0 or 1 (got: {raw!r})"
+    )
+
+
+def _glm53_inner_kv_spec(spec):
+    """Unwrap a UniformTypeKVCacheSpecs so the group's real spec class is named."""
+    specs = getattr(spec, "kv_cache_specs", None)
+    if isinstance(specs, dict) and specs:
+        return next(iter(specs.values()))
+    return spec
+
+
+def _glm53_spec_kind_names(spec) -> tuple:
+    return tuple(c.__name__ for c in type(spec).__mro__)
+
+
+def _glm53_spec_prefix_cacheable(spec) -> bool:
+    """Fork flag first, then upstream's, else True (legacy specs cache)."""
+    for name in ("participates_in_prefix_caching", "prefix_cacheable"):
+        value = getattr(spec, name, None)
+        if callable(value):
+            value = value()
+        if isinstance(value, bool):
+            return value
+    return True
+
+
+def _glm53_eagle_group_ids(vllm_config, kv_cache_config) -> set:
+    """Mirror of KVCacheCoordinator.__init__ (with patch_hybrid_prefix_hit.py).
+
+    ``is_eagle_group`` is authoritative when any group carries it. Otherwise,
+    when the speculative config is EAGLE-like, the exact-``SlidingWindowSpec``
+    groups are flagged (the DFlash2 drafter), else every group.
+    """
+    groups = list(kv_cache_config.kv_cache_groups)
+    ids = {i for i, g in enumerate(groups) if bool(getattr(g, "is_eagle_group", False))}
+    if ids:
+        return ids
+    spec_cfg = getattr(vllm_config, "speculative_config", None)
+    use_eagle = getattr(spec_cfg, "use_eagle", None) if spec_cfg is not None else None
+    if callable(use_eagle):
+        use_eagle = use_eagle()
+    if not use_eagle:
+        return set()
+    swa = {
+        i
+        for i, g in enumerate(groups)
+        if type(_glm53_inner_kv_spec(g.kv_cache_spec)).__name__ == "SlidingWindowSpec"
+    }
+    return swa or set(range(len(groups)))
+
+
+def _glm53_kv_capacity_rows(vllm_config, kv_cache_config) -> list:
+    """One dict per KV-cache group, from the same objects the stock line uses.
+
+    ``blocks_per_request`` is deliberately the same expression as the
+    comprehension in ``get_max_concurrency_for_kv_cache_config``: the sum of
+    this column IS that function's denominator.
+    """
+    eagle = _glm53_eagle_group_ids(vllm_config, kv_cache_config)
+    rows = []
+    for index, group in enumerate(kv_cache_config.kv_cache_groups):
+        spec = group.kv_cache_spec
+        inner = _glm53_inner_kv_spec(spec)
+        kinds = _glm53_spec_kind_names(inner)
+        row = {
+            "index": index,
+            "spec": kinds[0],
+            "kinds": kinds,
+            "layers": len(getattr(group, "layer_names", ()) or ()),
+            "block_size": int(spec.block_size),
+            "page_size_bytes": int(spec.page_size_bytes),
+            "blocks_per_request": cdiv(
+                spec.max_memory_usage_bytes(vllm_config),
+                spec.page_size_bytes,
+            ),
+            "prefix_cacheable": _glm53_spec_prefix_cacheable(spec),
+            "eagle": index in eagle,
+            "sliding_window": None,
+            "mamba_cache_mode": None,
+        }
+        if "SlidingWindowSpec" in kinds:
+            window = getattr(inner, "sliding_window", None)
+            row["sliding_window"] = int(window) if window is not None else None
+        if "MambaSpec" in kinds:
+            row["mamba_cache_mode"] = _glm53_mamba_cache_mode(spec)
+        rows.append(row)
+    return rows
+
+
+def _glm53_mamba_cache_mode(spec):
+    """The mode the managers act on: each resolved MambaSpec's own field
+    (set from cache_config at spec creation, but the spec is what the manager
+    reads). A uniform group whose members disagree is reported as "mixed" and
+    left unmodelled.
+    """
+    members = getattr(spec, "kv_cache_specs", None)
+    specs = list(members.values()) if isinstance(members, dict) and members else [spec]
+    modes = {getattr(s, "mamba_cache_mode", None) for s in specs}
+    if len(modes) != 1:
+        return "mixed"
+    return modes.pop()
+
+
+def _glm53_ids_per_segment(row: dict, alignment: int):
+    """Block ids one aligned cached segment costs in this group under DENSE
+    retention with block-aligned hits (what ``reachable_block_mask`` hashes
+    when no retention interval is set). ``None`` = not modelled: the summary
+    then withholds the capacity figure instead of guessing.
+    """
+    if not row["prefix_cacheable"]:
+        return 0
+    block_size = row["block_size"]
+    if block_size <= 0 or alignment % block_size:
+        return None
+    per_segment = alignment // block_size
+    # EXACT class names only. A subclass may come with its own manager and its
+    # own reservation rule (SinkFullAttentionSpec keeps permanent sink blocks,
+    # KpoolTailSpec is a scratch buffer, TQ/RSWA/HiddenState carry other
+    # semantics), so anything not listed is unmodelled, never costed by its
+    # base class.
+    kind = row["spec"]
+    if kind == "MambaSpec":
+        # align: one state snapshot per block position; all: every block.
+        return per_segment if row["mamba_cache_mode"] in ("align", "all") else None
+    if kind in ("SlidingWindowSpec", "SlidingWindowMLASpec"):
+        window = row["sliding_window"]
+        if not window:
+            return None
+        # SlidingWindowManager._contiguous_blocks_for_hit: the run a hit needs,
+        # +1 when the EAGLE last-block drop applies. reachable_block_mask
+        # caches every block once need >= per_segment.
+        need = cdiv(window - 1, block_size) + (1 if row["eagle"] else 0)
+        return min(need, per_segment)
+    if kind in ("FullAttentionSpec", "MLAAttentionSpec"):
+        # FullAttentionManager keeps the base reachable_block_mask (None):
+        # every block is hashed.
+        return per_segment
+    return None
+
+
+def _glm53_context_parallel_sizes(vllm_config) -> tuple:
+    pc = getattr(vllm_config, "parallel_config", None)
+    dcp = int(getattr(pc, "decode_context_parallel_size", 1) or 1)
+    pcp = int(getattr(pc, "prefill_context_parallel_size", 1) or 1)
+    return dcp, pcp
+
+
+def _glm53_kv_capacity_summary(rows: list, num_blocks: int, vllm_config=None) -> dict:
+    num_blocks = int(num_blocks)
+    usable = max(num_blocks - 1, 0)  # block id 0 is BlockPool's null block
+    blocks_per_request = sum(int(r["blocks_per_request"]) for r in rows)
+    # lcm of the raw group block sizes == the coordinator's scheduler block
+    # size when no context parallelism scales the per-rank block sizes.
+    alignment = 1
+    for r in rows:
+        alignment = math.lcm(alignment, max(int(r["block_size"]), 1))
+    per_group = [_glm53_ids_per_segment(r, alignment) for r in rows]
+    unmodelled = [r["index"] for r, v in zip(rows, per_group) if v is None]
+    withheld = None
+    dcp, pcp = _glm53_context_parallel_sizes(vllm_config) if vllm_config is not None else (1, 1)
+    if dcp > 1 or pcp > 1:
+        withheld = f"context parallelism (dcp={dcp}, pcp={pcp}) rescales block sizes; alignment not derived here"
+    total = sum(v for v in per_group if v)
+    capacity = None
+    segments = None
+    if rows and not unmodelled and withheld is None and total > 0:
+        segments = usable // total
+        capacity = segments * alignment
+    return {
+        "num_blocks": num_blocks,
+        "usable": usable,
+        "blocks_per_request": blocks_per_request,
+        "alignment": alignment,
+        "per_group": per_group,
+        "unmodelled": unmodelled,
+        "withheld": withheld,
+        "total": total,
+        "segments": segments,
+        "capacity_tokens": capacity,
+    }
+
+
+def _glm53_kv_capacity_lines(rows: list, summary: dict, max_model_len: int) -> list:
+    """Preformatted lines (info_once caches on its arguments: pass strings)."""
+    tag = _GLM53_KV_CAPACITY_TAG
+    lines = []
+    for r in rows:
+        extra = ""
+        if r["sliding_window"] is not None:
+            extra += f" window={r['sliding_window']} eagle={'yes' if r['eagle'] else 'no'}"
+        if r["mamba_cache_mode"] is not None:
+            extra += f" mamba_cache_mode={r['mamba_cache_mode']}"
+        cacheable = "yes" if r["prefix_cacheable"] else "no (scratch)"
+        lines.append(
+            f"{tag} group {r['index']}: {r['spec']} layers={r['layers']} "
+            f"block_size={r['block_size']} page_size={r['page_size_bytes']:,} B "
+            f"blocks/request@{int(max_model_len):,}={r['blocks_per_request']} "
+            f"prefix_caching={cacheable}{extra}"
+        )
+    bpr = summary["blocks_per_request"]
+    ratio = f"{summary['num_blocks'] / bpr:.2f}x" if bpr else "n/a"
+    head = (
+        f"{tag} usable block ids: {summary['usable']} "
+        f"(num_blocks={summary['num_blocks']} incl. the null block; "
+        f"{bpr} ids per {int(max_model_len):,}-token request => {ratio})"
+    )
+    if summary["capacity_tokens"] is None:
+        if summary["unmodelled"]:
+            why = "unmodelled: " + ", ".join(
+                f"group {r['index']} {r['spec']}" for r in rows if r["index"] in summary["unmodelled"]
+            )
+        elif summary.get("withheld"):
+            why = summary["withheld"]
+        else:
+            why = "no prefix-cacheable group costs ids"
+        lines.append(
+            f"{head}; ids per {summary['alignment']}-token cached segment across groups: "
+            f"not derived ({why}; per group: {summary['per_group']}); "
+            "cached-conversation capacity at this alignment: not derived"
+        )
+    else:
+        lines.append(
+            f"{head}; ids per {summary['alignment']}-token cached segment across groups: "
+            f"{summary['total']} (per group: {summary['per_group']}); "
+            f"cached-conversation capacity at this alignment ≈ {summary['capacity_tokens']:,} tokens "
+            f"= {summary['segments']} segments (aligned dense-retention prefix-cache upper bound: "
+            "nothing running, every reachable block hashed, block-aligned hits). "
+            "The 'GPU KV cache size' line above is max_concurrency x max_model_len, not this figure."
+        )
+    return lines
+
+
+def _glm53_log_kv_capacity(vllm_config, kv_cache_config, max_model_len) -> None:
+    """Called right after the stock 'GPU KV cache size' line. Log-only."""
+    # The knob is validated OUTSIDE the try: a malformed value must raise.
+    if not _glm53_kv_capacity_log_enabled():
+        logger.info_once(
+            f"{_GLM53_KV_CAPACITY_TAG} disabled ({_GLM53_KV_CAPACITY_ENV}=0)"
+        )
+        return
+    try:
+        rows = _glm53_kv_capacity_rows(vllm_config, kv_cache_config)
+        summary = _glm53_kv_capacity_summary(rows, kv_cache_config.num_blocks, vllm_config)
+        lines = _glm53_kv_capacity_lines(rows, summary, max_model_len)
+    except Exception as exc:  # diagnostic only: never take the server down
+        logger.warning_once(
+            f"{_GLM53_KV_CAPACITY_TAG} could not derive the block-level KV "
+            f"capacity (log-only; serving unaffected): {type(exc).__name__}: {exc}"
+        )
+        return
+    for line in lines:
+        logger.info_once(line)
+
+
+'''
+
+
+class _RecordingLogger:
+    """Host stand-in for vLLM's logger: keeps what would have been logged."""
+
+    def __init__(self) -> None:
+        self.info: list[str] = []
+        self.warnings: list[str] = []
+
+    def info_once(self, msg, *args, **kwargs) -> None:
+        self.info.append(msg % args if args else msg)
+
+    def warning_once(self, msg, *args, **kwargs) -> None:
+        self.warnings.append(msg % args if args else msg)
+
+
+def cdiv(a: int, b: int) -> int:
+    return -(-a // b)
+
+
+def load_helpers(logger: _RecordingLogger | None = None) -> dict:
+    """Exec HELPERS_SRC into a fresh namespace (what the tests drive)."""
+    ns: dict = {"os": os, "math": math, "cdiv": cdiv, "logger": logger or _RecordingLogger()}
+    exec(compile(HELPERS_SRC, "<glm53-kv-capacity-log helpers>", "exec"), ns)
+    return ns
+
+
+_HELPERS = load_helpers()
+kv_capacity_log_enabled = _HELPERS["_glm53_kv_capacity_log_enabled"]
+inner_kv_spec = _HELPERS["_glm53_inner_kv_spec"]
+spec_prefix_cacheable = _HELPERS["_glm53_spec_prefix_cacheable"]
+eagle_group_ids = _HELPERS["_glm53_eagle_group_ids"]
+kv_capacity_rows = _HELPERS["_glm53_kv_capacity_rows"]
+ids_per_segment = _HELPERS["_glm53_ids_per_segment"]
+kv_capacity_summary = _HELPERS["_glm53_kv_capacity_summary"]
+kv_capacity_lines = _HELPERS["_glm53_kv_capacity_lines"]
+
+
+# ---------------------------------------------------------------------------
+# Site 1 -- helpers, inserted above the function whose denominator they mirror
+# ---------------------------------------------------------------------------
+MARK_HELPERS = "# [glm53-kv-capacity-log] helpers -- log-only; see overlay/patch_kv_capacity_log.py\n"
+
+ANCHOR_HELPERS = """def get_max_concurrency_for_kv_cache_config(
+    vllm_config: VllmConfig, kv_cache_config: KVCacheConfig
+) -> float:
+"""
+
+PATCHED_HELPERS = HELPERS_SRC + ANCHOR_HELPERS
+
+
+# ---------------------------------------------------------------------------
+# Site 2 -- the call, appended after the stock line (which stays byte-identical)
+# ---------------------------------------------------------------------------
+MARK_CALL = "    _glm53_log_kv_capacity(vllm_config, kv_cache_config, max_model_len)  # [glm53-kv-capacity-log]\n"
+
+ANCHOR_CALL = """    logger.info_once(
+        "GPU KV cache size: %s tokens, "
+        "Maximum concurrency for %s tokens per request: %.2fx",
+        f"{num_tokens:,}",
+        f"{max_model_len:,}",
+        max_concurrency,
+    )
+"""
+
+PATCHED_CALL = ANCHOR_CALL + MARK_CALL
+
+
+SITES = (
+    ("capacity helpers", MARK_HELPERS, ANCHOR_HELPERS, PATCHED_HELPERS),
+    ("capacity log call", MARK_CALL, ANCHOR_CALL, PATCHED_CALL),
+)
+
+# Names the injected helpers rely on; each must be bound above the insert point.
+REQUIRED_BINDINGS = (
+    "from vllm.utils.math_utils import cdiv",
+    "import math\n",
+    "import os\n",
+    "logger = init_logger(__name__)\n",
+)
+
+
+def verified_state(text: str) -> bool:
+    """Exact post-state check.
+
+    Both replacements keep their anchor (they are insertions), so expect exactly
+    as many surviving anchors as the replacement itself contains, one mark per
+    site, and the helper block above the function it mirrors.
+    """
+    ok = all(
+        text.count(mark) == 1
+        and text.count(patched) == 1
+        and text.count(anchor) == patched.count(anchor)
+        for _name, mark, anchor, patched in SITES
+    )
+    return ok and text.index(MARK_HELPERS) < text.index(ANCHOR_HELPERS) < text.index(MARK_CALL)
+
+
+def prepare(source: str) -> tuple[str, str]:
+    """Idempotent, fail-closed. Returns ``(text, action)``. Nothing is written here."""
+    marks = sum(source.count(mark) for _n, mark, _a, _p in SITES)
+    if marks:
+        if marks != len(SITES) or not verified_state(source):
+            raise ValueError(
+                "partial/inconsistent kv-capacity-log patch "
+                f"(marks={marks}, expected {len(SITES)}) -- refusing to touch "
+                "a half-patched file"
+            )
+        return source, "already present"
+
+    for binding in REQUIRED_BINDINGS:
+        head = source[: source.find(ANCHOR_HELPERS)] if ANCHOR_HELPERS in source else source
+        if binding not in head:
+            raise ValueError(
+                f"kv_cache_utils.py does not bind {binding.strip()!r} above the "
+                "insert point; the injected helpers would NameError"
+            )
+
+    out = source
+    for name, _mark, anchor, patched in SITES:
+        n = out.count(anchor)
+        if n != 1:
+            raise ValueError(
+                f"pinned kv-capacity-log anchor '{name}' drifted (found {n}, expected 1)"
+            )
+    for name, _mark, anchor, patched in SITES:
+        out = out.replace(anchor, patched, 1)
+
+    if not verified_state(out):
+        raise ValueError("kv-capacity-log post-patch verification failed")
+    return out, "patched"
+
+
+def replace_file(target: Path, source: str) -> None:
+    tmp = target.with_name(f".{target.name}.glm53-kv-capacity-log.tmp")
+    try:
+        tmp.write_text(source)
+        os.chmod(tmp, stat.S_IMODE(target.stat().st_mode))
+        os.replace(tmp, target)
+    finally:
+        if tmp.exists():
+            tmp.unlink()
+
+
+def clear_pyc(target: Path) -> None:
+    cache = target.parent / "__pycache__"
+    if not cache.is_dir():
+        return
+    for pyc in cache.glob(f"{target.stem}*.pyc"):
+        pyc.unlink(missing_ok=True)
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = sys.argv if argv is None else argv
+    preflight_only = "--preflight" in argv[1:]
+
+    if not TARGET.is_file():
+        raise SystemExit(f"missing {TARGET}")
+    source = TARGET.read_text()
+    try:
+        patched, action = prepare(source)
+    except ValueError as exc:
+        raise SystemExit(f"kv-capacity-log preflight failed: {exc}") from exc
+    compile(patched, str(TARGET), "exec")
+
+    if preflight_only:
+        print(f"{TARGET.name}: kv-capacity-log preflight OK ({action})")
+        return 0
+
+    if patched != source:
+        replace_file(TARGET, patched)
+        clear_pyc(TARGET)
+    # Report the value as set, not as normalised: at image build time the knob
+    # is usually unset, and printing "1" for an explicitly empty value would
+    # hide the error the runtime will raise.
+    mode = os.environ.get(ENV_NAME, "1 (unset)")
+    print(f"{TARGET.name}: kv-capacity-log {action} ({ENV_NAME}={mode!r})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/start.sh
+++ b/start.sh
@@ -76,6 +76,14 @@ _cli_wait="${GLM53_MIXED_PREFILL_MAX_WAIT_MS-}"
 _cli_late="${GLM53_MIXED_PREFILL_LATE_CAP-}"
 _cli_esc="${GLM53_MIXED_PREFILL_ESCALATE_MS-}"  # LOCAL: W26
 _cli_latemax="${GLM53_MIXED_PREFILL_LATE_CAP_MAX-}"  # LOCAL: W26
+# LOCAL: W41/W42 caller-wins capture (begin) -- setness-aware: a caller-provided
+# value (even explicitly EMPTY, which is a value the validator must see) wins
+# over .env. ${VAR+a} is non-empty iff the variable was set at entry.
+_glm53_cli_kvlog_set="${GLM53_KV_CAPACITY_LOG+a}"
+_glm53_cli_kvlog_val="${GLM53_KV_CAPACITY_LOG-}"
+_glm53_cli_apcns_set="${GLM53_APC_NO_STORE+a}"
+_glm53_cli_apcns_val="${GLM53_APC_NO_STORE-}"
+# LOCAL: W41/W42 caller-wins capture (end)
 set -a
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/.env"
@@ -100,6 +108,10 @@ set +a
 [ -n "${_cli_util}" ] && GPU_MEM_UTIL="$_cli_util"
 [ -n "${_cli_lm}" ] && LANGUAGE_MODEL_ONLY="$_cli_lm"
 [ -n "${_cli_max_num_seqs}" ] && MAX_NUM_SEQS="$_cli_max_num_seqs"
+# LOCAL: W41/W42 caller-wins restore (begin)
+[ -n "${_glm53_cli_kvlog_set}" ] && GLM53_KV_CAPACITY_LOG="$_glm53_cli_kvlog_val"
+[ -n "${_glm53_cli_apcns_set}" ] && GLM53_APC_NO_STORE="$_glm53_cli_apcns_val"
+# LOCAL: W41/W42 caller-wins restore (end)
 
 # ----------------------------- configuration -------------------------------
 MODEL="${MODEL:-Mia-AiLab/GLM-5.3-Flash-EXL3-TR3-4bpw}"
@@ -209,6 +221,9 @@ SPINWAIT_PATCH_HOST="${SPINWAIT_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_spinwait_g
 FGAPC_PATCH_HOST="${FGAPC_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_fine_grained_apc.py}"
 # LOCAL: align-floor -- stop the mamba align split zeroing a sub-block chunk when LPTT >= block_size
 ALIGN_FLOOR_PATCH_HOST="${ALIGN_FLOOR_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_align_floor.py}"
+# LOCAL: W41 (kit PR #94) block-level KV capacity boot log, log-only; W42 (kit PR #95) per-request APC no-store
+KV_CAPACITY_LOG_PATCH_HOST="${KV_CAPACITY_LOG_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_kv_capacity_log.py}"
+APC_NO_STORE_PATCH_HOST="${APC_NO_STORE_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_apc_no_store.py}"
 KV_CACHE_DTYPE="${KV_CACHE_DTYPE:-fp8}"
 QUANTIZATION="${QUANTIZATION:-exl3}"
 LANGUAGE_MODEL_ONLY="${LANGUAGE_MODEL_ONLY:-0}"
@@ -282,6 +297,13 @@ GLM53_FINE_GRAINED_APC="${GLM53_FINE_GRAINED_APC:-0}"
 # LOCAL: 1 = floor a sub-block mixed-prefill chunk at the mixed cap instead of 0 when LPTT >= block_size
 # (scheduler livelock, dormant at LPTT=1792 — proven 0 mismatches over 608 combinations). Read once at import.
 GLM53_ALIGN_FLOOR="${GLM53_ALIGN_FLOOR:-1}"
+# LOCAL: W41/W42 knob defaults (begin) -- exactly 0 or 1; UNSET -> 1; "" is a
+# value and is rejected. Strict validation lives in validate_numeric_config
+# (start/restart only), so a bad value can never block stop/status/logs on a
+# running pair; the overlays re-validate in-process and fail closed at boot.
+GLM53_KV_CAPACITY_LOG="${GLM53_KV_CAPACITY_LOG-1}"
+GLM53_APC_NO_STORE="${GLM53_APC_NO_STORE-1}"
+# LOCAL: W41/W42 knob defaults (end)
 # EngineCore stock timeout is 300s; mid-serve Triton/TileLang JIT on TP=2 can
 # exceed that without being a true hang. NCCL watchdog is still 600s.
 VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS="${VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS:-1800}"
@@ -368,6 +390,15 @@ validate_numeric_config() {
         ""|low|high|max) ;;
         *) echo "GLM53_DEFAULT_REASONING_EFFORT must be one of: low high max (got: ${GLM53_DEFAULT_REASONING_EFFORT})" >&2; return 2 ;;
     esac
+    # LOCAL: W41/W42 strict-bool validation (begin) -- exactly 0 or 1; "" is a
+    # value and is rejected. Lives in validate_numeric_config (start/restart
+    # only): a bad value fails the boot, never stop/status/logs on a running
+    # pair; the overlays re-validate in-process and fail closed.
+    for _v in GLM53_KV_CAPACITY_LOG GLM53_APC_NO_STORE; do
+        case "${!_v}" in 0|1) ;; *) echo "$_v must be exactly 0 or 1 (got: '${!_v}')" >&2; return 2 ;; esac
+    done
+    unset _v
+    # LOCAL: W41/W42 strict-bool validation (end)
     # LOCAL: DEFAULT_MAX_NEW_TOKENS is spliced into generated shell + JSON; empty = off.
     if [ -n "${DEFAULT_MAX_NEW_TOKENS:-}" ]; then
         _glm53_canonical_positive_int DEFAULT_MAX_NEW_TOKENS "$DEFAULT_MAX_NEW_TOKENS" 1000000 || return
@@ -560,6 +591,8 @@ preflight() {
     [ -f "$SPINWAIT_PATCH_HOST" ] || die "$SPINWAIT_PATCH_HOST missing"  # LOCAL: W17
     [ -f "$FGAPC_PATCH_HOST" ] || die "$FGAPC_PATCH_HOST missing"  # LOCAL: W18
     [ -f "$ALIGN_FLOOR_PATCH_HOST" ] || die "$ALIGN_FLOOR_PATCH_HOST missing"  # LOCAL: align-floor
+    [ -f "$KV_CAPACITY_LOG_PATCH_HOST" ] || die "$KV_CAPACITY_LOG_PATCH_HOST missing"  # LOCAL: W41
+    [ -f "$APC_NO_STORE_PATCH_HOST" ] || die "$APC_NO_STORE_PATCH_HOST missing"  # LOCAL: W42
 
     local need_kb=$((180 * 1024 * 1024)) avail
     mkdir -p "$HF_CACHE_DIR"
@@ -1070,6 +1103,12 @@ fi
 if [ -f /opt/glm53/patch_align_floor.py ]; then
     python3 /opt/glm53/patch_align_floor.py
 fi
+if [ -f /opt/glm53/patch_kv_capacity_log.py ]; then  # LOCAL: W41 (after patch_hybrid_prefix_hit.py)
+    python3 /opt/glm53/patch_kv_capacity_log.py
+fi
+if [ -f /opt/glm53/patch_apc_no_store.py ]; then  # LOCAL: W42
+    python3 /opt/glm53/patch_apc_no_store.py
+fi
 say "launching: vllm serve ${MODEL_DIR} ${ARGS[*]}"
 exec vllm serve "${MODEL_DIR}" "${ARGS[@]}"
 EOF
@@ -1188,6 +1227,12 @@ fi
 if [ -f /opt/glm53/patch_align_floor.py ]; then
     python3 /opt/glm53/patch_align_floor.py
 fi
+if [ -f /opt/glm53/patch_kv_capacity_log.py ]; then  # LOCAL: W41 (after patch_hybrid_prefix_hit.py)
+    python3 /opt/glm53/patch_kv_capacity_log.py
+fi
+if [ -f /opt/glm53/patch_apc_no_store.py ]; then  # LOCAL: W42
+    python3 /opt/glm53/patch_apc_no_store.py
+fi
 say "joining TP2 at ${HEAD_IP}:${MASTER_PORT} as rank 1"
 exec vllm serve "${MODEL_DIR}" "${ARGS[@]}"
 EOF
@@ -1230,6 +1275,10 @@ launch_cluster() {
     scp -q -o BatchMode=yes "$FGAPC_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_fine_grained_apc.py"
     [ -f "$ALIGN_FLOOR_PATCH_HOST" ] || die "missing $ALIGN_FLOOR_PATCH_HOST"
     scp -q -o BatchMode=yes "$ALIGN_FLOOR_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_align_floor.py"
+    [ -f "$KV_CAPACITY_LOG_PATCH_HOST" ] || die "missing $KV_CAPACITY_LOG_PATCH_HOST"  # LOCAL: W41
+    scp -q -o BatchMode=yes "$KV_CAPACITY_LOG_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_kv_capacity_log.py"
+    [ -f "$APC_NO_STORE_PATCH_HOST" ] || die "missing $APC_NO_STORE_PATCH_HOST"  # LOCAL: W42
+    scp -q -o BatchMode=yes "$APC_NO_STORE_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_apc_no_store.py"
 
 
     local -a nccl_common=(
@@ -1263,6 +1312,8 @@ launch_cluster() {
         # dev routes when 1. Patched file is inert when 0/unset.
         -e "GLM53_EXPOSE_CACHE_RESET=$GLM53_EXPOSE_CACHE_RESET"
         -e "GLM53_ALIGN_FLOOR=$GLM53_ALIGN_FLOOR"
+        -e "GLM53_KV_CAPACITY_LOG=$GLM53_KV_CAPACITY_LOG"  # LOCAL: W41
+        -e "GLM53_APC_NO_STORE=$GLM53_APC_NO_STORE"  # LOCAL: W42
         # LOCAL: W9 ablation — 0 restores stock router-GEMM eligibility exactly
         -e "GLM53_ROUTER_GEMM_CUBLAS=${GLM53_ROUTER_GEMM_CUBLAS:-1}"
         # LOCAL: W17/W18 opt-in overlays (both ranks read these at patch time)
@@ -1366,6 +1417,8 @@ launch_cluster() {
         -v '/tmp/patch_spinwait_gb10.py:/opt/glm53/patch_spinwait_gb10.py:ro' \
         -v '/tmp/patch_fine_grained_apc.py:/opt/glm53/patch_fine_grained_apc.py:ro' \
         -v '/tmp/patch_align_floor.py:/opt/glm53/patch_align_floor.py:ro' \
+        -v '/tmp/patch_kv_capacity_log.py:/opt/glm53/patch_kv_capacity_log.py:ro' \
+        -v '/tmp/patch_apc_no_store.py:/opt/glm53/patch_apc_no_store.py:ro' \
         ${worker_preload} \
         ${worker_nccl} \
         -e NCCL_SOCKET_IFNAME='$WORKER_CX7_IF' \
@@ -1400,6 +1453,8 @@ launch_cluster() {
         -v "$SPINWAIT_PATCH_HOST:/opt/glm53/patch_spinwait_gb10.py:ro" \
         -v "$FGAPC_PATCH_HOST:/opt/glm53/patch_fine_grained_apc.py:ro" \
         -v "$ALIGN_FLOOR_PATCH_HOST:/opt/glm53/patch_align_floor.py:ro" \
+        -v "$KV_CAPACITY_LOG_PATCH_HOST:/opt/glm53/patch_kv_capacity_log.py:ro" \
+        -v "$APC_NO_STORE_PATCH_HOST:/opt/glm53/patch_apc_no_store.py:ro" \
         "${head_preload[@]}" \
         "${nccl_common[@]}" \
         -e NCCL_SOCKET_IFNAME="$HEAD_CX7_IF" \

--- a/tests/test_apc_no_store.py
+++ b/tests/test_apc_no_store.py
@@ -1,0 +1,1023 @@
+#!/usr/bin/env python3
+"""Host test for overlay/patch_apc_no_store.py (no GPU).
+
+Part A  patch mechanics on COPIES of the three target files: anchors land,
+        the result parses, byte-identical idempotent re-apply, every anchor
+        individually drifted -> non-zero exit AND no file written
+        (transactional), a partially-marked file is refused, the off-limits
+        files (kv_cache_manager / kv_cache_coordinator / single_type managers)
+        are not targets, both guards precede their ``_insert_block_hash`` call,
+        ``move_block_hashes`` is unguarded.
+Part B  resolver semantics: the injected helper block is exec'd in a bare
+        namespace with a capturing logger and driven over the full
+        accept/reject matrix, the typed > extra_args precedence, and the
+        GLM53_APC_NO_STORE kill-switch matrix (parse/reject happens BEFORE the
+        switch).
+Part C  behaviour on a real vLLM (CPU is enough): patched COPIES of the three
+        files are injected into ``sys.modules`` before ``vllm.v1.core`` is
+        imported, so real ``BlockPool`` / ``KVCacheManager`` /
+        ``HybridKVCacheCoordinator`` / managers run on top of the patched code.
+        Skipped with a loud line when ``import vllm`` fails; set
+        ``GLM53_REQUIRE_VLLM=1`` to make that a failure (the Dockerfile does).
+Part D  launcher: the "GLM53 numeric config guard" block of start.sh accepts
+        GLM53_APC_NO_STORE only as exactly 0 or 1 (unset -> 1).
+
+Sources: ``GLM53_VLLM_SRC_ROOT`` = a vLLM package directory holding
+``sampling_params.py``, ``v1/request.py``, ``v1/core/block_pool.py`` (default:
+the in-image path). Files that already carry the overlay MARK are accepted
+(Part A's apply/drift legs then run on the vendored anchor-context replicas
+below; Part C injects them as they are). With no source at all, Part A runs on
+the replicas only and Part C is skipped.
+
+Run:  python3 tests/test_apc_no_store.py
+      GLM53_VLLM_SRC_ROOT=/path/to/vllm python3 tests/test_apc_no_store.py
+      (Part C on the Mac: PYTHONPATH=<upstream clone> <cpu venv python> ...)
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+PATCH = next(
+    (
+        p
+        for p in (HERE / "patch_apc_no_store.py", HERE.parent / "overlay" / "patch_apc_no_store.py")
+        if p.is_file()
+    ),
+    None,
+)
+START = HERE.parent / "start.sh"
+DEFAULT_SRC_ROOT = Path("/usr/local/lib/python3.12/dist-packages/vllm")
+MARK = "# [glm53-apc-no-store]"
+REL = {
+    "GLM53_SAMPLING_PARAMS_PY": "sampling_params.py",
+    "GLM53_REQUEST_PY": "v1/request.py",
+    "GLM53_BLOCK_POOL_PY": "v1/core/block_pool.py",
+}
+FAILURES: list[str] = []
+CHECKS = 0
+
+
+def check(cond: bool, label: str) -> None:
+    global CHECKS
+    CHECKS += 1
+    print(("  ok   " if cond else "  FAIL ") + label)
+    if not cond:
+        FAILURES.append(label)
+
+
+def load_patcher():
+    spec = importlib.util.spec_from_file_location("glm53_patch_apc_no_store", PATCH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# ------------------------------------------------------------- replicas -----
+# Vendored anchor context: the exact lines the overlay anchors on, embedded in
+# enough surrounding code to parse. Used when no pristine source is available
+# (or the available one is already patched) so Parts A/B run anywhere.
+
+REPLICA_SAMPLING = '''# replica of vllm/sampling_params.py (anchor context only)
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+
+class SamplingParams(
+    object,
+):
+    """replica"""
+
+    n: int = 1
+    extra_args: dict | None = None
+    prompt_logprobs: int | None = None
+    skip_reading_prefix_cache: bool | None = None
+    thinking_token_budget: int | None = None
+
+    def __post_init__(self) -> None:
+        self._verify_args()
+
+        if self.skip_reading_prefix_cache is None:
+            # If prefix caching is enabled,
+            # the output of prompt logprobs may less than n_prompt_tokens,
+            # we need to skip reading cache at this request.
+            self.skip_reading_prefix_cache = self.prompt_logprobs is not None
+
+    def _verify_args(self) -> None:
+        pass
+'''
+
+REPLICA_REQUEST = '''# replica of vllm/v1/request.py (anchor context only)
+from vllm.sampling_params import SamplingParams
+
+
+class Request:
+    def __init__(self, request_id, sampling_params=None, pooling_params=None):
+        self.request_id = request_id
+        self.sampling_params = sampling_params
+        self.pooling_params = pooling_params
+        self.status = None
+
+        self.skip_reading_prefix_cache = self.get_skip_reading_prefix_cache()
+
+    def get_skip_reading_prefix_cache(self) -> bool:
+        if (
+            self.sampling_params is not None
+            and self.sampling_params.skip_reading_prefix_cache is not None
+        ):
+            return self.sampling_params.skip_reading_prefix_cache
+        elif (
+            self.pooling_params is not None
+            and self.pooling_params.skip_reading_prefix_cache is not None
+        ):
+            return self.pooling_params.skip_reading_prefix_cache
+        return False
+
+    def is_finished(self) -> bool:
+        return False
+'''
+
+REPLICA_BLOCK_POOL = '''# replica of vllm/v1/core/block_pool.py (anchor context only)
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+
+class BlockPool:
+    def __init__(self, hash_block_size):
+        self.hash_block_size = hash_block_size
+        self.enable_kv_cache_events = False
+
+    def cache_full_blocks(
+        self,
+        request,
+        blocks,
+        num_cached_blocks,
+        num_full_blocks,
+        block_size,
+        kv_cache_group_id,
+        block_mask=None,
+    ) -> None:
+        if num_cached_blocks >= num_full_blocks:
+            return
+        new_full_blocks = blocks[num_cached_blocks:num_full_blocks]
+        for i, blk in enumerate(new_full_blocks):
+            self._insert_block_hash(
+                (kv_cache_group_id, i),
+                blk,
+                num_tokens=(num_cached_blocks + i + 1) * block_size,
+            )
+
+    def cache_partial_block(
+        self,
+        request,
+        block,
+        num_tokens,
+        kv_cache_group_id,
+        block_size,
+    ):
+        if block.is_null:
+            return None
+
+        assert block_size > self.hash_block_size
+        block_hash_with_group_id = (kv_cache_group_id, num_tokens)
+        self._insert_block_hash(
+            block_hash_with_group_id,
+            block,
+            num_tokens=num_tokens,
+        )
+        return block_hash_with_group_id
+
+    def _insert_block_hash(self, block_hash_with_group_id, block, num_tokens):
+        block.block_hash = block_hash_with_group_id
+
+    def move_block_hashes(self, src_block, dst_block) -> None:
+        assert dst_block.block_hash is None
+        for block_hash in [src_block.block_hash]:
+            self._insert_block_hash(block_hash, dst_block, num_tokens=None)
+'''
+
+REPLICAS = {
+    "GLM53_SAMPLING_PARAMS_PY": REPLICA_SAMPLING,
+    "GLM53_REQUEST_PY": REPLICA_REQUEST,
+    "GLM53_BLOCK_POOL_PY": REPLICA_BLOCK_POOL,
+}
+
+
+def source_root() -> Path | None:
+    raw = os.environ.get("GLM53_VLLM_SRC_ROOT", "").strip()
+    root = Path(raw) if raw else DEFAULT_SRC_ROOT
+    if all((root / rel).is_file() for rel in REL.values()):
+        return root
+    if raw:
+        raise SystemExit(f"GLM53_VLLM_SRC_ROOT={root} lacks one of {sorted(REL.values())}")
+    return None
+
+
+def stage(into: Path, root: Path | None, pristine_only: bool) -> dict[str, Path]:
+    """Copy the three targets (real sources, or replicas) into ``into``."""
+    staged = {}
+    for env, rel in REL.items():
+        dst = into / Path(rel).name
+        src = (root / rel) if root else None
+        if src is not None and (not pristine_only or MARK not in src.read_text()):
+            shutil.copyfile(src, dst)
+        else:
+            dst.write_text(REPLICAS[env])
+        staged[env] = dst
+    return staged
+
+
+def run_patcher(staged: dict[str, Path]) -> subprocess.CompletedProcess[str]:
+    env = {k: v for k, v in os.environ.items() if not k.startswith("GLM53_")}
+    env.update({k: str(v) for k, v in staged.items()})
+    return subprocess.run([sys.executable, str(PATCH)], env=env, capture_output=True, text=True)
+
+
+def func_src(text: str, name: str) -> str:
+    for node in ast.walk(ast.parse(text)):
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            return ast.get_source_segment(text, node) or ""
+    return ""
+
+
+# ---------------------------------------------------------------- part A ----
+
+
+def part_a(root: Path | None) -> None:
+    print("Part A: patch mechanics")
+    patcher = load_patcher()
+    with tempfile.TemporaryDirectory() as raw:
+        tmp = Path(raw)
+        staged = stage(tmp, root, pristine_only=True)
+        using_real = root is not None and all(MARK not in (root / r).read_text() for r in REL.values())
+        print(f"  sources: {'pristine ' + str(root) if using_real else 'vendored replicas'}")
+        for p in staged.values():
+            check(MARK not in p.read_text(), f"A0 {p.name} starts pristine")
+        pristine = {k: p.read_text() for k, p in staged.items()}
+
+        r = run_patcher(staged)
+        check(r.returncode == 0, f"A1 first application exits 0 ({r.stdout.strip().splitlines()[-1] if r.stdout.strip() else r.stderr.strip()[:120]})")
+        texts = {k: p.read_text() for k, p in staged.items()}
+        for k, p in staged.items():
+            want = patcher.expected_marks(patcher.PLAN[p.name][1])
+            check(texts[k].count(MARK) == want, f"A1 {p.name} carries exactly {want} marks")
+            try:
+                ast.parse(texts[k])
+                ok = True
+            except SyntaxError as exc:
+                ok = False
+                print(f"       {exc}")
+            check(ok, f"A1 {p.name} parses")
+
+        sp = texts["GLM53_SAMPLING_PARAMS_PY"]
+        check("    skip_writing_prefix_cache: bool | None = None  # [glm53-apc-no-store]" in sp, "A2 SamplingParams field added")
+        check("_glm53_validate_no_store_params(self)  # [glm53-apc-no-store]" in sp, "A2 __post_init__ validates the flag")
+        check(sp.index("# [glm53-apc-no-store] helper-begin") < sp.index("\nclass SamplingParams("), "A2 helpers precede the class")
+        check(sp.index("logger = init_logger(__name__)") < sp.index("# [glm53-apc-no-store] helper-begin"), "A2 helpers follow the module logger")
+        rq = texts["GLM53_REQUEST_PY"]
+        check("self.skip_writing_prefix_cache = self.get_skip_writing_prefix_cache()" in rq, "A2 Request resolves the flag once")
+        check("def get_skip_writing_prefix_cache(self) -> bool:" in rq, "A2 Request.get_skip_writing_prefix_cache defined")
+        check(rq.index("def get_skip_reading_prefix_cache") < rq.index("def get_skip_writing_prefix_cache") < rq.index("def is_finished"), "A2 resolver sits between its read-side sibling and is_finished")
+        bp = texts["GLM53_BLOCK_POOL_PY"]
+        for fn in ("cache_full_blocks", "cache_partial_block"):
+            src = func_src(bp, fn)
+            check("skip_writing_prefix_cache" in src and "self._insert_block_hash(" in src and src.index("skip_writing_prefix_cache") < src.index("self._insert_block_hash("), f"A2 {fn}: guard precedes _insert_block_hash")
+        check("skip_writing_prefix_cache" not in func_src(bp, "move_block_hashes"), "A2 move_block_hashes is NOT guarded")
+        check(bp.index("def _glm53_log_nostore(") > bp.index("logger = init_logger(__name__)") and bp.index("def _glm53_log_nostore(") < bp.index("\nclass BlockPool:"), "A2 proof-of-life helper between the logger and the class")
+        # Non-targets: the whole point of the placement.
+        targets = {p.name for p, _, _ in patcher.PLAN.values()}
+        check(targets == {"sampling_params.py", "request.py", "block_pool.py"}, f"A2 the only targets are sampling_params / request / block_pool -> {sorted(targets)}")
+        for name in ("kv_cache_manager.py", "kv_cache_coordinator.py", "single_type_kv_cache_manager.py", "scheduler.py"):
+            check(name not in targets, f"A2 {name} is not a patch target")
+
+        r2 = run_patcher(staged)
+        check(r2.returncode == 0 and all(p.read_text() == texts[k] for k, p in staged.items()), "A3 re-apply exits 0 and is byte-identical (idempotent)")
+
+    # A4 drift: every anchor, one at a time, and no file may be written.
+    for fname, (_, edits, _requires) in patcher.PLAN.items():
+        env_key = next(k for k, rel in REL.items() if Path(rel).name == fname)
+        for label, old, _new in edits:
+            with tempfile.TemporaryDirectory() as raw:
+                tmp = Path(raw)
+                staged = stage(tmp, root, pristine_only=True)
+                victim = staged[env_key]
+                text = victim.read_text()
+                # duplicate the anchor -> count 2 -> replace_once must refuse
+                text = text.replace(old, old + old, 1)
+                victim.write_text(text)
+                before = {k: p.read_text() for k, p in staged.items()}
+                r = run_patcher(staged)
+                untouched = all(p.read_text() == before[k] for k, p in staged.items())
+                check(r.returncode != 0 and label in (r.stderr + r.stdout) and untouched, f"A4 drifted {fname}:{label} -> exit {r.returncode}, named in the error, nothing written")
+    # A5 partial marker: a file with SOME of its marks is refused, nothing written.
+    with tempfile.TemporaryDirectory() as raw:
+        tmp = Path(raw)
+        staged = stage(tmp, root, pristine_only=True)
+        run_patcher(staged)
+        bp = staged["GLM53_BLOCK_POOL_PY"]
+        text = bp.read_text()
+        text = text.replace(BLOCK_POOL_PARTIAL_LINE, "        if getattr(request, \"skip_writing_prefix_cache\", False):\n", 1)
+        bp.write_text(text)
+        # and make the other two pristine again so they WOULD be written
+        pristine = stage(tmp, root, pristine_only=True)
+        bp.write_text(text)
+        before = {k: p.read_text() for k, p in pristine.items()}
+        r = run_patcher(pristine)
+        check(r.returncode != 0 and "partially" in r.stderr and all(p.read_text() == before[k] for k, p in pristine.items()), f"A5 partially-marked block_pool.py refused (rc={r.returncode}) and the other two files stay untouched")
+    with tempfile.TemporaryDirectory() as raw:
+        tmp = Path(raw)
+        staged = stage(tmp, root, pristine_only=True)
+        run_patcher(staged)
+        bp = staged["GLM53_BLOCK_POOL_PY"]
+        text = bp.read_text()
+        # every MARK still present, but one guard body edited -> not "complete"
+        edited = text.replace('_glm53_log_nostore(request, "full")', 'pass  # edited', 1)
+        check(edited != text and edited.count(MARK) == text.count(MARK), "A5 fixture: marks intact, one snippet altered")
+        bp.write_text(edited)
+        r = run_patcher(staged)
+        check(r.returncode != 0 and "lacks the verbatim snippet" in r.stderr and bp.read_text() == edited, f"A5 fully-marked file with an altered snippet is refused (rc={r.returncode}), not skipped as applied")
+        bp.write_text(text[: len(text) // 2])
+        r = run_patcher(staged)
+        check(r.returncode != 0 and bp.read_text() == text[: len(text) // 2], f"A5 truncated (already-marked) file is refused (rc={r.returncode})")
+    with tempfile.TemporaryDirectory() as raw:
+        tmp = Path(raw)
+        staged = stage(tmp, root, pristine_only=True)
+        missing = staged["GLM53_REQUEST_PY"]
+        missing.unlink()
+        r = run_patcher(staged)
+        check(r.returncode != 0 and "missing" in r.stderr and MARK not in staged["GLM53_SAMPLING_PARAMS_PY"].read_text(), "A6 missing target -> refused, nothing written")
+        check(not [p for p in tmp.iterdir() if p.suffix == ".glm53"], "A6 no temp-file litter left behind")
+
+
+BLOCK_POOL_PARTIAL_LINE = '        if getattr(request, "skip_writing_prefix_cache", False):  # [glm53-apc-no-store]\n'
+
+
+# ---------------------------------------------------------------- part B ----
+
+
+class CapturingLogger:
+    def __init__(self) -> None:
+        self.lines: list[str] = []
+
+    def _rec(self, level, msg, *args):
+        self.lines.append(f"{level}: {msg % args if args else msg}")
+
+    def info_once(self, msg, *args, **kw):
+        self._rec("INFO", msg, *args)
+
+    def warning_once(self, msg, *args, **kw):
+        self._rec("WARN", msg, *args)
+
+    def warning(self, msg, *args, **kw):
+        self._rec("WARN", msg, *args)
+
+    def info(self, msg, *args, **kw):
+        self._rec("INFO", msg, *args)
+
+    def debug(self, msg, *args, **kw):
+        self._rec("DEBUG", msg, *args)
+
+
+def helper_namespace(env_value: str | None) -> tuple[dict, CapturingLogger]:
+    """exec the injected helper block from a freshly patched replica."""
+    with tempfile.TemporaryDirectory() as raw:
+        tmp = Path(raw)
+        staged = stage(tmp, None, pristine_only=True)
+        r = run_patcher(staged)
+        assert r.returncode == 0, r.stderr
+        text = staged["GLM53_SAMPLING_PARAMS_PY"].read_text()
+    begin = text.index("# [glm53-apc-no-store] helper-begin")
+    end = text.index("# [glm53-apc-no-store] helper-end")
+    block = text[begin:end]
+    log = CapturingLogger()
+    ns = {"logger": log}
+    saved = os.environ.pop("GLM53_APC_NO_STORE", None)
+    try:
+        if env_value is not None:
+            os.environ["GLM53_APC_NO_STORE"] = env_value
+        exec(compile(block, "<glm53-no-store-helpers>", "exec"), ns)  # noqa: S102
+    finally:
+        os.environ.pop("GLM53_APC_NO_STORE", None)
+        if saved is not None:
+            os.environ["GLM53_APC_NO_STORE"] = saved
+    return ns, log
+
+
+class Params:
+    def __init__(self, typed=None, extra=None):
+        self.skip_writing_prefix_cache = typed
+        self.extra_args = extra
+
+
+def raises_value_error(fn, *a):
+    try:
+        fn(*a)
+    except ValueError:
+        return True
+    return False
+
+
+def part_b() -> None:
+    print("Part B: resolver semantics (helper block exec'd in a bare namespace)")
+    ns, log = helper_namespace(None)
+    parse = ns["_glm53_parse_no_store"]
+    accepted = {True: True, False: False, 1: True, 0: False, "1": True, "0": False}
+    for value, want in accepted.items():
+        check(parse(value, "t") is want, f"B1 accept {value!r} -> {want}")
+    rejected = [2, -1, 1.0, 0.0, "true", "false", "yes", "no", " 1", "1 ", "01", "", None, [1], {"a": 1}, b"1", "True"]
+    for value in rejected:
+        check(raises_value_error(parse, value, "t"), f"B1 reject {value!r}")
+
+    try:
+        from pydantic import TypeAdapter
+        xargs_type = dict[str, str | int | float | list[str | int | float]] | None
+        ta = TypeAdapter(xargs_type)
+        coerced = {j: ta.validate_json(j)["skip_writing_prefix_cache"] for j in ('{"skip_writing_prefix_cache": true}', '{"skip_writing_prefix_cache": false}', '{"skip_writing_prefix_cache": "1"}', '{"skip_writing_prefix_cache": 1.0}')}
+        check(coerced['{"skip_writing_prefix_cache": true}'] == 1 and coerced['{"skip_writing_prefix_cache": false}'] == 0 and all(not isinstance(v, bool) for v in coerced.values()), f"B1 pydantic coerces a JSON boolean in the vllm_xargs type to int 1/0 (never a bool) -> {coerced}")
+        check(parse(coerced['{"skip_writing_prefix_cache": true}'], "t") is True and parse(coerced['{"skip_writing_prefix_cache": false}'], "t") is False, "B1 ... which the strict parser accepts with the intended meaning")
+        check(raises_value_error(parse, coerced['{"skip_writing_prefix_cache": 1.0}'], "t"), "B1 ... while JSON 1.0 stays a float and is rejected")
+    except ImportError:
+        print("  --   B1 pydantic not importable here: vllm_xargs coercion leg skipped (runs in the image / venv)")
+
+    validate = ns["_glm53_validate_no_store_params"]
+    resolve = ns["_glm53_resolve_no_store"]
+    p = Params(typed="1")
+    validate(p)
+    check(p.skip_writing_prefix_cache is True, "B2 typed field normalised to bool by validation")
+    check(raises_value_error(validate, Params(typed="yes")), "B2 typed 'yes' rejected at the API boundary")
+    check(raises_value_error(validate, Params(extra={"skip_writing_prefix_cache": 1.0})), "B2 extra_args 1.0 rejected at the API boundary")
+    validate(Params(extra={"other": "x"}))
+    validate(Params())
+    check(True, "B2 params without the flag validate clean")
+
+    check(resolve(None, "r") is False, "B3 no sampling params -> False")
+    check(resolve(Params(), "r") is False, "B3 unset -> False")
+    check(resolve(Params(extra={"skip_writing_prefix_cache": 1}), "r") is True, "B3 extra_args 1 -> True")
+    check(resolve(Params(extra={"skip_writing_prefix_cache": "0"}), "r") is False, "B3 extra_args '0' -> False")
+    check(resolve(Params(typed=True), "r") is True, "B3 typed True -> True")
+    check(resolve(Params(typed=False, extra={"skip_writing_prefix_cache": 1}), "r") is False, "B3 typed False wins over extra_args 1 (precedence typed > extra_args)")
+    check(resolve(Params(typed=True, extra={"skip_writing_prefix_cache": 0}), "r") is True, "B3 typed True wins over extra_args 0")
+    n_before = len(log.lines)
+    check(resolve(Params(extra={"skip_writing_prefix_cache": "yes"}), "r") is False, "B3 unparseable value in the engine -> False, never raises")
+    check(any("WARN" in ln and "stores normally" in ln for ln in log.lines[n_before:]), "B3 ... and it is logged as a warning")
+    check(any("INFO" in ln and "first request resolved skip_writing_prefix_cache=1" in ln for ln in log.lines), "B3 resolution receipt logged")
+
+    # Kill switch matrix. Rule: parse/reject BEFORE the switch; the switch only
+    # decides whether a valid 1 is honoured.
+    for env_value, enabled in ((None, True), ("1", True), ("0", False)):
+        ns2, log2 = helper_namespace(env_value)
+        check(ns2["_GLM53_NO_STORE_ENABLED"] is enabled, f"B4 GLM53_APC_NO_STORE={env_value!r} -> enabled={enabled}")
+        got = ns2["_glm53_resolve_no_store"](Params(extra={"skip_writing_prefix_cache": 1}), "r")
+        check(got is enabled, f"B4 valid 1 under GLM53_APC_NO_STORE={env_value!r} -> {enabled}")
+        check(raises_value_error(ns2["_glm53_validate_no_store_params"], Params(extra={"skip_writing_prefix_cache": "yes"})), f"B4 malformed value still rejected under GLM53_APC_NO_STORE={env_value!r}")
+        if not enabled:
+            check(any("ignoring skip_writing_prefix_cache=1" in ln for ln in log2.lines), "B4 kill switch logs the ignore once")
+    for bad in ("", " 1", "yes", "2", "true", "01"):
+        try:
+            helper_namespace(bad)
+            ok = False
+        except ValueError:
+            ok = True
+        check(ok, f"B4 GLM53_APC_NO_STORE={bad!r} fails closed at import")
+
+
+# ---------------------------------------------------------------- part C ----
+
+PART_C = r'''
+import logging, os, sys, importlib.util, shutil, subprocess
+from pathlib import Path
+
+ROOT = Path(sys.argv[1]); PATCH = Path(sys.argv[2]); TMP = Path(sys.argv[3])
+REL = {"GLM53_SAMPLING_PARAMS_PY": "sampling_params.py", "GLM53_REQUEST_PY": "v1/request.py", "GLM53_BLOCK_POOL_PY": "v1/core/block_pool.py"}
+staged = {}
+for env, rel in REL.items():
+    dst = TMP / Path(rel).name
+    shutil.copyfile(ROOT / rel, dst)
+    staged[env] = dst
+env = {k: v for k, v in os.environ.items() if not k.startswith("GLM53_")}
+env.update({k: str(v) for k, v in staged.items()})
+r = subprocess.run([sys.executable, str(PATCH)], env=env, capture_output=True, text=True)
+assert r.returncode == 0, r.stderr
+MARK = "# [glm53-apc-no-store]"
+assert all(MARK in p.read_text() for p in staged.values())
+
+FAIL = []
+N = 0
+def check(cond, label):
+    global N
+    N += 1
+    print(("  ok   " if cond else "  FAIL ") + label)
+    if not cond:
+        FAIL.append(label)
+
+import vllm  # noqa: F401  (package init only)
+
+def inject(modname, path):
+    spec = importlib.util.spec_from_file_location(modname, path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[modname] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+sp_mod = inject("vllm.sampling_params", staged["GLM53_SAMPLING_PARAMS_PY"])
+import vllm.v1  # noqa: F401
+req_mod = inject("vllm.v1.request", staged["GLM53_REQUEST_PY"])
+import vllm.v1.core  # noqa: F401
+bp_mod = inject("vllm.v1.core.block_pool", staged["GLM53_BLOCK_POOL_PY"])
+
+import torch
+from vllm.utils.hashing import sha256
+from vllm.v1.core.kv_cache_utils import init_none_hash, get_request_block_hasher, get_block_hash
+from vllm.v1.core.kv_cache_manager import KVCacheManager
+from vllm.v1.core import kv_cache_coordinator as kvc_mod
+from vllm.v1.kv_cache_interface import KVCacheConfig, KVCacheGroupSpec, FullAttentionSpec, MambaSpec, SlidingWindowSpec, MLAAttentionSpec
+try:
+    from vllm.v1.kv_cache_interface import KpoolTailSpec  # fork-only
+except Exception:
+    KpoolTailSpec = None
+SamplingParams = sp_mod.SamplingParams
+Request = req_mod.Request
+BlockPool = bp_mod.BlockPool
+check(kvc_mod.BlockPool is BlockPool, "C0 the coordinator (and so KVCacheManager) uses the patched BlockPool")
+check("skip_writing_prefix_cache" in BlockPool.cache_full_blocks.__code__.co_consts and "skip_writing_prefix_cache" in BlockPool.cache_partial_block.__code__.co_consts, "C0 guards present in the loaded BlockPool")
+init_none_hash(sha256)
+
+records = []
+class H(logging.Handler):
+    def emit(self, rec):
+        records.append(rec.getMessage())
+for name in ("vllm.sampling_params", "vllm.v1.core.block_pool"):
+    lg = logging.getLogger(name); lg.addHandler(H()); lg.setLevel(logging.DEBUG)
+
+def mk(rid, toks, no_store=None, extra=None, skip_reading=None, hbs=2):
+    sp = SamplingParams(max_tokens=17, skip_writing_prefix_cache=no_store, extra_args=extra, skip_reading_prefix_cache=skip_reading)
+    return Request(request_id=rid, prompt_token_ids=list(toks), sampling_params=sp, pooling_params=None, block_hasher=get_request_block_hasher(hbs, sha256))
+
+def full_cfg(block, num_blocks):
+    """Full attention (block > hash) + one mamba(align) group: the smallest
+    layout with a partial tail in the attention group (UnitaryKVCacheCoordinator
+    requires hash_block_size == block_size, so a single group cannot do it)."""
+    return KVCacheConfig(num_blocks=num_blocks, kv_cache_tensors=[], kv_cache_groups=[
+        KVCacheGroupSpec(["full"], FullAttentionSpec(block_size=block, num_kv_heads=1, head_size=1, dtype=torch.float32)),
+        KVCacheGroupSpec(["mamba"], MambaSpec(block_size=block, shapes=(1, 1), dtypes=(torch.float32,), mamba_cache_mode="align")),
+    ])
+
+def hybrid_cfg(hbs, block, num_blocks):
+    return KVCacheConfig(num_blocks=num_blocks, kv_cache_tensors=[], kv_cache_groups=[
+        KVCacheGroupSpec(["full"], FullAttentionSpec(block_size=hbs, num_kv_heads=1, head_size=1, dtype=torch.float32)),
+        KVCacheGroupSpec(["mamba"], MambaSpec(block_size=block, shapes=(1, 1), dtypes=(torch.float32,), mamba_cache_mode="align")),
+    ])
+
+def live_cfg(hbs, block, num_blocks):
+    groups = [KVCacheGroupSpec(["mla"], MLAAttentionSpec(block_size=block, num_kv_heads=1, head_size=1, dtype=torch.float32))]
+    if KpoolTailSpec is not None:
+        try:
+            groups.append(KVCacheGroupSpec(["kpool"], KpoolTailSpec(block_size=hbs, num_kv_heads=1, head_size=1, dtype=torch.float32, sliding_window=block)))
+        except Exception as exc:  # constructor shape differs -> say so, keep going
+            print(f"       note: KpoolTailSpec present but not constructible here ({exc}); 6-group layout")
+    for i in range(4):
+        groups.append(KVCacheGroupSpec([f"m{i}"], MambaSpec(block_size=block, shapes=((1, 1),), dtypes=(torch.float32,), mamba_cache_mode="align")))
+    groups.append(KVCacheGroupSpec(["swa"], SlidingWindowSpec(block_size=hbs, num_kv_heads=1, head_size=1, dtype=torch.float32, sliding_window=block), is_eagle_group=True))
+    return KVCacheConfig(num_blocks=num_blocks, kv_cache_tensors=[], kv_cache_groups=groups)
+
+def manager(cfg, hbs, sched, **kw):
+    return KVCacheManager(cfg, max_model_len=8192, scheduler_block_size=sched, hash_block_size=hbs, enable_caching=True, **kw)
+
+def hashes(m, rid):
+    return [[b.block_hash for b in grp] for grp in m.get_blocks(rid).blocks]
+
+def any_hash(m, rid):
+    return any(h is not None for grp in hashes(m, rid) for h in grp)
+
+def managers(m):
+    return list(m.coordinator.single_type_managers)
+
+def ncb(m, rid):
+    return [mgr.num_cached_block.get(rid) for mgr in managers(m)]
+
+def block_ids(m, rid):
+    return {b.block_id for grp in m.get_blocks(rid).blocks for b in grp if not b.is_null}
+
+def prefill(m, req, chunks):
+    """Chunked prefill: returns the per-step (num_cached_block vector, has-hash) trace."""
+    cb, n, _ = m.get_computed_blocks(req)
+    trace = []
+    done = 0
+    for i, c in enumerate(chunks):
+        out = m.allocate_slots(req, c, n if i == 0 else 0, cb if i == 0 else None)
+        assert out is not None, "allocate_slots returned None"
+        done += c
+        req.num_computed_tokens = n + done if i == 0 else req.num_computed_tokens + c
+        trace.append((ncb(m, req.request_id), any_hash(m, req.request_id)))
+    return n, trace
+
+# C1 -- BlockPool alone: LIFO front vs LRU back, isolated legs (distinct tokens).
+pool = BlockPool(num_gpu_blocks=32, enable_caching=True, hash_block_size=4)
+def store(pool, rid, toks, no_store):
+    req = mk(rid, toks, no_store=no_store, hbs=4)
+    blocks = pool.get_new_blocks(len(toks) // 4)
+    pool.cache_full_blocks(request=req, blocks=blocks, num_cached_blocks=0, num_full_blocks=len(blocks), block_size=4, kv_cache_group_id=0)
+    return blocks
+normal = store(pool, "n", range(100, 112), False)
+quiet = store(pool, "q", range(200, 212), True)
+check(all(b.block_hash is not None for b in normal), "C1 normal request: every full block hashed")
+check(all(b.block_hash is None for b in quiet), "C1 no-store request (distinct tokens): no block hashed")
+check(pool.get_cached_block(mk("x", range(200, 212), hbs=4).block_hashes[0], [0]) is None, "C1 no-store hashes are not reachable in the cache map")
+check(pool.get_cached_block(mk("y", range(100, 112), hbs=4).block_hashes[0], [0]) is not None, "C1 normal hashes are reachable in the cache map")
+pool.free_blocks(reversed(normal)); pool.free_blocks(reversed(quiet))
+reused = pool.get_new_blocks(3)
+check({b.block_id for b in reused} == {b.block_id for b in quiet}, "C1 after freeing both, the next 3 blocks recycled are exactly the no-store ones (LIFO front)")
+check(all(b.block_hash is not None for b in normal), "C1 the normal request's blocks are still cached after the recycle")
+blk = pool.get_new_blocks(1)[0]
+out = pool.cache_partial_block(request=mk("p", range(300, 316), no_store=True, hbs=4), block=blk, num_tokens=4, kv_cache_group_id=0, block_size=8)
+check(out is None and blk.block_hash is None, "C1 cache_partial_block returns None and inserts nothing for a no-store request")
+out = pool.cache_partial_block(request=mk("p2", range(400, 416), hbs=4), block=blk, num_tokens=4, kv_cache_group_id=0, block_size=8)
+check(out is not None and blk.block_hash is not None, "C1 control: cache_partial_block inserts for a normal request")
+
+# C2 -- KVCacheManager (full attention, hash 2 / block 4), multi-step, isolated legs.
+toks = list(range(1000, 1014))  # 14 tokens: 3 full blocks + 2-token partial tail
+legs = {}
+for label, ns in (("normal", False), ("nostore", True)):
+    m = manager(full_cfg(4, 20), 2, 4)
+    req = mk(label, toks, no_store=ns)
+    n, trace = prefill(m, req, (4, 4, 4, 2))
+    check(n == 0, f"C2 [{label}] cold start: 0 computed")
+    mgr = managers(m)[0]
+    check([t[0][0] for t in trace] == [1, 2, 3, 3], f"C2 [{label}] attention-group num_cached_block advances 1,2,3,3 over the four steps (sentinel) -> {[t[0] for t in trace]}")
+    check(req.request_id in mgr.num_cached_block, f"C2 [{label}] request is in num_cached_block after step 1 (fast path from step 2)")
+    legs[label] = (m, req, trace)
+mN, rN, tN = legs["normal"]; mQ, rQ, tQ = legs["nostore"]
+check(all(t[1] for t in tN), "C2 [normal] hashes present after every step")
+check(not any(t[1] for t in tQ), "C2 [nostore] no hash after any step")
+check([t[0] for t in tN] == [t[0] for t in tQ], "C2 the two legs' num_cached_block traces are identical (placement invariant)")
+blkN = mN.get_blocks("normal").blocks[0]; blkQ = mQ.get_blocks("nostore").blocks[0]
+check(blkN[3].block_hash is not None and blkN[3].block_hash_num_tokens == 14, "C2 [normal] partial tail entry at 14 tokens")
+check(blkQ[3].block_hash is None and blkQ[3].block_hash_num_tokens is None, "C2 [nostore] no partial tail entry")
+fN = mk("fN", toks + [7, 7]); fQ = mk("fQ", toks + [7, 7])
+_, nN, _ = mN.get_computed_blocks(fN); _, nQ, _ = mQ.get_computed_blocks(fQ)
+check(nN == 14, f"C2 [normal] same-prefix follow-up hits 14 (12 full + 2-token partial tail) -> {nN}")
+check(nQ == 0, f"C2 [nostore] same-prefix follow-up hits 0 -> {nQ}")
+idsN = block_ids(mN, "normal"); idsQ = block_ids(mQ, "nostore")
+mN.free(rN); mQ.free(rQ)
+gN = mk("gN", range(5000, 5004)); gQ = mk("gQ", range(5000, 5004))
+cb, n, _ = mN.get_computed_blocks(gN); mN.allocate_slots(gN, 4, n, cb)
+cb, n, _ = mQ.get_computed_blocks(gQ); mQ.allocate_slots(gQ, 4, n, cb)
+check(block_ids(mQ, "gQ") <= idsQ, "C2 [nostore] the next allocation recycles the freed no-store block first (front of the free queue)")
+check(not (block_ids(mN, "gN") & idsN), "C2 [normal] the next allocation does NOT touch the freed cached blocks (they sit at the back)")
+# C2r: sparse retention interval on the same shape -> still no hashes for no-store, sentinel still advances.
+# Upstream KVCacheConfig (22df3a3) carries prefix_cache_retention_interval as a dataclass field; the fork's
+# in-image build drives retention through VLLM_PREFIX_CACHE_RETENTION_INTERVAL instead and has no such field,
+# so this sub-check feature-detects it (found by the in-fork receipt run, 2026-09-01).
+from dataclasses import replace, fields
+if any(f.name == "prefix_cache_retention_interval" for f in fields(type(full_cfg(4, 24)))):
+    m = manager(replace(full_cfg(4, 24), prefix_cache_retention_interval=4), 2, 4)
+    req = mk("ret", toks, no_store=True)
+    _, trace = prefill(m, req, (4, 4, 4, 2))
+    check(not any(t[1] for t in trace) and [t[0][0] for t in trace] == [1, 2, 3, 3], "C2 [nostore + retention_interval] no hashes, sentinel unchanged")
+else:
+    check(True, "C2 [nostore + retention_interval] skipped: this vLLM's KVCacheConfig has no prefix_cache_retention_interval field (the fork build reads VLLM_PREFIX_CACHE_RETENTION_INTERVAL instead; upstream 22df3a3 field-based path is covered by the Mac venv run)")
+
+# C3 -- hybrid Full(hash 2) + Mamba(align, block 4): the upstream partial-tail fixture shape.
+def mamba(m):
+    return managers(m)[1]
+# (a) no-store PRODUCER of an unaligned tail, then continue-decode (running request).
+m = manager(hybrid_cfg(2, 4, 24), 2, 4)
+r0 = mk("p0", [0, 0, 1, 1, 2, 2], no_store=True)
+cb, n, _ = m.get_computed_blocks(r0)
+check(m.allocate_slots(r0, 6, n, cb) is not None, "C3a no-store producer: allocate 6 tokens (partial tail at 6)")
+check(not any_hash(m, "p0"), "C3a no hashes in either group")
+check("p0" not in mamba(m)._partial_hit_reqs and "p0" not in mamba(m)._producer_partial_tail_reqs, "C3a not registered as a partial-tail producer (no _partial_hit_reqs / _producer_partial_tail_reqs entry)")
+check(ncb(m, "p0") == [3, 1], f"C3a num_cached_block advanced as for a normal producer ([3,1]) -> {ncb(m, 'p0')}")
+ph = r0.block_hashes[6 // 2 - 1]
+check(m.block_pool.get_cached_block(ph, [1]) is None and m.block_pool.get_cached_block(ph, [0]) is None, "C3a partial hash not in the cache map for either group")
+r0.num_computed_tokens = 6; r0.append_output_token_ids([3])
+before_ids = block_ids(m, "p0")
+nb = m.allocate_slots(r0, 1)
+check(nb is not None, "C3a continue-decode allocates (get_num_blocks_to_allocate / allocate_new_blocks agree, no assertion)")
+copies, _ = m.take_kv_cache_block_copies()
+check(not any(c.src_block_id in before_ids for c in copies), "C3a no CoW copy sourced from the no-store producer's blocks (move_block_hashes path unreachable)")
+check(not any_hash(m, "p0"), "C3a still no hash on any of its blocks after the continue step")
+r0.num_computed_tokens = 7; r0.append_output_token_ids([4]); m.allocate_slots(r0, 1)
+check(not any_hash(m, "p0") and "p0" not in mamba(m)._partial_hit_reqs, "C3a second decode step: still unhashed, still no partial-hit registration")
+# control on a fresh manager: a NORMAL producer does get the partial entry and the CoW.
+m = manager(hybrid_cfg(2, 4, 24), 2, 4)
+c0 = mk("c0", [0, 0, 1, 1, 2, 2])
+cb, n, _ = m.get_computed_blocks(c0); m.allocate_slots(c0, 6, n, cb)
+check(m.block_pool.get_cached_block(c0.block_hashes[2], [1]) is not None, "C3a control: normal producer registers the mamba partial tail")
+c0.num_computed_tokens = 6; c0.append_output_token_ids([3]); m.allocate_slots(c0, 1)
+copies, _ = m.take_kv_cache_block_copies()
+check(len(copies) >= 1, "C3a control: normal producer's continue step queues a CoW copy")
+# (b)/(c) no-store READER of a normal producer's partial tail (with and without delay_cache_blocks)
+for delay in (False, True):
+    m = manager(hybrid_cfg(2, 4, 24), 2, 4)
+    c0 = mk("c0", [0, 0, 1, 1, 2, 2])
+    cb, n, _ = m.get_computed_blocks(c0); m.allocate_slots(c0, 6, n, cb); m.free(c0); m.new_step_starts()
+    ph = c0.block_hashes[2]
+    src = m.block_pool.get_cached_block(ph, [1])[0]
+    r1 = mk("r1", [0, 0, 1, 1, 2, 2, 3, 3], no_store=True)
+    cb, n, _ = m.get_computed_blocks(r1)
+    check(n == 6, f"C3b[delay={delay}] no-store reader read-hits 6 (lookups enabled)")
+    nb = m.allocate_slots(r1, 2, n, cb, delay_cache_blocks=delay)
+    check(nb is not None, f"C3b[delay={delay}] allocation ok")
+    cow = m.get_blocks("r1").blocks[1][1]
+    check(cow.block_id != src.block_id, f"C3b[delay={delay}] reader CoWs into a private mamba block")
+    copies, _ = m.take_kv_cache_block_copies()
+    check(any(c.src_block_id == src.block_id and c.dst_block_id == cow.block_id for c in copies), f"C3b[delay={delay}] CoW copy src->private queued")
+    check(src.block_hash is not None and get_block_hash(src.block_hash) == ph and src.block_hash_num_tokens == 6, f"C3b[delay={delay}] source partial entry kept its hash (no move onto the no-store request)")
+    check(cow.block_hash is None and cow.block_hash_num_tokens is None, f"C3b[delay={delay}] the private CoW block is unhashed (normal reader would carry the 8-token hash)")
+    own = {b.block_id for grp in m.get_blocks("r1").blocks for b in grp if not b.is_null} - {b.block_id for grp in cb.blocks for b in grp if not b.is_null}
+    check(own and not any(b.block_hash is not None for grp in m.get_blocks("r1").blocks for b in grp if b.block_id in own), f"C3b[delay={delay}] every block the no-store reader allocated itself is unhashed")
+    m.free(r1)
+    nxt = m.block_pool.get_new_blocks(1)[0]
+    check(nxt.block_id in own, f"C3b[delay={delay}] after free, the next block recycled is one of the reader's own (front of queue)")
+    m.block_pool.free_blocks([nxt])
+# (d) control: normal reader gets the 8-token hash on its CoW block
+m = manager(hybrid_cfg(2, 4, 24), 2, 4)
+c0 = mk("c0", [0, 0, 1, 1, 2, 2]); cb, n, _ = m.get_computed_blocks(c0); m.allocate_slots(c0, 6, n, cb); m.free(c0); m.new_step_starts()
+r1 = mk("r1", [0, 0, 1, 1, 2, 2, 3, 3]); cb, n, _ = m.get_computed_blocks(r1); m.allocate_slots(r1, 2, n, cb)
+check(m.get_blocks("r1").blocks[1][1].block_hash_num_tokens == 8, "C3d control: normal reader's CoW block is hashed at 8 tokens")
+
+# C3L -- the live layout: MLA + [KpoolTail] + 4 Mamba(align) + EAGLE SWA drafter, chunked prefill + decode
+for label, ns in (("normal", False), ("nostore", True)):
+    m = manager(live_cfg(2, 4, 96), 2, 4, use_eagle=True)
+    if label == "normal":
+        print(f"       layout: {[type(x).__name__ for x in managers(m)]} eagle={sorted(m.coordinator.eagle_group_ids)}")
+    req = mk(label, list(range(2000, 2014)), no_store=ns)
+    n, trace = prefill(m, req, (4, 4, 4, 2))
+    req.append_output_token_ids([9]); check(m.allocate_slots(req, 1) is not None, f"C3L [{label}] decode step after chunked prefill")
+    req.num_computed_tokens += 1; req.append_output_token_ids([9]); check(m.allocate_slots(req, 1) is not None, f"C3L [{label}] second decode step")
+    legs[label] = (m, req, trace)
+mN, rN, tN = legs["normal"]; mQ, rQ, tQ = legs["nostore"]
+check([t[0] for t in tN] == [t[0] for t in tQ], f"C3L per-group num_cached_block traces identical across all groups -> {[t[0] for t in tQ]}")
+check(all(t[1] for t in tN), "C3L [normal] hashes present")
+check(not any_hash(mQ, "nostore"), "C3L [nostore] no hash in ANY group (MLA, mamba x4, EAGLE SWA) after prefill + decode")
+check(all(mgr.cached_blocks_this_step == set() for mgr in managers(mQ) if hasattr(mgr, "cached_blocks_this_step")), "C3L [nostore] mamba cached_blocks_this_step stays empty")
+f = mk("f", list(range(2000, 2016)))
+_, nQ, _ = mQ.get_computed_blocks(f); _, nN, _ = mN.get_computed_blocks(mk("f2", list(range(2000, 2016))))
+check(nQ == 0 and nN > 0, f"C3L same-prefix follow-up: normal hits {nN}, no-store hits {nQ}")
+idsQ = block_ids(mQ, "nostore"); mQ.free(rQ)
+nxt = mQ.block_pool.get_new_blocks(4)
+check({b.block_id for b in nxt} <= idsQ, "C3L [nostore] freed blocks are the very next ids recycled")
+
+# C4 -- preemption bookkeeping: cold no-store recomputes from 0; a read-hit no-store resumes from what it read.
+m = manager(full_cfg(4, 20), 2, 4)
+req = mk("pre", toks, no_store=True)
+n, trace = prefill(m, req, (4, 4))
+m.free(req); req.num_computed_tokens = 0
+cb, n, _ = m.get_computed_blocks(req)
+check(n == 0, "C4 cold no-store request preempted mid-prefill resumes with 0 computed (nothing was stored)")
+check(m.allocate_slots(req, 4, n, cb) is not None and ncb(m, "pre")[0] == 1, "C4 ... and re-allocates cleanly from zero")
+m = manager(full_cfg(4, 20), 2, 4)
+a = mk("a", toks[:8]); cb, n, _ = m.get_computed_blocks(a); m.allocate_slots(a, 8, n, cb); m.free(a)
+b = mk("b", toks, no_store=True); cb, n, _ = m.get_computed_blocks(b)
+check(n == 8, "C4 read-hit no-store request hits the 8 cached tokens")
+m.allocate_slots(b, 6, n, cb); m.free(b); b.num_computed_tokens = 0
+cb, n2, _ = m.get_computed_blocks(b)
+check(n2 == 8, "C4 ... and after preemption resumes from those same 8 (its own 6 were never stored)")
+
+# C5 -- Request-level resolution on real SamplingParams; boundary rejection; zero-interaction combination.
+check(mk("x1", toks, extra={"skip_writing_prefix_cache": 1}).skip_writing_prefix_cache is True, "C5 extra_args 1 -> True on a real Request")
+check(mk("x2", toks, extra={"skip_writing_prefix_cache": "0"}).skip_writing_prefix_cache is False, "C5 extra_args '0' -> False")
+check(mk("x3", toks, no_store=True).skip_writing_prefix_cache is True, "C5 typed True -> True")
+check(mk("x4", toks).skip_writing_prefix_cache is False, "C5 default -> False")
+try:
+    SamplingParams(max_tokens=1, extra_args={"skip_writing_prefix_cache": "yes"}); rejected = False
+except ValueError as exc:
+    rejected = "skip_writing_prefix_cache" in str(exc)
+check(rejected, "C5 SamplingParams(extra_args={...: 'yes'}) raises ValueError naming the field (API boundary -> 400)")
+try:
+    SamplingParams(max_tokens=1, skip_writing_prefix_cache=1.0); rejected = False
+except ValueError:
+    rejected = True
+check(rejected, "C5 SamplingParams(skip_writing_prefix_cache=1.0) rejected")
+sp = SamplingParams(max_tokens=1, extra_args={"skip_writing_prefix_cache": 1}); sp.extra_args["skip_writing_prefix_cache"] = "yes"
+n_before = len(records)
+rr = Request(request_id="mut", prompt_token_ids=toks, sampling_params=sp, pooling_params=None, block_hasher=get_request_block_hasher(2, sha256))
+check(rr.skip_writing_prefix_cache is False and any("stores normally" in x for x in records[n_before:]), "C5 a value mutated after validation never raises in Request: False + warning")
+m = manager(full_cfg(4, 20), 2, 4)
+a = mk("a", toks[:8]); cb, n, _ = m.get_computed_blocks(a); m.allocate_slots(a, 8, n, cb); m.free(a)
+z = mk("z", toks, no_store=True, skip_reading=True); cb, n, _ = m.get_computed_blocks(z)
+check(n == 0, "C5 skip_reading + skip_writing: no read hit despite a cached prefix")
+m.allocate_slots(z, 14, n, cb)
+check(not any_hash(m, "z"), "C5 skip_reading + skip_writing: nothing stored either (zero cache interaction)")
+sp_mod._GLM53_NO_STORE_ENABLED = False
+check(mk("ks", toks, no_store=True).skip_writing_prefix_cache is False, "C5 kill switch off: typed True resolves to False (ignored)")
+sp_mod._GLM53_NO_STORE_ENABLED = True
+
+# C6 -- receipts
+res = [x for x in records if "first request resolved skip_writing_prefix_cache=1" in x]
+full = [x for x in records if "suppressing prefix-cache store (full site)" in x]
+part = [x for x in records if "suppressing prefix-cache store (partial site)" in x]
+check(len(res) == 1, f"C6 resolution receipt logged exactly once for the whole run ({len(res)})")
+check(len(full) == 1 and len(part) == 1, f"C6 suppression receipts logged exactly once per site (full={len(full)} partial={len(part)})")
+check(any("ignoring skip_writing_prefix_cache=1" in x for x in records), "C6 kill-switch ignore receipt logged")
+
+print(f"PARTC_RESULT checks={N} failures={len(FAIL)}")
+for f in FAIL:
+    print("PARTC_FAIL " + f)
+sys.exit(1 if FAIL else 0)
+'''
+
+
+def part_c(root: Path | None) -> None:
+    print("Part C: behaviour on a real vLLM (patched copies injected via sys.modules)")
+    require = os.environ.get("GLM53_REQUIRE_VLLM", "") == "1"
+    if root is None:
+        check(not require, "C0 no vLLM source root -> Part C skipped" + (" (GLM53_REQUIRE_VLLM=1: failing)" if require else ""))
+        return
+    probe = subprocess.run([sys.executable, "-c", "import vllm.v1.core.kv_cache_manager, torch"], capture_output=True, text=True)
+    if probe.returncode != 0:
+        msg = probe.stderr.strip().splitlines()[-1] if probe.stderr.strip() else "?"
+        check(not require, f"C0 `import vllm` failed under {sys.executable}: {msg} -> Part C skipped" + (" (GLM53_REQUIRE_VLLM=1: failing)" if require else ""))
+        return
+    with tempfile.TemporaryDirectory() as raw:
+        tmp = Path(raw)
+        script = tmp / "part_c.py"
+        script.write_text(PART_C)
+        env = {k: v for k, v in os.environ.items() if not k.startswith("GLM53_")}
+        env.setdefault("VLLM_LOGGING_LEVEL", "DEBUG")
+        r = subprocess.run([sys.executable, str(script), str(root), str(PATCH), str(tmp)], capture_output=True, text=True, env=env)
+        for line in r.stdout.splitlines():
+            if line.startswith("  ok") or line.startswith("  FAIL") or line.startswith("       "):
+                print(line)
+        summary = next((ln for ln in r.stdout.splitlines() if ln.startswith("PARTC_RESULT")), "")
+        fails = [ln[len("PARTC_FAIL "):] for ln in r.stdout.splitlines() if ln.startswith("PARTC_FAIL ")]
+        FAILURES.extend(fails)
+        global CHECKS
+        try:
+            CHECKS += int(summary.split("checks=")[1].split()[0])
+        except (IndexError, ValueError):
+            pass
+        if r.returncode != 0 and not fails:
+            tail = "\n".join((r.stderr or r.stdout).strip().splitlines()[-25:])
+            check(False, f"C0 Part C crashed (rc={r.returncode}):\n{tail}")
+        else:
+            check(r.returncode == 0, f"C summary: {summary or 'no summary line'}")
+
+
+# ---------------------------------------------------------------- part D ----
+
+
+
+def defaults_source() -> str:
+    """The fork's W41/W42 knob-defaults block in start.sh. Top level, but it
+    only substitutes UNSET -> 1 and never exits: strict validation lives in
+    validate_numeric_config (start/restart only), so a bad value can never
+    block stop/status/logs on a running pair."""
+    text = START.read_text()
+    begin = text.index("# LOCAL: W41/W42 knob defaults (begin)")
+    end_marker = "# LOCAL: W41/W42 knob defaults (end)"
+    return text[begin : text.index(end_marker, begin) + len(end_marker)]
+
+
+def validator_source() -> str:
+    """The W41/W42 strict-bool loop, verbatim from validate_numeric_config,
+    wrapped in a function so its ``return 2`` is executable standalone."""
+    text = START.read_text()
+    begin = text.index("# LOCAL: W41/W42 strict-bool validation (begin)")
+    end_marker = "# LOCAL: W41/W42 strict-bool validation (end)"
+    body = text[begin : text.index(end_marker, begin) + len(end_marker)]
+    return "_glm53_w4142_validate() {\n" + body + "\n}"
+
+
+def caller_wins_source() -> str:
+    """The setness-aware caller-wins capture + .env source + restore, as
+    verbatim slices of start.sh, runnable against a fake .env ($GLM53_FAKE_ENV)."""
+    text = START.read_text()
+
+    def _slice(marker: str) -> str:
+        begin = text.index(f"# LOCAL: W41/W42 {marker} (begin)")
+        end_marker = f"# LOCAL: W41/W42 {marker} (end)"
+        return text[begin : text.index(end_marker, begin) + len(end_marker)]
+
+    return (
+        _slice("caller-wins capture")
+        + '\nset -a\nsource "$GLM53_FAKE_ENV"\nset +a\n'
+        + _slice("caller-wins restore")
+    )
+
+
+def _run_defaults(knob: str, value: str | None) -> tuple[int, str, str]:
+    # Length|value output, binary-safe capture: a whitespace-only difference
+    # can never hide behind a stripped comparison -- passthrough is byte-exact.
+    script = defaults_source() + '\nv="${' + knob + '-unset}"; printf "%s|%s\\n" "${#v}" "$v"\n'
+    env = {"PATH": os.environ.get("PATH", "/usr/bin:/bin"), "LC_ALL": "C"}
+    if value is not None:
+        env[knob] = value
+    r = subprocess.run(["bash", "-c", script], capture_output=True, env=env)
+    out = r.stdout.decode("utf-8", "replace").rstrip("\n")
+    err = r.stderr.decode("utf-8", "replace").strip()
+    return r.returncode, out, err
+
+
+def _run_validator(knob: str, value: str) -> tuple[int, str, str]:
+    # The loop validates BOTH knobs; in the real launcher the top-level
+    # defaults block has already assigned the other one (unset -> 1), so the
+    # harness mirrors that instead of letting it reach the validator unset.
+    other = "GLM53_APC_NO_STORE" if knob == "GLM53_KV_CAPACITY_LOG" else "GLM53_KV_CAPACITY_LOG"
+    script = validator_source() + "\n_glm53_w4142_validate"
+    env = {"PATH": os.environ.get("PATH", "/usr/bin:/bin"), "LC_ALL": "C", knob: value, other: "1"}
+    r = subprocess.run(["bash", "-c", script], text=True, capture_output=True, env=env)
+    return r.returncode, r.stdout.strip(), r.stderr.strip()
+
+
+def _run_caller_wins(knob: str, caller: str | None, env_value: str) -> tuple[int, str, str]:
+    fake = tempfile.NamedTemporaryFile("w", suffix=".env", delete=False)
+    fake.write(f"{knob}={env_value}\n")
+    fake.close()
+    script = caller_wins_source() + f'\nprintf "%s\\n" "${{{knob}-unset}}"\n'
+    env = {
+        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+        "LC_ALL": "C",
+        "GLM53_FAKE_ENV": fake.name,
+    }
+    if caller is not None:
+        env[knob] = caller
+    r = subprocess.run(["bash", "-c", script], text=True, capture_output=True, env=env)
+    os.unlink(fake.name)
+    return r.returncode, r.stdout.strip(), r.stderr.strip()
+
+
+def _launcher_wiring(prefix: str, host_var: str, overlay: str, knob: str, tag: str) -> None:
+    src = START.read_text()
+    check(f'{host_var}="${{{host_var}:-$SCRIPT_DIR/overlay/{overlay}}}"' in src, f"{prefix}2 {host_var} defaults to the shipped overlay")
+    check(f'[ -f "${host_var}" ] || die "missing ${host_var}"' in src and f'scp -q -o BatchMode=yes "${host_var}" "${{WORKER_SSH}}:/tmp/{overlay}"' in src, f"{prefix}2 preflight existence check + scp to the worker")
+    check(f"-v '/tmp/{overlay}:/opt/glm53/{overlay}:ro'" in src and f'-v "${host_var}:/opt/glm53/{overlay}:ro"' in src, f"{prefix}2 read-only mount on both ranks")
+    check(f'-e "{knob}=${knob}"' in src, f"{prefix}2 the knob is forwarded in nccl_common (both ranks)")
+    runs = src.count(f"python3 /opt/glm53/{overlay}")
+    check(runs == 2, f"{prefix}3 both rank scripts run the overlay exactly once ({runs})")
+    # order: after every overlay that edits the same files / the hybrid+drafter pair, before ablit
+    for earlier in ("patch_glm5_drafter_group.py", "patch_hybrid_prefix_hit.py", "patch_apc_per_group_retention.py", "patch_fine_grained_apc.py", "patch_align_floor.py"):
+        check(src.index(f"python3 /opt/glm53/{earlier}") < src.index(f"python3 /opt/glm53/{overlay}"), f"{prefix}3 pinned order: {earlier} -> {overlay}")
+    if "python3 /opt/glm53/patch_ablit.py" in src:  # kit only; the public repo ships no ablit
+        check(src.index(f"python3 /opt/glm53/{overlay}") < src.index("python3 /opt/glm53/patch_ablit.py"), f"{prefix}3 pinned order: {overlay} -> patch_ablit.py (last)")
+    defaults = defaults_source()
+    check(f'{knob}="${{{knob}-1}}"' in defaults, f"{prefix}1 default 1 applies only when UNSET ('' is a value)")
+    for value, out in ((None, "1"), ("0", "0"), ("1", "1")):
+        rc, o, e = _run_defaults(knob, value)
+        check(rc == 0 and o == f"{len(out)}|{out}", f"{prefix}4 {knob}={value!r} accepted -> {o!r} (rc={rc} {e[:60]})")
+    for value in ("", " ", "01", "2", "yes", "true", "1 ", " 1", "1\r", "0x1", "-1"):
+        rc, o, e = _run_defaults(knob, value)
+        check(rc == 0 and o == f"{len(value)}|{value}", f"{prefix}4 top level passes {value!r} through byte-exact (rc=0) -- stop/status/logs unblockable")
+    src2 = START.read_text()
+    check(src2.count("# LOCAL: W41/W42 strict-bool validation (begin)") == 1, f"{prefix}5 strict-bool validator present exactly once")
+    check(src2.index("# LOCAL: W41/W42 strict-bool validation (begin)") > src2.index("validate_numeric_config() {"), f"{prefix}5 validator lives inside validate_numeric_config (start/restart only)")
+    check("start|restart) validate_numeric_config" in src2, f"{prefix}5 validator wired to start|restart only")
+    check("bool knob guard (begin)" not in src2, f"{prefix}5 no top-level W41/W42 guard remains")
+    for value in ("1", "0"):
+        rc, o, e = _run_validator(knob, value)
+        check(rc == 0, f"{prefix}6 validator accepts {value!r} (rc={rc} {e[:60]})")
+    for value in ("", " ", "01", "2", "yes", "true", "1 ", " 1", "1\r", "0x1", "-1"):
+        rc, o, e = _run_validator(knob, value)
+        check(rc == 2 and knob in e, f"{prefix}6 validator rejects {value!r} rc=2 with a named error (rc={rc} {e[:60]!r})")
+    for caller, env_value, want in (("0", "1", "0"), ("1", "0", "1"), ("", "1", ""), (None, "1", "1"), (None, "0", "0")):
+        rc, o, e = _run_caller_wins(knob, caller, env_value)
+        check(rc == 0 and o == want, f"{prefix}7 caller={caller!r} .env={env_value!r} -> {o!r} (want {want!r}, rc={rc} {e[:60]})")
+
+
+def part_d() -> None:
+    print("Part D: launcher wiring + knob GLM53_APC_NO_STORE (fork start.sh: defaults top-level, strict validation start/restart-only)")
+    if not START.is_file():
+        check(False, "D0 start.sh missing")
+        return
+    _launcher_wiring("D", "APC_NO_STORE_PATCH_HOST", "patch_apc_no_store.py", "GLM53_APC_NO_STORE", "[glm53-apc-no-store]")
+
+
+# ------------------------------------------------------------------ main -----
+
+
+def main() -> int:
+    if PATCH is None:
+        raise SystemExit("missing overlay/patch_apc_no_store.py")
+    root = source_root()
+    print(f"overlay: {PATCH}\nsources: {root or '(none: replicas only, Part C skipped)'}  python: {sys.executable}")
+    part_a(root)
+    part_b()
+    part_c(root)
+    part_d()
+    print()
+    if FAILURES:
+        print(f"FAILED ({len(FAILURES)}/{CHECKS}): " + "; ".join(FAILURES))
+        return 1
+    print(f"no-store overlay OK ({CHECKS} checks)")
+    return 0
+
+
+def test_apc_no_store() -> None:
+    """pytest entry point."""
+    FAILURES.clear()
+    assert main() == 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_kv_capacity_log.py
+++ b/tests/test_kv_capacity_log.py
@@ -1,0 +1,872 @@
+#!/usr/bin/env python3
+"""Tests for the honest KV-capacity boot log overlay (host-only, no GPU, no torch).
+
+Part A  the derivation, driven through the SAME helper text the overlay writes
+        into kv_cache_utils.py (exec'd, not re-implemented): the deployment's
+        hybrid layout reproduces the logged stock line (643 ids / 414 per
+        request -> 1,553,140 tokens, 1.55x) and the runbook numbers (642 usable
+        ids, 38 ids per 3584-token segment, 57,344 tokens); the 820-id boot;
+        single-group / uniform-type / EAGLE / unmodelled / null-block edges;
+        the knob matrix; failure modes (malformed knob raises, derivation
+        error -> warning, no config mutation, hashable log arguments).
+Part B  patch mechanics on a fixture built from verbatim excerpts of the live
+        container's kv_cache_utils.py (both pinned anchors in file order, in a
+        module that compiles): stock line byte-identical after patching,
+        end-to-end call through the patched update_kv_cache_capacity with
+        vllm stubbed, idempotent re-apply, per-anchor drift -> non-zero exit
+        with NOTHING written, partial / altered markers refused, missing
+        binding refused, --preflight, pyc clear; the real installed file when
+        present (mandatory with GLM53_REQUIRE_TARGET=1, i.e. in the image).
+Part C  launcher wiring: the numeric-config guard accepts exactly 0/1 for
+        GLM53_KV_CAPACITY_LOG (unset -> 1), caller capture is set-ness aware,
+        artifact guard entry, scp + both mounts + `-e` forward, overlay order
+        after patch_glm5_drafter_group.py, Dockerfile test-before-patch,
+        .env.example and README rows.
+"""
+from __future__ import annotations
+
+import copy
+import os
+import subprocess
+import sys
+import tempfile
+import types
+from pathlib import Path
+
+
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parent
+PATCH = next(
+    p
+    for p in (HERE / "patch_kv_capacity_log.py", ROOT / "overlay" / "patch_kv_capacity_log.py")
+    if p.is_file()
+)
+sys.path.insert(0, str(PATCH.parent))
+import patch_kv_capacity_log as P  # noqa: E402
+
+START = ROOT / "start.sh"
+DOCKERFILE = ROOT / "Dockerfile"
+ENV_EXAMPLE = ROOT / ".env.example"
+README = ROOT / "README.md"
+
+CHECKS = 0
+FAILURES: list[str] = []
+
+
+def check(cond: bool, label: str) -> None:
+    global CHECKS
+    CHECKS += 1
+    print(("  ok   " if cond else "  FAIL ") + label)
+    if not cond:
+        FAILURES.append(label)
+
+
+# --------------------------------------------------------------------------
+# synthetic specs, duck-typed exactly as the fork's kv_cache_interface.py
+# (class NAMES and MRO matter: the helpers classify by them)
+# --------------------------------------------------------------------------
+class _Ns:
+    def __init__(self, **kw):
+        self.__dict__.update(kw)
+
+
+class KVCacheSpec:
+    def __init__(self, block_size: int, page: int):
+        self.block_size = block_size
+        self._page = page
+
+    @property
+    def page_size_bytes(self) -> int:
+        return self._page
+
+
+class AttentionSpec(KVCacheSpec):
+    pass
+
+
+class FullAttentionSpec(AttentionSpec):
+    def max_memory_usage_bytes(self, cfg) -> int:  # I:295-300
+        return P.cdiv(cfg.model_config.max_model_len, self.block_size) * self.page_size_bytes
+
+
+class MLAAttentionSpec(FullAttentionSpec):
+    pass
+
+
+class SlidingWindowSpec(AttentionSpec):
+    def __init__(self, block_size: int, page: int, window: int):
+        super().__init__(block_size, page)
+        self.sliding_window = window
+
+    def max_admission_blocks_per_request(self, max_in_flight_tokens: int, max_model_len: int) -> int:  # I:616-637
+        num_tokens = min(self.sliding_window - 1 + max_in_flight_tokens, max_model_len)
+        return P.cdiv(num_tokens, self.block_size) + 1
+
+    def max_memory_usage_bytes(self, cfg) -> int:  # I:639-647
+        return self.max_admission_blocks_per_request(cfg.max_in_flight_tokens, cfg.model_config.max_model_len) * self.page_size_bytes
+
+
+class SlidingWindowMLASpec(SlidingWindowSpec):
+    pass
+
+
+class KpoolTailSpec(SlidingWindowSpec):  # I:739-786
+    def max_admission_blocks_per_request(self, max_in_flight_tokens: int, max_model_len: int) -> int:
+        return 1
+
+    @property
+    def participates_in_prefix_caching(self) -> bool:
+        return False
+
+
+class MambaSpec(KVCacheSpec):  # I:790-821
+    def __init__(self, block_size: int, page: int, num_speculative_blocks: int, mamba_cache_mode: str = "align"):
+        super().__init__(block_size, page)
+        self.num_speculative_blocks = num_speculative_blocks
+        self.mamba_cache_mode = mamba_cache_mode  # set from cache_config at spec creation (abstract.py:74)
+
+    def max_memory_usage_bytes(self, cfg) -> int:
+        mode = cfg.cache_config.mamba_cache_mode  # the fork reads cache_config here (I:813-818)
+        if mode == "all":
+            return (P.cdiv(cfg.model_config.max_model_len, self.block_size) + self.num_speculative_blocks) * self.page_size_bytes
+        if mode == "align":
+            return self.page_size_bytes * (2 + self.num_speculative_blocks)
+        return self.page_size_bytes * (1 + self.num_speculative_blocks)
+
+
+class ChunkedLocalAttentionSpec(AttentionSpec):
+    def max_memory_usage_bytes(self, cfg) -> int:
+        return 3 * self.page_size_bytes
+
+
+class CrossAttentionSpec(AttentionSpec):
+    def max_memory_usage_bytes(self, cfg) -> int:
+        return 2 * self.page_size_bytes
+
+
+class SinkFullAttentionSpec(FullAttentionSpec):  # I:866: its manager keeps permanent sink blocks
+    pass
+
+
+class TQFullAttentionSpec(FullAttentionSpec):  # I:392
+    pass
+
+
+class RSWASpec(FullAttentionSpec):  # I:508
+    pass
+
+
+class UniformTypeKVCacheSpecs(KVCacheSpec):  # I:920-948
+    def __init__(self, kv_cache_specs: dict):
+        self.kv_cache_specs = kv_cache_specs
+        self.block_size = next(iter(kv_cache_specs.values())).block_size
+
+    @property
+    def participates_in_prefix_caching(self) -> bool:
+        return all(getattr(s, "participates_in_prefix_caching", True) for s in self.kv_cache_specs.values())
+
+    @property
+    def page_size_bytes(self) -> int:
+        return sum(s.page_size_bytes for s in self.kv_cache_specs.values())
+
+    def max_memory_usage_bytes(self, cfg) -> int:
+        pages = max(P.cdiv(s.max_memory_usage_bytes(cfg), s.page_size_bytes) for s in self.kv_cache_specs.values())
+        return pages * self.page_size_bytes
+
+
+def group(spec, layers: int, eagle: bool = False):
+    return _Ns(layer_names=[f"layer.{i}" for i in range(layers)], kv_cache_spec=spec, is_eagle_group=eagle)
+
+
+# Live deployment (head Spark): MAX_MODEL_LEN 1e6, MNBT 2048, async scheduling
+# (max_concurrent_batches 2 -> max_in_flight_tokens 4096), k=7 DFlash2 tokens,
+# mamba block 3584 in align mode, drafter SWA window 2048 block 64, kpool 4.
+LIVE_MAX_MODEL_LEN = 1_000_000
+LIVE_IN_FLIGHT = 2 * 2048
+LIVE_SPEC_TOKENS = 7
+MLA_PAGE = 2_351_104 * 11  # 3584 x 656 B x 11 layers (fp8_ds_mla), uniform group
+
+
+def live_cfg(max_model_len=LIVE_MAX_MODEL_LEN, mamba_mode="align", use_eagle=True, in_flight=LIVE_IN_FLIGHT, dcp=1, pcp=1):
+    spec_cfg = _Ns(use_eagle=(lambda: use_eagle)) if use_eagle is not None else None
+    return _Ns(
+        model_config=_Ns(max_model_len=max_model_len),
+        cache_config=_Ns(mamba_cache_mode=mamba_mode),
+        parallel_config=_Ns(decode_context_parallel_size=dcp, prefill_context_parallel_size=pcp),
+        speculative_config=spec_cfg,
+        max_in_flight_tokens=in_flight,
+    )
+
+
+def live_groups(mamba_mode="align"):
+    return (
+        [group(MLAAttentionSpec(3584, MLA_PAGE), 11), group(KpoolTailSpec(4, 1024, 4), 11)]
+        + [group(MambaSpec(3584, 4096, LIVE_SPEC_TOKENS, mamba_mode), 9) for _ in range(4)]
+        + [group(SlidingWindowSpec(64, 8192, 2048), 1)]
+    )
+
+
+def kv_config(num_blocks: int, groups=None, mamba_mode="align"):
+    return _Ns(num_blocks=num_blocks, kv_cache_groups=live_groups(mamba_mode) if groups is None else groups)
+
+
+def stock_line(num_blocks: int, bpr: int, max_model_len: int) -> tuple[str, str]:
+    """What update_kv_cache_capacity prints: int(mc * L) and %.2fx."""
+    mc = num_blocks / bpr
+    return f"{int(mc * max_model_len):,}", f"{mc:.2f}x"
+
+
+def drive(cfg, kc, max_model_len=None, env=None):
+    """Run the shipped _glm53_log_kv_capacity with a recording logger."""
+    log = P._RecordingLogger()
+    ns = P.load_helpers(log)
+    saved = os.environ.get(P.ENV_NAME)
+    try:
+        if env is None:
+            os.environ.pop(P.ENV_NAME, None)
+        else:
+            os.environ[P.ENV_NAME] = env
+        ns["_glm53_log_kv_capacity"](cfg, kc, cfg.model_config.max_model_len if max_model_len is None else max_model_len)
+    finally:
+        if saved is None:
+            os.environ.pop(P.ENV_NAME, None)
+        else:
+            os.environ[P.ENV_NAME] = saved
+    return log
+
+
+# --------------------------------------------------------------------------
+# Part A -- derivation
+# --------------------------------------------------------------------------
+def part_a() -> None:
+    print("Part A: derivation (shipped helper text, exec'd)")
+    check(P.HELPERS_SRC in P.PATCHED_HELPERS and P.PATCHED_HELPERS.endswith(P.ANCHOR_HELPERS), "A0 the exec'd helper text is the text written above the anchor, verbatim")
+
+    cfg, kc = live_cfg(), kv_config(643)
+    rows = P.kv_capacity_rows(cfg, kc)
+    bpr = [r["blocks_per_request"] for r in rows]
+    check(bpr == [280, 1, 9, 9, 9, 9, 97], f"A1 blocks/request per group = {bpr} (MLA cdiv(1e6,3584); kpool 1; mamba align 2+7; drafter cdiv(min(2047+4096,1e6),64)+1)")
+    check(sum(bpr) == 414, "A1 sum = 414 = the stock denominator (DESIGN-drafter-retention §3)")
+    tokens, ratio = stock_line(643, 414, LIVE_MAX_MODEL_LEN)
+    check(tokens == "1,553,140" and ratio == "1.55x", f"A1 stock line reproduced from 643 ids: {tokens} tokens, {ratio} (runbook 08-31)")
+    check([r["spec"] for r in rows] == ["MLAAttentionSpec", "KpoolTailSpec"] + ["MambaSpec"] * 4 + ["SlidingWindowSpec"], "A1 spec names by group")
+    check([r["prefix_cacheable"] for r in rows] == [True, False, True, True, True, True, True], "A1 only the kpool tail opts out of prefix caching")
+    check([r["eagle"] for r in rows] == [False] * 6 + [True], "A1 EAGLE flag: the exact-SlidingWindowSpec drafter group only (coordinator fallback mirrored)")
+    check(rows[6]["sliding_window"] == 2048 and rows[2]["mamba_cache_mode"] == "align", "A1 window / mamba mode carried on the rows")
+
+    s = P.kv_capacity_summary(rows, 643)
+    check(s["usable"] == 642 and s["num_blocks"] == 643, "A2 usable block ids = 642 (643 minus the null block)")
+    check(s["alignment"] == 3584, "A2 alignment = lcm(3584, 4, 64) = 3584 (the coordinator's scheduler block)")
+    check(s["per_group"] == [1, 0, 1, 1, 1, 1, 33], f"A2 ids per 3584-token segment per group = {s['per_group']}")
+    check(s["total"] == 38, "A2 ids per segment across groups = 38 (1 MLA + 4 mamba + 33 drafter)")
+    check(s["segments"] == 16 and s["capacity_tokens"] == 57_344, "A2 capacity = 642 // 38 * 3584 = 57,344 tokens (partial final segment floored: 642 = 16*38 + 34)")
+    check(s["unmodelled"] == [] and s["blocks_per_request"] == 414, "A2 nothing unmodelled; denominator carried")
+
+    lines = P.kv_capacity_lines(rows, s, LIVE_MAX_MODEL_LEN)
+    check(len(lines) == 8 and all(isinstance(x, str) and "%" not in x for x in lines), "A3 8 preformatted lines (7 groups + summary), hashable strings, no printf directives (info_once caches on its args)")
+    check(lines[0] == "[glm53-kv-capacity-log] group 0: MLAAttentionSpec layers=11 block_size=3584 page_size=25,862,144 B blocks/request@1,000,000=280 prefix_caching=yes", "A3 group 0 line verbatim")
+    check(lines[1].endswith("blocks/request@1,000,000=1 prefix_caching=no (scratch) window=4 eagle=no") and "KpoolTailSpec" in lines[1], "A3 kpool tail line: scratch, 1 block/request")
+    check(lines[6] == "[glm53-kv-capacity-log] group 6: SlidingWindowSpec layers=1 block_size=64 page_size=8,192 B blocks/request@1,000,000=97 prefix_caching=yes window=2048 eagle=yes", "A3 drafter line verbatim")
+    summary = lines[7]
+    for frag in (
+        "usable block ids: 642 (num_blocks=643 incl. the null block; 414 ids per 1,000,000-token request => 1.55x)",
+        "ids per 3584-token cached segment across groups: 38 (per group: [1, 0, 1, 1, 1, 1, 33])",
+        "cached-conversation capacity at this alignment ≈ 57,344 tokens = 16 segments",
+        "dense-retention",
+        "'GPU KV cache size' line above is max_concurrency x max_model_len, not this figure",
+    ):
+        check(frag in summary, f"A3 summary carries {frag[:60]!r}")
+
+    log = drive(cfg, kc)
+    check(log.info == lines and not log.warnings, "A4 _glm53_log_kv_capacity emits exactly those lines through logger.info_once, no warning")
+
+    # The current rightsized boot (deploy/dogfood-next 2026-09-01 08:0x): 820 ids.
+    rows820 = P.kv_capacity_rows(cfg, kv_config(820))
+    s820 = P.kv_capacity_summary(rows820, 820)
+    tokens, ratio = stock_line(820, 414, LIVE_MAX_MODEL_LEN)
+    check(tokens == "1,980,676" and ratio == "1.98x", f"A5 820 ids -> stock line {tokens} / {ratio} (boot log 09-01 01:09:54)")
+    check(s820["usable"] == 819 and s820["segments"] == 21 and s820["capacity_tokens"] == 75_264, "A5 820 ids -> 819 usable, 21 segments, 75,264 tokens")
+    line = P.kv_capacity_lines(rows820, s820, LIVE_MAX_MODEL_LEN)[-1]
+    check("usable block ids: 819 (num_blocks=820" in line and "≈ 75,264 tokens = 21 segments" in line, "A5 820-id summary line")
+
+    # Single-group full-attention model: the stock figure and the summary agree
+    # up to the null block, which is the whole point of the label upstream.
+    one = [group(FullAttentionSpec(16, 4096), 32)]
+    c1 = live_cfg(max_model_len=4096, use_eagle=None)
+    r1 = P.kv_capacity_rows(c1, kv_config(1000, one))
+    s1 = P.kv_capacity_summary(r1, 1000)
+    check(r1[0]["blocks_per_request"] == 256 and s1["alignment"] == 16 and s1["per_group"] == [1] and s1["capacity_tokens"] == 999 * 16, "A6 single full-attention group: capacity = usable * block_size = 15,984")
+    check(stock_line(1000, 256, 4096)[0] == "16,000" and 16_000 - s1["capacity_tokens"] == 16, "A6 ... one block (the null block) below the stock 16,000 figure")
+
+    # UniformTypeKVCacheSpecs wrapper: name the inner class, page = sum, opt-out propagates.
+    uni = UniformTypeKVCacheSpecs({"a": MLAAttentionSpec(3584, 100), "b": MLAAttentionSpec(3584, 200)})
+    ru = P.kv_capacity_rows(cfg, kv_config(10, [group(uni, 2)]))
+    check(ru[0]["spec"] == "MLAAttentionSpec" and ru[0]["page_size_bytes"] == 300 and ru[0]["blocks_per_request"] == 280 and ru[0]["prefix_cacheable"], "A7 uniform-type wrapper unwrapped for the name; page/blocks from the wrapper")
+    uni_scratch = UniformTypeKVCacheSpecs({"a": KpoolTailSpec(4, 8, 4)})
+    check(P.spec_prefix_cacheable(uni_scratch) is False and P.spec_prefix_cacheable(uni) is True, "A7 wrapper participation aggregates its members")
+
+    # Participation flags: fork's first, upstream's second, default True.
+    class _Up(FullAttentionSpec):
+        @property
+        def prefix_cacheable(self):
+            return False
+
+    class _Both(FullAttentionSpec):
+        @property
+        def participates_in_prefix_caching(self):
+            return True
+
+        @property
+        def prefix_cacheable(self):
+            return False
+
+    check(P.spec_prefix_cacheable(_Up(16, 1)) is False, "A8 upstream `prefix_cacheable` False is honoured when the fork flag is absent")
+    check(P.spec_prefix_cacheable(_Both(16, 1)) is True, "A8 the fork flag wins when both exist")
+    check(P.spec_prefix_cacheable(FullAttentionSpec(16, 1)) is True, "A8 neither flag -> participates (legacy specs cache)")
+    ru2 = P.kv_capacity_rows(cfg, kv_config(10, [group(_Up(16, 1), 1)]))
+    check(P.kv_capacity_summary(ru2, 10)["per_group"] == [0], "A8 an opted-out group costs 0 ids per segment")
+
+    # EAGLE detection.
+    ids = P.eagle_group_ids(live_cfg(use_eagle=None), kv_config(10))
+    check(ids == set(), "A9 no speculative config -> no EAGLE group")
+    ids = P.eagle_group_ids(live_cfg(use_eagle=False), kv_config(10))
+    check(ids == set(), "A9 use_eagle() False -> no EAGLE group")
+    gs = live_groups()
+    gs[0].is_eagle_group = True
+    check(P.eagle_group_ids(cfg, kv_config(10, gs)) == {0}, "A9 is_eagle_group is authoritative when any group carries it (fallback not consulted)")
+    gs = [group(MLAAttentionSpec(3584, 1), 1), group(SlidingWindowMLASpec(64, 1, 2048), 1)]
+    check(P.eagle_group_ids(cfg, kv_config(10, gs)) == {0, 1}, "A9 use_eagle() with no exact SlidingWindowSpec group -> every group (upstream fallback; SlidingWindowMLASpec subclass is NOT the drafter predicate, same as the coordinator overlay)")
+    rn = P.kv_capacity_rows(live_cfg(use_eagle=None), kv_config(10))
+    check(P.kv_capacity_summary(rn, 643)["per_group"][6] == 32, "A9 drafter without EAGLE: cdiv(2047, 64) = 32 ids per segment")
+    wide = [group(MLAAttentionSpec(3584, 1), 1), group(SlidingWindowSpec(64, 1, 4096), 1)]
+    sw = P.kv_capacity_summary(P.kv_capacity_rows(cfg, kv_config(10, wide)), 10)
+    check(sw["per_group"] == [1, 56], "A9 window wider than the segment: need 65 >= 56 -> every block of the segment (reachable_block_mask returns None)")
+
+    # Unmodelled kinds withhold the capacity instead of guessing.
+    rr = P.kv_capacity_rows(live_cfg(mamba_mode="none"), kv_config(643, mamba_mode="none"))
+    ss = P.kv_capacity_summary(rr, 643)
+    check(ss["unmodelled"] == [2, 3, 4, 5] and ss["capacity_tokens"] is None and ss["segments"] is None, "A10 mamba_cache_mode=none: mamba groups unmodelled, capacity withheld")
+    ll = P.kv_capacity_lines(rr, ss, LIVE_MAX_MODEL_LEN)[-1]
+    check("not derived (unmodelled: group 2 MambaSpec" in ll and "cached-conversation capacity at this alignment: not derived" in ll and "≈" not in ll, "A10 ... and the summary line says so")
+    rr = P.kv_capacity_rows(live_cfg(mamba_mode="align"), kv_config(643, mamba_mode="none"))
+    ss = P.kv_capacity_summary(rr, 643)
+    check(rr[2]["mamba_cache_mode"] == "none" and ss["unmodelled"] == [2, 3, 4, 5], "A10 the mode is read from the MambaSpec the manager acts on, not cache_config (spec none / config align -> unmodelled)")
+    mixed_mamba = UniformTypeKVCacheSpecs({"a": MambaSpec(3584, 8, 7, "align"), "b": MambaSpec(3584, 8, 7, "none")})
+    rr = P.kv_capacity_rows(cfg, kv_config(10, [group(mixed_mamba, 2)]))
+    check(rr[0]["mamba_cache_mode"] == "mixed" and P.kv_capacity_summary(rr, 10)["per_group"] == [None], "A10 a uniform mamba group with disagreeing member modes is 'mixed' and unmodelled")
+    rr = P.kv_capacity_rows(live_cfg(mamba_mode="all"), kv_config(643, mamba_mode="all"))
+    ss = P.kv_capacity_summary(rr, 643)
+    check([r["blocks_per_request"] for r in rr][2] == 287 and ss["per_group"][2] == 1 and ss["total"] == 38, "A10 mamba all-mode: 280+7 blocks/request, still one state per block position")
+    for cls in (SinkFullAttentionSpec, TQFullAttentionSpec, RSWASpec):
+        rr = P.kv_capacity_rows(c1, kv_config(100, [group(cls(16, 1), 1)]))
+        check(P.kv_capacity_summary(rr, 100)["per_group"] == [None], f"A10 {cls.__name__} (a FullAttentionSpec subclass with its own manager rule) is unmodelled, never costed as dense")
+    rr = P.kv_capacity_rows(live_cfg(use_eagle=None), kv_config(10, [group(MLAAttentionSpec(3584, 1), 1), group(SlidingWindowMLASpec(64, 1, 2048), 1)]))
+    check(P.kv_capacity_summary(rr, 10)["per_group"] == [1, 32], "A10 SlidingWindowMLASpec is costed by the window rule (exact-name allowlist), no EAGLE without a speculative config")
+    for label, kw in (("dcp=2", {"dcp": 2}), ("pcp=2", {"pcp": 2})):
+        rr = P.kv_capacity_rows(live_cfg(**kw), kv_config(643))
+        ss = P.kv_capacity_summary(rr, 643, live_cfg(**kw))
+        ll = P.kv_capacity_lines(rr, ss, LIVE_MAX_MODEL_LEN)[-1]
+        check(ss["capacity_tokens"] is None and ss["withheld"] and "context parallelism" in ll and "not derived" in ll, f"A10 {label}: the figure is withheld (block sizes are rescaled per rank; alignment not derived here)")
+    ss = P.kv_capacity_summary(rows, 643, cfg)
+    check(ss["withheld"] is None and ss["capacity_tokens"] == 57_344, "A10 dcp=pcp=1 (this kit): nothing withheld")
+    mixed = [group(FullAttentionSpec(16, 1), 1), group(ChunkedLocalAttentionSpec(16, 1), 1), group(CrossAttentionSpec(16, 1), 1)]
+    sm = P.kv_capacity_summary(P.kv_capacity_rows(c1, kv_config(100, mixed)), 100)
+    check(sm["per_group"] == [1, None, None] and sm["unmodelled"] == [1, 2] and sm["capacity_tokens"] is None, "A10 chunked-local / cross attention are unmodelled")
+    check(P.ids_per_segment({"prefix_cacheable": True, "block_size": 16, "spec": "WeirdSpec", "kinds": ("WeirdSpec", "KVCacheSpec", "object"), "eagle": False, "sliding_window": None, "mamba_cache_mode": None}, 16) is None, "A10 an unknown spec kind is unmodelled (never silently costed)")
+    check(P.ids_per_segment({"prefix_cacheable": True, "block_size": 64, "spec": "SlidingWindowSpec", "kinds": ("SlidingWindowSpec", "AttentionSpec", "KVCacheSpec", "object"), "eagle": True, "sliding_window": None, "mamba_cache_mode": None}, 3584) is None, "A10 a sliding-window spec without a window is unmodelled")
+
+    # Null block / tiny pools / max_model_len below the alignment.
+    for nb, usable, cap in ((1, 0, 0), (0, 0, 0), (38, 37, 0), (39, 38, 3584)):
+        st = P.kv_capacity_summary(rows, nb)
+        check(st["usable"] == usable and st["capacity_tokens"] == cap, f"A11 num_blocks={nb}: usable={usable}, capacity={cap} (never negative)")
+    small = live_cfg(max_model_len=1000)
+    rs = P.kv_capacity_rows(small, kv_config(643))
+    ss = P.kv_capacity_summary(rs, 643)
+    check([r["blocks_per_request"] for r in rs][0] == 1 and ss["capacity_tokens"] == 57_344, "A11 max_model_len 1000 < alignment: 1 MLA block/request; the segment arithmetic is independent of max_model_len")
+    s_empty = P.kv_capacity_summary([], 643)
+    l_empty = P.kv_capacity_lines([], s_empty, 10)
+    check(s_empty["capacity_tokens"] is None and len(l_empty) == 1 and "not derived (no prefix-cacheable group costs ids" in l_empty[0] and "=> n/a" in l_empty[0], "A11 empty group list: one summary line, capacity not derived, no division by zero")
+    s_scratch = P.kv_capacity_summary(P.kv_capacity_rows(cfg, kv_config(10, [group(KpoolTailSpec(4, 8, 4), 1)])), 10)
+    check(s_scratch["total"] == 0 and s_scratch["capacity_tokens"] is None and "not derived (no prefix-cacheable group costs ids" in P.kv_capacity_lines([], s_scratch, 10)[-1], "A11 only opted-out groups: capacity not derived rather than infinite")
+
+    # Knob matrix (same contract as the launcher's _glm53_validate_bool_flag).
+    def knob(value):
+        saved = os.environ.get(P.ENV_NAME)
+        try:
+            if value is None:
+                os.environ.pop(P.ENV_NAME, None)
+            else:
+                os.environ[P.ENV_NAME] = value
+            return P.kv_capacity_log_enabled()
+        finally:
+            if saved is None:
+                os.environ.pop(P.ENV_NAME, None)
+            else:
+                os.environ[P.ENV_NAME] = saved
+
+    check(knob(None) is True and knob("1") is True and knob("0") is False, "A12 unset -> on, 1 -> on, 0 -> off")
+    for bad in ("", " ", "01", "2", "yes", "true", "1 ", " 1", "1\r", "0x1", "-1", "on"):
+        try:
+            knob(bad)
+            check(False, f"A12 {bad!r} raises")
+        except ValueError as exc:
+            check(P.ENV_NAME in str(exc), f"A12 {bad!r} raises ValueError naming the knob")
+    log = drive(cfg, kc, env="0")
+    check(log.info == ["[glm53-kv-capacity-log] disabled (GLM53_KV_CAPACITY_LOG=0)"] and not log.warnings, "A12 disabled: one line saying so, nothing derived")
+    try:
+        drive(cfg, kc, env="yes")
+        check(False, "A12 malformed knob raises out of the log call (not swallowed by the derivation guard)")
+    except ValueError:
+        check(True, "A12 malformed knob raises out of the log call (not swallowed by the derivation guard)")
+
+    # Derivation failure -> warning, boot proceeds, nothing else logged.
+    class _Broken(FullAttentionSpec):
+        def max_memory_usage_bytes(self, cfg):
+            raise RuntimeError("synthetic spec failure")
+
+    log = drive(cfg, kv_config(10, [group(_Broken(16, 1), 1)]))
+    check(log.info == [] and len(log.warnings) == 1 and "RuntimeError: synthetic spec failure" in log.warnings[0] and "serving unaffected" in log.warnings[0], "A13 derivation exception -> one warning naming it, no info lines, no raise")
+
+    # No config mutation.
+    cfg2, kc2 = live_cfg(), kv_config(643)
+    before = (copy.deepcopy(cfg2.__dict__["model_config"].__dict__), copy.deepcopy(cfg2.cache_config.__dict__), kc2.num_blocks, [(g.kv_cache_spec.block_size, g.is_eagle_group, list(g.layer_names)) for g in kc2.kv_cache_groups])
+    drive(cfg2, kc2)
+    after = (cfg2.model_config.__dict__, cfg2.cache_config.__dict__, kc2.num_blocks, [(g.kv_cache_spec.block_size, g.is_eagle_group, list(g.layer_names)) for g in kc2.kv_cache_groups])
+    check(before == after, "A14 the log call mutates neither vllm_config nor kv_cache_config")
+
+
+# --------------------------------------------------------------------------
+# Part B -- patch mechanics on a fixture of the live file
+# --------------------------------------------------------------------------
+# Verbatim excerpts of glm53-exl3-head's kv_cache_utils.py (vLLM
+# 0.1.dev20051+g487ecf187, read read-only 2026-09-01), trimmed to the lines the
+# overlay depends on, in file order, in a module that compiles. The in-image
+# docstring of get_max_concurrency_for_kv_cache_config differs from upstream
+# 22df3a3; the signature line (the anchor) and the log block are identical in
+# both.
+FIXTURE = (
+    '''# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""KV-Cache Utilities."""
+
+import copy
+import hashlib
+import math
+import os
+from collections import defaultdict
+
+from vllm import envs
+from vllm.config import VllmConfig
+from vllm.logger import init_logger
+from vllm.utils.math_utils import cdiv, round_up
+from vllm.v1.kv_cache_interface import (
+    KVCacheConfig,
+    KVCacheGroupSpec,
+)
+
+
+logger = init_logger(__name__)
+
+# The hash seed for the first block of any prefix block sequence.
+NONE_HASH = 0
+
+
+def is_kv_cache_type_uniform(kv_cache_spec: dict) -> bool:
+    try:
+        kv_cache_spec_values = list(kv_cache_spec.values())
+        _ = kv_cache_spec_values[0].merge(kv_cache_spec_values)
+    except AssertionError:
+        return False
+    return True
+
+
+'''
+    + P.ANCHOR_HELPERS
+    + '''    """
+    Get the maximum concurrency for the given KV cache configuration.
+
+    Block ids are globally unique across groups (one BlockPool), so a
+    max-length request costs the sum over groups of that group's block
+    demand — layout-independent, each group divides by its own page size.
+    """
+    num_blocks_per_request = sum(
+        cdiv(
+            group.kv_cache_spec.max_memory_usage_bytes(vllm_config),
+            group.kv_cache_spec.page_size_bytes,
+        )
+        for group in kv_cache_config.kv_cache_groups
+    )
+    max_concurrency = kv_cache_config.num_blocks / num_blocks_per_request
+    return max_concurrency
+
+
+def may_override_num_blocks(vllm_config: VllmConfig, num_blocks: int) -> int:
+    """
+    Override the number of kv cache blocks if `num_gpu_blocks_override` is set.
+    The override is logged once, at the call site in `get_kv_cache_configs`.
+    """
+    if vllm_config.cache_config.num_gpu_blocks_override is not None:
+        num_blocks = vllm_config.cache_config.num_gpu_blocks_override
+    return num_blocks
+
+
+def get_kv_cache_capacity(
+    vllm_config: VllmConfig, kv_cache_config: KVCacheConfig
+) -> tuple[int, float]:
+    """
+    Get the group-aware KV cache token capacity and max concurrency.
+    """
+    max_model_len = vllm_config.model_config.max_model_len
+    max_concurrency = get_max_concurrency_for_kv_cache_config(
+        vllm_config, kv_cache_config
+    )
+    return int(max_concurrency * max_model_len), max_concurrency
+
+
+def update_kv_cache_capacity(
+    vllm_config: VllmConfig, kv_cache_config: KVCacheConfig
+) -> None:
+    """Store and log the resolved KV cache capacity."""
+    num_tokens, max_concurrency = get_kv_cache_capacity(vllm_config, kv_cache_config)
+    vllm_config.cache_config.kv_cache_size_tokens = num_tokens
+    vllm_config.cache_config.kv_cache_max_concurrency = max_concurrency
+    max_model_len = vllm_config.model_config.max_model_len
+'''
+    + P.ANCHOR_CALL
+    + '''
+
+def _max_memory_usage_bytes_from_groups(
+    vllm_config: VllmConfig,
+    kv_cache_groups: list[KVCacheGroupSpec],
+) -> int:
+    return 0
+'''
+)
+
+
+def _stub_vllm(logger: P._RecordingLogger) -> dict:
+    """sys.modules stubs so the (patched) fixture can be exec'd end to end."""
+    mods = {}
+
+    def mod(name, **attrs):
+        m = types.ModuleType(name)
+        m.__dict__.update(attrs)
+        mods[name] = m
+        return m
+
+    mod("vllm", envs=types.SimpleNamespace())
+    mod("vllm.config", VllmConfig=object)
+    mod("vllm.logger", init_logger=lambda name: logger)
+    mod("vllm.utils")
+    mod("vllm.utils.math_utils", cdiv=P.cdiv, round_up=lambda x, y: -(-x // y) * y)
+    mod("vllm.v1")
+    mod("vllm.v1.kv_cache_interface", KVCacheConfig=object, KVCacheGroupSpec=object)
+    return mods
+
+
+def exec_module(text: str, logger: P._RecordingLogger) -> dict:
+    saved = {k: sys.modules.get(k) for k in _stub_vllm(logger)}
+    try:
+        sys.modules.update(_stub_vllm(logger))
+        ns: dict = {"__name__": "kv_cache_utils_fixture"}
+        exec(compile(text, "kv_cache_utils_fixture.py", "exec"), ns)
+        return ns
+    finally:
+        for k, v in saved.items():
+            if v is None:
+                sys.modules.pop(k, None)
+            else:
+                sys.modules[k] = v
+
+
+def run_overlay(target: Path, *args: str, env_extra: dict | None = None) -> subprocess.CompletedProcess[str]:
+    env = {**os.environ, "GLM53_KV_CACHE_UTILS_PY": str(target)}
+    env.pop(P.ENV_NAME, None)
+    if env_extra:
+        env.update(env_extra)
+    return subprocess.run([sys.executable, str(PATCH), *args], text=True, capture_output=True, env=env)
+
+
+def part_b() -> None:
+    print("Part B: patch mechanics (fixture of the live kv_cache_utils.py)")
+    compile(FIXTURE, "fixture", "exec")
+    check(FIXTURE.count(P.ANCHOR_HELPERS) == 1 and FIXTURE.count(P.ANCHOR_CALL) == 1, "B0 fixture carries both pinned anchors exactly once")
+    check(not P.verified_state(FIXTURE) and all(m not in FIXTURE for _n, m, _a, _p in P.SITES), "B0 pristine fixture is not in the verified state and carries no mark")
+
+    patched, action = P.prepare(FIXTURE)
+    compile(patched, "patched", "exec")
+    check(action == "patched" and P.verified_state(patched), "B1 prepare -> patched, verified state")
+    check(patched.count(P.ANCHOR_CALL) == 1 and patched.count(P.ANCHOR_HELPERS) == 1, "B1 the stock 'GPU KV cache size' info_once and the function signature survive byte-identical")
+    check(P.ANCHOR_CALL + P.MARK_CALL in patched, "B1 the overlay call is the very next line after the stock line (same function, same indentation)")
+    check(patched.index(P.MARK_HELPERS) < patched.index(P.ANCHOR_HELPERS) < patched.index(P.MARK_CALL), "B1 helpers precede the function they mirror, the call comes last")
+    check(P.HELPERS_SRC in patched, "B1 the injected helper text is HELPERS_SRC verbatim")
+    stock_before = FIXTURE[FIXTURE.index("def update_kv_cache_capacity") : FIXTURE.index(P.ANCHOR_CALL) + len(P.ANCHOR_CALL)]
+    stock_after = patched[patched.index("def update_kv_cache_capacity") : patched.index(P.ANCHOR_CALL) + len(P.ANCHOR_CALL)]
+    check(stock_before == stock_after, "B1 update_kv_cache_capacity up to and including the stock line is unchanged")
+
+    # End to end through the patched text: the stock line first, then ours.
+    log = P._RecordingLogger()
+    ns = exec_module(patched, log)
+    cfg, kc = live_cfg(), kv_config(643)
+    cfg.cache_config.num_gpu_blocks_override = None
+    saved = os.environ.pop(P.ENV_NAME, None)
+    try:
+        ns["update_kv_cache_capacity"](cfg, kc)
+    finally:
+        if saved is not None:
+            os.environ[P.ENV_NAME] = saved
+    check(log.info[0] == "GPU KV cache size: 1,553,140 tokens, Maximum concurrency for 1,000,000 tokens per request: 1.55x", "B2 patched update_kv_cache_capacity still logs the stock line first, verbatim")
+    check(len(log.info) == 9 and log.info[1].startswith("[glm53-kv-capacity-log] group 0: MLAAttentionSpec") and "usable block ids: 642" in log.info[8] and "38 (per group: [1, 0, 1, 1, 1, 1, 33])" in log.info[8] and not log.warnings, "B2 ... followed by the 7 group lines and the summary (642 / 38 / 57,344)")
+    check(cfg.cache_config.kv_cache_size_tokens == 1_553_140 and abs(cfg.cache_config.kv_cache_max_concurrency - 643 / 414) < 1e-12, "B2 kv_cache_size_tokens / kv_cache_max_concurrency stored exactly as stock")
+    log0 = P._RecordingLogger()
+    ns0 = exec_module(FIXTURE, log0)
+    cfg0 = live_cfg()
+    cfg0.cache_config.num_gpu_blocks_override = None
+    ns0["update_kv_cache_capacity"](cfg0, kv_config(643))
+    check(log0.info == log.info[:1], "B2 pristine fixture logs exactly the first of those lines (the overlay adds, never alters)")
+
+    again, action2 = P.prepare(patched)
+    check(again == patched and action2 == "already present", "B3 idempotent: prepare on a patched file is a byte-identical no-op")
+
+    with tempfile.TemporaryDirectory() as raw:
+        tmp = Path(raw)
+        target = tmp / "kv_cache_utils.py"
+        target.write_text(FIXTURE)
+        os.chmod(target, 0o644)
+        pyc_dir = tmp / "__pycache__"
+        pyc_dir.mkdir()
+        stale = pyc_dir / "kv_cache_utils.cpython-312.pyc"
+        stale.write_bytes(b"stale")
+
+        r = run_overlay(target, "--preflight")
+        check(r.returncode == 0 and "preflight OK (patched)" in r.stdout and target.read_text() == FIXTURE and stale.exists(), f"B4 --preflight on a pristine file: rc=0, reports 'patched', writes nothing (stdout={r.stdout.strip()!r})")
+        r = run_overlay(target)
+        check(r.returncode == 0 and "kv-capacity-log patched" in r.stdout and target.read_text() == patched, f"B4 apply: rc=0, file == prepare() output (stdout={r.stdout.strip()!r})")
+        check(not stale.exists(), "B4 stale bytecode for the target was cleared")
+        check(stat_mode(target) == 0o644 and not list(tmp.glob(".*.tmp")), "B4 mode preserved, no temp litter")
+        r = run_overlay(target)
+        check(r.returncode == 0 and "already present" in r.stdout and target.read_text() == patched, "B4 second apply: 'already present', byte-identical")
+        r = run_overlay(target, "--preflight", env_extra={P.ENV_NAME: ""})
+        check(r.returncode == 0 and "already present" in r.stdout, "B4 --preflight does not consult the knob (an empty knob is the runtime's error, not the installer's)")
+        r = run_overlay(target, env_extra={P.ENV_NAME: ""})
+        check(r.returncode == 0 and "GLM53_KV_CAPACITY_LOG=''" in r.stdout, "B4 apply reports the knob as set (empty shown as '', not normalised to 1)")
+
+        # Drift: each anchor altered by one character, one at a time -> refused, nothing written.
+        for name, _mark, anchor, _patched in P.SITES:
+            drifted = FIXTURE.replace(anchor, anchor.replace("_", "-", 1), 1)  # one character
+            assert drifted != FIXTURE
+            target.write_text(drifted)
+            r = run_overlay(target)
+            check(r.returncode != 0 and "drifted" in r.stderr and name in r.stderr and target.read_text() == drifted and not list(tmp.glob(".*.tmp")), f"B5 anchor '{name}' drifted -> non-zero exit naming it, file untouched")
+            try:
+                P.prepare(drifted)
+                check(False, f"B5 prepare() raises on drifted '{name}'")
+            except ValueError as exc:
+                check(name in str(exc), f"B5 prepare() raises on drifted '{name}'")
+
+        # Partial / altered markers refused.
+        half = FIXTURE.replace(P.ANCHOR_HELPERS, P.PATCHED_HELPERS, 1)
+        target.write_text(half)
+        r = run_overlay(target)
+        check(r.returncode != 0 and "partial" in r.stderr and target.read_text() == half, "B6 only the helpers present (marks=1 of 2) -> refused, untouched")
+        altered = patched.replace("_glm53_log_kv_capacity(vllm_config, kv_cache_config, max_model_len)  # [glm53-kv-capacity-log]", "_glm53_log_kv_capacity(vllm_config, kv_cache_config, 0)  # [glm53-kv-capacity-log]", 1)
+        target.write_text(altered)
+        r = run_overlay(target)
+        check(r.returncode != 0 and "partial" in r.stderr and target.read_text() == altered, "B6 marked but altered call -> refused, untouched")
+        dup = patched + "\n" + P.MARK_CALL
+        target.write_text(dup)
+        r = run_overlay(target)
+        check(r.returncode != 0 and target.read_text() == dup, "B6 duplicated mark -> refused, untouched")
+
+        # A file that lacks a binding the helpers need is refused before any write.
+        nobind = FIXTURE.replace("import math\n", "", 1)
+        target.write_text(nobind)
+        r = run_overlay(target)
+        check(r.returncode != 0 and "does not bind 'import math'" in r.stderr and target.read_text() == nobind, "B7 missing `import math` above the insert point -> refused (helpers would NameError)")
+        nolog = FIXTURE.replace("logger = init_logger(__name__)\n", "", 1)
+        target.write_text(nolog)
+        r = run_overlay(target)
+        check(r.returncode != 0 and "logger = init_logger" in r.stderr and target.read_text() == nolog, "B7 missing module logger -> refused")
+
+        r = run_overlay(tmp / "absent.py")
+        check(r.returncode != 0 and "missing" in r.stderr, "B7 missing target -> non-zero exit")
+
+    # The real installed file, when present (mandatory in the image).
+    installed = P.TARGET
+    if installed.is_file():
+        text = installed.read_text()
+        try:
+            out, act = P.prepare(text)
+            compile(out, str(installed), "exec")
+            check(act in ("patched", "already present") and P.verified_state(out), f"B8 installed {installed}: preflight OK ({act})")
+            check(text.count(P.ANCHOR_CALL) == 1, "B8 installed file carries the stock 'GPU KV cache size' block exactly once")
+        except ValueError as exc:
+            check(False, f"B8 installed {installed}: preflight failed: {exc}")
+    elif os.environ.get("GLM53_REQUIRE_TARGET") == "1":
+        check(False, f"B8 GLM53_REQUIRE_TARGET=1 but {installed} is missing")
+    else:
+        print(f"  skip B8 installed file not present ({installed})")
+
+
+def stat_mode(path: Path) -> int:
+    return path.stat().st_mode & 0o777
+
+
+# --------------------------------------------------------------------------
+# Part C -- launcher / image wiring
+# --------------------------------------------------------------------------
+
+def defaults_source() -> str:
+    """The fork's W41/W42 knob-defaults block in start.sh. Top level, but it
+    only substitutes UNSET -> 1 and never exits: strict validation lives in
+    validate_numeric_config (start/restart only), so a bad value can never
+    block stop/status/logs on a running pair."""
+    text = START.read_text()
+    begin = text.index("# LOCAL: W41/W42 knob defaults (begin)")
+    end_marker = "# LOCAL: W41/W42 knob defaults (end)"
+    return text[begin : text.index(end_marker, begin) + len(end_marker)]
+
+
+def validator_source() -> str:
+    """The W41/W42 strict-bool loop, verbatim from validate_numeric_config,
+    wrapped in a function so its ``return 2`` is executable standalone."""
+    text = START.read_text()
+    begin = text.index("# LOCAL: W41/W42 strict-bool validation (begin)")
+    end_marker = "# LOCAL: W41/W42 strict-bool validation (end)"
+    body = text[begin : text.index(end_marker, begin) + len(end_marker)]
+    return "_glm53_w4142_validate() {\n" + body + "\n}"
+
+
+def caller_wins_source() -> str:
+    """The setness-aware caller-wins capture + .env source + restore, as
+    verbatim slices of start.sh, runnable against a fake .env ($GLM53_FAKE_ENV)."""
+    text = START.read_text()
+
+    def _slice(marker: str) -> str:
+        begin = text.index(f"# LOCAL: W41/W42 {marker} (begin)")
+        end_marker = f"# LOCAL: W41/W42 {marker} (end)"
+        return text[begin : text.index(end_marker, begin) + len(end_marker)]
+
+    return (
+        _slice("caller-wins capture")
+        + '\nset -a\nsource "$GLM53_FAKE_ENV"\nset +a\n'
+        + _slice("caller-wins restore")
+    )
+
+
+def _run_defaults(knob: str, value: str | None) -> tuple[int, str, str]:
+    # Length|value output, binary-safe capture: a whitespace-only difference
+    # can never hide behind a stripped comparison -- passthrough is byte-exact.
+    script = defaults_source() + '\nv="${' + knob + '-unset}"; printf "%s|%s\\n" "${#v}" "$v"\n'
+    env = {"PATH": os.environ.get("PATH", "/usr/bin:/bin"), "LC_ALL": "C"}
+    if value is not None:
+        env[knob] = value
+    r = subprocess.run(["bash", "-c", script], capture_output=True, env=env)
+    out = r.stdout.decode("utf-8", "replace").rstrip("\n")
+    err = r.stderr.decode("utf-8", "replace").strip()
+    return r.returncode, out, err
+
+
+def _run_validator(knob: str, value: str) -> tuple[int, str, str]:
+    # The loop validates BOTH knobs; in the real launcher the top-level
+    # defaults block has already assigned the other one (unset -> 1), so the
+    # harness mirrors that instead of letting it reach the validator unset.
+    other = "GLM53_APC_NO_STORE" if knob == "GLM53_KV_CAPACITY_LOG" else "GLM53_KV_CAPACITY_LOG"
+    script = validator_source() + "\n_glm53_w4142_validate"
+    env = {"PATH": os.environ.get("PATH", "/usr/bin:/bin"), "LC_ALL": "C", knob: value, other: "1"}
+    r = subprocess.run(["bash", "-c", script], text=True, capture_output=True, env=env)
+    return r.returncode, r.stdout.strip(), r.stderr.strip()
+
+
+def _run_caller_wins(knob: str, caller: str | None, env_value: str) -> tuple[int, str, str]:
+    fake = tempfile.NamedTemporaryFile("w", suffix=".env", delete=False)
+    fake.write(f"{knob}={env_value}\n")
+    fake.close()
+    script = caller_wins_source() + f'\nprintf "%s\\n" "${{{knob}-unset}}"\n'
+    env = {
+        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+        "LC_ALL": "C",
+        "GLM53_FAKE_ENV": fake.name,
+    }
+    if caller is not None:
+        env[knob] = caller
+    r = subprocess.run(["bash", "-c", script], text=True, capture_output=True, env=env)
+    os.unlink(fake.name)
+    return r.returncode, r.stdout.strip(), r.stderr.strip()
+
+
+def _launcher_wiring(prefix: str, host_var: str, overlay: str, knob: str, tag: str) -> None:
+    src = START.read_text()
+    check(f'{host_var}="${{{host_var}:-$SCRIPT_DIR/overlay/{overlay}}}"' in src, f"{prefix}2 {host_var} defaults to the shipped overlay")
+    check(f'[ -f "${host_var}" ] || die "missing ${host_var}"' in src and f'scp -q -o BatchMode=yes "${host_var}" "${{WORKER_SSH}}:/tmp/{overlay}"' in src, f"{prefix}2 preflight existence check + scp to the worker")
+    check(f"-v '/tmp/{overlay}:/opt/glm53/{overlay}:ro'" in src and f'-v "${host_var}:/opt/glm53/{overlay}:ro"' in src, f"{prefix}2 read-only mount on both ranks")
+    check(f'-e "{knob}=${knob}"' in src, f"{prefix}2 the knob is forwarded in nccl_common (both ranks)")
+    runs = src.count(f"python3 /opt/glm53/{overlay}")
+    check(runs == 2, f"{prefix}3 both rank scripts run the overlay exactly once ({runs})")
+    # order: after every overlay that edits the same files / the hybrid+drafter pair, before ablit
+    for earlier in ("patch_glm5_drafter_group.py", "patch_hybrid_prefix_hit.py", "patch_apc_per_group_retention.py", "patch_fine_grained_apc.py", "patch_align_floor.py"):
+        check(src.index(f"python3 /opt/glm53/{earlier}") < src.index(f"python3 /opt/glm53/{overlay}"), f"{prefix}3 pinned order: {earlier} -> {overlay}")
+    if "python3 /opt/glm53/patch_ablit.py" in src:  # kit only; the public repo ships no ablit
+        check(src.index(f"python3 /opt/glm53/{overlay}") < src.index("python3 /opt/glm53/patch_ablit.py"), f"{prefix}3 pinned order: {overlay} -> patch_ablit.py (last)")
+    defaults = defaults_source()
+    check(f'{knob}="${{{knob}-1}}"' in defaults, f"{prefix}1 default 1 applies only when UNSET ('' is a value)")
+    for value, out in ((None, "1"), ("0", "0"), ("1", "1")):
+        rc, o, e = _run_defaults(knob, value)
+        check(rc == 0 and o == f"{len(out)}|{out}", f"{prefix}4 {knob}={value!r} accepted -> {o!r} (rc={rc} {e[:60]})")
+    for value in ("", " ", "01", "2", "yes", "true", "1 ", " 1", "1\r", "0x1", "-1"):
+        rc, o, e = _run_defaults(knob, value)
+        check(rc == 0 and o == f"{len(value)}|{value}", f"{prefix}4 top level passes {value!r} through byte-exact (rc=0) -- stop/status/logs unblockable")
+    src2 = START.read_text()
+    check(src2.count("# LOCAL: W41/W42 strict-bool validation (begin)") == 1, f"{prefix}5 strict-bool validator present exactly once")
+    check(src2.index("# LOCAL: W41/W42 strict-bool validation (begin)") > src2.index("validate_numeric_config() {"), f"{prefix}5 validator lives inside validate_numeric_config (start/restart only)")
+    check("start|restart) validate_numeric_config" in src2, f"{prefix}5 validator wired to start|restart only")
+    check("bool knob guard (begin)" not in src2, f"{prefix}5 no top-level W41/W42 guard remains")
+    for value in ("1", "0"):
+        rc, o, e = _run_validator(knob, value)
+        check(rc == 0, f"{prefix}6 validator accepts {value!r} (rc={rc} {e[:60]})")
+    for value in ("", " ", "01", "2", "yes", "true", "1 ", " 1", "1\r", "0x1", "-1"):
+        rc, o, e = _run_validator(knob, value)
+        check(rc == 2 and knob in e, f"{prefix}6 validator rejects {value!r} rc=2 with a named error (rc={rc} {e[:60]!r})")
+    for caller, env_value, want in (("0", "1", "0"), ("1", "0", "1"), ("", "1", ""), (None, "1", "1"), (None, "0", "0")):
+        rc, o, e = _run_caller_wins(knob, caller, env_value)
+        check(rc == 0 and o == want, f"{prefix}7 caller={caller!r} .env={env_value!r} -> {o!r} (want {want!r}, rc={rc} {e[:60]})")
+
+
+def part_c() -> None:
+    print("Part C: launcher wiring (fork start.sh: defaults top-level, strict validation start/restart-only)")
+    if not START.is_file():
+        check(False, "C0 start.sh missing")
+        return
+    _launcher_wiring("C", "KV_CAPACITY_LOG_PATCH_HOST", "patch_kv_capacity_log.py", "GLM53_KV_CAPACITY_LOG", "[glm53-kv-capacity-log]")
+    overlay_text = PATCH.read_text()
+    last = [ln for ln in overlay_text.splitlines() if ln.strip()][-1]
+    check(last == "    sys.exit(main())" and "[glm53-kv-capacity-log]" in overlay_text, "C3 overlay ends with the EOF sentinel and carries its identity string")
+    # The fork documents its knobs in the public repo's env.example (the kit's
+    # .env.example is upstream's template); check whichever carries the fork knobs.
+    for cand in (ROOT / "env.example", ENV_EXAMPLE):
+        if cand.is_file() and "GLM53_ALIGN_FLOOR" in cand.read_text():
+            check("GLM53_KV_CAPACITY_LOG=1" in cand.read_text(), f"C6 {cand.name} documents the knob")
+            break
+
+
+def main() -> int:
+    print(f"overlay: {PATCH}  python: {sys.executable}")
+    part_a()
+    part_b()
+    part_c()
+    print()
+    if FAILURES:
+        print(f"FAILED ({len(FAILURES)}/{CHECKS}): " + "; ".join(FAILURES))
+        return 1
+    print(f"kv-capacity-log overlay OK ({CHECKS} checks)")
+    return 0
+
+
+def test_kv_capacity_log() -> None:
+    """pytest entry point."""
+    FAILURES.clear()
+    assert main() == 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_numeric_config.py
+++ b/tests/test_numeric_config.py
@@ -17,7 +17,13 @@ def guard_source() -> str:
     begin = source.index("# GLM53 numeric config guard (begin)")
     end_marker = "# GLM53 numeric config guard (end)"
     end = source.index(end_marker, begin) + len(end_marker)
-    return source[begin:end]
+    # Mirror production ordering: the W41/W42 knob-defaults block always runs
+    # before validate_numeric_config, so the strict-bool loop never sees an
+    # UNSET knob (unset -> 1 happens in the defaults, "" stays a value).
+    d_begin = source.index("# LOCAL: W41/W42 knob defaults (begin)")
+    d_end_marker = "# LOCAL: W41/W42 knob defaults (end)"
+    d_end = source.index(d_end_marker, d_begin) + len(d_end_marker)
+    return source[d_begin:d_end] + "\n" + source[begin:end]
 
 
 def validate(util: str, model: str, seqs: str, batch: str) -> subprocess.CompletedProcess[str]:


### PR DESCRIPTION
## W41 + W42: honest KV-capacity boot log + per-request prefix-cache no-store

Two production overlays from the 2x DGX Spark cluster, plus their host test suites and the launcher wiring. Deploys with no `.env` change, no image rebuild, and no JIT-cache wipe (neither knob is in the shape hash).

### W41 — block-level KV capacity boot log (kit PR #94, `overlay/patch_kv_capacity_log.py`)

The stock `GPU KV cache size` line is, for a multi-group hybrid, a *concurrency* figure in token units — it read "1,553,140 tokens" while the pool is 566 usable block ids and one cached 3584-token segment costs 38 of them. Two reviewers independently misread it as a prefix cache (upstream feature request: vllm-project/vllm#54662).

Log-only overlay: after the byte-identical stock line it logs one line per KV-cache group (spec, block size, page bytes, blocks per request, prefix-cacheable, eagle/mamba mode) plus a summary of usable block ids and the aligned dense-retention cached-conversation upper bound, derived from the same config objects the stock line uses. Derivation errors are a `warning_once` — never boot-fatal. Knob `GLM53_KV_CAPACITY_LOG` (exactly 0/1, unset = 1).

Live boot now prints: `usable block ids: 566 (num_blocks=567 incl. the null block; 406 ids per 1,000,000-token request => 1.40x); ids per 3584-token cached segment across groups: 38 (per group: [1, 0, 1, 1, 1, 1, 33]); cached-conversation capacity ≈ 50,176 tokens = 14 segments`.

### W42 — per-request GPU prefix-cache no-store (kit PR #95, `overlay/patch_apc_no_store.py`)

vLLM has a read-side opt-out (`skip_reading_prefix_cache`) but no write-side one. A one-off batch/eval request's blocks get hashed, queue behind other sessions' cached prefixes in `BlockPool.free_blocks`' LRU, and evict them.

New surface: `SamplingParams.skip_writing_prefix_cache` (typed field or `vllm_xargs: {"skip_writing_prefix_cache": 1}`). Mechanism: suppress only the two request-driven hash-insertion sites in `block_pool.py` — `num_cached_block` sentinel accounting, lookups, and the reader-side partial-hit CoW are untouched. No-store blocks stay unhashed and recycle LIFO from the front of the free queue. Strict value validation (bool / int 0-1 / str "0"/"1") as an HTTP 400 at the API boundary; the engine-side resolver never raises. Kill switch `GLM53_APC_NO_STORE=0` turns a valid 1 into a logged no-op.

Verified live: both store-suppression receipts (`full site`, `partial site`) fire on a large cold no-store request; a 6,000-token cached peer stayed warm (0.27 s → 0.26 s) across two no-store requests.

### Launcher wiring

Knob defaults at top level (substitute UNSET → 1, cannot exit); strict 0/1 validation lives in `validate_numeric_config`, wired to `start|restart` only, so a malformed value can never block `stop`/`status`/`logs` on a running pair; setness-aware caller-wins capture/restore around the `.env` source, so caller exports — including explicitly empty values — beat `.env`.

### Tests

- `tests/test_kv_capacity_log.py` — 159 checks (derivation vs the deployment's hybrid layout, patch mechanics, launcher wiring)
- `tests/test_apc_no_store.py` — 141 checks with the real image sources (patch mechanics, resolver matrix, kill-switch matrix, real-vLLM leg in-image, launcher wiring)
- `tests/test_numeric_config.py` — harness updated to mirror production ordering (knob defaults before validation)
- Full suite: 58 passed / 1 skipped; rendered diffs of both overlays against the pinned production image's pristine sources parse clean and are idempotent

### Production receipts

Boot 21:16:08Z → active 21:19Z. Pool byte-identical (1,396,551 tokens), shape stamp untouched, loopback bind unchanged, acceptance 7/7, serving 6/6, structured acceptance 1.0000/7.0 with all seven positions at 1.00, structured 66.6–69.2 tok/s and prose 28.2–34.1 tok/s on the clean runs (bench co-batched with the owner's live session on two outliers — noted in docs/06).
