### PR TITLE
docs: parameters and prefix-cache ledgers at the v1.3.3 deployed state

### DIFF
--- a/docs/02-parameters.md
+++ b/docs/02-parameters.md
@@ -88,3 +88,28 @@ cache is invisible to it). 0.87 demands 105.87 GiB free against boots measured a
   instead of full 3,584-token pages (the coordinator's veto came from a scratch
   buffer that never caches anyway — `docs/04`). This is what makes small prompts and
   follow-up turns cache; it costs ~3% structured decode, accepted deliberately.
+
+## Added 2026-09-01
+
+- `GLM53_DEFAULT_REASONING_EFFORT=high` — server-side default reasoning effort
+  (W27). The W16 template maps *unset* to `max`, so any client sending only
+  `enable_thinking` ran at the most expensive setting; this knob injects
+  `--default-chat-template-kwargs '{"reasoning_effort":"high"}'` as one argv
+  element. Strict enum (`low|high|max`, empty = off), validated start/restart
+  only, not in the JIT shape hash. Per-request `chat_template_kwargs` win.
+- `GLM53_ALIGN_FLOOR=1` — align-floor overlay (dormant at LPTT=1792). Stops the
+  mamba align split from zeroing a sub-block chunk when `LPTT >= block_size`;
+  required before any `LPTT >= 3584` arm. Read once at import.
+- `GLM53_KV_CAPACITY_LOG=1` — honest KV-capacity boot log (W41, log-only).
+  After the stock line, prints one line per KV-cache group plus the usable
+  block-id count and the aligned dense-retention cached-conversation capacity —
+  the stock "GPU KV cache size" number is a concurrency figure in token units
+  for a multi-group hybrid, not a cache capacity. Derivation errors are logged,
+  never boot-fatal. Not in the JIT shape hash.
+- `GLM53_APC_NO_STORE=1` — kill switch for the per-request prefix-cache
+  no-store surface (W42). A request sent with `vllm_xargs
+  {"skip_writing_prefix_cache": 1}` (or the typed `SamplingParams` field) never
+  inserts its blocks into the GPU prefix cache; lookups are unaffected and its
+  blocks stay unhashed, recycling LIFO-first, so one-off batch lanes stop
+  evicting other sessions' cached prefixes. Malformed values are an HTTP 400 at
+  the API boundary. Not in the JIT shape hash.

--- a/docs/04-prefix-caching.md
+++ b/docs/04-prefix-caching.md
@@ -88,6 +88,28 @@ lives behind concurrent hits), and re-validate at the next image rebase (upstrea
 #52216 changes the retention default and promotes the env to a real argument).
 Client-side compaction around **300k** (the measured solo ceiling) still stands.
 
+## Per-request no-store (2026-09-01): the write-side opt-out the API never had
+
+vLLM ships a read-side opt-out (`skip_reading_prefix_cache`) but nothing on the
+write side, so a one-off batch or eval request **stores** every block it touches.
+`BlockPool.free_blocks` appends hashed blocks to the back of the free queue, so
+the batch job's blocks queue behind — and eventually evict — other sessions'
+cached prefixes: the batch lane re-orders the LRU in its own favour.
+
+`overlay/patch_apc_no_store.py` adds the write-side twin:
+`SamplingParams.skip_writing_prefix_cache` (typed field) or `vllm_xargs:
+{"skip_writing_prefix_cache": 1}` on /v1/chat/completions, /v1/completions,
+/v1/responses. A no-store request suppresses only the two request-driven
+hash-insertion sites in `block_pool.py` — allocation accounting (`num_cached_block`
+sentinel), lookups, and the reader-side partial-hit CoW are untouched, so it can
+still read-hit. Its blocks carry no hash, are prepended to the free queue, and are
+the very next ids recycled. Verified live: both suppression receipts (`full site`,
+`partial site`) in the engine log, and a cached 6,000-token peer stayed warm
+(0.27 s → 0.26 s) across two no-store requests. Kill switch `GLM53_APC_NO_STORE=0`
+makes a valid 1 a logged no-op; malformed values are an HTTP 400 at the API
+boundary. Combine with `skip_reading_prefix_cache` for zero cache interaction;
+prefer short lanes with a low `priority`.
+
 ## Verifying, not assuming
 
 The lifetime hit-rate on a dashboard hides all of this (it averages over benches and


### PR DESCRIPTION
Release-prep docs for v1.3.3. `docs/02-parameters.md` gains the 2026-09-01 knob additions (`GLM53_DEFAULT_REASONING_EFFORT`, `GLM53_ALIGN_FLOOR`, `GLM53_KV_CAPACITY_LOG`, `GLM53_APC_NO_STORE`); `docs/04-prefix-caching.md` gains the per-request no-store section with the live receipts. No code changes.