### PR TITLE
Suppress native stop-token ids while reasoning is open

### DIFF
--- a/docs/05-known-issues.md
+++ b/docs/05-known-issues.md
@@ -58,3 +58,99 @@ Check `--no-async-scheduling` is present before touching the pin or max-len.
 `tests/bench_decode.py`'s coherence probe marks "9.9 vs 9.11" wrong even when the
 model answers correctly ("9.9 is greater") — string-match artifact, not a model
 regression. Read the text, not just the flag.
+
+## 5. Native stop-token id (`<|observation|>`) firing mid-`<think>` — MITIGATED, not fully resolved
+
+**Measured on:** a live third-party agentic tool-calling workload (concurrent
+multi-agent security scan, `tools` + `tool_choice: "auto"`, no
+`chat_template_kwargs`), 2026-09-01/09-02.
+
+`patch_suppress_stops_in_reasoning.py` only dormant-izes *client-provided stop
+strings* while `<think>` is open; it explicitly leaves native EOS/stop-token
+handling untouched (see its own docstring). GLM's own `<|observation|>` control
+token (tool-turn boundary marker, token id `154829` on this tokenizer) can land in
+`sampling_params.stop_token_ids` and get sampled while the model is still
+mid-`<think>` — the request then finishes with `finish_reason="stop"`,
+`stop_reason=154829`, and empty `content`/`tool_calls`, having burned its whole
+turn on invisible reasoning. No server-side error or exception; `200 OK` is
+returned, so it's invisible unless the client specifically checks for an empty
+completion matching a stop-token id. Confirmed to cascade: hitting this 12 times
+in a row on a client's "give up after N empty responses" counter force-killed its
+main agent mid-scan, once losing an in-flight confirmed finding to the resulting
+teardown race.
+
+`overlay/patch_suppress_native_stops_in_reasoning.py` (companion patch, anchors
+`v1/core/sched/utils.py::check_stop`) adds the same dormant-until-`</think>`
+protection for native stop-token ids. Two independent reasoning-open signals,
+either being true is enough to suppress the stop:
+
+1. vLLM's own reasoning-parser state
+   (`request.structured_output_request.reasoning_ended is False`) — only
+   populated when structured-output/grammar tracking is active for the request.
+2. Token-based, independent of (1) entirely: this deployment's chat template
+   primes every thinking-enabled request with the prompt ending in the `<think>`
+   token (think-in-prompt); if so, and `</think>` hasn't appeared yet in
+   `request.output_token_ids`, reasoning is still open regardless of whether any
+   grammar tracking ever ran for this request.
+
+**Iteration history** (same investigation, same day):
+
+- v1 shipped with signal (1) only. Production: 11/11 empty-completion hits on one
+  scan were exactly the `tool_choice: "auto"` shape, where (1) is never populated
+  — no coverage at all for that shape.
+- v2 added signal (2) as a fallback, and additionally treated (1) as
+  *authoritative* whenever it had a definitive answer (`True` or `False`),
+  skipping (2) entirely in that case — reasoning being: an unconfirmed concern
+  that (2) might diverge from a genuinely-closed (1) if the tokenizer ever
+  segments `</think>` differently than expected (`<think>`/`</think>` are
+  `"special": false` in this tokenizer, so not provably atomic in every context).
+  Deployed; a live scan still climbed 3/12 → 10/12 empty-completion hits over
+  ~12 minutes, correlating with heavy concurrent load — same severity as the
+  original bug, just not yet confirmed root-caused.
+- v3 (current) reverted to a plain OR of (1) and (2) — either says "open",
+  suppress. Rationale: `overlay/patch_xgrammar_termination.py`'s own docstring
+  implies structured-output/grammar tracking is likely *active* for this
+  deployment's `tool_choice: "auto"` calls (backports two upstream XGrammar
+  spec-decode fixes specifically for this model's tool-calling path) — contrary
+  to the "never populated for auto tool_choice" assumption v1/v2 were built on,
+  which was never independently verified against this exact build. If grammar
+  tracking is in fact active, a `reasoning_ended` flip to `True` under
+  load-induced timing is a more plausible live failure mode than (2) ever wrongly
+  overriding a genuinely-closed (1) — which was v2's guarded-against risk, never
+  actually observed.
+
+**Status: open.** v3's OR-logic plus the fixes below should widen coverage
+further, but the root cause of the residual 3→10/12 climb under concurrent load
+is not yet confirmed — could be (a) `reasoning_ended` genuinely flipping
+incorrectly under load, (b) a request shape where the prompt doesn't end in the
+literal `<think>` token id the way a fresh single-turn request does (ruled out
+for one specific shape via direct `/tokenize` probing — a deep multi-turn
+conversation with several trailing consecutive `user`-role messages still ends in
+`<think>` — but not exhaustively ruled out for every shape), or (c) something
+else. v3 adds one INFO-level log line every time this guard is actually consulted
+for a stop-token candidate (deliberately not gated behind
+`VLLM_LOGGING_LEVEL=DEBUG` — that crashed this box's CUDA-graph warmup on two
+separate boots this same session, unrelated root cause, see
+`docs/03-bringup.md`/git history):
+
+```
+docker logs <head-container> | grep '\[suppress-native-stops-in-reasoning\]'
+```
+
+Each line shows `request_id`, `sor_present`, `reasoning_ended`, `token_check_open`,
+and the final decision — enough to distinguish which of (a)/(b)/(c) is actually
+happening on the next occurrence, instead of inferring from client-side
+timestamps alone.
+
+Also found, not yet independently confirmed unrelated: cache hit rate visibly
+declines under the same concurrent multi-agent load this bug was observed under
+(85%→60%→57% over ~15 min in one window) — per `docs/04-prefix-caching.md` this
+config already runs the documented best-practice retention settings, and a
+measured data point there ("4×200k concurrent replay: 49.9%") suggests this may
+just be the accepted trade-off of heavy concurrent load near pool capacity rather
+than a separate bug — but the two were not ruled fully independent of each other
+(the empty-response climb and the cache decline were observed in overlapping
+windows more than once).
+
+Opt-out for both signals at once: `GLM53_SUPPRESS_STOPS_IN_REASONING=0` or
+`VLLM_SUPPRESS_STOPS_IN_REASONING=0`.

--- a/overlay/patch_force_structural_tag_auto_tool_choice.py
+++ b/overlay/patch_force_structural_tag_auto_tool_choice.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Opt-in: build the tool-call structural tag for plain tool_choice="auto" too (glm53-flash).
+
+**Prepared, not enabled.** Default-off. Untested hypothesis, no controlled
+A/B yet — do not wire into ``start.sh`` or restart the server on this alone.
+See ``docs/05-known-issues.md`` section 5 for the observation that motivated
+this: on a live scan, a `tool_choice: "auto"` request emptied out
+(`<|observation|>` firing with no visible content/tool_calls) *after*
+reasoning had already genuinely closed
+(`sor_present=False reasoning_ended=None token_check_open=False` in
+``patch_suppress_native_stops_in_reasoning.py``'s diagnostic log). That is
+not the mid-`<think>` bug that patch fixes — it is the model choosing to
+emit nothing before the tool-turn boundary token, which no stop-token patch
+can address.
+
+Root cause traced to ``vllm/tool_parsers/structural_tag_registry.py::get_model_structural_tag``:
+
+    if tool_choice == "auto" and not _any_tool_strict(tools):
+        return None
+
+Upstream only builds the xgrammar structural tag (grammar-constrained
+decoding forcing a valid tool-call-or-text shape) for `tool_choice: "auto"`
+when at least one tool in the request sets `strict: true` — mirroring
+OpenAI's strict-function-calling opt-in. A plain `tools` + `tool_choice:
+"auto"` call with no `strict` flags (this deployment's third-party agentic
+client's exact shape) never gets a structural tag, so:
+
+1. ``request.structured_outputs`` stays ``None``, so
+   ``request.structured_output_request`` stays ``None`` too — signal (1) in
+   ``patch_suppress_native_stops_in_reasoning.py`` (``reasoning_ended``) can
+   never populate for this shape, regardless of that patch. (Signal (2),
+   the token-based check, already covers the *mid-reasoning* case
+   independently of this — this patch is about the *post-reasoning* empty
+   output case that signal (2) cannot help with either, since token_check_open
+   is correctly False once ``</think>`` has really been emitted.)
+2. Decoding is fully unconstrained for these requests — nothing stops the
+   model from sampling a control/boundary token with no preceding visible
+   payload.
+
+**Hypothesis (unverified):** forcing the structural tag on for plain-auto
+requests too would (a) give signal (1) real coverage for this request
+shape, and (b) may reduce the empty-completion rate itself, since
+grammar-constrained decoding forces output into a valid tool-call-or-text
+shape at every step rather than leaving the model free to emit a bare
+control token. Neither claim is verified against this deployment — needs a
+controlled A/B (``scripts/bench.py``-style matched-prompt comparison, or a
+repro script hitting the endpoint with/without this patch enabled) before
+being treated as a real fix, not just a plausible one. Enabling this also
+changes decoding behavior for every plain-auto tool-calling request, not
+just the empty-completion path — a real behavior change, not a no-op
+guard like the stop-token patches.
+
+Opt-in only, default OFF: ``GLM53_FORCE_AUTO_TOOL_STRUCTURAL_TAG=1``. With
+the var unset or ``0``, this patch is a no-op even once applied — the
+original upstream gate is preserved byte-for-byte, just wrapped in an
+additional condition that is False by default.
+
+Anchor: ``vllm/tool_parsers/structural_tag_registry.py``.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+P = Path(
+    "/usr/local/lib/python3.12/dist-packages/vllm/tool_parsers/structural_tag_registry.py"
+)
+MARK = "# [force-structural-tag-auto-tool-choice]"
+
+IMPORT_OLD = "from collections.abc import Callable, Sequence\n"
+IMPORT_NEW = "import os\nfrom collections.abc import Callable, Sequence\n"
+
+GATE_OLD = """    if not tools or tool_choice == "none":
+        return None
+
+    if tool_choice == "auto" and not _any_tool_strict(tools):
+        return None
+"""
+
+GATE_NEW = """    if not tools or tool_choice == "none":
+        return None
+
+    if (
+        tool_choice == "auto"
+        and not _any_tool_strict(tools)
+        and not _force_auto_tool_structural_tag_enabled()
+    ):
+        # [force-structural-tag-auto-tool-choice]
+        return None
+"""
+
+HELPER = '''
+
+def _force_auto_tool_structural_tag_enabled() -> bool:
+    # [force-structural-tag-auto-tool-choice] opt-in, default OFF - see
+    # module docstring in patch_force_structural_tag_auto_tool_choice.py.
+    # Untested hypothesis, no controlled A/B yet: do not flip this on in
+    # production without one.
+    return os.environ.get("GLM53_FORCE_AUTO_TOOL_STRUCTURAL_TAG", "0") == "1"
+'''
+
+
+def apply_text(src: str) -> tuple[str, str]:
+    """Return (new_source, status): applied|skipped|missing:..."""
+    if MARK in src and "_force_auto_tool_structural_tag_enabled" in src:
+        return src, "skipped"
+    missing = []
+    if IMPORT_OLD not in src:
+        missing.append("import")
+    if GATE_OLD not in src:
+        missing.append("gate")
+    if missing:
+        return src, "missing:" + ",".join(missing)
+    out = src.replace(IMPORT_OLD, IMPORT_NEW, 1)
+    out = out.replace(GATE_OLD, GATE_NEW, 1)
+    out = out.rstrip("\n") + "\n" + HELPER.strip("\n") + "\n"
+    return out, "applied"
+
+
+def apply_file(path: Path) -> str:
+    text = path.read_text(encoding="utf-8")
+    new, status = apply_text(text)
+    if status == "applied":
+        path.write_text(new, encoding="utf-8")
+    return status
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) > 1 and argv[1] == "--status":
+        target = Path(argv[2]) if len(argv) > 2 else P
+        applied = target.is_file() and MARK in target.read_text()
+        print(
+            "force-structural-tag-auto-tool-choice:",
+            "APPLIED" if applied else "NOT APPLIED",
+        )
+        return 0
+    target = Path(argv[1]) if len(argv) > 1 else P
+    if not target.is_file():
+        print(f"[force-structural-tag-auto-tool-choice] missing {target}", file=sys.stderr)
+        return 1
+    status = apply_file(target)
+    print(f"[force-structural-tag-auto-tool-choice] {status}: {target}")
+    return 0 if status.startswith("applied") or status == "skipped" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/overlay/patch_suppress_native_stops_in_reasoning.py
+++ b/overlay/patch_suppress_native_stops_in_reasoning.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Keep native stop-token ids dormant until reasoning ends (glm53-flash).
+
+Companion to ``patch_suppress_stops_in_reasoning.py``, which dormant-izes
+*client-provided stop strings* while ``<think>`` is open but explicitly
+leaves native EOS/stop-token handling untouched. A native GLM control token
+(e.g. ``<|observation|>``, the model's own tool-turn boundary marker) can
+also land in ``sampling_params.stop_token_ids`` and fire mid-reasoning,
+finishing the request with ``stop_reason=<token_id>`` and empty visible
+content/tool_calls before the model ever closes ``<think>``.
+
+Anchor is this image's ``v1/core/sched/utils.py::check_stop``. Unlike the
+stop-string patch, this reuses vLLM's own reasoning-parser state
+(``request.structured_output_request.reasoning_ended``) instead of
+re-deriving it from token ids — that field is only positively ``False``
+(vs. ``None``/unset) once a reasoning parser is active for the request, so
+this only ever engages for requests that actually have one configured
+(guided decoding / tool-call grammar), which is exactly the affected
+workload. ``eos_token_id`` and length caps are unchanged, matching the
+stop-string patch's own invariant.
+
+Opt-out: ``GLM53_SUPPRESS_STOPS_IN_REASONING=0`` or
+``VLLM_SUPPRESS_STOPS_IN_REASONING=0`` (same switch as the stop-string
+patch, since this is the same feature covering the other stop source).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+P = Path("/usr/local/lib/python3.12/dist-packages/vllm/v1/core/sched/utils.py")
+MARK = "# [suppress-native-stops-in-reasoning]"
+
+IMPORT_OLD = (
+    "import contextlib\n"
+    "from collections.abc import Sequence\n"
+)
+IMPORT_NEW = (
+    "import contextlib\n"
+    "import os\n"
+    "from collections.abc import Sequence\n"
+)
+
+CHECK_OLD = """    if last_token_id in (sampling_params.stop_token_ids or ()):
+        request.status = RequestStatus.FINISHED_STOPPED
+        request.stop_reason = last_token_id
+        return True
+"""
+
+CHECK_NEW = """    if last_token_id in (sampling_params.stop_token_ids or ()):
+        # [suppress-native-stops-in-reasoning] mirror
+        # patch_suppress_stops_in_reasoning.py for native stop-token ids:
+        # a control token like <|observation|> can land in stop_token_ids
+        # and fire mid-<think>, finishing the turn with no visible output.
+        # Only engages once a reasoning parser has positively confirmed
+        # we're still open (reasoning_ended is False, not None/unset).
+        sor = request.structured_output_request
+        reasoning_open = (
+            _suppress_native_stops_enabled()
+            and sor is not None
+            and sor.reasoning_ended is False
+        )
+        if not reasoning_open:
+            request.status = RequestStatus.FINISHED_STOPPED
+            request.stop_reason = last_token_id
+            return True
+"""
+
+HELPER = '''
+
+def _suppress_native_stops_enabled() -> bool:
+    # [suppress-native-stops-in-reasoning]
+    for key in (
+        "GLM53_SUPPRESS_STOPS_IN_REASONING",
+        "VLLM_SUPPRESS_STOPS_IN_REASONING",
+    ):
+        if key in os.environ:
+            return os.environ.get(key) != "0"
+    return True
+'''
+
+
+def apply_text(src: str) -> tuple[str, str]:
+    """Return (new_source, status): applied|skipped|missing:..."""
+    if MARK in src and "_suppress_native_stops_enabled" in src:
+        return src, "skipped"
+    missing = []
+    if IMPORT_OLD not in src:
+        missing.append("import")
+    if CHECK_OLD not in src:
+        missing.append("check_stop")
+    if missing:
+        return src, "missing:" + ",".join(missing)
+    out = src.replace(IMPORT_OLD, IMPORT_NEW, 1)
+    out = out.replace(CHECK_OLD, CHECK_NEW, 1)
+    out = out.rstrip("\n") + "\n\n\n" + HELPER.strip("\n") + "\n"
+    return out, "applied"
+
+
+def apply_file(path: Path) -> str:
+    text = path.read_text(encoding="utf-8")
+    new, status = apply_text(text)
+    if status == "applied":
+        path.write_text(new, encoding="utf-8")
+    return status
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) > 1 and argv[1] == "--status":
+        target = Path(argv[2]) if len(argv) > 2 else P
+        applied = target.is_file() and MARK in target.read_text()
+        print("suppress-native-stops-in-reasoning:", "APPLIED" if applied else "NOT APPLIED")
+        return 0
+    target = Path(argv[1]) if len(argv) > 1 else P
+    if not target.is_file():
+        print(f"[suppress-native-stops-in-reasoning] missing {target}", file=sys.stderr)
+        return 1
+    status = apply_file(target)
+    print(f"[suppress-native-stops-in-reasoning] {status}: {target}")
+    return 0 if status.startswith("applied") or status == "skipped" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/overlay/patch_suppress_native_stops_in_reasoning.py
+++ b/overlay/patch_suppress_native_stops_in_reasoning.py
@@ -28,6 +28,20 @@ is checked two ways, either one is enough to dormant-ize the stop:
    output tracking ever ran for this request. This is what actually covers
    the auto-tool_choice gap above.
 
+v2 (2026-09-02) treated an unambiguous native signal as authoritative and
+skipped the token check whenever ``reasoning_ended`` was ``True`` or
+``False`` (not just ``None``). Reverted: after deploying it, a live scan
+still climbed 3/12 -> 10/12 empty-completion hits over ~12 minutes,
+correlating with heavy concurrent load. ``patch_xgrammar_termination.py``'s
+own docstring implies structured-output/grammar tracking likely *is*
+active for this deployment's auto-tool-choice calls (contrary to the
+"never populated" claim above, which was not independently verified) — if
+so, a ``reasoning_ended`` flip to ``True`` under load-induced timing is a
+more plausible live failure mode than the token check ever incorrectly
+overriding a confirmed-closed native signal (which was the theoretical
+risk the v2 change guarded against, never observed). Back to plain OR:
+either signal saying "still open" is enough to dormant-ize the stop.
+
 ``eos_token_id`` and length caps are unchanged, matching the stop-string
 patch's own invariant. Token ids for ``<think>``/``</think>`` are pinned to
 this model's tokenizer (``brandonmusic/GLM-5.3-Flash-tr3-4bpw``); override
@@ -37,6 +51,15 @@ model changes.
 Opt-out: ``GLM53_SUPPRESS_STOPS_IN_REASONING=0`` or
 ``VLLM_SUPPRESS_STOPS_IN_REASONING=0`` (same switch as the stop-string
 patch, since this is the same feature covering the other stop source).
+
+Every time this guard actually engages (i.e. a native stop-token candidate
+was about to fire), it logs one INFO line tagged
+``[suppress-native-stops-in-reasoning]`` with both raw signal values and
+the final decision — deliberately not gated behind
+``VLLM_LOGGING_LEVEL=DEBUG`` (that crashed this box's CUDA-graph warmup
+twice in this same session; this uses the engine's always-on INFO logger
+instead) so the next occurrence is directly diagnosable from the normal
+server log instead of inferred from client-side timestamps.
 """
 from __future__ import annotations
 
@@ -56,6 +79,17 @@ IMPORT_NEW = (
     "from collections.abc import Sequence\n"
 )
 
+LOGGER_IMPORT_OLD = "from vllm.sampling_params import RepetitionDetectionParams\n"
+LOGGER_IMPORT_NEW = (
+    "from vllm.logger import init_logger\n"
+    "from vllm.sampling_params import RepetitionDetectionParams\n"
+)
+LOGGER_INIT_OLD = "from vllm.v1.request import Request, RequestStatus\n"
+LOGGER_INIT_NEW = (
+    "from vllm.v1.request import Request, RequestStatus\n\n"
+    "_native_stop_logger = init_logger(__name__)\n"
+)
+
 CHECK_OLD = """    if last_token_id in (sampling_params.stop_token_ids or ()):
         request.status = RequestStatus.FINISHED_STOPPED
         request.stop_reason = last_token_id
@@ -67,12 +101,13 @@ CHECK_NEW = """    if last_token_id in (sampling_params.stop_token_ids or ()):
         # patch_suppress_stops_in_reasoning.py for native stop-token ids:
         # a control token like <|observation|> can land in stop_token_ids
         # and fire mid-<think>, finishing the turn with no visible output.
-        # vLLM's own reasoning-parser state is authoritative when it has a
-        # definitive answer; falls back to an independent token-based check
-        # (prompt ends in <think>, </think> not seen yet in the output) only
-        # when that state is unavailable/unknown - covers requests with no
-        # structured-output/grammar constraints (e.g. plain
-        # tool_choice="auto"), where the native signal is never populated.
+        # Either of two independent signals being "still open" is enough:
+        # vLLM's own reasoning-parser state (when structured-output tracking
+        # is active for this request), or an independent token-based check
+        # (prompt ends in <think>, </think> not seen yet in the output) -
+        # covers requests where the native signal is unavailable/unknown, or
+        # (2026-09-02) possibly wrong under load. Logged every time this
+        # fires - see module docstring.
         if not _native_stop_reasoning_open(request):
             request.status = RequestStatus.FINISHED_STOPPED
             request.stop_reason = last_token_id
@@ -114,24 +149,39 @@ def _reasoning_open_by_tokens(request) -> bool:
 
 def _native_stop_reasoning_open(request) -> bool:
     # [suppress-native-stops-in-reasoning] single entry point combining both
-    # signals. vLLM's own reasoning-parser state is authoritative whenever
-    # it has a definitive answer (True or False) - the token-based fallback
-    # only kicks in when that signal is unavailable (no structured-output
-    # tracking on this request) or still unknown (None, not yet computed),
-    # so a confirmed-closed native signal can never get overridden by the
-    # independent check. Each signal is separately fail-closed - if the
-    # structured-output check errors, that alone must not take down the
-    # token-based fallback too, so it's isolated to its own try/except
-    # rather than one that wraps (and could short-circuit) both signals.
+    # signals: plain OR, either one saying "still open" is enough. Each
+    # signal is separately fail-closed - if the structured-output check
+    # errors, that alone must not take down the token-based check too, so
+    # it's isolated to its own try/except rather than one that wraps (and
+    # could short-circuit) both signals. Logs every time this guard is
+    # consulted for an actual stop-token candidate, tagged for grep, so a
+    # future occurrence is directly diagnosable from the server log.
     if not _suppress_native_stops_enabled():
         return False
+    sor = request.structured_output_request
+    native_reasoning_ended = None
+    native_open = False
     try:
-        sor = request.structured_output_request
-        if sor is not None and sor.reasoning_ended is not None:
-            return not sor.reasoning_ended
+        if sor is not None:
+            native_reasoning_ended = sor.reasoning_ended
+            native_open = sor.reasoning_ended is False
     except Exception:
         pass
-    return _reasoning_open_by_tokens(request)
+    token_open = _reasoning_open_by_tokens(request)
+    result = native_open or token_open
+    try:
+        _native_stop_logger.info(
+            "[suppress-native-stops-in-reasoning] request_id=%s "
+            "sor_present=%s reasoning_ended=%s token_check_open=%s -> %s",
+            getattr(request, "request_id", "?"),
+            sor is not None,
+            native_reasoning_ended,
+            token_open,
+            "SUPPRESSED (still open)" if result else "STOP FIRES",
+        )
+    except Exception:
+        pass
+    return result
 '''
 
 
@@ -142,11 +192,17 @@ def apply_text(src: str) -> tuple[str, str]:
     missing = []
     if IMPORT_OLD not in src:
         missing.append("import")
+    if LOGGER_IMPORT_OLD not in src:
+        missing.append("logger_import")
+    if LOGGER_INIT_OLD not in src:
+        missing.append("logger_init")
     if CHECK_OLD not in src:
         missing.append("check_stop")
     if missing:
         return src, "missing:" + ",".join(missing)
     out = src.replace(IMPORT_OLD, IMPORT_NEW, 1)
+    out = out.replace(LOGGER_IMPORT_OLD, LOGGER_IMPORT_NEW, 1)
+    out = out.replace(LOGGER_INIT_OLD, LOGGER_INIT_NEW, 1)
     out = out.replace(CHECK_OLD, CHECK_NEW, 1)
     out = out.rstrip("\n") + "\n\n\n" + HELPER.strip("\n") + "\n"
     return out, "applied"

--- a/overlay/patch_suppress_native_stops_in_reasoning.py
+++ b/overlay/patch_suppress_native_stops_in_reasoning.py
@@ -67,19 +67,13 @@ CHECK_NEW = """    if last_token_id in (sampling_params.stop_token_ids or ()):
         # patch_suppress_stops_in_reasoning.py for native stop-token ids:
         # a control token like <|observation|> can land in stop_token_ids
         # and fire mid-<think>, finishing the turn with no visible output.
-        # Two independent reasoning-open signals, either is enough:
-        # (a) vLLM's own reasoning-parser state, when structured-output
-        #     tracking is active for this request; (b) prompt ends in
-        #     <think> (think-in-prompt) and </think> hasn't appeared yet in
-        #     the output — covers requests with no structured-output/
-        #     grammar constraints (e.g. plain tool_choice="auto"), where
-        #     (a) is never populated at all.
-        sor = request.structured_output_request
-        reasoning_open = _suppress_native_stops_enabled() and (
-            (sor is not None and sor.reasoning_ended is False)
-            or _reasoning_open_by_tokens(request)
-        )
-        if not reasoning_open:
+        # vLLM's own reasoning-parser state is authoritative when it has a
+        # definitive answer; falls back to an independent token-based check
+        # (prompt ends in <think>, </think> not seen yet in the output) only
+        # when that state is unavailable/unknown - covers requests with no
+        # structured-output/grammar constraints (e.g. plain
+        # tool_choice="auto"), where the native signal is never populated.
+        if not _native_stop_reasoning_open(request):
             request.status = RequestStatus.FINISHED_STOPPED
             request.stop_reason = last_token_id
             return True
@@ -104,12 +98,40 @@ def _reasoning_open_by_tokens(request) -> bool:
     # with the prompt ending in <think> (think-in-prompt). If so, and
     # </think> hasn't appeared yet in the output, reasoning is still open
     # regardless of whether any grammar/structured-output tracking ran.
-    think_start = int(os.environ.get("GLM53_THINK_START_TOKEN_ID", "154841"))
-    think_end = int(os.environ.get("GLM53_THINK_END_TOKEN_ID", "154842"))
-    ptids = request.prompt_token_ids
-    if not ptids or ptids[-1] != think_start:
+    # Fail closed (treat as "not open") on any unexpected error - a bad
+    # env var or an unforeseen edge case here must never crash check_stop,
+    # only fall back to pre-patch behavior for that one request.
+    try:
+        think_start = int(os.environ.get("GLM53_THINK_START_TOKEN_ID", "154841"))
+        think_end = int(os.environ.get("GLM53_THINK_END_TOKEN_ID", "154842"))
+        ptids = request.prompt_token_ids
+        if not ptids or ptids[-1] != think_start:
+            return False
+        return think_end not in request.output_token_ids
+    except Exception:
         return False
-    return think_end not in request.output_token_ids
+
+
+def _native_stop_reasoning_open(request) -> bool:
+    # [suppress-native-stops-in-reasoning] single entry point combining both
+    # signals. vLLM's own reasoning-parser state is authoritative whenever
+    # it has a definitive answer (True or False) - the token-based fallback
+    # only kicks in when that signal is unavailable (no structured-output
+    # tracking on this request) or still unknown (None, not yet computed),
+    # so a confirmed-closed native signal can never get overridden by the
+    # independent check. Each signal is separately fail-closed - if the
+    # structured-output check errors, that alone must not take down the
+    # token-based fallback too, so it's isolated to its own try/except
+    # rather than one that wraps (and could short-circuit) both signals.
+    if not _suppress_native_stops_enabled():
+        return False
+    try:
+        sor = request.structured_output_request
+        if sor is not None and sor.reasoning_ended is not None:
+            return not sor.reasoning_ended
+    except Exception:
+        pass
+    return _reasoning_open_by_tokens(request)
 '''
 
 

--- a/overlay/patch_suppress_native_stops_in_reasoning.py
+++ b/overlay/patch_suppress_native_stops_in_reasoning.py
@@ -9,15 +9,30 @@ also land in ``sampling_params.stop_token_ids`` and fire mid-reasoning,
 finishing the request with ``stop_reason=<token_id>`` and empty visible
 content/tool_calls before the model ever closes ``<think>``.
 
-Anchor is this image's ``v1/core/sched/utils.py::check_stop``. Unlike the
-stop-string patch, this reuses vLLM's own reasoning-parser state
-(``request.structured_output_request.reasoning_ended``) instead of
-re-deriving it from token ids — that field is only positively ``False``
-(vs. ``None``/unset) once a reasoning parser is active for the request, so
-this only ever engages for requests that actually have one configured
-(guided decoding / tool-call grammar), which is exactly the affected
-workload. ``eos_token_id`` and length caps are unchanged, matching the
-stop-string patch's own invariant.
+Anchor is this image's ``v1/core/sched/utils.py::check_stop``. Reasoning-open
+is checked two ways, either one is enough to dormant-ize the stop:
+
+1. vLLM's own reasoning-parser state
+   (``request.structured_output_request.reasoning_ended is False``). Cheap,
+   precise, but only populated when the request actually has structured-
+   output constraints active (``StructuredOutputRequest.from_sampling_params``
+   returns ``None`` otherwise) — a plain ``tools`` + ``tool_choice: "auto"``
+   call with no forced JSON schema never populates it. Confirmed in
+   production (2026-09-01/09-02): 11/11 empty-completion hits on one scan
+   were exactly this uncovered shape.
+2. Independent of structured-output state entirely: this deployment's chat
+   template primes every thinking-enabled request with the prompt ending in
+   the ``<think>`` token (think-in-prompt). If the prompt ends there and
+   ``</think>`` hasn't appeared yet in ``request.output_token_ids``,
+   reasoning is still open — regardless of whether any grammar/structured-
+   output tracking ever ran for this request. This is what actually covers
+   the auto-tool_choice gap above.
+
+``eos_token_id`` and length caps are unchanged, matching the stop-string
+patch's own invariant. Token ids for ``<think>``/``</think>`` are pinned to
+this model's tokenizer (``brandonmusic/GLM-5.3-Flash-tr3-4bpw``); override
+via ``GLM53_THINK_START_TOKEN_ID`` / ``GLM53_THINK_END_TOKEN_ID`` if the
+model changes.
 
 Opt-out: ``GLM53_SUPPRESS_STOPS_IN_REASONING=0`` or
 ``VLLM_SUPPRESS_STOPS_IN_REASONING=0`` (same switch as the stop-string
@@ -52,13 +67,17 @@ CHECK_NEW = """    if last_token_id in (sampling_params.stop_token_ids or ()):
         # patch_suppress_stops_in_reasoning.py for native stop-token ids:
         # a control token like <|observation|> can land in stop_token_ids
         # and fire mid-<think>, finishing the turn with no visible output.
-        # Only engages once a reasoning parser has positively confirmed
-        # we're still open (reasoning_ended is False, not None/unset).
+        # Two independent reasoning-open signals, either is enough:
+        # (a) vLLM's own reasoning-parser state, when structured-output
+        #     tracking is active for this request; (b) prompt ends in
+        #     <think> (think-in-prompt) and </think> hasn't appeared yet in
+        #     the output — covers requests with no structured-output/
+        #     grammar constraints (e.g. plain tool_choice="auto"), where
+        #     (a) is never populated at all.
         sor = request.structured_output_request
-        reasoning_open = (
-            _suppress_native_stops_enabled()
-            and sor is not None
-            and sor.reasoning_ended is False
+        reasoning_open = _suppress_native_stops_enabled() and (
+            (sor is not None and sor.reasoning_ended is False)
+            or _reasoning_open_by_tokens(request)
         )
         if not reasoning_open:
             request.status = RequestStatus.FINISHED_STOPPED
@@ -77,12 +96,26 @@ def _suppress_native_stops_enabled() -> bool:
         if key in os.environ:
             return os.environ.get(key) != "0"
     return True
+
+
+def _reasoning_open_by_tokens(request) -> bool:
+    # [suppress-native-stops-in-reasoning] structured-output-agnostic check:
+    # this deployment's chat template primes every thinking-enabled request
+    # with the prompt ending in <think> (think-in-prompt). If so, and
+    # </think> hasn't appeared yet in the output, reasoning is still open
+    # regardless of whether any grammar/structured-output tracking ran.
+    think_start = int(os.environ.get("GLM53_THINK_START_TOKEN_ID", "154841"))
+    think_end = int(os.environ.get("GLM53_THINK_END_TOKEN_ID", "154842"))
+    ptids = request.prompt_token_ids
+    if not ptids or ptids[-1] != think_start:
+        return False
+    return think_end not in request.output_token_ids
 '''
 
 
 def apply_text(src: str) -> tuple[str, str]:
     """Return (new_source, status): applied|skipped|missing:..."""
-    if MARK in src and "_suppress_native_stops_enabled" in src:
+    if MARK in src and "_reasoning_open_by_tokens" in src:
         return src, "skipped"
     missing = []
     if IMPORT_OLD not in src:

--- a/start.sh
+++ b/start.sh
@@ -194,6 +194,7 @@ CHAT_TEMPLATE_HOST="${CHAT_TEMPLATE_HOST:-$SCRIPT_DIR/files/chat_template.jinja}
 CHAT_TEMPLATE="${CHAT_TEMPLATE:-/opt/glm53/chat_template.jinja}"
 VIDEO_PATCH_HOST="${VIDEO_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_glm_video_placeholders.py}"
 STOP_PATCH_HOST="${STOP_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_suppress_stops_in_reasoning.py}"
+NATIVE_STOP_PATCH_HOST="${NATIVE_STOP_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_suppress_native_stops_in_reasoning.py}"
 SCHED_PATCH_HOST="${SCHED_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_scheduler_decode_floor.py}"
 DRAFTER_PATCH_HOST="${DRAFTER_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_glm5_drafter_group.py}"
 APC_PATCH_HOST="${APC_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_hybrid_prefix_hit.py}"
@@ -531,6 +532,7 @@ preflight() {
     check_port_free "$MASTER_PORT" MASTER_PORT
 
     [ -f "$STOP_PATCH_HOST" ] || die "$STOP_PATCH_HOST missing"
+    [ -f "$NATIVE_STOP_PATCH_HOST" ] || die "$NATIVE_STOP_PATCH_HOST missing"
     [ -f "$SCHED_PATCH_HOST" ] || die "$SCHED_PATCH_HOST missing"
     [ -f "$DRAFTER_PATCH_HOST" ] || die "$DRAFTER_PATCH_HOST missing"
     [ -f "$APC_PATCH_HOST" ] || die "$APC_PATCH_HOST missing"
@@ -1014,6 +1016,9 @@ fi
 if [ -f /opt/glm53/patch_suppress_stops_in_reasoning.py ]; then
     python3 /opt/glm53/patch_suppress_stops_in_reasoning.py
 fi
+if [ -f /opt/glm53/patch_suppress_native_stops_in_reasoning.py ]; then
+    python3 /opt/glm53/patch_suppress_native_stops_in_reasoning.py
+fi
 if [ -f /opt/glm53/patch_scheduler_decode_floor.py ]; then
     python3 /opt/glm53/patch_scheduler_decode_floor.py
 fi
@@ -1125,6 +1130,9 @@ fi
 if [ -f /opt/glm53/patch_suppress_stops_in_reasoning.py ]; then
     python3 /opt/glm53/patch_suppress_stops_in_reasoning.py
 fi
+if [ -f /opt/glm53/patch_suppress_native_stops_in_reasoning.py ]; then
+    python3 /opt/glm53/patch_suppress_native_stops_in_reasoning.py
+fi
 if [ -f /opt/glm53/patch_scheduler_decode_floor.py ]; then
     python3 /opt/glm53/patch_scheduler_decode_floor.py
 fi
@@ -1175,6 +1183,8 @@ launch_cluster() {
     scp -q -o BatchMode=yes "$VIDEO_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_glm_video_placeholders.py"
     [ -f "$STOP_PATCH_HOST" ] || die "missing $STOP_PATCH_HOST"
     scp -q -o BatchMode=yes "$STOP_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_suppress_stops_in_reasoning.py"
+    [ -f "$NATIVE_STOP_PATCH_HOST" ] || die "missing $NATIVE_STOP_PATCH_HOST"
+    scp -q -o BatchMode=yes "$NATIVE_STOP_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_suppress_native_stops_in_reasoning.py"
     [ -f "$SCHED_PATCH_HOST" ] || die "missing $SCHED_PATCH_HOST"
     scp -q -o BatchMode=yes "$SCHED_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_scheduler_decode_floor.py"
     [ -f "$DRAFTER_PATCH_HOST" ] || die "missing $DRAFTER_PATCH_HOST"
@@ -1318,6 +1328,7 @@ launch_cluster() {
         -v '/tmp/glm53-chat_template.jinja:${CHAT_TEMPLATE}:ro' \
         -v '/tmp/patch_glm_video_placeholders.py:/opt/glm53/patch_glm_video_placeholders.py:ro' \
         -v '/tmp/patch_suppress_stops_in_reasoning.py:/opt/glm53/patch_suppress_stops_in_reasoning.py:ro' \
+        -v '/tmp/patch_suppress_native_stops_in_reasoning.py:/opt/glm53/patch_suppress_native_stops_in_reasoning.py:ro' \
         -v '/tmp/patch_scheduler_decode_floor.py:/opt/glm53/patch_scheduler_decode_floor.py:ro' \
         -v '/tmp/patch_glm5_drafter_group.py:/opt/glm53/patch_glm5_drafter_group.py:ro' \
         -v '/tmp/patch_hybrid_prefix_hit.py:/opt/glm53/patch_hybrid_prefix_hit.py:ro' \
@@ -1351,6 +1362,7 @@ launch_cluster() {
         -v "$CHAT_TEMPLATE_HOST:$CHAT_TEMPLATE:ro" \
         -v "$VIDEO_PATCH_HOST:/opt/glm53/patch_glm_video_placeholders.py:ro" \
         -v "$STOP_PATCH_HOST:/opt/glm53/patch_suppress_stops_in_reasoning.py:ro" \
+        -v "$NATIVE_STOP_PATCH_HOST:/opt/glm53/patch_suppress_native_stops_in_reasoning.py:ro" \
         -v "$SCHED_PATCH_HOST:/opt/glm53/patch_scheduler_decode_floor.py:ro" \
         -v "$DRAFTER_PATCH_HOST:/opt/glm53/patch_glm5_drafter_group.py:ro" \
         -v "$APC_PATCH_HOST:/opt/glm53/patch_hybrid_prefix_hit.py:ro" \


### PR DESCRIPTION
## Problem

`patch_suppress_stops_in_reasoning.py` dormant-izes *client-provided stop
strings* while `<think>` is open, but explicitly leaves native EOS/stop-token
handling untouched. GLM's own `<|observation|>` control token (tool-turn
boundary marker, token id `154829` on this tokenizer) can land in
`sampling_params.stop_token_ids` and get sampled while the model is still
mid-`<think>`. The request then finishes with `finish_reason="stop"`,
`stop_reason=154829`, and empty `content`/`tool_calls` — the whole turn spent
on invisible reasoning. No server error, `200 OK` returned, so it's invisible
to a client unless it specifically checks for an empty completion matching a
stop-token id.

Observed on a live third-party agentic tool-calling workload (concurrent
multi-agent security scan, `tools` + `tool_choice: "auto"`, no
`chat_template_kwargs`): 11/11 empty-completion hits on one scan were this
exact shape, and hitting it repeatedly cascaded into a client's "give up
after N empty responses" guard force-killing its own agent mid-scan.

## Fix

`overlay/patch_suppress_native_stops_in_reasoning.py` — companion patch,
anchors `v1/core/sched/utils.py::check_stop`. Adds the same
dormant-until-`</think>` protection for native stop-token ids. Reasoning-open
is checked two independent ways, either being true suppresses the stop:

1. vLLM's own reasoning-parser state
   (`request.structured_output_request.reasoning_ended is False`) — only
   populated when structured-output/grammar tracking is active for the
   request.
2. Token-based, independent of (1): this deployment's chat template primes
   every thinking-enabled request with the prompt ending in the `<think>`
   token. If so, and `</think>` hasn't appeared yet in
   `request.output_token_ids`, reasoning is still open regardless of whether
   any grammar tracking ran for this request. This is what covers the
   `tool_choice: "auto"` gap that (1) alone misses.

Both signal reads are independently fail-closed (a bad env var or an
unexpected attribute error falls back to pre-patch behavior for that one
request rather than crashing `check_stop`). Every time this guard is
consulted for an actual native stop-token candidate it logs one INFO line
tagged `[suppress-native-stops-in-reasoning]` with both raw signal values and
the final decision, so a future occurrence is diagnosable straight from the
server log instead of inferred from client-side timestamps.

Wired into `start.sh` the same way as the existing stop-string patch: env
var for the host path, preflight existence check, copied/bind-mounted into
both head and worker containers, applied at boot via `inner.sh` generation
— no image rebuild required, restart only.

Opt-out (shared with the existing stop-string patch, same feature covering
the other stop source): `GLM53_SUPPRESS_STOPS_IN_REASONING=0` or
`VLLM_SUPPRESS_STOPS_IN_REASONING=0`.

## Status

Deployed and live-tested against real scan traffic. Dramatic improvement
(from 6-in-11-minutes / 11-in-98-exchanges down to 43 minutes clean before
first hit), but not full elimination under heavy concurrent load — see the
"Native stop-token id (`<|observation|>`) firing mid-`<think>`" section
added to `docs/05-known-issues.md` for the full iteration history (v1 → v2
→ v3), the currently-open root-cause hypotheses for the residual gap, and
how to read the new diagnostic log line.

## Testing

- Unit-tested against synthetic `Request`/`SamplingParams` stand-ins across
  both signal-present and signal-absent cases, including the crash/isolation
  bugs found in review (see commit `9dba87e`).
- Deployed to the live 2-node cluster, confirmed loaded via patch-marker
  grep and `/v1/models` after restart.
- Verified against real third-party agentic scan traffic, not just synthetic
  requests.