### PR TITLE
S2a: stage exllamav3 d5e4361 MoE ticket scheduler onto the pinned ext

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -372,6 +372,8 @@ COPY overlay/patch_exl3_ext_aarch64.py /opt/glm53/patch_exl3_ext_aarch64.py
 COPY overlay/patch_exl3_fat_kernel.py /opt/glm53/patch_exl3_fat_kernel.py
 COPY overlay/exl3_fat_gemm.cu /opt/glm53/exl3-fat-kernel/exl3_fat_gemm.cu
 COPY overlay/exl3_fat_gemm.cuh /opt/glm53/exl3-fat-kernel/exl3_fat_gemm.cuh
+COPY overlay/patch_exl3_ticket_scheduler.py /opt/glm53/patch_exl3_ticket_scheduler.py
+COPY overlay/exl3-ticket/ /opt/glm53/exl3-ticket/
 
 ARG EXLLAMAV3_COMMIT=c5d9c657966ffeeaa9353f0cc899f18629da4a13
 ENV TORCH_CUDA_ARCH_LIST=12.1a
@@ -421,6 +423,7 @@ RUN set -eux; \
     python3 -c "from pathlib import Path; assert (Path('/tmp/exllamav3')/'exllamav3/modules/quant/exl3.py').is_file()"; \
     python3 /opt/glm53/patch_exl3_ext_aarch64.py /tmp/exllamav3/exllamav3/exllamav3_ext; \
     python3 /opt/glm53/patch_exl3_fat_kernel.py /tmp/exllamav3/exllamav3/exllamav3_ext /opt/glm53/exl3-fat-kernel; \
+    python3 /opt/glm53/patch_exl3_ticket_scheduler.py /tmp/exllamav3/exllamav3/exllamav3_ext; \
     export CPATH="/usr/local/lib/python3.12/dist-packages/nvidia/cu13/include${CPATH:+:$CPATH}"; \
     export CPLUS_INCLUDE_PATH="/usr/local/lib/python3.12/dist-packages/nvidia/cu13/include${CPLUS_INCLUDE_PATH:+:$CPLUS_INCLUDE_PATH}"; \
     export C_INCLUDE_PATH="/usr/local/lib/python3.12/dist-packages/nvidia/cu13/include${C_INCLUDE_PATH:+:$C_INCLUDE_PATH}"; \
@@ -428,6 +431,7 @@ RUN set -eux; \
     TORCH_CUDA_ARCH_LIST=12.1a MAX_JOBS=8 \
       pip install --no-deps --no-build-isolation --no-cache-dir .; \
     python3 -c "import torch; import exllamav3_ext; assert hasattr(exllamav3_ext, 'exl3_moe'), dir(exllamav3_ext); assert hasattr(exllamav3_ext, 'exl3_fat_gemm'), dir(exllamav3_ext); assert hasattr(exllamav3_ext, 'exl3_fat_gemm_scatter'), dir(exllamav3_ext); print('exllamav3_ext', exllamav3_ext.__file__, 'exl3_moe=yes fat_gemm=yes')"; \
+    python3 -c "import inspect, exllamav3_ext; assert 'num_active' in inspect.signature(exllamav3_ext.exl3_moe).parameters, 'ticket scheduler (d5e4361) not applied'; print('exl3_moe num_active=yes (ticket scheduler)')"; \
     rm -rf /tmp/exllamav3 /root/.cache/pip
 
 # Keep this AFTER the CUDA compile layer so Python-only hook edits do not

--- a/Dockerfile
+++ b/Dockerfile
@@ -376,6 +376,12 @@ COPY overlay/patch_exl3_ticket_scheduler.py /opt/glm53/patch_exl3_ticket_schedul
 COPY overlay/exl3-ticket/ /opt/glm53/exl3-ticket/
 
 ARG EXLLAMAV3_COMMIT=c5d9c657966ffeeaa9353f0cc899f18629da4a13
+# Build-time opt-out for the S2a ticket-scheduler overlay (docs/11 S2a):
+# --build-arg GLM53_EXL3_TICKET_SCHEDULER=0 ships the pristine pin ext.
+# Rollback at runtime = previous image tag + .env IMAGE= flip (the scheduler
+# is compile-time, not a runtime knob).
+ARG GLM53_EXL3_TICKET_SCHEDULER=1
+ENV GLM53_EXL3_TICKET_SCHEDULER=${GLM53_EXL3_TICKET_SCHEDULER}
 ENV TORCH_CUDA_ARCH_LIST=12.1a
 ENV FLASHINFER_CUDA_ARCH_LIST=12.1a
 ENV MAX_JOBS=8
@@ -431,7 +437,11 @@ RUN set -eux; \
     TORCH_CUDA_ARCH_LIST=12.1a MAX_JOBS=8 \
       pip install --no-deps --no-build-isolation --no-cache-dir .; \
     python3 -c "import torch; import exllamav3_ext; assert hasattr(exllamav3_ext, 'exl3_moe'), dir(exllamav3_ext); assert hasattr(exllamav3_ext, 'exl3_fat_gemm'), dir(exllamav3_ext); assert hasattr(exllamav3_ext, 'exl3_fat_gemm_scatter'), dir(exllamav3_ext); print('exllamav3_ext', exllamav3_ext.__file__, 'exl3_moe=yes fat_gemm=yes')"; \
-    python3 -c "import inspect, exllamav3_ext; assert 'num_active' in inspect.signature(exllamav3_ext.exl3_moe).parameters, 'ticket scheduler (d5e4361) not applied'; print('exl3_moe num_active=yes (ticket scheduler)')"; \
+    if [ "${GLM53_EXL3_TICKET_SCHEDULER}" = "1" ]; then \
+      python3 -c "import exllamav3_ext; doc = exllamav3_ext.exl3_moe.__doc__ or ''; assert 'num_active' in doc or 'arg29' in doc or doc.count('arg') >= 30, 'ticket scheduler (d5e4361) not applied'; print('exl3_moe num_active=yes (ticket scheduler)')"; \
+    else \
+      echo 'GLM53_EXL3_TICKET_SCHEDULER=0: skipping ticket-scheduler assertion'; \
+    fi; \
     rm -rf /tmp/exllamav3 /root/.cache/pip
 
 # Keep this AFTER the CUDA compile layer so Python-only hook edits do not

--- a/docs/11-gb10-kernel-program.md
+++ b/docs/11-gb10-kernel-program.md
@@ -193,19 +193,59 @@ structured converged 68.38/68.44/68.67 @ 0.9832/6.882, watchdog re-armed.
 
 ### S2 — fat-GEMM micro-opts + kernel-range cherry-pick (image rebuild window)
 
-- Candidates: (a) pipeline/unroll the K16 MMA issue — multiple `mma.sync.m16n8k16`
-  per dequant word (no drop-in FP16 K32/K64 shape on SM121); (b) smaller tail-tile
-  for the 128–384 row band; (c) SMEM audit — stage A tile + B dequant in one pass
-  to cut one `__syncthreads()`; (d) **cherry-pick `d5e4361` (MoE ticket scheduler)
-  + autotune commits onto the pinned ext**; (e) verify the `5224ae4` Hadamard
-  overflow fix applies to the pin.
-- Pre-ship: final-reviewer handoff on the `.cu` diff + Grok CUDA review (the W24
-  pattern).
-- Gates: standing protocol + prefill probes (60k/240k) + a decode pass (the fused
-  `exl3_moe` path changes if `d5e4361` lands) + fat-path stats line (`99.7%`
-  engagement receipt re-measured).
-- Expected win: modest (bandwidth-bound); the scheduler cherry-pick is the part with
-  real decode upside.
+**S2a — MoE ticket-scheduler cherry-pick: STAGED 2026-09-02 (pre-ship review; window
+not yet run).**
+
+- **What ships:** upstream exllamav3 `d5e4361` ("MoE: Replace kernel round-robin
+  assignment with dynamic ticket scheduler and add dynamic group sizing", 2026-07-06)
+  cherry-picked onto the pinned `c5d9c657` ext. Verified in a throwaway worktree:
+  clean cherry-pick, and the vendored diff (pin→patched) contains **only** the
+  ticket-scheduler hunks — zero lines from the intervening commits (`9fe8b47` mul1
+  instances, `2f297e4` mgemm defaults), which are correctly excluded. The mechanism:
+  groups claim active experts via atomicAdd on a self-resetting scheduler in the
+  lock buffer (`MOE_SCHED_*`, +66 ints), group width becomes runtime
+  (`gridDim.x`, up to `MOE_MAX_SMS_PER_EXPERT`=32) instead of compile-time 8, and
+  `exl3_moe` gains a trailing `num_active` parameter (`-1` = unknown).
+- **Kit compatibility (verified):** the overlay `exl3.py` already introspects the
+  parameter (`_exl3_moe_accepts_num_active`) and passes `-1` today — stock launch
+  geometry preserved; the ticket scheduler replaces round-robin assignment with no
+  caller change, which is where the decode upside lives (idle groups steal heavy
+  experts instead of serializing their statically assigned share under skewed
+  agentic traffic). Dynamic group widening stays latent until a caller passes a
+  real count (would need a D2H sync; deliberately not taken).
+- **Packaging:** `overlay/patch_exl3_ticket_scheduler.py` — byte-exact three-state
+  installer (patched→skip / pristine→atomic replace / anything else→fail closed)
+  over vendored `overlay/exl3-ticket/{pristine,patched}` sets (pin bytes vs
+  pin+d5e4361 bytes); build-time opt-out `GLM53_EXL3_TICKET_SCHEDULER=0`; Dockerfile
+  wired after the fat-kernel step with a build assert on the `num_active`
+  signature. The d5e4361 hunk in exllamav3's own `block_sparse_mlp.py` is
+  deliberately not applied (not used by the vLLM serve path). 8 host tests
+  (`tests/test_exl3_ticket_scheduler.py`); full suite 66 passed / 1 skipped.
+- **(e) Hadamard `5224ae4` verdict: NOT APPLICABLE to this deployment.** The fix
+  casts `gridDim.y * 128 * blockIdx.x` to `size_t` in `hadamard.cu`'s standalone
+  launchers; overflow needs `gridDim.y * blockIdx.x ≥ 2^24` while our shapes keep
+  that product ~10^3 (MNBT 3584 → gridDim.y ≤ 28; N/128 ≤ 32). Our serving path
+  (fused `exl3_moe` + the fat kernel's own Hadamard) does not use those launchers.
+  Recorded; no cherry-pick.
+- **Autotune ride-alongs (`d409d3d`/`555ee4f`/`2a1cf9a`):** dropped from S2a — they
+  carry `comp_units/`-era context and touch autotune flow the pin does not have in
+  the same form; revisit at a pin advance, not as a hand-cherry-pick.
+
+**S2b — hand micro-opts on `exl3_fat_gemm.cu` (queued behind S2a's window):**
+(a) pipeline/unroll the K16 MMA issue — multiple `mma.sync.m16n8k16` per dequant
+word (no drop-in FP16 K32/K64 shape on SM121); (b) smaller tail-tile for the
+128–384 row band; (c) SMEM audit — stage A tile + B dequant in one pass to cut one
+`__syncthreads()`. Requires Grok CUDA review + Nsight profile first (the wall is
+bandwidth; measure where the time actually goes before touching the kernel).
+
+**Gates for the S2a window (when run):** image rebuild (digest changes → shape
+hash changes → one-time JIT wipe both nodes, wipe guard verified); same-boot-class
+warm-JIT A/B vs the current image; pool byte-identical; 0 IMA; acceptance 7/7;
+serving 6/6; structured/prose decode bands (the fused `exl3_moe` path changes —
+decode is the decision variable this time); cold prefill 60k/240k not-continued;
+fat-path stats re-measured; `systemctl --user reset-failed` before restarts;
+watchdog disarm/re-arm. Rollback: previous image tag + `.env` `IMAGE=` flip
+(pre-window `.env` snapshot taken per protocol).
 
 ### S3 — Sparkinfer Trellis design study (gated on S1/S2 outcomes)
 
@@ -229,8 +269,9 @@ structured converged 68.38/68.44/68.67 @ 0.9832/6.882, watchdog re-armed.
 
 1. ~~S1 row-tiling sweep~~ — **RUN 2026-09-02, REJECTED** (§6): TRF=128 + fat kernel
    stands; row-tile kill-arm −20.9%.
-2. **S2** `d5e4361` ticket-scheduler cherry-pick — best decode upside per line of code.
-3. **S2(a–c)** fat-GEMM micro-opts — one rebuild window, fold with 2.
+2. **S2a** `d5e4361` ticket-scheduler cherry-pick — **STAGED 2026-09-02**, pre-ship
+   review; best decode upside per line of code (§6).
+3. **S2b** fat-GEMM micro-opts — queued behind S2a's window + Nsight profile.
 4. **W28** indexer workspace — memory lane, unblocks a pin raise.
 5. **S3** Trellis study — largest potential, largest cost; decide after S1/S2.
 6. Watch: adaptive-K #52228/#52559, CUTLASS #43814, DeepGEMM sm120 port.

--- a/docs/11-gb10-kernel-program.md
+++ b/docs/11-gb10-kernel-program.md
@@ -216,11 +216,14 @@ not yet run).**
 - **Packaging:** `overlay/patch_exl3_ticket_scheduler.py` — byte-exact three-state
   installer (patched→skip / pristine→atomic replace / anything else→fail closed)
   over vendored `overlay/exl3-ticket/{pristine,patched}` sets (pin bytes vs
-  pin+d5e4361 bytes); build-time opt-out `GLM53_EXL3_TICKET_SCHEDULER=0`; Dockerfile
-  wired after the fat-kernel step with a build assert on the `num_active`
-  signature. The d5e4361 hunk in exllamav3's own `block_sparse_mlp.py` is
-  deliberately not applied (not used by the vLLM serve path). 8 host tests
-  (`tests/test_exl3_ticket_scheduler.py`); full suite 66 passed / 1 skipped.
+  pin+d5e4361 bytes); build-time opt-out `GLM53_EXL3_TICKET_SCHEDULER=0` (real
+  `ARG`+`ENV` forwarding; the build assert skips on opt-out builds); Dockerfile
+  wired after the fat-kernel step with a pybind-safe `__doc__`-based build assert
+  on the `num_active` signature (`inspect.signature` raises on pybind11 builtins;
+  deployed-unpatched receipt: 29 generated args, no `num_active` → discriminates).
+  The d5e4361 hunk in exllamav3's own `block_sparse_mlp.py` is deliberately not
+  applied (not used by the vLLM serve path). 10 host tests
+  (`tests/test_exl3_ticket_scheduler.py`); full suite 68 passed / 1 skipped.
 - **(e) Hadamard `5224ae4` verdict: NOT APPLICABLE to this deployment.** The fix
   casts `gridDim.y * 128 * blockIdx.x` to `size_t` in `hadamard.cu`'s standalone
   launchers; overflow needs `gridDim.y * blockIdx.x ≥ 2^24` while our shapes keep

--- a/overlay/exl3-ticket/patched/exl3_devctx.cu
+++ b/overlay/exl3-ticket/patched/exl3_devctx.cu
@@ -1,0 +1,87 @@
+#include <cuda_fp16.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <cooperative_groups.h>
+namespace cg = cooperative_groups;
+#include "exl3_devctx.cuh"
+#include "../util.h"
+#include "../util.cuh"
+
+//DevCtx::DevCtc()
+//{
+//    int num_sms[MAX_DEVICES] = {};
+//    int cc[MAX_DEVICES] = {};
+//    void* locks[MAX_DEVICES] = {};
+//    std::mutex mtx;
+//}
+
+DevCtx& DevCtx::instance()
+{
+    static DevCtx ctx;
+    return ctx;
+}
+
+int DevCtx::get_num_sms(int device)
+{
+    std::lock_guard<std::mutex> lock(mtx);
+    if (!num_sms[device])
+        cuda_check(cudaDeviceGetAttribute(&num_sms[device], cudaDevAttrMultiProcessorCount, device));
+    return num_sms[device];
+}
+
+int DevCtx::get_cc(int device)
+{
+    std::lock_guard<std::mutex> lock(mtx);
+    if (!cc[device])
+    {
+        cudaDeviceProp prop;
+        cuda_check(cudaGetDeviceProperties(&prop, device));
+        if (prop.major >= 10) cc[device] = CC_BLACKWELL;
+        else if (prop.major >= 9) cc[device] = CC_HOPPER;
+        else if (prop.major >= 8 && prop.minor >= 9) cc[device] = CC_ADA;
+        else if (prop.major >= 8) cc[device] = CC_AMPERE;
+        else cc[device] = CC_OLD;
+    }
+    return cc[device];
+}
+
+void* DevCtx::get_ws(int device)
+{
+    std::lock_guard<std::mutex> lock(mtx);
+    if (!ws[device])
+    {
+        cudaSetDevice(device);
+        cudaMalloc(&ws[device], WORKSPACE_SIZE);
+    }
+    return ws[device];
+}
+
+int* DevCtx::get_locks(int device)
+{
+    std::lock_guard<std::mutex> lock(mtx);
+    if (!locks[device])
+    {
+        cudaSetDevice(device);
+        size_t size = (MAX_TILES_C + MAX_BARRIERS * 2 + MOE_SCHED_INTS) * sizeof(int);
+        cudaMalloc(&locks[device], size);
+        cudaMemset(locks[device], 0, size);
+    }
+    return (int*) locks[device];
+}
+
+int g_get_cc(int device)
+{
+    return DevCtx::instance().get_cc(device);
+}
+
+int g_get_num_sms(int device)
+{
+    return DevCtx::instance().get_num_sms(device);
+}
+
+void prepare_ctx(int device)
+{
+    DevCtx::instance().get_num_sms(device);
+    DevCtx::instance().get_cc(device);
+    DevCtx::instance().get_locks(device);
+}

--- a/overlay/exl3-ticket/patched/exl3_devctx.cuh
+++ b/overlay/exl3-ticket/patched/exl3_devctx.cuh
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <tuple>
+#include <mutex>
+
+// Max allowable output size, in tiles. Used to allocate global lock buffer per device for sync across threadblocks
+#define MAX_TILES_C (1024 * 1024)
+#define MAX_BARRIERS 1024
+#define BARRIER_LOCKS_OFFSET MAX_TILES_C
+
+// MoE expert scheduler state, after the barrier counters: [0] next ticket, [1] retired groups,
+// [2 + group] ticket published to group. Self-resetting, zero-initialized with the rest of the buffer
+#define MOE_MAX_GROUPS 64
+#define MOE_SCHED_OFFSET (MAX_TILES_C + 2 * MAX_BARRIERS)
+#define MOE_SCHED_INTS (2 + MOE_MAX_GROUPS)
+
+// Workspace size
+#define WORKSPACE_SIZE (16*1024*1024)
+
+// Treat hopper and blackwell as same arch for now
+#define MAX_DEVICES 16
+#define CC_OLD        1
+#define CC_AMPERE     2
+#define CC_ADA        3
+#define CC_HOPPER     4
+#define CC_BLACKWELL  4
+
+// Singleton to manage context for each device. Stores device attributes and a large-enough lock buffer per device
+class DevCtx
+{
+private:
+    int num_sms[MAX_DEVICES] = {};
+    int cc[MAX_DEVICES] = {};
+    void* locks[MAX_DEVICES] = {};
+    void* ws[MAX_DEVICES] = {};
+    std::mutex mtx;
+
+public:
+    static DevCtx& instance();
+    int get_num_sms(int device);
+    int get_cc(int device);
+    void* get_ws(int device);
+    int* get_locks(int device);
+
+private:
+    DevCtx() = default;
+    DevCtx(const DevCtx&) = delete;
+    DevCtx& operator=(const DevCtx&) = delete;
+};
+
+int g_get_cc(int device);
+int g_get_num_sms(int device);
+
+void prepare_ctx(int device);

--- a/overlay/exl3-ticket/patched/exl3_moe.cu
+++ b/overlay/exl3-ticket/patched/exl3_moe.cu
@@ -1,0 +1,299 @@
+#include <cuda_fp16.h>
+#include "exl3_gemm.cuh"
+
+#include <c10/cuda/CUDAGuard.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <cooperative_groups.h>
+namespace cg = cooperative_groups;
+#include "../util.h"
+#include "../util.cuh"
+#include "comp_units/exl3_moe_instances.cuh"
+#include "exl3_devctx.cuh"
+#include <set>
+
+int exl3_moe_max_concurrency(int device)
+{
+    int num_sms = DevCtx::instance().get_num_sms(device);
+    return num_sms / MOE_SMS_PER_EXPERT;
+}
+
+std::set<void*> moe_kernel_attr_set[MAX_DEVICES] = {};
+
+fp_exl3_moe_kernel exl3_moe_kernel_instances[] =
+{
+    exl3_moe_kernel_k0_n128(), exl3_moe_kernel_k0_n256(), // Switch Kg, Ku and Kd at runtime
+    exl3_moe_kernel_k1_n128(), exl3_moe_kernel_k1_n256(), // Compile-time Kg = Ku = Kd
+    exl3_moe_kernel_k2_n128(), exl3_moe_kernel_k2_n256(), // ...
+    exl3_moe_kernel_k3_n128(), exl3_moe_kernel_k3_n256(),
+    exl3_moe_kernel_k4_n128(), exl3_moe_kernel_k4_n256(),
+    exl3_moe_kernel_k5_n128(), exl3_moe_kernel_k5_n256(),
+    exl3_moe_kernel_k6_n128(), exl3_moe_kernel_k6_n256(),
+    exl3_moe_kernel_k7_n128(), exl3_moe_kernel_k7_n256(),
+    exl3_moe_kernel_k8_n128(), exl3_moe_kernel_k8_n256()
+};
+
+/*
+Fused mixture-of-experts MLP operation for EXL3 weights
+
+inputs:
+    hidden_state:
+        input hidden state - shape (bsz, hidden_dim) - fp16
+
+    output_state:
+        output hidden state - shape (bsz, hidden_dim) - fp32
+        zero-initialized
+
+    expert_count:
+        bincount of expert indices across all tokens in batch - shape (num_experts + 1,) - int64
+        last item is ignored, used for the case where some tokens may activate less than num_experts_per_token
+        experts (specifically in expert split mode)
+
+    token_sorted:
+        token indices, sorted by expert - shape (bsz * num_experts_per_tok,)  - int64
+
+    weight_sorted:
+        routing weight per token, sorted by expert - shape (bsz * num_experts_per_tok,) - fp16
+
+    temp_state_g:
+    temp_state_u:
+        temp state storage - shape (concurrency, max_tokens_per_expert, hidden_dim), fp16
+
+    temp_intermediate_g
+    temp_intermediate_u:
+        temp intermediate storage - shape (concurrency, max_tokens_per_expert, intermediate_dim), fp16
+
+    act_function:
+        int, see exl3_moe.cuh
+
+    K_gate
+    K_up
+    K_down:
+        int, bitrates for gate, up, down tensors
+
+    gate_ptrs_trellis
+    gate_ptrs_suh
+    gate_ptrs_svh
+    up_ptrs_trellis
+    up_ptrs_suh
+    up_ptrs_svh
+    down_ptrs_trellis
+    down_ptrs_suh
+    down_ptrs_svh:
+        tensors of data_ptrs to quantized tensor data - each shape (num_experts,) - void*
+
+    gate_mcg
+    gate_mul1
+    up_mcg
+    up_mul1
+    down_mcg
+    down_mul1:
+        bool, codebook flags
+
+    num_active:
+        number of experts with 0 < token count <= max_tokens_per_expert, i.e. the number of experts this kernel
+        will process. Used to size the launch: fewer, wider expert groups when few experts are active. Pass -1 if
+        unknown (defaults to MOE_SMS_PER_EXPERT-wide groups at max concurrency)
+*/
+
+void exl3_moe
+(
+    const at::Tensor& hidden_state,
+    const at::Tensor& output_state,
+    const at::Tensor& expert_count,
+    const at::Tensor& token_sorted,
+    const at::Tensor& weight_sorted,
+
+    const at::Tensor& temp_state_g,
+    const at::Tensor& temp_state_u,
+    const at::Tensor& temp_intermediate_g,
+    const at::Tensor& temp_intermediate_u,
+
+    const int act_function,
+
+    const int K_gate,
+    const int K_up,
+    const int K_down,
+
+    const at::Tensor& gate_ptrs_trellis,
+    const at::Tensor& gate_ptrs_suh,
+    const at::Tensor& gate_ptrs_svh,
+    const at::Tensor& up_ptrs_trellis,
+    const at::Tensor& up_ptrs_suh,
+    const at::Tensor& up_ptrs_svh,
+    const at::Tensor& down_ptrs_trellis,
+    const at::Tensor& down_ptrs_suh,
+    const at::Tensor& down_ptrs_svh,
+
+    const bool gate_mcg,
+    const bool gate_mul1,
+    const bool up_mcg,
+    const bool up_mul1,
+    const bool down_mcg,
+    const bool down_mul1,
+
+    const float act_limit,
+    const int num_active
+)
+{
+    const at::cuda::OptionalCUDAGuard device_guard(hidden_state.device());
+    cudaStream_t stream = at::cuda::getCurrentCUDAStream().stream();
+
+    // Nothing for the fused kernel to do
+    if (num_active == 0) return;
+
+    // Validate args
+    TORCH_CHECK_DTYPE(hidden_state, kHalf);
+    TORCH_CHECK_DIM(hidden_state, 2);
+    size_t bsz = hidden_state.size(0);
+    size_t hidden_dim = hidden_state.size(1);
+
+    TORCH_CHECK_DTYPE(output_state, kFloat);
+    TORCH_CHECK_SHAPES_FULL(output_state, hidden_state);
+
+    TORCH_CHECK_DTYPE(expert_count, kLong);
+    TORCH_CHECK_DIM(expert_count, 1);
+    size_t num_experts = expert_count.size(0) - 1;
+
+    TORCH_CHECK_DTYPE(token_sorted, kLong);
+    TORCH_CHECK_DIM(token_sorted, 1);
+    TORCH_CHECK_SHAPES_FULL(token_sorted, weight_sorted);
+    size_t num_experts_per_tok = token_sorted.size(0) / bsz;
+
+    TORCH_CHECK_DTYPE(temp_state_g, kHalf);
+    TORCH_CHECK_DTYPE(temp_state_u, kHalf);
+    TORCH_CHECK_DIM(temp_state_g, 3);
+    TORCH_CHECK_SHAPES(temp_state_g, 2, hidden_state, 1, 1);
+    TORCH_CHECK_SHAPES_FULL(temp_state_g, temp_state_u);
+    size_t max_tokens_per_expert = temp_state_g.size(1);
+    size_t concurrency = temp_state_g.size(0);
+
+    TORCH_CHECK_DTYPE(temp_intermediate_g, kHalf);
+    TORCH_CHECK_DTYPE(temp_intermediate_u, kHalf);
+    TORCH_CHECK_DIM(temp_intermediate_g, 3);
+    TORCH_CHECK_DIM(temp_intermediate_u, 3);
+    TORCH_CHECK_SHAPES_FULL(temp_intermediate_g, temp_intermediate_u);
+    TORCH_CHECK_SHAPES(temp_intermediate_g, 1, temp_state_g, 1, 1);
+    size_t intermediate_dim = temp_intermediate_g.size(2);
+
+    // TORCH_CHECK(!(gate_mcg && gate_mul1), "Specified both mcg and mul1 (gate)");
+    // TORCH_CHECK(!(up_mcg && up_mul1), "Specified both mcg and mul1 (up)");
+    // TORCH_CHECK(!(down_mcg && down_mul1), "Specified both mcg and mul1 (down)");
+    TORCH_CHECK(gate_mcg && !gate_mul1, "MoE kernel: Only mcg codebook is currently supported");
+    TORCH_CHECK(up_mcg && !up_mul1, "MoE kernel: Only mcg codebook is currently supported");
+    TORCH_CHECK(down_mcg && !down_mul1, "MoE kernel: Only mcg codebook is currently supported");
+
+    // TORCH_CHECK(act_function == MOE_ACT_SILU, "MoE kernel: Only SiLU is currently supported");
+
+    int K = 0;
+    if (K_gate == K_up && K_up == K_down) K = K_gate;
+
+    TORCH_CHECK_DIM(gate_ptrs_trellis, 1);
+    TORCH_CHECK(gate_ptrs_trellis.size(0) == num_experts, "Number of gate tensors doesn't match num_experts");
+    TORCH_CHECK_SHAPES_FULL(gate_ptrs_trellis, gate_ptrs_suh);
+    TORCH_CHECK_SHAPES_FULL(gate_ptrs_trellis, gate_ptrs_svh);
+    TORCH_CHECK_SHAPES_FULL(gate_ptrs_trellis, up_ptrs_trellis);
+    TORCH_CHECK_SHAPES_FULL(gate_ptrs_trellis, up_ptrs_suh);
+    TORCH_CHECK_SHAPES_FULL(gate_ptrs_trellis, up_ptrs_svh);
+    TORCH_CHECK_SHAPES_FULL(gate_ptrs_trellis, down_ptrs_trellis);
+    TORCH_CHECK_SHAPES_FULL(gate_ptrs_trellis, down_ptrs_suh);
+    TORCH_CHECK_SHAPES_FULL(gate_ptrs_trellis, down_ptrs_svh);
+
+    // Device properties
+    int device;
+    cudaGetDevice(&device);
+    int num_sms = DevCtx::instance().get_num_sms(device);
+    int cc = DevCtx::instance().get_cc(device);
+    int* locks = DevCtx::instance().get_locks(device);
+
+    // Launch. All blocks of the grid must be co-resident for the group barriers, so groups * width <= num_sms.
+    // With a known number of active experts, launch only as many groups as there are experts and widen them to
+    // use the freed SMs, up to MOE_MAX_SMS_PER_EXPERT
+    int block_dim = EXL3_GEMM_BASE_THREADS * MOE_TILESIZE_K / 16;
+    TORCH_CHECK(concurrency * MOE_SMS_PER_EXPERT <= num_sms, "Concurrency too high for device num_sms");
+    int num_groups = MIN((int) concurrency, MOE_MAX_GROUPS);
+    int group_size = MOE_SMS_PER_EXPERT;
+    if (num_active > 0)
+    {
+        num_groups = MIN(num_groups, num_active);
+        group_size = MIN(num_sms / num_groups, MOE_MAX_SMS_PER_EXPERT);
+    }
+    dim3 grid_dim(group_size, 1, num_groups);
+
+    int N_off = 0;
+    if (hidden_dim % 256 == 0 && intermediate_dim % 256 == 0) N_off = 1;
+    fp_exl3_moe_kernel kernel = exl3_moe_kernel_instances[2 * K + N_off];
+
+    if (moe_kernel_attr_set[device].find((void*) kernel) == moe_kernel_attr_set[device].end())
+    {
+        cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, SMEM_MAX);
+        moe_kernel_attr_set[device].insert((void*) kernel);
+        cuda_check(cudaPeekAtLastError());
+    }
+
+    void* _hidden_state = hidden_state.data_ptr();
+    void* _temp_state_g = temp_state_g.data_ptr();
+    void* _temp_state_u = temp_state_u.data_ptr();
+    void* _temp_intermediate_g = temp_intermediate_g.data_ptr();
+    void* _temp_intermediate_u = temp_intermediate_u.data_ptr();
+    void* _output_state = output_state.data_ptr();
+
+    void* _gate_ptrs_trellis = gate_ptrs_trellis.data_ptr();
+    void* _gate_ptrs_suh = gate_ptrs_suh.data_ptr();
+    void* _gate_ptrs_svh = gate_ptrs_svh.data_ptr();
+    void* _up_ptrs_trellis = up_ptrs_trellis.data_ptr();
+    void* _up_ptrs_suh = up_ptrs_suh.data_ptr();
+    void* _up_ptrs_svh = up_ptrs_svh.data_ptr();
+    void* _down_ptrs_trellis = down_ptrs_trellis.data_ptr();
+    void* _down_ptrs_suh = down_ptrs_suh.data_ptr();
+    void* _down_ptrs_svh = down_ptrs_svh.data_ptr();
+
+    void* _expert_count = expert_count.data_ptr();
+    void* _token_sorted = token_sorted.data_ptr();
+    void* _weight_sorted = weight_sorted.data_ptr();
+
+    void* kernelArgs[] =
+    {
+        &_hidden_state,
+        &_temp_state_g,
+        &_temp_state_u,
+        &_temp_intermediate_g,
+        &_temp_intermediate_u,
+        &_output_state,
+        &_gate_ptrs_trellis,
+        &_gate_ptrs_suh,
+        &_gate_ptrs_svh,
+        &_up_ptrs_trellis,
+        &_up_ptrs_suh,
+        &_up_ptrs_svh,
+        &_down_ptrs_trellis,
+        &_down_ptrs_suh,
+        &_down_ptrs_svh,
+        &_expert_count,
+        &_token_sorted,
+        &_weight_sorted,
+        (void*) &hidden_dim,
+        (void*) &intermediate_dim,
+        (void*) &num_experts,
+        (void*) &num_experts_per_tok,
+        (void*) &max_tokens_per_expert,
+        (void*) &num_groups,
+        (void*) &act_limit,
+        (void*) &act_function,
+        (void*) &K_gate,
+        (void*) &K_up,
+        (void*) &K_down,
+        (void*) &locks
+    };
+
+    cudaLaunchKernel
+    (
+        (void*) kernel,
+        grid_dim,
+        block_dim,
+        kernelArgs,
+        SMEM_MAX,
+        stream
+    );
+
+    cuda_check(cudaPeekAtLastError());
+}

--- a/overlay/exl3-ticket/patched/exl3_moe.cuh
+++ b/overlay/exl3-ticket/patched/exl3_moe.cuh
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <ATen/Tensor.h>
+#include "../graph.cuh"
+
+int exl3_moe_max_concurrency(int device);
+
+void exl3_moe
+(
+    const at::Tensor& hidden_state,
+    const at::Tensor& output_state,
+    const at::Tensor& expert_count,
+    const at::Tensor& token_sorted,
+    const at::Tensor& weight_sorted,
+
+    const at::Tensor& temp_state_g,
+    const at::Tensor& temp_state_u,
+    const at::Tensor& temp_intermediate_g,
+    const at::Tensor& temp_intermediate_u,
+
+    const int act_function,
+
+    const int K_gate,
+    const int K_up,
+    const int K_down,
+
+    const at::Tensor& gate_ptrs_trellis,
+    const at::Tensor& gate_ptrs_suh,
+    const at::Tensor& gate_ptrs_svh,
+    const at::Tensor& up_ptrs_trellis,
+    const at::Tensor& up_ptrs_suh,
+    const at::Tensor& up_ptrs_svh,
+    const at::Tensor& down_ptrs_trellis,
+    const at::Tensor& down_ptrs_suh,
+    const at::Tensor& down_ptrs_svh,
+
+    const bool gate_mcg,
+    const bool gate_mul1,
+    const bool up_mcg,
+    const bool up_mul1,
+    const bool down_mcg,
+    const bool down_mul1,
+
+    const float act_limit,
+    const int num_active
+);
+

--- a/overlay/exl3-ticket/patched/exl3_moe_common.cuh
+++ b/overlay/exl3-ticket/patched/exl3_moe_common.cuh
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <cuda_fp16.h>
+#include <stdint.h>
+
+#define MOE_ACT_SILU 0
+#define MOE_ACT_GELU 1
+
+#define MOE_SMS_PER_EXPERT 8       // default/minimum group width, also sets max concurrency (buffer count)
+#define MOE_MAX_SMS_PER_EXPERT 32  // widest expert group when few experts are active
+#define MOE_TILESIZE_K 32
+#define MOE_TILESIZE_M 16
+#define MOE_SH_STAGES 3
+#define MOE_FRAG_STAGES 3
+
+#ifndef EXL3_GEMM_BASE_THREADS
+#define EXL3_GEMM_BASE_THREADS 256
+#endif
+
+#ifndef SMEM_MAX
+#define SMEM_MAX (90 * 1024)  // max shared memory on compute capability 8.6
+#endif
+
+#define EXL3_MOE_KERNEL_ARGS                    \
+    const half* __restrict__ hidden_state,      \
+    half* __restrict__ temp_state_g,            \
+    half* __restrict__ temp_state_u,            \
+    half* __restrict__ temp_intermediate_g,     \
+    half* __restrict__ temp_intermediate_u,     \
+    float* __restrict__ output_state,           \
+                                                \
+    const uint16_t** __restrict__ gate_trellis, \
+    const half** __restrict__ gate_suh,         \
+    const half** __restrict__ gate_svh,         \
+    const uint16_t** __restrict__ up_trellis,   \
+    const half** __restrict__ up_suh,           \
+    const half** __restrict__ up_svh,           \
+    const uint16_t** __restrict__ down_trellis, \
+    const half** __restrict__ down_suh,         \
+    const half** __restrict__ down_svh,         \
+                                                \
+    const int64_t* __restrict__ expert_count,   \
+    const int64_t* __restrict__ token_sorted,   \
+    const half* __restrict__ weight_sorted,     \
+                                                \
+    const int hidden_dim,                       \
+    const int intermediate_dim,                 \
+    const int num_experts,                      \
+    const int num_experts_per_tok,              \
+    const int max_tokens_per_expert,            \
+    const int concurrency,                      \
+    const float act_limit,                      \
+    const int act_function,                     \
+    const int K_gate,                           \
+    const int K_up,                             \
+    const int K_down,                           \
+                                                \
+    int* __restrict__ locks

--- a/overlay/exl3-ticket/patched/exl3_moe_kernel.cuh
+++ b/overlay/exl3-ticket/patched/exl3_moe_kernel.cuh
@@ -1,0 +1,279 @@
+#pragma once
+
+#include <cuda_bf16.h>
+#include <cublas_v2.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "exl3_moe_common.cuh"
+#include "../util.h"
+#include "../util.cuh"
+#include "exl3_kernel_map.cuh"
+#include "hadamard_inner.cuh"
+#include "exl3_gemm_inner.cuh"
+#include "exl3_devctx.cuh"
+#include "../ptx.cuh"
+
+template<int t_bits, int MOE_TILESIZE_N>
+__global__ __launch_bounds__(EXL3_GEMM_BASE_THREADS * MOE_TILESIZE_K / 16)
+void exl3_moe_kernel(EXL3_MOE_KERNEL_ARGS)
+{
+    const int group_idx = blockIdx.z;
+    const int block_idx = blockIdx.x;
+    const int group_size = gridDim.x;  // SMs per expert, set at launch
+    const int num_groups = gridDim.z;
+    const int block_threads = EXL3_GEMM_BASE_THREADS * MOE_TILESIZE_K / 16;  // blockDim.x
+    const int group_threads = group_size * block_threads;
+    const int warp_id = threadIdx.x / 32;
+    const int warps_per_group = group_threads / 32;
+    const int warps_per_block = block_threads / 32;
+    const int warp_idx0 = block_idx * warps_per_block + warp_id;
+
+    // Buffers for group
+    temp_state_g += group_idx * max_tokens_per_expert * hidden_dim;
+    temp_state_u += group_idx * max_tokens_per_expert * hidden_dim;
+    temp_intermediate_g += group_idx * max_tokens_per_expert * intermediate_dim;
+    temp_intermediate_u += group_idx * max_tokens_per_expert * intermediate_dim;
+
+    // Barriers for group sync
+    int* barrier_counters_sense = locks + BARRIER_LOCKS_OFFSET;
+
+    // Expert scheduler state, self-resetting: [0] next ticket, [1] retired groups, [2 + g] ticket for group g
+    int* sched = locks + MOE_SCHED_OFFSET;
+
+    // Individual GEMM barriers per group
+    locks += group_idx * MAX(hidden_dim, intermediate_dim) / 128;
+
+    // Dynamic expert assignment: active experts are numbered in scan order, and each group processes the active
+    // expert matching its current ticket. Initial tickets are the group indices; after finishing an expert, a group
+    // draws the next unclaimed ticket, so load balances greedily without assuming uniform cost per expert
+    int ticket = group_idx;
+
+    // Loop over experts
+    int start = 0;
+    int end = 0;
+    int expert_idx = 0;
+    int expert_idx_assign = 0;
+    for (; expert_idx < num_experts; ++expert_idx)
+    {
+        // Token span for current expert
+        start = end;
+        end += expert_count[expert_idx];
+        int token_count = end - start;
+
+        // Skip if no tokens or too many tokens for fused kernel (batch is handled by reconstruct path outside kernel)
+        if (token_count == 0) continue;
+        if (token_count > max_tokens_per_expert) continue;
+
+        // Skip if expert is claimed by a different group
+        if (expert_idx_assign++ != ticket) continue;
+
+        // EXL3 weights for g, u, d
+        const uint16_t* exp_gate_trellis = gate_trellis[expert_idx];
+        const half* exp_gate_suh = gate_suh[expert_idx];
+        const half* exp_gate_svh = gate_svh[expert_idx];
+        const uint16_t* exp_up_trellis = up_trellis[expert_idx];
+        const half* exp_up_suh = up_suh[expert_idx];
+        const half* exp_up_svh = up_svh[expert_idx];
+        const uint16_t* exp_down_trellis = down_trellis[expert_idx];
+        const half* exp_down_suh = down_suh[expert_idx];
+        const half* exp_down_svh = down_svh[expert_idx];
+
+        // Gather + input hadamard for g, u
+        auto had_gather_gu_in = [&]()
+        {
+            const int warps_per_token = hidden_dim / 128;
+            const int total_warps = token_count * warps_per_token;
+            const int64_t* top_x = token_sorted + start;
+            for (int warp_idx = warp_idx0; warp_idx < total_warps; warp_idx += warps_per_group)
+            {
+                int token_idx = top_x[warp_idx / warps_per_token];
+                int token_off = warp_idx % warps_per_token;
+                const half* in_ptr = hidden_state + token_idx * hidden_dim + token_off * 128;
+                had_hf_r_128_inner<true, false>
+                (
+                    in_ptr,
+                    temp_state_g + 128 * warp_idx,
+                    exp_gate_suh + 128 * token_off,
+                    0.088388347648f
+                );
+                had_hf_r_128_inner<true, false>
+                (
+                    in_ptr,
+                    temp_state_u + 128 * warp_idx,
+                    exp_up_suh + 128 * token_off,
+                    0.088388347648f
+                );
+            }
+            group_barrier(group_idx, group_size, barrier_counters_sense);
+        };
+
+        had_gather_gu_in();
+
+        // g, u GEMM
+        auto gemm_up = [&](const half* in_addr, half* out_addr, const uint16_t* trellis, const int K)
+        {
+            int size_m = token_count;
+            while (size_m > 0)
+            {
+                #define ARGS            \
+                    in_addr,            \
+                    trellis,            \
+                    out_addr,           \
+                    MIN(size_m, 16),    \
+                    hidden_dim,         \
+                    intermediate_dim,   \
+                    locks,              \
+                    nullptr
+                #define SHAPE_ARGS      \
+                    MOE_TILESIZE_M,     \
+                    MOE_TILESIZE_K,     \
+                    MOE_TILESIZE_N,     \
+                    MOE_SH_STAGES,      \
+                    MOE_FRAG_STAGES
+                if constexpr (t_bits)
+                    exl3_gemm_kernel_inner<t_bits, false, 1, SHAPE_ARGS, false>(ARGS);
+                else switch(K)
+                {
+                    case 1: exl3_gemm_kernel_inner<1, false, 1, SHAPE_ARGS, false>(ARGS); break;
+                    case 2: exl3_gemm_kernel_inner<2, false, 1, SHAPE_ARGS, false>(ARGS); break;
+                    case 3: exl3_gemm_kernel_inner<3, false, 1, SHAPE_ARGS, false>(ARGS); break;
+                    case 4: exl3_gemm_kernel_inner<4, false, 1, SHAPE_ARGS, false>(ARGS); break;
+                    case 5: exl3_gemm_kernel_inner<5, false, 1, SHAPE_ARGS, false>(ARGS); break;
+                    case 6: exl3_gemm_kernel_inner<6, false, 1, SHAPE_ARGS, false>(ARGS); break;
+                    case 7: exl3_gemm_kernel_inner<7, false, 1, SHAPE_ARGS, false>(ARGS); break;
+                    case 8: exl3_gemm_kernel_inner<8, false, 1, SHAPE_ARGS, false>(ARGS); break;
+                };
+                #undef ARGS
+                #undef SHAPE_ARGS
+
+                in_addr += 16 * hidden_dim;
+                out_addr += 16 * intermediate_dim;
+                size_m -= 16;
+            }
+        };
+
+        gemm_up(temp_state_g, temp_intermediate_g, exp_gate_trellis, K_gate);
+        gemm_up(temp_state_u, temp_intermediate_u, exp_up_trellis, K_up);
+        group_barrier(group_idx, group_size, barrier_counters_sense);
+
+        // Output hadamard for g, u + activation+gate + input hadamard for d
+        auto had_guad = [&]()
+        {
+            const int warps_per_token = intermediate_dim / 128;
+            const int total_warps = token_count * warps_per_token;
+            for (int warp_idx = warp_idx0; warp_idx < total_warps; warp_idx += warps_per_group)
+            {
+                int token_off = warp_idx % warps_per_token;
+                had_hf_r_128_guad_inner
+                (
+                    temp_intermediate_g + 128 * warp_idx,
+                    temp_intermediate_u + 128 * warp_idx,
+                    temp_intermediate_g + 128 * warp_idx,
+                    exp_gate_svh + 128 * token_off,
+                    exp_up_svh + 128 * token_off,
+                    exp_down_suh + 128 * token_off,
+                    0.088388347648f,
+                    act_limit,
+                    act_function
+                );
+            }
+            group_barrier(group_idx, group_size, barrier_counters_sense);
+        };
+
+        had_guad();
+
+        // d GEMM
+        auto gemm_down = [&](const half* in_addr, half* out_addr, const uint16_t* trellis, const int K)
+        {
+            int size_m = token_count;
+            while (size_m > 0)
+            {
+                #define ARGS            \
+                    in_addr,            \
+                    trellis,            \
+                    out_addr,           \
+                    MIN(size_m, 16),    \
+                    intermediate_dim,   \
+                    hidden_dim,         \
+                    locks,              \
+                    nullptr
+                #define SHAPE_ARGS      \
+                    MOE_TILESIZE_M,     \
+                    MOE_TILESIZE_K,     \
+                    MOE_TILESIZE_N,     \
+                    MOE_SH_STAGES,      \
+                    MOE_FRAG_STAGES
+                if constexpr (t_bits)
+                    exl3_gemm_kernel_inner<t_bits, false, 1, SHAPE_ARGS, false>(ARGS);
+                else switch(K)
+                {
+                    case 1: exl3_gemm_kernel_inner<1, false, 1, SHAPE_ARGS, false>(ARGS); break;
+                    case 2: exl3_gemm_kernel_inner<2, false, 1, SHAPE_ARGS, false>(ARGS); break;
+                    case 3: exl3_gemm_kernel_inner<3, false, 1, SHAPE_ARGS, false>(ARGS); break;
+                    case 4: exl3_gemm_kernel_inner<4, false, 1, SHAPE_ARGS, false>(ARGS); break;
+                    case 5: exl3_gemm_kernel_inner<5, false, 1, SHAPE_ARGS, false>(ARGS); break;
+                    case 6: exl3_gemm_kernel_inner<6, false, 1, SHAPE_ARGS, false>(ARGS); break;
+                    case 7: exl3_gemm_kernel_inner<7, false, 1, SHAPE_ARGS, false>(ARGS); break;
+                    case 8: exl3_gemm_kernel_inner<8, false, 1, SHAPE_ARGS, false>(ARGS); break;
+                };
+                #undef ARGS
+                #undef SHAPE_ARGS
+
+                in_addr += 16 * intermediate_dim;
+                out_addr += 16 * hidden_dim;
+                size_m -= 16;
+            }
+        };
+
+        gemm_down(temp_intermediate_g, temp_state_g, exp_down_trellis, K_down);
+        group_barrier(group_idx, group_size, barrier_counters_sense);
+
+        // Output hadamard for d + scatter add
+        auto had_d_out = [&]()
+        {
+            const int warps_per_token = hidden_dim / 128;
+            const int total_warps = token_count * warps_per_token;
+            const int64_t* top_x = token_sorted + start;
+            const half* weights = weight_sorted + start;
+            for (int warp_idx = warp_idx0; warp_idx < total_warps; warp_idx += warps_per_group)
+            {
+                int token_idx = top_x[warp_idx / warps_per_token];
+                half weight = weights[warp_idx / warps_per_token];
+                int token_off = warp_idx % warps_per_token;
+                float* out_ptr = output_state + token_idx * hidden_dim + token_off * 128;
+                had_hf_r_128_d_inner
+                (
+                    temp_state_g + 128 * warp_idx,
+                    out_ptr,
+                    exp_down_svh + 128 * token_off,
+                    0.088388347648f * __half2float(weight)
+                );
+            }
+        };
+
+        had_d_out();
+
+        // Draw the next ticket and publish it to the group through the end-of-expert barrier, which also protects
+        // the temp buffers for reuse. Grabbed tickets continue from num_groups since 0..num_groups-1 are implicit
+        if (block_idx == 0 && threadIdx.x == 0)
+            sched[2 + group_idx] = num_groups + atomicAdd(&sched[0], 1);
+        group_barrier(group_idx, group_size, barrier_counters_sense);
+        ticket = sched[2 + group_idx];
+    }
+
+    // Retire group; last group out resets the scheduler for the next launch. The acq_rel increment orders each
+    // group's earlier ticket grabs before the last group's reset (plain atomics are relaxed, so without this a
+    // straggler's in-flight grab could land after the reset and leak into the next launch)
+    if (block_idx == 0 && threadIdx.x == 0)
+    {
+        cuda::atomic_ref<int, cuda::thread_scope_device> next_ticket(sched[0]);
+        cuda::atomic_ref<int, cuda::thread_scope_device> retired_groups(sched[1]);
+        int retired = retired_groups.fetch_add(1, cuda::memory_order_acq_rel);
+        if (retired == num_groups - 1)
+        {
+            next_ticket.store(0, cuda::memory_order_relaxed);
+            retired_groups.store(0, cuda::memory_order_relaxed);
+        }
+    }
+}

--- a/overlay/exl3-ticket/pristine/exl3_devctx.cu
+++ b/overlay/exl3-ticket/pristine/exl3_devctx.cu
@@ -1,0 +1,87 @@
+#include <cuda_fp16.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <cooperative_groups.h>
+namespace cg = cooperative_groups;
+#include "exl3_devctx.cuh"
+#include "../util.h"
+#include "../util.cuh"
+
+//DevCtx::DevCtc()
+//{
+//    int num_sms[MAX_DEVICES] = {};
+//    int cc[MAX_DEVICES] = {};
+//    void* locks[MAX_DEVICES] = {};
+//    std::mutex mtx;
+//}
+
+DevCtx& DevCtx::instance()
+{
+    static DevCtx ctx;
+    return ctx;
+}
+
+int DevCtx::get_num_sms(int device)
+{
+    std::lock_guard<std::mutex> lock(mtx);
+    if (!num_sms[device])
+        cuda_check(cudaDeviceGetAttribute(&num_sms[device], cudaDevAttrMultiProcessorCount, device));
+    return num_sms[device];
+}
+
+int DevCtx::get_cc(int device)
+{
+    std::lock_guard<std::mutex> lock(mtx);
+    if (!cc[device])
+    {
+        cudaDeviceProp prop;
+        cuda_check(cudaGetDeviceProperties(&prop, device));
+        if (prop.major >= 10) cc[device] = CC_BLACKWELL;
+        else if (prop.major >= 9) cc[device] = CC_HOPPER;
+        else if (prop.major >= 8 && prop.minor >= 9) cc[device] = CC_ADA;
+        else if (prop.major >= 8) cc[device] = CC_AMPERE;
+        else cc[device] = CC_OLD;
+    }
+    return cc[device];
+}
+
+void* DevCtx::get_ws(int device)
+{
+    std::lock_guard<std::mutex> lock(mtx);
+    if (!ws[device])
+    {
+        cudaSetDevice(device);
+        cudaMalloc(&ws[device], WORKSPACE_SIZE);
+    }
+    return ws[device];
+}
+
+int* DevCtx::get_locks(int device)
+{
+    std::lock_guard<std::mutex> lock(mtx);
+    if (!locks[device])
+    {
+        cudaSetDevice(device);
+        size_t size = (MAX_TILES_C + MAX_BARRIERS * 2) * sizeof(int);
+        cudaMalloc(&locks[device], size);
+        cudaMemset(locks[device], 0, size);
+    }
+    return (int*) locks[device];
+}
+
+int g_get_cc(int device)
+{
+    return DevCtx::instance().get_cc(device);
+}
+
+int g_get_num_sms(int device)
+{
+    return DevCtx::instance().get_num_sms(device);
+}
+
+void prepare_ctx(int device)
+{
+    DevCtx::instance().get_num_sms(device);
+    DevCtx::instance().get_cc(device);
+    DevCtx::instance().get_locks(device);
+}

--- a/overlay/exl3-ticket/pristine/exl3_devctx.cuh
+++ b/overlay/exl3-ticket/pristine/exl3_devctx.cuh
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <tuple>
+#include <mutex>
+
+// Max allowable output size, in tiles. Used to allocate global lock buffer per device for sync across threadblocks
+#define MAX_TILES_C (1024 * 1024)
+#define MAX_BARRIERS 1024
+#define BARRIER_LOCKS_OFFSET MAX_TILES_C
+
+// Workspace size
+#define WORKSPACE_SIZE (16*1024*1024)
+
+// Treat hopper and blackwell as same arch for now
+#define MAX_DEVICES 16
+#define CC_OLD        1
+#define CC_AMPERE     2
+#define CC_ADA        3
+#define CC_HOPPER     4
+#define CC_BLACKWELL  4
+
+// Singleton to manage context for each device. Stores device attributes and a large-enough lock buffer per device
+class DevCtx
+{
+private:
+    int num_sms[MAX_DEVICES] = {};
+    int cc[MAX_DEVICES] = {};
+    void* locks[MAX_DEVICES] = {};
+    void* ws[MAX_DEVICES] = {};
+    std::mutex mtx;
+
+public:
+    static DevCtx& instance();
+    int get_num_sms(int device);
+    int get_cc(int device);
+    void* get_ws(int device);
+    int* get_locks(int device);
+
+private:
+    DevCtx() = default;
+    DevCtx(const DevCtx&) = delete;
+    DevCtx& operator=(const DevCtx&) = delete;
+};
+
+int g_get_cc(int device);
+int g_get_num_sms(int device);
+
+void prepare_ctx(int device);

--- a/overlay/exl3-ticket/pristine/exl3_moe.cu
+++ b/overlay/exl3-ticket/pristine/exl3_moe.cu
@@ -1,0 +1,281 @@
+#include <cuda_fp16.h>
+#include "exl3_gemm.cuh"
+
+#include <c10/cuda/CUDAGuard.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <cooperative_groups.h>
+namespace cg = cooperative_groups;
+#include "../util.h"
+#include "../util.cuh"
+#include "comp_units/exl3_moe_instances.cuh"
+#include "exl3_devctx.cuh"
+#include <set>
+
+int exl3_moe_max_concurrency(int device)
+{
+    int num_sms = DevCtx::instance().get_num_sms(device);
+    return num_sms / MOE_SMS_PER_EXPERT;
+}
+
+std::set<void*> moe_kernel_attr_set[MAX_DEVICES] = {};
+
+fp_exl3_moe_kernel exl3_moe_kernel_instances[] =
+{
+    exl3_moe_kernel_k0_n128(), exl3_moe_kernel_k0_n256(), // Switch Kg, Ku and Kd at runtime
+    exl3_moe_kernel_k1_n128(), exl3_moe_kernel_k1_n256(), // Compile-time Kg = Ku = Kd
+    exl3_moe_kernel_k2_n128(), exl3_moe_kernel_k2_n256(), // ...
+    exl3_moe_kernel_k3_n128(), exl3_moe_kernel_k3_n256(),
+    exl3_moe_kernel_k4_n128(), exl3_moe_kernel_k4_n256(),
+    exl3_moe_kernel_k5_n128(), exl3_moe_kernel_k5_n256(),
+    exl3_moe_kernel_k6_n128(), exl3_moe_kernel_k6_n256(),
+    exl3_moe_kernel_k7_n128(), exl3_moe_kernel_k7_n256(),
+    exl3_moe_kernel_k8_n128(), exl3_moe_kernel_k8_n256()
+};
+
+/*
+Fused mixture-of-experts MLP operation for EXL3 weights
+
+inputs:
+    hidden_state:
+        input hidden state - shape (bsz, hidden_dim) - fp16
+
+    output_state:
+        output hidden state - shape (bsz, hidden_dim) - fp32
+        zero-initialized
+
+    expert_count:
+        bincount of expert indices across all tokens in batch - shape (num_experts + 1,) - int64
+        last item is ignored, used for the case where some tokens may activate less than num_experts_per_token
+        experts (specifically in expert split mode)
+
+    token_sorted:
+        token indices, sorted by expert - shape (bsz * num_experts_per_tok,)  - int64
+
+    weight_sorted:
+        routing weight per token, sorted by expert - shape (bsz * num_experts_per_tok,) - fp16
+
+    temp_state_g:
+    temp_state_u:
+        temp state storage - shape (concurrency, max_tokens_per_expert, hidden_dim), fp16
+
+    temp_intermediate_g
+    temp_intermediate_u:
+        temp intermediate storage - shape (concurrency, max_tokens_per_expert, intermediate_dim), fp16
+
+    act_function:
+        int, see exl3_moe.cuh
+
+    K_gate
+    K_up
+    K_down:
+        int, bitrates for gate, up, down tensors
+
+    gate_ptrs_trellis
+    gate_ptrs_suh
+    gate_ptrs_svh
+    up_ptrs_trellis
+    up_ptrs_suh
+    up_ptrs_svh
+    down_ptrs_trellis
+    down_ptrs_suh
+    down_ptrs_svh:
+        tensors of data_ptrs to quantized tensor data - each shape (num_experts,) - void*
+
+    gate_mcg
+    gate_mul1
+    up_mcg
+    up_mul1
+    down_mcg
+    down_mul1:
+        bool, codebook flags
+*/
+
+void exl3_moe
+(
+    const at::Tensor& hidden_state,
+    const at::Tensor& output_state,
+    const at::Tensor& expert_count,
+    const at::Tensor& token_sorted,
+    const at::Tensor& weight_sorted,
+
+    const at::Tensor& temp_state_g,
+    const at::Tensor& temp_state_u,
+    const at::Tensor& temp_intermediate_g,
+    const at::Tensor& temp_intermediate_u,
+
+    const int act_function,
+
+    const int K_gate,
+    const int K_up,
+    const int K_down,
+
+    const at::Tensor& gate_ptrs_trellis,
+    const at::Tensor& gate_ptrs_suh,
+    const at::Tensor& gate_ptrs_svh,
+    const at::Tensor& up_ptrs_trellis,
+    const at::Tensor& up_ptrs_suh,
+    const at::Tensor& up_ptrs_svh,
+    const at::Tensor& down_ptrs_trellis,
+    const at::Tensor& down_ptrs_suh,
+    const at::Tensor& down_ptrs_svh,
+
+    const bool gate_mcg,
+    const bool gate_mul1,
+    const bool up_mcg,
+    const bool up_mul1,
+    const bool down_mcg,
+    const bool down_mul1,
+
+    const float act_limit
+)
+{
+    const at::cuda::OptionalCUDAGuard device_guard(hidden_state.device());
+    cudaStream_t stream = at::cuda::getCurrentCUDAStream().stream();
+
+    // Validate args
+    TORCH_CHECK_DTYPE(hidden_state, kHalf);
+    TORCH_CHECK_DIM(hidden_state, 2);
+    size_t bsz = hidden_state.size(0);
+    size_t hidden_dim = hidden_state.size(1);
+
+    TORCH_CHECK_DTYPE(output_state, kFloat);
+    TORCH_CHECK_SHAPES_FULL(output_state, hidden_state);
+
+    TORCH_CHECK_DTYPE(expert_count, kLong);
+    TORCH_CHECK_DIM(expert_count, 1);
+    size_t num_experts = expert_count.size(0) - 1;
+
+    TORCH_CHECK_DTYPE(token_sorted, kLong);
+    TORCH_CHECK_DIM(token_sorted, 1);
+    TORCH_CHECK_SHAPES_FULL(token_sorted, weight_sorted);
+    size_t num_experts_per_tok = token_sorted.size(0) / bsz;
+
+    TORCH_CHECK_DTYPE(temp_state_g, kHalf);
+    TORCH_CHECK_DTYPE(temp_state_u, kHalf);
+    TORCH_CHECK_DIM(temp_state_g, 3);
+    TORCH_CHECK_SHAPES(temp_state_g, 2, hidden_state, 1, 1);
+    TORCH_CHECK_SHAPES_FULL(temp_state_g, temp_state_u);
+    size_t max_tokens_per_expert = temp_state_g.size(1);
+    size_t concurrency = temp_state_g.size(0);
+
+    TORCH_CHECK_DTYPE(temp_intermediate_g, kHalf);
+    TORCH_CHECK_DTYPE(temp_intermediate_u, kHalf);
+    TORCH_CHECK_DIM(temp_intermediate_g, 3);
+    TORCH_CHECK_DIM(temp_intermediate_u, 3);
+    TORCH_CHECK_SHAPES_FULL(temp_intermediate_g, temp_intermediate_u);
+    TORCH_CHECK_SHAPES(temp_intermediate_g, 1, temp_state_g, 1, 1);
+    size_t intermediate_dim = temp_intermediate_g.size(2);
+
+    // TORCH_CHECK(!(gate_mcg && gate_mul1), "Specified both mcg and mul1 (gate)");
+    // TORCH_CHECK(!(up_mcg && up_mul1), "Specified both mcg and mul1 (up)");
+    // TORCH_CHECK(!(down_mcg && down_mul1), "Specified both mcg and mul1 (down)");
+    TORCH_CHECK(gate_mcg && !gate_mul1, "MoE kernel: Only mcg codebook is currently supported");
+    TORCH_CHECK(up_mcg && !up_mul1, "MoE kernel: Only mcg codebook is currently supported");
+    TORCH_CHECK(down_mcg && !down_mul1, "MoE kernel: Only mcg codebook is currently supported");
+
+    // TORCH_CHECK(act_function == MOE_ACT_SILU, "MoE kernel: Only SiLU is currently supported");
+
+    int K = 0;
+    if (K_gate == K_up && K_up == K_down) K = K_gate;
+
+    TORCH_CHECK_DIM(gate_ptrs_trellis, 1);
+    TORCH_CHECK(gate_ptrs_trellis.size(0) == num_experts, "Number of gate tensors doesn't match num_experts");
+    TORCH_CHECK_SHAPES_FULL(gate_ptrs_trellis, gate_ptrs_suh);
+    TORCH_CHECK_SHAPES_FULL(gate_ptrs_trellis, gate_ptrs_svh);
+    TORCH_CHECK_SHAPES_FULL(gate_ptrs_trellis, up_ptrs_trellis);
+    TORCH_CHECK_SHAPES_FULL(gate_ptrs_trellis, up_ptrs_suh);
+    TORCH_CHECK_SHAPES_FULL(gate_ptrs_trellis, up_ptrs_svh);
+    TORCH_CHECK_SHAPES_FULL(gate_ptrs_trellis, down_ptrs_trellis);
+    TORCH_CHECK_SHAPES_FULL(gate_ptrs_trellis, down_ptrs_suh);
+    TORCH_CHECK_SHAPES_FULL(gate_ptrs_trellis, down_ptrs_svh);
+
+    // Device properties
+    int device;
+    cudaGetDevice(&device);
+    int num_sms = DevCtx::instance().get_num_sms(device);
+    int cc = DevCtx::instance().get_cc(device);
+    int* locks = DevCtx::instance().get_locks(device);
+
+    // Launch
+    int block_dim = EXL3_GEMM_BASE_THREADS * MOE_TILESIZE_K / 16;
+    TORCH_CHECK(concurrency * MOE_SMS_PER_EXPERT <= num_sms, "Concurrency too high for device num_sms");
+    dim3 grid_dim(MOE_SMS_PER_EXPERT, 1, concurrency);
+
+    int N_off = 0;
+    if (hidden_dim % 256 == 0 && intermediate_dim % 256 == 0) N_off = 1;
+    fp_exl3_moe_kernel kernel = exl3_moe_kernel_instances[2 * K + N_off];
+
+    if (moe_kernel_attr_set[device].find((void*) kernel) == moe_kernel_attr_set[device].end())
+    {
+        cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, SMEM_MAX);
+        moe_kernel_attr_set[device].insert((void*) kernel);
+        cuda_check(cudaPeekAtLastError());
+    }
+
+    void* _hidden_state = hidden_state.data_ptr();
+    void* _temp_state_g = temp_state_g.data_ptr();
+    void* _temp_state_u = temp_state_u.data_ptr();
+    void* _temp_intermediate_g = temp_intermediate_g.data_ptr();
+    void* _temp_intermediate_u = temp_intermediate_u.data_ptr();
+    void* _output_state = output_state.data_ptr();
+
+    void* _gate_ptrs_trellis = gate_ptrs_trellis.data_ptr();
+    void* _gate_ptrs_suh = gate_ptrs_suh.data_ptr();
+    void* _gate_ptrs_svh = gate_ptrs_svh.data_ptr();
+    void* _up_ptrs_trellis = up_ptrs_trellis.data_ptr();
+    void* _up_ptrs_suh = up_ptrs_suh.data_ptr();
+    void* _up_ptrs_svh = up_ptrs_svh.data_ptr();
+    void* _down_ptrs_trellis = down_ptrs_trellis.data_ptr();
+    void* _down_ptrs_suh = down_ptrs_suh.data_ptr();
+    void* _down_ptrs_svh = down_ptrs_svh.data_ptr();
+
+    void* _expert_count = expert_count.data_ptr();
+    void* _token_sorted = token_sorted.data_ptr();
+    void* _weight_sorted = weight_sorted.data_ptr();
+
+    void* kernelArgs[] =
+    {
+        &_hidden_state,
+        &_temp_state_g,
+        &_temp_state_u,
+        &_temp_intermediate_g,
+        &_temp_intermediate_u,
+        &_output_state,
+        &_gate_ptrs_trellis,
+        &_gate_ptrs_suh,
+        &_gate_ptrs_svh,
+        &_up_ptrs_trellis,
+        &_up_ptrs_suh,
+        &_up_ptrs_svh,
+        &_down_ptrs_trellis,
+        &_down_ptrs_suh,
+        &_down_ptrs_svh,
+        &_expert_count,
+        &_token_sorted,
+        &_weight_sorted,
+        (void*) &hidden_dim,
+        (void*) &intermediate_dim,
+        (void*) &num_experts,
+        (void*) &num_experts_per_tok,
+        (void*) &max_tokens_per_expert,
+        (void*) &concurrency,
+        (void*) &act_limit,
+        (void*) &act_function,
+        (void*) &K_gate,
+        (void*) &K_up,
+        (void*) &K_down,
+        (void*) &locks
+    };
+
+    cudaLaunchKernel
+    (
+        (void*) kernel,
+        grid_dim,
+        block_dim,
+        kernelArgs,
+        SMEM_MAX,
+        stream
+    );
+
+    cuda_check(cudaPeekAtLastError());
+}

--- a/overlay/exl3-ticket/pristine/exl3_moe.cuh
+++ b/overlay/exl3-ticket/pristine/exl3_moe.cuh
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <ATen/Tensor.h>
+#include "../graph.cuh"
+
+int exl3_moe_max_concurrency(int device);
+
+void exl3_moe
+(
+    const at::Tensor& hidden_state,
+    const at::Tensor& output_state,
+    const at::Tensor& expert_count,
+    const at::Tensor& token_sorted,
+    const at::Tensor& weight_sorted,
+
+    const at::Tensor& temp_state_g,
+    const at::Tensor& temp_state_u,
+    const at::Tensor& temp_intermediate_g,
+    const at::Tensor& temp_intermediate_u,
+
+    const int act_function,
+
+    const int K_gate,
+    const int K_up,
+    const int K_down,
+
+    const at::Tensor& gate_ptrs_trellis,
+    const at::Tensor& gate_ptrs_suh,
+    const at::Tensor& gate_ptrs_svh,
+    const at::Tensor& up_ptrs_trellis,
+    const at::Tensor& up_ptrs_suh,
+    const at::Tensor& up_ptrs_svh,
+    const at::Tensor& down_ptrs_trellis,
+    const at::Tensor& down_ptrs_suh,
+    const at::Tensor& down_ptrs_svh,
+
+    const bool gate_mcg,
+    const bool gate_mul1,
+    const bool up_mcg,
+    const bool up_mul1,
+    const bool down_mcg,
+    const bool down_mul1,
+
+    const float act_limit
+);
+

--- a/overlay/exl3-ticket/pristine/exl3_moe_common.cuh
+++ b/overlay/exl3-ticket/pristine/exl3_moe_common.cuh
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <cuda_fp16.h>
+#include <stdint.h>
+
+#define MOE_ACT_SILU 0
+#define MOE_ACT_GELU 1
+
+#define MOE_SMS_PER_EXPERT 8
+#define MOE_TILESIZE_K 32
+#define MOE_TILESIZE_M 16
+#define MOE_SH_STAGES 3
+#define MOE_FRAG_STAGES 3
+
+#ifndef EXL3_GEMM_BASE_THREADS
+#define EXL3_GEMM_BASE_THREADS 256
+#endif
+
+#ifndef SMEM_MAX
+#define SMEM_MAX (90 * 1024)  // max shared memory on compute capability 8.6
+#endif
+
+#define EXL3_MOE_KERNEL_ARGS                    \
+    const half* __restrict__ hidden_state,      \
+    half* __restrict__ temp_state_g,            \
+    half* __restrict__ temp_state_u,            \
+    half* __restrict__ temp_intermediate_g,     \
+    half* __restrict__ temp_intermediate_u,     \
+    float* __restrict__ output_state,           \
+                                                \
+    const uint16_t** __restrict__ gate_trellis, \
+    const half** __restrict__ gate_suh,         \
+    const half** __restrict__ gate_svh,         \
+    const uint16_t** __restrict__ up_trellis,   \
+    const half** __restrict__ up_suh,           \
+    const half** __restrict__ up_svh,           \
+    const uint16_t** __restrict__ down_trellis, \
+    const half** __restrict__ down_suh,         \
+    const half** __restrict__ down_svh,         \
+                                                \
+    const int64_t* __restrict__ expert_count,   \
+    const int64_t* __restrict__ token_sorted,   \
+    const half* __restrict__ weight_sorted,     \
+                                                \
+    const int hidden_dim,                       \
+    const int intermediate_dim,                 \
+    const int num_experts,                      \
+    const int num_experts_per_tok,              \
+    const int max_tokens_per_expert,            \
+    const int concurrency,                      \
+    const float act_limit,                      \
+    const int act_function,                     \
+    const int K_gate,                           \
+    const int K_up,                             \
+    const int K_down,                           \
+                                                \
+    int* __restrict__ locks

--- a/overlay/exl3-ticket/pristine/exl3_moe_kernel.cuh
+++ b/overlay/exl3-ticket/pristine/exl3_moe_kernel.cuh
@@ -1,0 +1,248 @@
+#pragma once
+
+#include <cuda_bf16.h>
+#include <cublas_v2.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "exl3_moe_common.cuh"
+#include "../util.h"
+#include "../util.cuh"
+#include "exl3_kernel_map.cuh"
+#include "hadamard_inner.cuh"
+#include "exl3_gemm_inner.cuh"
+#include "exl3_devctx.cuh"
+#include "../ptx.cuh"
+
+template<int t_bits, int MOE_TILESIZE_N>
+__global__ __launch_bounds__(EXL3_GEMM_BASE_THREADS * MOE_TILESIZE_K / 16)
+void exl3_moe_kernel(EXL3_MOE_KERNEL_ARGS)
+{
+    const int group_idx = blockIdx.z;
+    const int block_idx = blockIdx.x;
+    const int block_threads = EXL3_GEMM_BASE_THREADS * MOE_TILESIZE_K / 16;  // blockDim.x
+    const int group_threads = MOE_SMS_PER_EXPERT * block_threads;
+    const int warp_id = threadIdx.x / 32;
+    const int warps_per_group = group_threads / 32;
+    const int warps_per_block = block_threads / 32;
+    const int warp_idx0 = block_idx * warps_per_block + warp_id;
+
+    // Buffers for group
+    temp_state_g += group_idx * max_tokens_per_expert * hidden_dim;
+    temp_state_u += group_idx * max_tokens_per_expert * hidden_dim;
+    temp_intermediate_g += group_idx * max_tokens_per_expert * intermediate_dim;
+    temp_intermediate_u += group_idx * max_tokens_per_expert * intermediate_dim;
+
+    // Barriers for group sync
+    int* barrier_counters_sense = locks + BARRIER_LOCKS_OFFSET;
+
+    // Individual GEMM barriers per group
+    locks += group_idx * MAX(hidden_dim, intermediate_dim) / 128;
+
+    // Loop over experts
+    int start = 0;
+    int end = 0;
+    int expert_idx = 0;
+    int expert_idx_assign = 0;
+    for (; expert_idx < num_experts; ++expert_idx)
+    {
+        // Token span for current expert
+        start = end;
+        end += expert_count[expert_idx];
+        int token_count = end - start;
+
+        // Skip if no tokens or too many tokens for fused kernel (batch is handled by reconstruct path outside kernel)
+        if (token_count == 0) continue;
+        if (token_count > max_tokens_per_expert) continue;
+
+        // Skip if expert is assigned to different group
+        if (expert_idx_assign++ % concurrency != group_idx) continue;
+
+        // EXL3 weights for g, u, d
+        const uint16_t* exp_gate_trellis = gate_trellis[expert_idx];
+        const half* exp_gate_suh = gate_suh[expert_idx];
+        const half* exp_gate_svh = gate_svh[expert_idx];
+        const uint16_t* exp_up_trellis = up_trellis[expert_idx];
+        const half* exp_up_suh = up_suh[expert_idx];
+        const half* exp_up_svh = up_svh[expert_idx];
+        const uint16_t* exp_down_trellis = down_trellis[expert_idx];
+        const half* exp_down_suh = down_suh[expert_idx];
+        const half* exp_down_svh = down_svh[expert_idx];
+
+        // Gather + input hadamard for g, u
+        auto had_gather_gu_in = [&]()
+        {
+            const int warps_per_token = hidden_dim / 128;
+            const int total_warps = token_count * warps_per_token;
+            const int64_t* top_x = token_sorted + start;
+            for (int warp_idx = warp_idx0; warp_idx < total_warps; warp_idx += warps_per_group)
+            {
+                int token_idx = top_x[warp_idx / warps_per_token];
+                int token_off = warp_idx % warps_per_token;
+                const half* in_ptr = hidden_state + token_idx * hidden_dim + token_off * 128;
+                had_hf_r_128_inner<true, false>
+                (
+                    in_ptr,
+                    temp_state_g + 128 * warp_idx,
+                    exp_gate_suh + 128 * token_off,
+                    0.088388347648f
+                );
+                had_hf_r_128_inner<true, false>
+                (
+                    in_ptr,
+                    temp_state_u + 128 * warp_idx,
+                    exp_up_suh + 128 * token_off,
+                    0.088388347648f
+                );
+            }
+            group_barrier(group_idx, MOE_SMS_PER_EXPERT, barrier_counters_sense);
+        };
+
+        had_gather_gu_in();
+
+        // g, u GEMM
+        auto gemm_up = [&](const half* in_addr, half* out_addr, const uint16_t* trellis, const int K)
+        {
+            int size_m = token_count;
+            while (size_m > 0)
+            {
+                #define ARGS            \
+                    in_addr,            \
+                    trellis,            \
+                    out_addr,           \
+                    MIN(size_m, 16),    \
+                    hidden_dim,         \
+                    intermediate_dim,   \
+                    locks,              \
+                    nullptr
+                #define SHAPE_ARGS      \
+                    MOE_TILESIZE_M,     \
+                    MOE_TILESIZE_K,     \
+                    MOE_TILESIZE_N,     \
+                    MOE_SH_STAGES,      \
+                    MOE_FRAG_STAGES
+                if constexpr (t_bits)
+                    exl3_gemm_kernel_inner<t_bits, false, 1, SHAPE_ARGS, false>(ARGS);
+                else switch(K)
+                {
+                    case 1: exl3_gemm_kernel_inner<1, false, 1, SHAPE_ARGS, false>(ARGS); break;
+                    case 2: exl3_gemm_kernel_inner<2, false, 1, SHAPE_ARGS, false>(ARGS); break;
+                    case 3: exl3_gemm_kernel_inner<3, false, 1, SHAPE_ARGS, false>(ARGS); break;
+                    case 4: exl3_gemm_kernel_inner<4, false, 1, SHAPE_ARGS, false>(ARGS); break;
+                    case 5: exl3_gemm_kernel_inner<5, false, 1, SHAPE_ARGS, false>(ARGS); break;
+                    case 6: exl3_gemm_kernel_inner<6, false, 1, SHAPE_ARGS, false>(ARGS); break;
+                    case 7: exl3_gemm_kernel_inner<7, false, 1, SHAPE_ARGS, false>(ARGS); break;
+                    case 8: exl3_gemm_kernel_inner<8, false, 1, SHAPE_ARGS, false>(ARGS); break;
+                };
+                #undef ARGS
+                #undef SHAPE_ARGS
+
+                in_addr += 16 * hidden_dim;
+                out_addr += 16 * intermediate_dim;
+                size_m -= 16;
+            }
+        };
+
+        gemm_up(temp_state_g, temp_intermediate_g, exp_gate_trellis, K_gate);
+        gemm_up(temp_state_u, temp_intermediate_u, exp_up_trellis, K_up);
+        group_barrier(group_idx, MOE_SMS_PER_EXPERT, barrier_counters_sense);
+
+        // Output hadamard for g, u + activation+gate + input hadamard for d
+        auto had_guad = [&]()
+        {
+            const int warps_per_token = intermediate_dim / 128;
+            const int total_warps = token_count * warps_per_token;
+            for (int warp_idx = warp_idx0; warp_idx < total_warps; warp_idx += warps_per_group)
+            {
+                int token_off = warp_idx % warps_per_token;
+                had_hf_r_128_guad_inner
+                (
+                    temp_intermediate_g + 128 * warp_idx,
+                    temp_intermediate_u + 128 * warp_idx,
+                    temp_intermediate_g + 128 * warp_idx,
+                    exp_gate_svh + 128 * token_off,
+                    exp_up_svh + 128 * token_off,
+                    exp_down_suh + 128 * token_off,
+                    0.088388347648f,
+                    act_limit,
+                    act_function
+                );
+            }
+            group_barrier(group_idx, MOE_SMS_PER_EXPERT, barrier_counters_sense);
+        };
+
+        had_guad();
+
+        // d GEMM
+        auto gemm_down = [&](const half* in_addr, half* out_addr, const uint16_t* trellis, const int K)
+        {
+            int size_m = token_count;
+            while (size_m > 0)
+            {
+                #define ARGS            \
+                    in_addr,            \
+                    trellis,            \
+                    out_addr,           \
+                    MIN(size_m, 16),    \
+                    intermediate_dim,   \
+                    hidden_dim,         \
+                    locks,              \
+                    nullptr
+                #define SHAPE_ARGS      \
+                    MOE_TILESIZE_M,     \
+                    MOE_TILESIZE_K,     \
+                    MOE_TILESIZE_N,     \
+                    MOE_SH_STAGES,      \
+                    MOE_FRAG_STAGES
+                if constexpr (t_bits)
+                    exl3_gemm_kernel_inner<t_bits, false, 1, SHAPE_ARGS, false>(ARGS);
+                else switch(K)
+                {
+                    case 1: exl3_gemm_kernel_inner<1, false, 1, SHAPE_ARGS, false>(ARGS); break;
+                    case 2: exl3_gemm_kernel_inner<2, false, 1, SHAPE_ARGS, false>(ARGS); break;
+                    case 3: exl3_gemm_kernel_inner<3, false, 1, SHAPE_ARGS, false>(ARGS); break;
+                    case 4: exl3_gemm_kernel_inner<4, false, 1, SHAPE_ARGS, false>(ARGS); break;
+                    case 5: exl3_gemm_kernel_inner<5, false, 1, SHAPE_ARGS, false>(ARGS); break;
+                    case 6: exl3_gemm_kernel_inner<6, false, 1, SHAPE_ARGS, false>(ARGS); break;
+                    case 7: exl3_gemm_kernel_inner<7, false, 1, SHAPE_ARGS, false>(ARGS); break;
+                    case 8: exl3_gemm_kernel_inner<8, false, 1, SHAPE_ARGS, false>(ARGS); break;
+                };
+                #undef ARGS
+                #undef SHAPE_ARGS
+
+                in_addr += 16 * intermediate_dim;
+                out_addr += 16 * hidden_dim;
+                size_m -= 16;
+            }
+        };
+
+        gemm_down(temp_intermediate_g, temp_state_g, exp_down_trellis, K_down);
+        group_barrier(group_idx, MOE_SMS_PER_EXPERT, barrier_counters_sense);
+
+        // Output hadamard for d + scatter add
+        auto had_d_out = [&]()
+        {
+            const int warps_per_token = hidden_dim / 128;
+            const int total_warps = token_count * warps_per_token;
+            const int64_t* top_x = token_sorted + start;
+            const half* weights = weight_sorted + start;
+            for (int warp_idx = warp_idx0; warp_idx < total_warps; warp_idx += warps_per_group)
+            {
+                int token_idx = top_x[warp_idx / warps_per_token];
+                half weight = weights[warp_idx / warps_per_token];
+                int token_off = warp_idx % warps_per_token;
+                float* out_ptr = output_state + token_idx * hidden_dim + token_off * 128;
+                had_hf_r_128_d_inner
+                (
+                    temp_state_g + 128 * warp_idx,
+                    out_ptr,
+                    exp_down_svh + 128 * token_off,
+                    0.088388347648f * __half2float(weight)
+                );
+            }
+            group_barrier(group_idx, MOE_SMS_PER_EXPERT, barrier_counters_sense);
+        };
+
+        had_d_out();
+    }
+}

--- a/overlay/patch_exl3_ticket_scheduler.py
+++ b/overlay/patch_exl3_ticket_scheduler.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Install the exllamav3 MoE dynamic ticket scheduler (upstream d5e4361) onto the
+pinned extension source at image build time.
+
+Upstream exllamav3 commit d5e4361 ("MoE: Replace kernel round-robin assignment
+with dynamic ticket scheduler and add dynamic group sizing", 2026-07-06)
+replaces the fused `exl3_moe` kernel's static round-robin expert->group
+assignment with a self-resetting ticket scheduler: groups claim the next
+unclaimed active expert via atomicAdd instead of `idx % concurrency`, so idle
+groups steal heavy experts instead of serializing their statically assigned
+share. It also makes the group width runtime-configurable (gridDim.x) and
+sizes the lock buffer for the scheduler state (MOE_SCHED_INTS).
+
+The kit pins exllamav3 at c5d9c657; this patch cherry-picks d5e4361 onto that
+pin (verified: clean apply, +75/-16 over 7 files). Only the 6 ext quant files
+are shipped here — the d5e4361 hunk in modules/block_sparse_mlp.py belongs to
+exllamav3's own python stack, which the vLLM serve path does not use (the kit
+overlay drives exllamav3_ext directly).
+
+Byte-exact three-state installer:
+  patched  -> file already matches the vendored post-patch bytes: skip
+  pristine -> file matches the pin's bytes: atomic replace with patched
+  other    -> anchor drift: FAIL CLOSED, nothing written
+
+The vendored sets live in overlay/exl3-ticket/{pristine,patched}/ next to this
+script. The kit's overlay exl3.py already introspects the new trailing
+`num_active` parameter (_exl3_moe_accepts_num_active) and passes -1 (unknown)
+today, preserving the stock launch geometry; dynamic group widening engages
+only when a caller passes a real active count.
+
+Build-time opt-out: GLM53_EXL3_TICKET_SCHEDULER=0 skips the patch entirely
+(rollback = previous image tag; the scheduler is compile-time, not a runtime
+knob).
+"""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+FILES = (
+    "exl3_devctx.cu",
+    "exl3_devctx.cuh",
+    "exl3_moe.cu",
+    "exl3_moe.cuh",
+    "exl3_moe_common.cuh",
+    "exl3_moe_kernel.cuh",
+)
+
+
+def _sha(data: bytes) -> str:
+    import hashlib
+
+    return hashlib.sha256(data).hexdigest()
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        raise SystemExit("usage: patch_exl3_ticket_scheduler.py EXLLAMAV3_EXT")
+    ext_root = Path(sys.argv[1]).resolve()
+    quant = ext_root / "quant"
+    if not quant.is_dir():
+        raise SystemExit(f"invalid extension root (no quant/): {ext_root}")
+
+    script_dir = Path(__file__).resolve().parent
+    pristine_dir = script_dir / "exl3-ticket" / "pristine"
+    patched_dir = script_dir / "exl3-ticket" / "patched"
+    for d in (pristine_dir, patched_dir):
+        if not d.is_dir():
+            raise SystemExit(f"missing vendored set: {d}")
+
+    if os.environ.get("GLM53_EXL3_TICKET_SCHEDULER", "1") == "0":
+        print("ticket-scheduler: GLM53_EXL3_TICKET_SCHEDULER=0, skipping")
+        return 0
+
+    n_patched = 0
+    n_already = 0
+    plan: list[tuple[Path, bytes]] = []
+    for name in FILES:
+        pristine = (pristine_dir / name).read_bytes()
+        patched = (patched_dir / name).read_bytes()
+        if pristine == patched:
+            raise SystemExit(f"vendored sets identical for {name} — packaging bug")
+        target = quant / name
+        current = target.read_bytes()
+        if current == patched:
+            n_already += 1
+            print(f"ticket-scheduler: {name} already patched")
+            continue
+        if current != pristine:
+            raise SystemExit(
+                f"ticket-scheduler FATAL: {target} matches neither the pinned "
+                f"pristine bytes ({_sha(pristine)[:12]}) nor the patched bytes "
+                f"({_sha(patched)[:12]}); on-disk sha {_sha(current)[:12]} — "
+                f"anchor drifted, refusing"
+            )
+        plan.append((target, patched))
+
+    if plan and n_already:
+        # Partial state = the source tree was not pristine to begin with (the
+        # installer is run once on a fresh pin tarball at image build).
+        # Refuse BEFORE writing anything so the build investigates instead of
+        # shipping a surprise.
+        raise SystemExit(
+            "ticket-scheduler FATAL: mixed pristine/patched state across files "
+            "on first application — source tree unexpected, nothing written"
+        )
+    for target, patched in plan:
+        fd, tmp = tempfile.mkstemp(dir=str(target.parent), prefix=f".{target.name}.")
+        try:
+            with os.fdopen(fd, "wb") as f:
+                f.write(patched)
+            os.replace(tmp, target)
+        except BaseException:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+            raise
+        if target.read_bytes() != patched:
+            raise SystemExit(f"ticket-scheduler FATAL: post-write verify failed for {target.name}")
+        n_patched += 1
+        print(f"ticket-scheduler: {target.name} pristine -> patched (atomic)")
+
+    if n_patched and n_already:
+        # Partial state = one file drifted into patched-ness while others are
+        # pristine. The per-file logic above is safe (every file independently
+        # pristine->patched), but a mixed result on a first run means the
+        # source tree was not pristine to begin with; refuse loudly so the
+        # image build investigates instead of shipping a surprise.
+        raise SystemExit(
+            "ticket-scheduler FATAL: mixed pristine/patched state across files "
+            "on first application — source tree unexpected"
+        )
+    print(
+        f"ticket-scheduler: done (patched={n_patched}, already={n_already}, "
+        f"total={len(FILES)})"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_exl3_ticket_scheduler.py
+++ b/tests/test_exl3_ticket_scheduler.py
@@ -130,5 +130,37 @@ def test_missing_bindings_is_not_our_concern(tmp_path):
     assert r.returncode == 0, r.stderr
 
 
+def test_mixed_state_refused_before_any_write(tmp_path):
+    # One file already patched, five pristine: the installer must refuse on
+    # the pre-scan and leave every file untouched.
+    ext = _make_ext(tmp_path, PRISTINE)
+    shutil.copyfile(PATCHED / "exl3_devctx.cuh", ext / "quant" / "exl3_devctx.cuh")
+    before = _read_all(ext)
+    r = _run(ext)
+    assert r.returncode != 0
+    assert "mixed pristine/patched state" in (r.stderr + r.stdout)
+    assert _read_all(ext) == before
+
+
+def test_dockerfile_wiring():
+    """Static guard: the build must declare + forward the opt-out, copy the
+    vendored sets, run the installer after the fat-kernel step, and assert
+    num_active via the pybind-safe __doc__ check (inspect.signature raises
+    ValueError on pybind11 builtins)."""
+    dockerfile = (KIT_ROOT / "Dockerfile").read_text()
+    assert "ARG GLM53_EXL3_TICKET_SCHEDULER=1" in dockerfile
+    assert "ENV GLM53_EXL3_TICKET_SCHEDULER=${GLM53_EXL3_TICKET_SCHEDULER}" in dockerfile
+    assert "COPY overlay/exl3-ticket/ /opt/glm53/exl3-ticket/" in dockerfile
+    assert (
+        "python3 /opt/glm53/patch_exl3_ticket_scheduler.py" in dockerfile
+    ), "installer not wired into the build"
+    fat_pos = dockerfile.index("patch_exl3_fat_kernel.py /tmp/exllamav3")
+    ticket_pos = dockerfile.index("patch_exl3_ticket_scheduler.py /tmp/exllamav3")
+    assert ticket_pos > fat_pos, "ticket-scheduler step must follow the fat-kernel step"
+    assert "inspect.signature(exllamav3_ext.exl3_moe)" not in dockerfile
+    assert "'num_active' in doc or 'arg29' in doc" in dockerfile
+    assert 'if [ "${GLM53_EXL3_TICKET_SCHEDULER}" = "1" ]' in dockerfile
+
+
 def _read_all_of(source_dir: Path) -> dict[str, bytes]:
     return {n: (source_dir / n).read_bytes() for n in FILES}

--- a/tests/test_exl3_ticket_scheduler.py
+++ b/tests/test_exl3_ticket_scheduler.py
@@ -1,0 +1,134 @@
+"""Byte-exact three-state installer tests for the exllamav3 ticket-scheduler overlay.
+
+The installer (overlay/patch_exl3_ticket_scheduler.py) applies upstream
+exllamav3 d5e4361 onto the pinned c5d9c657 ext source at image build time from
+vendored pristine/patched byte sets. These tests exercise the installer logic
+host-side with fixture extension roots — no torch, no CUDA.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+KIT_ROOT = Path(__file__).resolve().parent.parent
+PATCHER = KIT_ROOT / "overlay" / "patch_exl3_ticket_scheduler.py"
+TICKET_DIR = KIT_ROOT / "overlay" / "exl3-ticket"
+PRISTINE = TICKET_DIR / "pristine"
+PATCHED = TICKET_DIR / "patched"
+FILES = (
+    "exl3_devctx.cu",
+    "exl3_devctx.cuh",
+    "exl3_moe.cu",
+    "exl3_moe.cuh",
+    "exl3_moe_common.cuh",
+    "exl3_moe_kernel.cuh",
+)
+
+
+def _run(ext_root: Path, env_extra: dict[str, str] | None = None):
+    env = dict(os.environ)
+    env.pop("GLM53_EXL3_TICKET_SCHEDULER", None)
+    if env_extra:
+        env.update(env_extra)
+    return subprocess.run(
+        [sys.executable, str(PATCHER), str(ext_root)],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def _make_ext(tmp_path: Path, source_dir: Path) -> Path:
+    ext = tmp_path / "ext"
+    (ext / "quant").mkdir(parents=True)
+    for name in FILES:
+        shutil.copyfile(source_dir / name, ext / "quant" / name)
+    return ext
+
+
+def _read_all(ext: Path) -> dict[str, bytes]:
+    return {n: (ext / "quant" / n).read_bytes() for n in FILES}
+
+
+def test_vendored_sets_exist_and_differ():
+    for name in FILES:
+        p = (PRISTINE / name).read_bytes()
+        q = (PATCHED / name).read_bytes()
+        assert p and q and p != q, name
+
+
+def test_semantic_markers():
+    kernel = (PATCHED / "exl3_moe_kernel.cuh").read_text()
+    assert "atomicAdd(&sched[0], 1)" in kernel
+    assert "sched = locks + MOE_SCHED_OFFSET" in kernel
+    assert "expert_idx_assign++ != ticket" in kernel
+    assert "expert_idx_assign++ % concurrency" not in kernel
+    devctx_h = (PATCHED / "exl3_devctx.cuh").read_text()
+    assert "MOE_SCHED_INTS" in devctx_h and "MOE_MAX_GROUPS" in devctx_h
+    moe_h = (PATCHED / "exl3_moe.cuh").read_text()
+    assert "num_active" in moe_h
+    pristine_kernel = (PRISTINE / "exl3_moe_kernel.cuh").read_text()
+    assert "MOE_SCHED_OFFSET" not in pristine_kernel
+
+
+def test_pristine_root_gets_fully_patched(tmp_path):
+    ext = _make_ext(tmp_path, PRISTINE)
+    r = _run(ext)
+    assert r.returncode == 0, r.stderr
+    assert "patched=6, already=0" in r.stdout
+    assert _read_all(ext) == _read_all_of(PATCHED)
+
+
+def test_idempotent_rerun_is_noop(tmp_path):
+    ext = _make_ext(tmp_path, PATCHED)
+    before = _read_all(ext)
+    r = _run(ext)
+    assert r.returncode == 0, r.stderr
+    assert "patched=0, already=6" in r.stdout
+    assert _read_all(ext) == before
+
+
+def test_drift_fails_closed_and_writes_nothing(tmp_path):
+    ext = _make_ext(tmp_path, PRISTINE)
+    drifted = ext / "quant" / "exl3_moe.cu"
+    drifted.write_bytes(drifted.read_bytes() + b"\n// drift\n")
+    before = _read_all(ext)
+    r = _run(ext)
+    assert r.returncode != 0
+    assert "anchor drifted" in (r.stderr + r.stdout)
+    assert _read_all(ext) == before, "installer must not write on drift"
+
+
+def test_optout_env_leaves_pristine(tmp_path):
+    ext = _make_ext(tmp_path, PRISTINE)
+    before = _read_all(ext)
+    r = _run(ext, {"GLM53_EXL3_TICKET_SCHEDULER": "0"})
+    assert r.returncode == 0, r.stderr
+    assert _read_all(ext) == before
+
+
+def test_missing_quant_dir_fails(tmp_path):
+    ext = tmp_path / "empty-ext"
+    ext.mkdir()
+    r = _run(ext)
+    assert r.returncode != 0
+    assert "invalid extension root" in (r.stderr + r.stdout)
+
+
+def test_missing_bindings_is_not_our_concern(tmp_path):
+    # The fat-kernel installer owns bindings.cpp; this patcher only replaces
+    # quant files and must not require or touch bindings.
+    ext = _make_ext(tmp_path, PRISTINE)
+    assert not (ext / "bindings.cpp").exists()
+    r = _run(ext)
+    assert r.returncode == 0, r.stderr
+
+
+def _read_all_of(source_dir: Path) -> dict[str, bytes]:
+    return {n: (source_dir / n).read_bytes() for n in FILES}


### PR DESCRIPTION
## What

Stages **S2a** of the GB10 kernel program (docs/11 section 6): the exllamav3 **MoE dynamic ticket scheduler** (upstream `d5e4361`) cherry-picked onto the pinned `c5d9c657` ext, applied at image build time by a byte-exact three-state installer. No production change in this PR — the rebuild + A/B window follows after pre-ship review.

## Why this commit

The fused `exl3_moe` kernel (every MoE layer, decode + small prefill) assigns experts to SM groups by static round-robin (`idx % concurrency`): a group holding several heavy experts serializes them while light groups idle. `d5e4361` replaces that with a self-resetting ticket scheduler (groups claim the next unclaimed expert via `atomicAdd`), makes group width runtime-configurable (up to 32 SMs/expert), and sizes the lock buffer for the scheduler state. The kit's overlay `exl3.py` already introspects the new `num_active` parameter and passes `-1` (unknown) today, so stock geometry is preserved and the caller needs no change.

## Verification done here

- Clean cherry-pick onto the pin in a throwaway worktree; the vendored `pin -> patched` diff contains **only** ticket-scheduler hunks (zero lines from the intervening `9fe8b47` mul1 / `2f297e4` mgemm commits).
- The d5e4361 hunk in exllamav3's own `block_sparse_mlp.py` is deliberately not applied (unused by the vLLM serve path).
- `overlay/patch_exl3_ticket_scheduler.py`: patched -> skip / pristine -> atomic replace / drift -> fail closed **before** writing; mixed pristine/patched state refused before any write.
- Build-time opt-out is a real knob: `ARG`+`ENV GLM53_EXL3_TICKET_SCHEDULER` (default 1) reaches the installer; `--build-arg ...=0` ships the pristine pin ext.
- Dockerfile wired after the fat-kernel step, with a **pybind-safe** `__doc__`-based build assert on `num_active` (`inspect.signature` raises `ValueError` on pybind11 builtins). Receipt: the deployed unpatched ext reports 29 generated args (`arg0..arg28`), no `num_active` in doc — the check fails on pristine and flips true with d5e4361's 30th arg.
- `tests/test_exl3_ticket_scheduler.py`: **10 host tests** (states, drift, mixed-state, opt-out, Dockerfile wiring); full suite **68 passed / 1 skipped**.

## Also closed in docs/11

- **S2(e)**: Hadamard overflow fix `5224ae4` is **not applicable** to our shapes (needs `gridDim.y*blockIdx.x >= 2^24`; ours ~10^3; serving path does not use those launchers).
- Autotune ride-alongs dropped until a pin advance; S2b (hand micro-opts on `exl3_fat_gemm.cu`) queued behind this window + an Nsight profile.

## Window plan (after review)

Image rebuild (digest change -> shape hash change -> one-time JIT wipe both nodes), same-boot-class warm-JIT A/B, decode as decision variable, pool byte-identical, 0 IMA, acceptance 7/7, serving 6/6, fat-path stats re-measured. Rollback: prior image tag + `IMAGE=` flip.
