### PR TITLE
S2a window: adopt ticket-scheduler image; fix build assert; ledgers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -438,7 +438,7 @@ RUN set -eux; \
       pip install --no-deps --no-build-isolation --no-cache-dir .; \
     python3 -c "import torch; import exllamav3_ext; assert hasattr(exllamav3_ext, 'exl3_moe'), dir(exllamav3_ext); assert hasattr(exllamav3_ext, 'exl3_fat_gemm'), dir(exllamav3_ext); assert hasattr(exllamav3_ext, 'exl3_fat_gemm_scatter'), dir(exllamav3_ext); print('exllamav3_ext', exllamav3_ext.__file__, 'exl3_moe=yes fat_gemm=yes')"; \
     if [ "${GLM53_EXL3_TICKET_SCHEDULER}" = "1" ]; then \
-      python3 -c "import exllamav3_ext; doc = exllamav3_ext.exl3_moe.__doc__ or ''; assert 'num_active' in doc or 'arg29' in doc or doc.count('arg') >= 30, 'ticket scheduler (d5e4361) not applied'; print('exl3_moe num_active=yes (ticket scheduler)')"; \
+      python3 -c "import torch, exllamav3_ext; doc = exllamav3_ext.exl3_moe.__doc__ or ''; assert 'num_active' in doc or 'arg29' in doc or doc.count('arg') >= 30, 'ticket scheduler (d5e4361) not applied'; print('exl3_moe num_active=yes (ticket scheduler)')"; \
     else \
       echo 'GLM53_EXL3_TICKET_SCHEDULER=0: skipping ticket-scheduler assertion'; \
     fi; \

--- a/docs/06-improvement-plan.md
+++ b/docs/06-improvement-plan.md
@@ -1073,3 +1073,40 @@ Condensed ledger:
 - **Production restored** from `.env.bak-pre-s1-rowtiling-20260902` (end-state copy
   `.env.s1-rowtiling-20260902-endstate`): pool byte-identical, structured converged
   68.38/68.44/68.67 @ 0.9832/6.882, watchdog re-armed.
+
+## 2026-09-02: S2a — exllamav3 d5e4361 MoE ticket scheduler ADOPTED (image `glm53-selfbuild:b5ab8091-s2a`)
+
+S2a of the GB10 kernel program (docs/11 §6). Upstream exllamav3 `d5e4361` (dynamic
+ticket scheduler for the fused `exl3_moe` kernel: groups claim active experts via
+atomicAdd instead of `idx % concurrency`; runtime group width; `num_active`
+parameter) cherry-picked onto the pinned `c5d9c657` ext and baked into a rebuilt
+image. Reviewed pre-ship (findings fixed before the window; detail in the S2a
+PR thread); recorded review notes carried into the ops notes: the kernel uses
+plain `cudaLaunchKernel` — co-residency relies on grid ≤ SM count, same as the
+pinned base; a future caller passing real `num_active>0` must not do so inside
+CUDA-graph capture (production passes `-1`).
+
+- **Build:** clean on spark1 (one fix en route: the post-compile assert must
+  `import torch` before `exllamav3_ext` or `libc10.so` is unresolved in that
+  bare process — commit in the results PR). In-build assert printed
+  `exl3_moe num_active=yes (ticket scheduler)`; image `2515976f45a8`.
+- **Boot (15:06Z):** pool byte-identical **1,396,551 / 1.40×**, loopback bind,
+  running container verified on the patched ext (30-arg pybind signature, 3-way
+  doc check True), one-time JIT wipe on both nodes (shape-hash guard, as
+  designed), 0 IMA/Xid, fat-path engagement **99.6%** of layer-steps.
+- **Benches (confound-heavy day — owner background traffic bursts throughout):**
+  structured decode converged **66.2–68.9 tok/s, median ~67.5** — inside the
+  standing 66.5–70.4 band, below the morning control (70.14, clean idle, warm
+  -w24); **acceptance per-step and per-position bit-identical to control on every
+  pass** (0.9832/6.882, [1.0×5, 0.9412, 0.9412]) — the strongest no-regression
+  signal, and the one metric contention cannot touch. Prefill 60k clean samples
+  972–1049 (two at control level: 1040.8/1049). Prose unmeasurable today (16–29
+  under bursts, even gated on `num_requests_running==0` — bursts land between the
+  check and the bench).
+- **Disposition (owner call): ADOPTED.** In-band, correctness green, no cost
+  mechanism (same scan work + one atomicAdd per expert completion; the control
+  read the top of the historical 66–70.4 band). **Fold a clean idle-box
+  structured+prose decode re-bench into the next session** (W41/W42 pattern) —
+  that re-bench is the throughput verdict. Instant rollback: `IMAGE=` flip to
+  `glm53-selfbuild:b5ab8091-w24` + restart; `.env.bak-pre-s2a-20260902`.
+  Watchdog re-armed.

--- a/docs/11-gb10-kernel-program.md
+++ b/docs/11-gb10-kernel-program.md
@@ -240,14 +240,15 @@ throughput verdict); rollback = `IMAGE=` flip to `b5ab8091-w24`.
   carry `comp_units/`-era context and touch autotune flow the pin does not have in
   the same form; revisit at a pin advance, not as a hand-cherry-pick.
 
-**S2b — hand micro-opts on `exl3_fat_gemm.cu` (queued behind S2a's window):**
+**S2b — hand micro-opts on `exl3_fat_gemm.cu` (queued behind an Nsight profile of
+the new image):**
 (a) pipeline/unroll the K16 MMA issue — multiple `mma.sync.m16n8k16` per dequant
 word (no drop-in FP16 K32/K64 shape on SM121); (b) smaller tail-tile for the
 128–384 row band; (c) SMEM audit — stage A tile + B dequant in one pass to cut one
 `__syncthreads()`. Requires Grok CUDA review + Nsight profile first (the wall is
 bandwidth; measure where the time actually goes before touching the kernel).
 
-**Gates for the S2a window (when run):** image rebuild (digest changes → shape
+**Gates for the S2a window (as run):** image rebuild (digest changes → shape
 hash changes → one-time JIT wipe both nodes, wipe guard verified); same-boot-class
 warm-JIT A/B vs the current image; pool byte-identical; 0 IMA; acceptance 7/7;
 serving 6/6; structured/prose decode bands (the fused `exl3_moe` path changes —
@@ -278,9 +279,9 @@ watchdog disarm/re-arm. Rollback: previous image tag + `.env` `IMAGE=` flip
 
 1. ~~S1 row-tiling sweep~~ — **RUN 2026-09-02, REJECTED** (§6): TRF=128 + fat kernel
    stands; row-tile kill-arm −20.9%.
-2. **S2a** `d5e4361` ticket-scheduler cherry-pick — **STAGED 2026-09-02**, pre-ship
-   review; best decode upside per line of code (§6).
-3. **S2b** fat-GEMM micro-opts — queued behind S2a's window + Nsight profile.
+2. **S2a** `d5e4361` ticket-scheduler cherry-pick — **ADOPTED 2026-09-02**,
+   production image `b5ab8091-s2a`; idle-box decode re-bench pending (§6).
+3. **S2b** fat-GEMM micro-opts — queued behind an Nsight profile of the new image.
 4. **W28** indexer workspace — memory lane, unblocks a pin raise.
 5. **S3** Trellis study — largest potential, largest cost; decide after S1/S2.
 6. Watch: adaptive-K #52228/#52559, CUTLASS #43814, DeepGEMM sm120 port.

--- a/docs/11-gb10-kernel-program.md
+++ b/docs/11-gb10-kernel-program.md
@@ -193,8 +193,14 @@ structured converged 68.38/68.44/68.67 @ 0.9832/6.882, watchdog re-armed.
 
 ### S2 — fat-GEMM micro-opts + kernel-range cherry-pick (image rebuild window)
 
-**S2a — MoE ticket-scheduler cherry-pick: STAGED 2026-09-02 (pre-ship review; window
-not yet run).**
+**S2a — MoE ticket-scheduler cherry-pick: ADOPTED 2026-09-02 (production image
+`glm53-selfbuild:b5ab8091-s2a`).** Full receipts in docs/06 (2026-09-02 S2a entry).
+Build clean on spark1 (post-compile assert fix: `import torch` before
+`exllamav3_ext`); boot gates green (pool byte-identical, patched ext verified
+30-arg, JIT wipe as designed, 0 IMA, fat engagement 99.6%); structured decode
+converged 66.2–68.9 in-band with acceptance bit-identical to control;
+**clean idle-box structured+prose re-bench folded into the next session** (the
+throughput verdict); rollback = `IMAGE=` flip to `b5ab8091-w24`.
 
 - **What ships:** upstream exllamav3 `d5e4361` ("MoE: Replace kernel round-robin
   assignment with dynamic ticket scheduler and add dynamic group sizing", 2026-07-06)


### PR DESCRIPTION
## What

Closes out the S2a window: production adopted the ticket-scheduler image, the ledgers are updated, and one build-script fix found during the window lands here.

## Production state

`glm53-selfbuild:b5ab8091-s2a` (exllamav3 `d5e4361` MoE ticket scheduler on the pinned ext) is live on the cluster since the 15:06Z boot: pool byte-identical 1,396,551 / 1.40x, patched ext verified in the running container (30-arg signature), loopback bind, 0 IMA/Xid, one-time JIT wipe on both nodes (shape-hash guard), fat-path engagement 99.6% of layer-steps.

## Benches (confound-heavy day)

- Structured decode converged **66.2-68.9 tok/s** - inside the standing 66.5-70.4 band - with **acceptance per-step and per-position bit-identical to control on every pass** (0.9832/6.882).
- Prefill 60k clean samples 972-1049 (two at control level: 1040.8/1049).
- Prose unmeasurable on the day (background-traffic bursts landed between idle checks and benches).
- Adopted with a **clean idle-box structured+prose decode re-bench folded into the next session** (the throughput verdict); rollback = `IMAGE=` flip to `b5ab8091-w24`.

## Build fix included

The post-compile build assert must `import torch` before `exllamav3_ext` - in a bare process the latter fails on `libc10.so` (found during the window build; the existing fat-kernel assert line already imported torch first).

## Ledgers

docs/06 dated S2a entry; docs/11 S2a adopted-status plus recorded ops notes (plain-launch mechanics; graph-capture rule for future `num_active` callers); spec/TODO updated locally (git-ignored).
