### PR TITLE
GB10 program items 1-3: re-bench parity, S2b profile + PROCEED verdict, S3 study

### DIFF
--- a/docs/11-gb10-kernel-program.md
+++ b/docs/11-gb10-kernel-program.md
@@ -280,8 +280,17 @@ watchdog disarm/re-arm. Rollback: previous image tag + `.env` `IMAGE=` flip
 1. ~~S1 row-tiling sweep~~ — **RUN 2026-09-02, REJECTED** (§6): TRF=128 + fat kernel
    stands; row-tile kill-arm −20.9%.
 2. **S2a** `d5e4361` ticket-scheduler cherry-pick — **ADOPTED 2026-09-02**,
-   production image `b5ab8091-s2a`; idle-box decode re-bench pending (§6).
-3. **S2b** fat-GEMM micro-opts — queued behind an Nsight profile of the new image.
+   production image `b5ab8091-s2a`; re-bench verdict **PARITY** (§6; idle-box
+   protocol settled, structured −5.5% marginally investigated and exonerated,
+   prose parity); item closed.
+3. **S2b** fat-GEMM micro-opts — **profiled 2026-09-02: latency-bound at ~52
+   TFLOP/s** (flat across 8× K; ncu SM 42.6%/Mem 41.5%); verdict **PROCEED with
+   a 3-stage `cp.async` pipeline** (candidates (b)/(c) deferred/subsumed), gated
+   on G0 (fat share ≥15% of prefill) + G1 (registers/occupancy); receipts on
+   spark1 `~/s2b-profile-receipts-backup/`.
 4. **W28** indexer workspace — memory lane, unblocks a pin raise.
-5. **S3** Trellis study — largest potential, largest cost; decide after S1/S2.
+5. **S3** Trellis study — **DONE 2026-09-02: FEASIBLE, PARKED with trigger**
+   (`docs/12-sparkinfer-trellis-study.md`; pilot = stopped-window `b12x`
+   microbench on rank-sliced shapes; trigger = clears the S2b projection
+   midline ~74 TFLOP/s).
 6. Watch: adaptive-K #52228/#52559, CUTLASS #43814, DeepGEMM sm120 port.

--- a/docs/11-gb10-kernel-program.md
+++ b/docs/11-gb10-kernel-program.md
@@ -199,8 +199,11 @@ Build clean on spark1 (post-compile assert fix: `import torch` before
 `exllamav3_ext`); boot gates green (pool byte-identical, patched ext verified
 30-arg, JIT wipe as designed, 0 IMA, fat engagement 99.6%); structured decode
 converged 66.2–68.9 in-band with acceptance bit-identical to control;
-**clean idle-box structured+prose re-bench folded into the next session** (the
-throughput verdict); rollback = `IMAGE=` flip to `b5ab8091-w24`.
+**idle-box re-bench executed 2026-09-02: PARITY** (n=9/phase log-audited;
+structured median 66.27, prose 27.96 vs control 28.06; the marginal −5.5%
+structured delta investigated per the decision rule and exonerated — mechanism
+ordering, control within the re-bench range, anchor asymmetry; item closed);
+rollback = `IMAGE=` flip to `b5ab8091-w24`.
 
 - **What ships:** upstream exllamav3 `d5e4361` ("MoE: Replace kernel round-robin
   assignment with dynamic ticket scheduler and add dynamic group sizing", 2026-07-06)
@@ -240,13 +243,22 @@ throughput verdict); rollback = `IMAGE=` flip to `b5ab8091-w24`.
   carry `comp_units/`-era context and touch autotune flow the pin does not have in
   the same form; revisit at a pin advance, not as a hand-cherry-pick.
 
-**S2b — hand micro-opts on `exl3_fat_gemm.cu` (queued behind an Nsight profile of
-the new image):**
-(a) pipeline/unroll the K16 MMA issue — multiple `mma.sync.m16n8k16` per dequant
-word (no drop-in FP16 K32/K64 shape on SM121); (b) smaller tail-tile for the
-128–384 row band; (c) SMEM audit — stage A tile + B dequant in one pass to cut one
-`__syncthreads()`. Requires Grok CUDA review + Nsight profile first (the wall is
-bandwidth; measure where the time actually goes before touching the kernel).
+**S2b — hand micro-opts on `exl3_fat_gemm.cu`: PROFILED 2026-09-02, verdict
+PROCEED with a modified plan.** The Nsight/counter profile (receipts on spark1
+`~/s2b-profile-receipts-backup/`; CUDA-event K/N/M sweeps + SpeedOfLight
+counters, prod stopped) found the kernel **latency-bound at ~52 TFLOP/s, flat
+across an 8× K range** (A 29→234 MB does not move it; ncu SM 42.6% / Mem 41.5%,
+"below 60% … latency issues"). Candidate disposition: (a) reframed to a
+**3-stage `cp.async` pipeline** (load/`wait`/single-`__syncthreads`/compute;
+helpers already in `ptx.cuh`; 3×(4 KB A + 1 KB B) + 8 KB `sh_c` ≈ 23 KB SMEM);
+(b) tail-tile deferred (MNBT-padded prefill never lands in the 128–384 band);
+(c) subsumed by the pipeline (the removable barrier was the buffer-reuse one).
+Execution gates: **G0** — measure the fat kernel's share of a 240k prefill;
+<15% → PARK; **G1** — `ptxas -v` registers/achieved occupancy; >128 regs ⇒
+one-line `__launch_bounds__(256, 2)` fix first. Expected +25–60% kernel
+(~65–83 TFLOP/s), ~8–21% end-to-end prefill. Validation gates: bit-exactness
+vs the current kernel across K/N/M edge shapes, compute-sanitizer
+memcheck/racecheck/synccheck, then the standing model A/B gates.
 
 **Gates for the S2a window (as run):** image rebuild (digest changes → shape
 hash changes → one-time JIT wipe both nodes, wipe guard verified); same-boot-class
@@ -257,14 +269,15 @@ fat-path stats re-measured; `systemctl --user reset-failed` before restarts;
 watchdog disarm/re-arm. Rollback: previous image tag + `.env` `IMAGE=` flip
 (pre-window `.env` snapshot taken per protocol).
 
-### S3 — Sparkinfer Trellis design study (gated on S1/S2 outcomes)
+### S3 — Sparkinfer Trellis design study — DONE 2026-09-02: FEASIBLE, PARKED with trigger
 
-- Work: capability matrix vs our EXL3 K4-MCG TR3 checkpoint; TP=2/DCP feasibility on
-  GB10 (their receipts are TP4/DCP4 on 96 GB discrete); CUDA-graph lifetime vs our
-  DFlash2 slot-share constraints (their own release keeps async OFF — same class as
-  our constraint); bandwidth translation honesty (§2 table).
-- Pivot rule: adopt only if a quantified case shows a win over the post-S2 state
-  under identical gates; otherwise park the doc as the standing reference.
+Study complete: `docs/12-sparkinfer-trellis-study.md`. All hard gates pass
+(aarch64 GB10/SM121 proven in community production, Apache-2.0, torch 2.13
+clears the floor, MCG/TR3 checkpoint in range); the cross-fork port cost and
+unmeasured GB10 perf keep it parked behind a cheap discriminating pilot
+(stopped-window `b12x` microbench on rank-sliced TP=2 shapes with an
+output-parity smoke; trigger = clears the S2b projection midline ~74 TFLOP/s;
+park permanently below ~55). Automatic re-open triggers in docs/12 §8.
 
 ### Adjacent lanes (queued; own docs/06 entries when opened)
 

--- a/docs/12-sparkinfer-trellis-study.md
+++ b/docs/12-sparkinfer-trellis-study.md
@@ -14,7 +14,9 @@ serves EXL3/Trellis weights on a physical Spark with CUDA graphs on), and our
 image's **torch 2.13.0+cu130** clears the `torch >= 2.12` floor. But integration
 is a large cross-fork port (§4), the perf advantage on GB10 is unmeasured for
 our shapes, and per the pivot rule the bar is a win **over the post-S2b state** —
-S2b's pipeline (docs/06, 2026-09-02 entry) is projected to lift the same fat
+S2b's pipeline (status and receipts: `docs/11` §6 S2b and
+`nvidia@spark1:~/s2b-profile-receipts-backup/`; the docs/06 ledger entry lands
+with the S2b window) is projected to lift the same fat
 path +25–60% before S3 would land. Decision trigger: a stopped-window microbench
 of `trellis3_t256` W4A16 on our exact shapes vs the measured fat-kernel numbers
 (§6). If Trellis clears the **S2b projection midline (65–83 TFLOP/s, mid ≈74)**

--- a/docs/12-sparkinfer-trellis-study.md
+++ b/docs/12-sparkinfer-trellis-study.md
@@ -1,0 +1,167 @@
+# 12 — S3 design study: Sparkinfer Trellis (`trellis3_t256`) as the EXL3 MoE path
+
+Written 2026-09-02, closing item 3 of the GB10 kernel program (`docs/11`).
+Companion to `docs/06` (ledger) and `docs/11` §6 (S2a/S2b).
+
+## 1. Verdict
+
+**FEASIBLE — PARKED as a standing reference with one cheap discriminating
+trigger.** Sparkinfer's EXL3 Trellis path is technically compatible with this
+deployment on every hard gate (§3), including the two questions this study was
+commissioned to settle: **aarch64 GB10/SM121 is proven in community production**
+([0xSero's pinned recipe](https://github.com/0xSero/deepseek-v4-flash-0731-spark-sparkinfer)
+serves EXL3/Trellis weights on a physical Spark with CUDA graphs on), and our
+image's **torch 2.13.0+cu130** clears the `torch >= 2.12` floor. But integration
+is a large cross-fork port (§4), the perf advantage on GB10 is unmeasured for
+our shapes, and per the pivot rule the bar is a win **over the post-S2b state** —
+S2b's pipeline (docs/06, 2026-09-02 entry) is projected to lift the same fat
+path +25–60% before S3 would land. Decision trigger: a stopped-window microbench
+of `trellis3_t256` W4A16 on our exact shapes vs the measured fat-kernel numbers
+(§6). If Trellis clears the **S2b projection midline (65–83 TFLOP/s, mid ≈74)**
+where our kernel does 52 — measured on the rank-sliced geometry production
+actually runs — the port conversation becomes real; adoption itself stays gated
+on the measured post-S2b value under the standing protocol. Below ~55 TFLOP/s,
+park permanently.
+
+## 2. What Sparkinfer is
+
+[`local-inference-lab/b12x`](https://github.com/local-inference-lab/b12x)
+(renamed from `sparkinfer` — the PyPI `sparkinfer` dist is a 0.0.1 stub; the
+real library ships as `b12x` on PyPI and via GitHub), **Apache 2.0**. An
+SM120/SM121-first CuTe DSL kernel library — the same "consumer Blackwell,
+warp-level MMA, no tcgen05" reality as our fat kernel, so it passes the
+program's intake gates by construction. The op list drifts constantly (gemm,
+attention.{paged,sparse_mla,varlen}, moe.{fused_moe,ep_moe}, norm.hyperconnection,
+quantizers, PCIe collectives, …), uniform `plan`/`bind`/`run` facade, **pure
+JIT** (CuTe DSL wheel — README now pins `nvidia-cutlass-dsl==4.6.2`; pin a
+commit, probe versions at pilot), disk cache keyed on device compute
+capability, and a `freeze_kernel_resolution("serving")` API against compiling
+inside CUDA-graph capture.
+
+Upstream's own caveat, quoted: *"not intended to be used in production …
+due to … the fast-moving pace of the library"* — it is a fast-moving research
+lineage, and our adoption would pin a commit.
+
+The EXL3 arm is [sparkinfer PR #49](https://github.com/local-inference-lab/b12x/pull/49)
+(`trellis3_t256` fused W4A16): consumes **native EXL3 MCG-codebook tensors
+without repacking or requant**, 3/4/5/6 bpw, per-projection rotations, grouped
+routed execution, prepare-time validation with fail-closed rejection, and the
+vLLM consumer owns a bit-faithful parity fallback. vLLM side:
+[local-inference-lab/vllm PR #139](https://github.com/local-inference-lab/vllm/pull/139)
+on the "Gilded Gnosis" v20 fork — receipts TP4/DCP4 on 4× RTX PRO 6000:
+prefill 1.9–2.3k → 3.0–3.7k tok/s (+58–64%); tr3 rank-sliced MTP heads load
+and serve (`hybrid_tr3_tail` — our checkpoint is TR3).
+
+## 3. Capability matrix vs this deployment
+
+| Gate | Requirement | Ours | Verdict |
+|---|---|---|---|
+| MMA path | warp-level, no tcgen05/TMEM | GB10 sm_121 — Sparkinfer's primary target | **PASS** |
+| SMEM | ≤101,376 B/CTA | their kernels are SM120/121-native (SGLang-class configs already fail there — they solved it) | **PASS** (probe at pilot) |
+| Toolchain | CUDA 13, torch ≥2.12, Python 3.10+ | torch 2.13.0+cu130, CUDA 13.0, py3.12 | **PASS** |
+| Arch/OS | aarch64 GB10 | proven by the 0xSero GB10 recipe (pinned image, physical Spark) | **PASS** |
+| Checkpoint | EXL3 MCG codebook, 3–6 bpw | `brandonmusic/GLM-5.3-Flash-tr3-4bpw` uniform-K4 TR3 MCG | **PASS** (K4 in range; TR3 MTP head also proven upstream) |
+| K/N alignment | "compatible K/N alignment" | hidden 4096 / moe_intermediate 2048; **production serves per-rank slices under TP=2** (gate/up 4096→1024, down 1024→4096) — the pilot must measure those, not just full-size | **PASS** (prepare-time validation probe at pilot, on the rank-sliced geometry) |
+| CUDA graphs | graph-replayable, JIT disk cache | our decode graphs capture `exl3_moe`; their ops are graph-validated; JIT cache must be warm pre-capture — our boot shape-warmup slot can host it | **PASS** (with warmup wiring) |
+| Spec-decode coexistence | — | theirs: MTP; ours: DFlash2 k=7 + slot-share — **untested combination** | **OPEN** (pilot item) |
+| Async scheduling | their release keeps it OFF | ours is OFF for the same class of reasons | **ALIGNED** |
+| License | — | Apache 2.0 | **PASS** |
+
+## 4. Integration paths (costed)
+
+- **(a) Rebase onto Gilded Gnosis v20** — rejected. Their fork is a different
+  vLLM lineage (`0.11.2.dev280+gilded.gnosis`, vLLM `5517197`); ours is the
+  `487ecf187` fork + the kit's ~40 windows of adopted overlays (retention,
+  decode-floor, align-floor, no-store, xgrammar, spinwait, router-GEMM,
+  fat kernel, ticket scheduler). A rebase forfeits or re-ports all of it.
+- **(b) Port their 13-file EXL3 layer onto our fork** — moderate-large. Their
+  overlay touches `quantization/exl3.py` (we own a 44 KB one),
+  `models/{deepseek_v2,glm4_moe}.py`, `mla/indexer.py`, `scheduler.py`,
+  `envs.py` — several collide with our own overlays. Rank-sliced loader
+  semantics also differ (their checkpoints are rank-sliced; ours is the
+  MiaAI EXL3 shard layout — the loader needs our naming layer on top).
+- **(c) Narrow path: Trellis as the fat-path engine** — replace the fat-expert
+  branch of our `exl3.py` dispatch (`exl3_fat_gemm` + batched tier) with
+  `sparkinfer.moe.trellis_moe` planned execution for oversized experts, keeping
+  our loader, our KV/retention work, our DFlash2 stack. Smallest blast radius,
+  directly comparable to S2b on identical gates. Upstream's
+  `freeze_kernel_resolution("serving")` runs after our boot shape-warmup so
+  nothing compiles inside capture. This is the only path worth costing further
+  today.
+
+## 5. The item-2 context (why S3 must beat post-S2b)
+
+The S2b profile (2026-09-02; ncu receipts on
+`nvidia@spark1:~/s2b-profile-receipts-backup/`, ledger entry lands with the S2b
+window) measured our fat kernel **latency-bound at ~52 TFLOP/s (Compute SM
+42.6% / Memory 41.5%, flat across an 8× K range)** — i.e. ~57% of GB10's
+~92 TFLOP/s fp16 tensor ceiling, with a validated +25–60% pipeline lift planned
+(projection band 65–83 TFLOP/s, mid ≈74). Two consequences:
+
+1. S2b is cheap, controlled, and already specified — it goes first regardless.
+2. Sparkinfer's Trellis kernels are exactly the kind of well-pipelined CuTe DSL
+   implementation that may already sit near the ceiling. **If Trellis on our
+   rank-sliced shapes clears the projection midline (~74 TFLOP/s), it matches
+   the post-S2b projection with a maintained implementation and the port
+   (path c) earns a window (adoption still gated on the measured post-S2b
+   value); if it lands ~55–65, S2b does the same job in-house; below ~55, S3
+   is permanently parked** (their receipts' +58–64% came from TP4/DCP4 x86
+   stacks with ~7× our bandwidth — do not extrapolate).
+
+## 6. The discriminating pilot (cheap, no vLLM integration)
+
+A stopped-window container run (GPU memory is fully reserved by prod otherwise):
+
+1. Install from a pinned commit of the renamed repo (PyPI `sparkinfer` is a
+   stub): `pip install git+https://github.com/local-inference-lab/b12x@<commit>`
+   into a scratch venv/container from our image.
+2. Prepare W4A16 Trellis weights from our routed-expert tensors via their
+   prepare API (native MCG tensors — no repack; this also exercises their
+   prepare-time validation on our exact checkpoint tensors).
+3. Plan + bind + run `trellis3_t256` on **both geometries** — full-size
+   (hidden 4096 → intermediate 2048) AND the **rank-sliced tensors production
+   actually serves under TP=2** (gate/up K=4096→N=1024; down K=1024→N=4096) —
+   at M ∈ {128, 256, 384} and M=3584; CUDA-event timing with their compile
+   cache warm. **Output-parity smoke before the TFLOP/s screen counts**:
+   execute prepared weights on a fixed input and compare against reference
+   EXL3 reconstruction (or our fat-kernel output on identical inputs),
+   bit-exact or within dequant tolerance — a throughput number on mis-wired
+   layouts must not trigger anything.
+4. The §1/§5 trigger is evaluated on the **rank-sliced geometry**; the full-size
+   numbers are reported for reference.
+5. Compare against the measured fat-kernel numbers (52 TFLOP/s flat, receipts in
+   `nvidia@spark1:~/s2b-profile-receipts-backup/`).
+
+Cost: ~1–2 GB GPU, one stopped window (~20 min including boot-back), no prod
+risk beyond the window itself. **This pilot is the trigger** — it either opens
+path (c) as a real window or closes S3 permanently.
+
+## 7. Risk register
+
+- **Fast-moving upstream**: pin a commit; the compile-cache device-key work
+  (PR #49) is the version to track.
+- **DFlash2 coexistence untested**: their stack pairs Trellis with MTP; our
+  DFlash2 k=7 + slot-share path has its own graph/scratch contracts. Pilot item:
+  plan/execute inside a captured decode-shaped graph.
+- **JIT cache discipline**: CuTe DSL JIT adds a third cache family (the CuTe
+  DSL disk cache) next to Triton/TileLang — the shape-hash wipe guard
+  (`prod-start.sh`) must learn it, or a spec-config change silently poisons
+  captured graphs (the 2026-08-28 incident class). Upstream's
+  `freeze_kernel_resolution` covers the capture-time half; the wipe guard covers
+  the config-change half.
+- **TP=2 sharding**: their receipts are TP4/DCP4; our gate/up column-wise +
+  down row-wise sharding feeds the fat path per-rank tensors — the Trellis plan
+  must accept rank-sliced shapes (their rank-sliced loader work suggests yes).
+- **Upstream honesty**: their +58–64% receipts are APC-retracted-class sensitive
+  (the same retraction hit the W24 author's numbers); only our own same-gate
+  A/B counts.
+
+## 8. Standing decision
+
+Parked. Re-open automatically when: (a) the pilot trigger (§6) fires — Trellis
+clears the S2b projection midline (~74 TFLOP/s) on the rank-sliced geometry —
+with adoption still gated on the measured post-S2b value; or (b) S2b lands and
+its measured end-to-end prefill gain is <5% (the pipeline underdelivers →
+Trellis becomes the cheapest remaining lever), or (c) our fork's rebase onto a
+lineage that already carries EXL3 (docs/07) happens to be Gilded Gnosis — then
+path (a) re-costs to near zero.


### PR DESCRIPTION
## What

Closes GB10 kernel-program items 1-3 (docs/11): the s2a idle-box re-bench verdict, the S2b fat-path profile + verdict, and the S3 Sparkinfer Trellis design study (new docs/12). Docs-only; no production change (s2a remains live).

## Item 1 — re-bench: PARITY

n=9 per phase, log-audited invocations on s2a: structured median **66.27** (-5.5% vs the morning n=3 control at the historical band ceiling), prose **27.96** (-0.4%); acceptance bit-identical every pass (0.9832/6.882). The marginal structured breach triggered the investigate branch and was exonerated: the ticket scheduler's only cost is prose-amplified ~2.8x (observed the opposite ordering), the control value sits inside the re-bench's own 61.7-86.6 range, and the anchor is a ceiling sample. s2a retained.

## Item 2 — S2b: PROCEED (modified plan)

Profiled on the production node (stopped window): CUDA-event sweeps + host-Nsight counters. The fat kernel is **latency-bound at ~52 TFLOP/s flat across an 8x K range** (A 29->234 MB does not move it; ncu SM 42.6% / Mem 41.5%). Verdict: (a) reframed to a 3-stage `cp.async` pipeline (helpers already in `ptx.cuh`), (b) deferred, (c) subsumed; gated on G0 (fat-kernel share of prefill >=15% else PARK) and G1 (register/occupancy check — a possible one-line `__launch_bounds__(256,2)` fix). Expected +25-60% kernel, ~8-21% end-to-end prefill. Receipts: `spark1:~/s2b-profile-receipts-backup/`.

## Item 3 — S3 study: FEASIBLE, PARKED with trigger (new docs/12)

All hard gates pass (aarch64 GB10/SM121 proven by the 0xSero community recipe; Apache-2.0; torch 2.13 clears >=2.12; MCG/TR3 checkpoint in range). Cross-fork port cost + unmeasured GB10 perf keep it parked behind a cheap pilot: stopped-window `b12x` microbench on **rank-sliced TP=2 shapes** (gate/up 4096->1024, down 1024->4096) with an output-parity smoke; trigger = clears the S2b projection midline (~74 TFLOP/s). Upstream renamed to `b12x` (PyPI `sparkinfer` is a stub) — the pilot installs from a pinned commit.

## Review

All three items were reviewed pre-ship; the S3 study review produced six required findings, all applied here.
