### PR TITLE
docs: match env.example to the live kernel stack; drop the end-to-end overclaim

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,9 @@ Prefill and content type, honestly: the prefill figures come from natural-langua
 essentially content-independent** — but **tokens per document is not**: code and
 JSON tokenize denser (more tokens per kB), so the same document can cost 20–50%
 more prompt tokens and proportionally longer TTFT. Read the rows above as
-per-token rates, not per-document promises. The 240k receipts (966–1072 tok/s)
-were measured under same-day controls with the pipelined fat-GEMM MoE
-(docs/06, 2026-09-02 S2b entry); an idle-box re-bench is pending.
+per-token rates, not per-document promises. The 240k receipts (906–1072 tok/s,
+full-set median 1001) were measured under same-day controls with the pipelined
+fat-GEMM MoE (`docs/06`, 2026-09-02 S2b entry).
 
 No other public recipe serves this model on this hardware with all five of: EXL3
 (the only quantization GB10 can actually run — it lacks the instruction NVFP4
@@ -81,14 +81,14 @@ Metric provenance, honestly: the cache/latency rows were re-measured on
 medians of 3+ converged temp-0 passes; prefill and latency rows are matched
 same-day probe runs — a reference from another day or image drifts by a few
 percent, so every A/B here runs its control arm the same day). The kernel rows
-are from the 2026-09-02 wave (fat-GEMM pipeline adopted; end-to-end prefill
-end-to-end parity pending the same-day-control comparison (full-set median +0.3% at 240k, best pass +7.4%; ambient bursts unresolved); **an idle-box re-bench of the decode
-medians and the new prefill band is pending** — ambient agent traffic on the
-same box makes small decode deltas unresolvable until then). The 500k/111×
-replay row is from the 2026-08-30 cutover battery on the same image. Every bench
-and probe ships in `tests/` and `local/` — reproduce any row in minutes. The
-offline regression suite runs with `pip install -r requirements-dev.txt && pytest
-tests/ -q`.
+are from the 2026-09-02 wave (fat-GEMM pipeline adopted; isolated kernel
+**+41%** at production shapes, bit-exact ×56). End-to-end prefill vs the
+same-day control is **parity under ambient bursts** (240k full-set median
+**+0.3%**, individual passes −3.2% to +7.4%) — do not read the isolated kernel
+gain as a matching tok/s jump. The 500k/111× replay row is from the
+2026-08-30 cutover battery on the same image. Every bench and probe ships in
+`tests/` and `local/` — reproduce any row in minutes. The offline regression
+suite runs with `pip install -r requirements-dev.txt && pytest tests/ -q`.
 
 ## The serving image: preview vLLM, pinned and completed
 
@@ -174,7 +174,9 @@ clients. **Tokenize** is mounted at the root (`/v1/tokenize` is 404) and validat
 > and (3) a **3-stage `cp.async` pipeline** in the fat GEMM k-loop —
 > **+38.6/+41.4/+40.8%** kernel throughput at production shapes (52 → ~73.5
 > TFLOP/s), bit-exact vs the stock kernel over 56 comparisons,
-> compute-sanitizer-clean; end-to-end prefill parity-to-+7% at 240k under ambient bursts (2026-09-02;
+> compute-sanitizer-clean. End-to-end prefill vs the same-day control is
+> parity under ambient bursts (240k full-set median +0.3%, individual passes
+> −3.2% to +7.4%; 2026-09-02;
 > `docs/11-gb10-kernel-program.md` is the full program ledger, with the rejected
 > arms too). If you update `exllamav3` or rebuild, the JIT-cache shape guard
 > wipes Triton/TileLang caches on **both** nodes by design; and if you touch the

--- a/docs/02-parameters.md
+++ b/docs/02-parameters.md
@@ -113,3 +113,17 @@ cache is invisible to it). 0.87 demands 105.87 GiB free against boots measured a
   blocks stay unhashed, recycling LIFO-first, so one-off batch lanes stop
   evicting other sessions' cached prefixes. Malformed values are an HTTP 400 at
   the API boundary. Not in the JIT shape hash.
+
+## Added 2026-09-02
+
+- `EXL3_FAT_SORTED=1` / `EXL3_FAT_BATCHED=1` / `EXL3_FAT_KERNEL=1` — the
+  fat-expert prefill path (W24) plus the 2026-09-02 kernel stack. Higher
+  tiers imply the lower ones. KERNEL needs `exllamav3_ext.exl3_fat_gemm`,
+  which this repo's Dockerfile bakes; the last public GHCR digest does not
+  export it, so leaving these on against that pin fails at start. Isolated
+  kernel receipts: **+41%** at production shapes (52 → ~73.5 TFLOP/s),
+  bit-exact ×56, sanitizer-clean. End-to-end prefill vs the same-day
+  control is parity under ambient bursts (240k full-set median +0.3%).
+  Ticket-scheduler cherry-pick (`d5e4361`) is baked at image build
+  (`GLM53_EXL3_TICKET_SCHEDULER=1`, not an env.example knob). Rollback of
+  the kernel stack is an `IMAGE=` flip, not a flag.

--- a/docs/11-gb10-kernel-program.md
+++ b/docs/11-gb10-kernel-program.md
@@ -305,6 +305,6 @@ permanently below the incumbent). Automatic re-open triggers in docs/12 §8.
 4. **W28** indexer workspace — memory lane, unblocks a pin raise.
 5. **S3** Trellis study — **DONE 2026-09-02: FEASIBLE, PARKED with trigger**
    (`docs/12-sparkinfer-trellis-study.md`; pilot = stopped-window `b12x`
-   microbench on rank-sliced shapes; trigger = clears the S2b projection
-   midline ~74 TFLOP/s).
+   microbench on rank-sliced shapes; trigger = clears the measured post-S2b
+   incumbent ~73.5 TFLOP/s with margin — only ≥ ~80 opens a real window).
 6. Watch: adaptive-K #52228/#52559, CUTLASS #43814, DeepGEMM sm120 port.

--- a/docs/12-sparkinfer-trellis-study.md
+++ b/docs/12-sparkinfer-trellis-study.md
@@ -125,10 +125,12 @@ attention/KDA, drafter work and allreduce own the rest). Two consequences:
    implementation that could sit at or above 73.5. **If Trellis on our
    rank-sliced shapes clears the measured incumbent (~73.5 TFLOP/s) with a
    maintained implementation, path (c) earns a window (adoption still gated on
-   the standing protocol) — but the honest ceiling is ~+4–5% end-to-end, and
-   the S2b experience says that ceiling is what actually lands**; below
-   ~73.5, park permanently (their receipts' +58–64% came from TP4/DCP4 x86
-   stacks with ~7× our bandwidth — do not extrapolate).
+   the standing protocol) — but the honest ceiling is ~+4–5% end-to-end.
+   S2b is the cautionary: a +41% isolated kernel landed as a +0.3% full-set
+   median under ambient traffic, so end-to-end has to be measured, not
+   inferred from TFLOP/s**; below ~73.5, park permanently (their receipts'
+   +58–64% came from TP4/DCP4 x86 stacks with ~7× our bandwidth — do not
+   extrapolate).
 
 ## 6. The discriminating pilot (cheap, no vLLM integration)
 

--- a/docs/12-sparkinfer-trellis-study.md
+++ b/docs/12-sparkinfer-trellis-study.md
@@ -110,8 +110,9 @@ The S2b profile (2026-09-02; ncu receipts on
 **latency-bound at ~52 TFLOP/s (Compute SM 42.6% / Memory 41.5%, flat across an
 8× K range)**. S2b then **landed**: the 3-stage `cp.async` pipeline (docs/06
 2026-09-02 S2b entry) measures **~73.5 TFLOP/s (+41%)** isolated; its end-to-end
-prefill delta measured **parity-to-+7.4% under burst contamination (full-set
-median +0.3%)**, so the effective fat-kernel share of prefill time is
+prefill delta measured **parity under burst contamination (full-set median
++0.3%, individual passes −3.2% to +7.4%)**, so the effective fat-kernel share
+of prefill time is
 **well below the 61% analytic bound (order ~20–30%)** — thin experts,
 attention/KDA, drafter work and allreduce own the rest). Two consequences:
 
@@ -124,10 +125,10 @@ attention/KDA, drafter work and allreduce own the rest). Two consequences:
    implementation that could sit at or above 73.5. **If Trellis on our
    rank-sliced shapes clears the measured incumbent (~73.5 TFLOP/s) with a
    maintained implementation, path (c) earns a window (adoption still gated on
-   the standing protocol) — but the honest ceiling is ~+7% end-to-end, and the
-   S2b experience says that ceiling is what actually lands**; below ~73.5,
-   park permanently (their receipts' +58–64% came from TP4/DCP4 x86 stacks
-   with ~7× our bandwidth — do not extrapolate).
+   the standing protocol) — but the honest ceiling is ~+4–5% end-to-end, and
+   the S2b experience says that ceiling is what actually lands**; below
+   ~73.5, park permanently (their receipts' +58–64% came from TP4/DCP4 x86
+   stacks with ~7× our bandwidth — do not extrapolate).
 
 ## 6. The discriminating pilot (cheap, no vLLM integration)
 

--- a/docs/12-sparkinfer-trellis-study.md
+++ b/docs/12-sparkinfer-trellis-study.md
@@ -117,9 +117,9 @@ attention/KDA, drafter work and allreduce own the rest). Two consequences:
 
 1. S2b is done — S3's bar is a **measured incumbent (~73.5 TFLOP/s)**, not a
    projection, and S3's end-to-end payoff is arithmetically capped: even a
-   perfect Trellis kernel at the ~92 TFLOP/s ceiling is worth only **~+6–7%
-   end-to-end prefill** (share ~20–30% × 73.5/92 ≈ 0.80–0.89 Amdahl factor).
-   Computed: 80 TFLOP/s → **+2.1–2.5%**; 92 TFLOP/s → **+4.2–5.3%**.
+   perfect Trellis kernel at the ~92 TFLOP/s ceiling is worth only **~+4–5%
+   end-to-end prefill**. Computed: 80 TFLOP/s → **+2.1–2.5%**; 92 TFLOP/s →
+   **+4.2–5.3%**.
 2. Sparkinfer's Trellis kernels are exactly the kind of well-pipelined CuTe DSL
    implementation that could sit at or above 73.5. **If Trellis on our
    rank-sliced shapes clears the measured incumbent (~73.5 TFLOP/s) with a
@@ -184,7 +184,7 @@ path (c) as a real window or closes S3 permanently.
 Parked — and the S2b landing **lowered the ceiling**: with the fat kernel at
 ~73.5 TFLOP/s (share not resolvable under the traffic day's contamination,
 bounded well below the 61% FLOP bound), even a perfect
-Trellis is worth ~+6–7% end-to-end prefill. Re-open automatically when: (a) the
+Trellis is worth ~+4–5% end-to-end prefill. Re-open automatically when: (a) the
 pilot trigger (§6) fires — Trellis clears the measured incumbent (~73.5
 TFLOP/s) on the rank-sliced geometry **with enough margin to matter after
 Amdahl** (i.e. ≥ ~80 TFLOP/s puts the realistic end-to-end win at the top of

--- a/env.example
+++ b/env.example
@@ -37,9 +37,13 @@ SERVED_MODEL_NAME=GLM-5.3-Flash-EXL3
 # probe/test in this kit (acceptance, serving-test, benches) defaults to 8000.
 # Found by the v1.0.1 reproduce test — without this, a fresh boot lands on 8888.
 PORT=8000
-# PROD: pinned BY DIGEST, not the mutable :exl3 tag; SKIP_PULL=1 so a start never
-# silently upgrades the runtime. Update deliberately, then re-run acceptance.
-IMAGE=ghcr.io/miaai-lab/glm-5.3-flash-2x-dgx-sparks@sha256:9bb1557a4234fce63d59599e44d10747eabd742beb337eebf9e7070be8a0fd58
+# PROD since 2026-08-30 is a local Dockerfile build, not a pulled artifact.
+# After `docker build -t glm53-selfbuild .` (README), this name matches.
+# Production currently runs the tagged build `glm53-selfbuild:b5ab8091-s2b`.
+# Last public GHCR digest (pre-kernel-stack, no exl3_fat_gemm — leave the
+# EXL3_FAT_* flags off if you boot it):
+# IMAGE=ghcr.io/miaai-lab/glm-5.3-flash-2x-dgx-sparks@sha256:9bb1557a4234fce63d59599e44d10747eabd742beb337eebf9e7070be8a0fd58
+IMAGE=glm53-selfbuild
 SKIP_PULL=1
 # HF_TOKEN=                          # only needed for gated repos; keep out of git
 
@@ -191,9 +195,14 @@ DFLASH_TOKENS=7                     # k=7; verify batch = 8 tokens/seq — cudag
 READY_TIMEOUT=4800                  # cold JIT after a cache wipe is slow, not dead
 VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=1800
 
-# --- W24 (kit PR #77): fat-expert prefill acceleration, tiered opt-in ---------
-# Higher tiers imply the lower ones. All OFF by default; the CUDA kernel tier
-# requires an image built with the exl3_fat_gemm extension (Dockerfile does it).
-# EXL3_FAT_SORTED=1     # contiguous expert slices of the existing sort
-# EXL3_FAT_BATCHED=1    # E1: persistent scratch + concatenated gate+up trellis
-# EXL3_FAT_KERNEL=1     # E2: fused direct/scatter trellis GEMM (SM121)
+# --- W24 + S2a/S2b: fat-expert prefill + ticket scheduler (PROD = all on) -----
+# Higher fat tiers imply the lower ones. All three ON in production since
+# 2026-08-31 (W24); the CUDA kernel is baked by this repo's Dockerfile (fat
+# GEMM + the 2026-09-02 3-stage cp.async pipeline + the d5e4361 ticket
+# scheduler). Require the self-built image: the GHCR digest above does not
+# export exl3_fat_gemm, so KERNEL=1 on that pin fails at start. Off = the
+# pre-W24 fused-MoE path on a rebuilt image; GHCR users must leave these
+# commented.
+EXL3_FAT_SORTED=1     # contiguous expert slices of the existing sort
+EXL3_FAT_BATCHED=1    # E1: persistent scratch + concatenated gate+up trellis
+EXL3_FAT_KERNEL=1     # E2: fused direct/scatter trellis GEMM (SM121; pipelined)


### PR DESCRIPTION
The public tree at `main` already carries the S2a ticket scheduler and the S2b 3-stage `cp.async` pipeline (PRs #21–#26). This PR is the honesty/config pass before tagging **v1.4.0**.

## What changed

- **README:** the 2026-09-02 provenance paragraph was mangled. Isolated kernel receipts stay **+41%** (52 to ~73.5 TFLOP/s, bit-exact x56). End-to-end prefill vs the same-day control is **parity under ambient bursts** — 240k full-set median **+0.3%**, individual passes -3.2% to +7.4%. Do not read the isolated kernel gain as a matching tok/s jump.
- **env.example:** production knobs now match the live pair. `IMAGE=glm53-selfbuild` (last public GHCR digest kept as a commented fallback that does **not** export `exl3_fat_gemm`). `EXL3_FAT_SORTED/BATCHED/KERNEL=1` are on; KERNEL=1 against that GHCR pin fails at start.
- **docs/02:** records the fat-kernel flags and the image requirement.
- **docs/11 / docs/12:** S3 trigger unified on the measured incumbent (~73.5 TFLOP/s; only >= ~80 opens a real window). Amdahl ceiling is **+4-5%** end-to-end, not +6-7%.

## Why

A clone of this tree with the previous `env.example` would have pulled the GHCR digest and left the fat-kernel flags off — so it would not run the kernels the README advertises. The `+3-7.4%` end-to-end phrasing was an ad-hoc clean-subset reading of `{906, 966, 971, 1031, 1072}` vs control 997.8.

## Tests

`python3 -m compileall -q local overlay tests` OK. `uv run --with pytest --with jinja2 pytest tests/ -q` → **68 passed, 1 skipped**.

No production restart. Cluster stays on `glm53-selfbuild:b5ab8091-s2b`.
