### PR TITLE
M0' idle-box s2b re-bench + Window A soak: NEED-MORE-DATA, ledgers + receipts

### DIFF
--- a/docs/06-improvement-plan.md
+++ b/docs/06-improvement-plan.md
@@ -20,6 +20,25 @@ fusions, and all of EXL3 — zero EXL3 code exists in vLLM mainline). Consequenc
   container start, or as a rebuilt upstream image.
 - Upstream "merged" ≠ "in this build" — date every candidate against `b908a21f9a`.
 
+## Current queue (rewritten 2026-09-02 night, W44 closed 2026-09-03)
+
+The S1/S2 kernel program is closed. Production is `glm53-selfbuild:b5ab8091-s2b`
+(fat GEMM pipelined, ticket scheduler live). Further fat-kernel ISA is below the
+Amdahl noise floor: isolated **+41%** landed as **+0.3%** end-to-end prefill
+because the fat path is only ~25–30% of a prefill step.
+
+**W44 CLOSED 2026-09-03:** the 2.71 lifetime spec-accept vs bench 6.88 is
+**traffic mix, not a broken drafter.** Same-boot no-store four-arm: structured
+temp-0 thinking-off **7.0 / 1.000 all positions** (70.1 tok/s); production
+prose thinking-on temp-1 max **2.32 / 0.331** (27.97 tok/s). Lifetime 2.55
+token-weighted matches P0/P1, not S0. Do not spend a kernel or k-window on
+this number. Next: idle-box s2b re-bench (si was 0 at W44; Swap still 6.5 GiB
+parked — watch the first pass) **or** W28 Codex fixes into the next restart.
+
+Full rewrite, live numbers, CUDA ranking, and the closed/rejected list:
+**[§ "2026-09-02 night: live-log rewrite of the A/B program"](#2026-09-02-night-live-log-rewrite-of-the-ab-program)**
+at the end of this file. `spec/TODO.md` is the operator checklist.
+
 ## W1 — xgrammar backport adoption (2026-08-29, verified in production)
 
 **XGrammar termination + reasoning-window backports** (`overlay/patch_xgrammar_termination.py`,
@@ -1188,3 +1207,239 @@ zero-fill, if-form per the pinned header's Blackwell note).
   post-push, pre-ship (APPROVED, recorded notes only). Future kernel waves go
   through the PR flow.
 - Watchdog re-armed; fat engagement 99.9% on s2b.
+
+## 2026-09-02 night: live-log rewrite of the A/B program
+
+Rewritten from the running `b5ab8091-s2b` pair (boot 19:31Z, snapshot ~22:59Z),
+a CUDA-kernel review of the remaining EXL3/fat/fused surface, and a same-night
+web survey of vLLM / Sparkinfer / GB10 items. This replaces the kernel-first
+queue in `docs/11` §7 for **what to run next**. Historical S1/S2/W16–W42
+ledgers above stay as receipts.
+
+### Live snapshot (do not treat as idle-box numbers)
+
+| Signal | This boot | Standing baseline / meaning |
+|---|---|---|
+| Image / health | `glm53-selfbuild:b5ab8091-s2b`, `/health` 200, loopback `:8000` | production |
+| Pool | **1,396,551 tok / 1.40×**, pin 14.36 GiB, 567 gpu blocks | byte-identical |
+| Honest cache (W41) | 566 usable ids; **38 ids / 3584-token segment**; cached-conversation capacity **≈ 50,176 tok = 14 segments** | the stock "1.40M tokens" line is concurrency, not prefix capacity |
+| KV usage | live **14.1–14.3%**, peak **18.9%** | `kv_cache_usage_perc` counts RUNNING blocks only; 14% ≈ one ~200k-class in-flight request, **not** a 14%-full prefix cache |
+| Prefix hit | lifetime **4.1%** (90,496 / 2,226,485 queries) | expected on unique-salt cold prefills + one long session that fills 3–4 of 14 segments |
+| Prefill | logger spikes **32k tok/s** are APC-hit / tiny remaining tails; idle-box cold still **~1044 / 998** at 60k/240k (S1 control) | do not quote 32k as cold compute |
+| Prose decode | logger last samples **19–28 tok/s**, nonzero p50 **19.1**, max 44 | bench band **27.9–31**; live is thinking-on + swap |
+| Spec decode | lifetime accept/draft **0.388**, mean accept length **2.71**; live pos-6 often **0.00–0.09** | **W44 CLOSED:** structured path still 7.0; 2.71 is P0/P1 mix. Not a decode-kernel lever. |
+| Concurrency | running **max 1**, waiting **0** across 81 logger samples | `MAX_NUM_SEQS=4` unused **this** boot (one long droid session). Not proof the cap never bites. |
+| Host memory | spark1 MemFree **6.5 GiB**, MemAvailable **5.0**, Swap **6.8 GiB**, si **28–124**/s; spark2 MemFree **5.6 GiB**; GPU 95–96% @ 72–73 °C | swap-degraded head historically **−10% prefill**. Do **not** `swapoff`. |
+| Fat path | 99.7–99.9% of prefill layers fat; max_rows 3584; avg_max ~1280; hist 37,001 in the **1024–2048** bucket (`_FAT_BUCKET_EDGES`) | fat ISA already spent (Amdahl ~25–30% of the step) |
+| Boot warning | `max_num_scheduled_tokens is set to 3584 based on the speculative decoding settings` | known; MNBT already = page size. Not a knob to raise (8192 indexer smem). |
+
+Mean request this boot: **~45.4k prompt tokens**, mean TTFT **45.5 s** (23/49 ≤ 1 s = cache hits; 16/49 > 7.5 s; 5/49 > 160 s). Prompt:generation token ratio **~214:1** — the box is prefill-heavy agent traffic, not a decode soak.
+
+### CUDA-reviewer ranking (no file edits; kernel surface)
+
+Fat kernel: `FAT_TILE_M/K/N = 128/16/128`, 3-stage `cp.async`, 23,552 B SMEM, 2 CTAs/SM. Clean. Isolated 73.5 TFLOP/s vs a ~92 ceiling ⇒ any further fat win **≤ ~+4–5% e2e**. Stop.
+
+Remaining candidates the review would still run, in order:
+
+1. ~~**Spec-accept recovery (not a kernel).**~~ **W44 CLOSED 2026-09-03.** Lifetime 2.55 vs bench 7.0 is production prose/thinking-on mix; structured path still 7.0/1.000. Do not chase with a kernel or k-window. Adaptive verification remains W40, not next.
+2. **W28 indexer workspace reclaim** (~5,035 MiB locked: `max_model_len × 40 × 132 B`). Only credible basis for a pin raise, which is the only way to grow the 14-segment prefix. Blocked on the three Codex fail-opens.
+3. **`num_active` widening on the fused thin launch**, using the `counts_host` D2H **already paid** by the fat path. Today dispatch hardcodes `n_active_host = -1`, so `MOE_SMS_PER_EXPERT` stays 8. Overlay + stopped microbench; no rebuild. Targets the *complement* of the spent fat path.
+4. **KDA/GDN profile-first.** P0 traces (2026-08-29) already put KDA at ~6% of a 1024-token chunk. Confirm on MNBT=3584 before any Triton/CuTe work. Do not guess.
+5. **Sub-16-row fused GEMM** — decode-tail kernel, moderate risk. W44 showed the accept gap is traffic mix, so this is occupancy/GEMV work, not "fix 2.71".
+
+Explicitly **do not reopen**: more fat ISA, tail-tiles for the 128–384 band (hist is in 1024–2048), ROW_TILE / TRF≠128, dual-rail, DFLASH k=8, draft TP=2, Marlin sm121 (#49546), raising the KV pin without W28, adaptive k at **drafting**.
+
+S3 Sparkinfer `trellis3_t256` stays parked behind the existing trigger (rank-sliced microbench ≥ ~80 TFLOP/s vs 73.5). Same-night survey: b12x/#49 still SM120a / TP4 receipts, no GB10 rank-sliced number. Ceiling still ~+4–5% e2e.
+
+### What the web survey added (no new "run now")
+
+- **vLLM #54661** (per-group retention RFC) is our W25 evidence written upstream. Already shipped. Do not re-A/B it.
+- **#54458** (hybrid page inflation 7808) is a different geometry; ours is 3584 and W41 already prints the honest 14-segment cap.
+- **#54831** (GLM-5.3 `tail_cache` block_size=4 blocks KV offload / LMCache) — W21 stays parked for a real reason, not laziness.
+- **#52559** graph-aware adaptive K — still W40; needs a v2-runner overlay decision. Gains reported at **high concurrency** (c128–c256); our live boot is c=1.
+- **#53798 / #54057** — still the correctness pair to bundle into the next restart.
+- Spark blog / llama.cpp fp8-KV warnings do **not** transfer: we run packed `fp8_ds_mla` because MLA needs it, not software-dequant q8_0. Recorded tension, not a window.
+
+### Rewritten A/B queue
+
+Protocol unchanged: disarm the **timer**, then wait for any in-flight `watchdog.service` to go inactive before stopping the unit (S2b incident); `reset-failed`; `local/prod-start.sh` only; `POST /reset_prefix_cache` for cold-cache rounds; bench only after ActiveState=active **and** warmup sweep finished; log-audit POST overlap on decode passes; both-node MemFree tripwire on any memory-touching restart.
+
+#### Now — no restart
+
+| # | Window | What | Gate | Why now |
+|---|---|---|---|---|
+| M0 | **Unblocked on traffic (W44 ran idle, si=0); Swap 6.5 GiB parked** | Idle-box s2b re-bench (60k/240k + structured/prose, n=9 log-audited) | same-day control; \|Δmedian\| < 5% = parity | **NEXT if the box stays quiet.** First pass may still read low from parked-swap fault-in — run to convergence. Never `swapoff`. |
+| **W44** | **CLOSED 2026-09-03 (measurement)** | Four-arm no-store probe `local/w44-spec-accept-probe.py` + 313-window boot histogram. See the dated W44 entry below. | Traffic mix, not a broken drafter. Structured path still 7.0. | CUDA C4 diagnosed; no kernel follow-up. |
+| M1 | ops, not a window | After the current request ends: if si stays >0 and prose stays <24, schedule a **clean bounce** (prod-start MemFree≥90) rather than research. Never `swapoff`. | MemFree ≥ ~8 GiB idle, si≈0 | Historic −10% prefill on a swap-degraded head. |
+
+#### Next idle-box session (cache-reset OK; no unit bounce)
+
+| # | Window | What | Gate |
+|---|---|---|---|
+| M0′ | s2b re-bench | The standing S2b/S2a-retain numbers. 60k/240k cold (`POST /reset_prefix_cache` between rounds) + structured/prose n=9. | e2e prefill ≥ +5% vs S1 control 1044.3/997.8 keeps s2b; ≤0% revisit (`IMAGE=` → `b5ab8091-s2a`). Decode wash expected. |
+| W29r | confirming repeat | Long-ctx ladder past ~325k. One sample at 415k/518k showed accept 0.909/0.888. | Second ladder. Acceptance is the metric; ignore first-row tok/s (fault-in). |
+| F0x | measurement | Extend F0 195k → 325–400k (compaction lives at 300k). | Informational; pairs with W29r. |
+
+#### Next restart (one JIT wipe; bundle correctness)
+
+W43 (`MAX_NUM_SEQS` 4→8) is **no longer automatic-next**. This boot never queued. The restart we do take still **must** carry #53798 + #54057 (mamba resume divisor; sparse-MLA `masked_mha_available`) — they are cheap, hybrid-crash-class, and the wipe is already paid by any shape-hash change.
+
+**Pick one decision variable for that restart, not both:**
+
+- Capacity waits (`waiting>0` / reason=capacity) since this rewrite →
+  **W43** (seqs 4→8, capture 40 48 56 64). Memory tripwire both nodes.
+- Else (tonight's shape: one long session) → land the **W28 Codex
+  fixes**, then **W28** indexer right-size (reclaim first; pin raise
+  **never in the same window**).
+- Either way: commit the 608-combination align-floor unit test **before**
+  A3. A3 itself (LPTT ≥ 3584, prove the floor acts) stays after this
+  restart.
+
+#### Cheap overlay / stopped-window after the above
+
+| # | Candidate | Type | Expected | Blocker |
+|---|---|---|---|---|
+| C1 | `num_active` from already-synced `counts_host` on fat layers | overlay, stopped microbench | thin-path occupancy; decode stays `-1` | none technical |
+| A3 | align-floor at LPTT ≥ 3584 | env, one restart | `decode-floor-v3` must log a sub-block cap | committed tests first |
+| W31 | fine-grained APC #59 → #84 | overlay | TTFT 0.9–4.0 s → 0.3–0.5 s claimed; we already have W18's 64-grid | same-day A/B vs our numbers |
+| W40 | adaptive verification / v2 runner | runner decision, not a knob | #52559/#52228; gains are high-c | overlay compat; GB10 #49548 collapsed aggregate 232→24–157 |
+| S3 | `trellis3_t256` pilot | stopped container | only if M0′ shows s2b e2e < 5% **or** rank-sliced ≥ ~80 TFLOP/s | docs/12 §6 |
+
+### Closed this rewrite (do not re-queue)
+
+S1 row-tiling, S2a ticket scheduler, S2b cp.async fat pipeline (kernel done; e2e pending idle numbers only), dual-rail NCCL, DFLASH k=8, draft TP=2, MNBT 7168, 500k window, ROW_TILE=1, TRF≠128, more fat-kernel ISA, adaptive k at drafting, raising the KV pin, Marlin, `/reset_prefix_cache` (already live), W25 per-group retention (already live; #54661 is us), **W44 spec-accept "drafter broken" hypothesis**.
+
+## 2026-09-03: W44 — live spec-accept diagnostic CLOSED (traffic mix, not a broken drafter)
+
+Ran after the 2026-09-02 night rewrite, on the same `b5ab8091-s2b` boot (now idle:
+`num_requests_running=0`, `kv_cache_usage_perc=0`, instant `si=0`; Swap still
+~6.5 GiB parked). No restart. Probe sent W42 `skip_writing_prefix_cache`;
+hits 5,937,024 → 5,937,024 and queries +146 (= 34+40+33+39 prompt tokens)
+are **consistent with** no-store (a miss would also leave hits unchanged
+even if a write occurred). Standing cache was not reset.
+
+**Boot histogram (313 SpecDecoding 10s windows, 152,019 drafted tokens):**
+
+| | min | p50 | mean | max |
+|---|---:|---:|---:|---:|
+| mean accept length | 1.87 | 3.47 | 3.71 | 8.0 |
+| draft accept % | 12.4 | 35.2 | 38.7 | 100 |
+
+Buckets: 3–4 n=138, 2–3 n=89, 4–5 n=55, ≥6 n=**18**, 5–6 n=12, <2 n=1.
+Token-weighted per-position: **0.779, 0.566, 0.405, 0.294, 0.217, 0.161, 0.125**.
+Token-weighted mean accept = 55,318 / 21,717 drafts = **2.55**. Only 18/313
+windows look like the structured bench.
+
+**Four-arm no-store probe** (`local/w44-spec-accept-probe.py`, max_tokens=200,
+through the tunnel, running=0):
+
+| Arm | tok/s | acc/step | ratio | pos-6 | notes |
+|---|---:|---:|---:|---:|---|
+| S0 structured, thinking off, temp 0 | **70.12** | **7.000** | **1.000** | **1.00** | bench twin; all seven positions 1.00 |
+| P0 prose, thinking off, temp 0 | **30.46** | **2.796** | 0.400 | 0.07 | in the 27.9–31 prose band |
+| S1 structured, thinking on, temp 1, effort=max | 54.44 | 5.931 | 0.847 | 0.69 | CoT dilutes the count; still far above prose |
+| P1 prose, thinking on, temp 1, effort=max | **27.97** | **2.317** | 0.331 | 0.05 | **droid production path**; 854 reasoning chars, 0 content (still thinking at 200 tokens) |
+
+Receipt: `local/w44-spec-accept-20260903.json`.
+
+**Verdict.** DFlash2 k=7 is healthy on the structured path (S0 = the standing
+1.0000/7.0 gate). The lifetime 2.55–2.71 is the mix of P0/P1 windows that
+dominate agent traffic, plus thinking-on CoT (P1, and the live pos-6 ≈ 0
+samples). It is **not** swap, **not** prefix-state, **not** a verification
+bug, and **not** W29's long-ctx decay (these arms were 33–40 prompt tokens).
+
+**Do not:** reopen k=8, adaptive k at drafting, or a kernel window aimed at
+"fixing 2.71". Those would chase production-mix arithmetic.
+
+**What would still move decode,** if we ever want it: recover *prose*
+acceptance (P0 2.80 / P1 2.32) toward structured. That is the known
+structured/prose trade k=8 already lost on (−9.1% prose). Adaptive
+**verification** (#52228/#52559) remains the only theoretically honest
+path, and it is still W40 (v2-runner decision; GB10 #49548 is the
+counter-evidence at high concurrency). Not next.
+
+**Queue after W44:** idle-box s2b re-bench is unblocked on *traffic* (box
+was idle, si=0); Swap 6.5 GiB parked means the **first** pass may still
+read low — run to convergence. Else the next restart is still W28 Codex
+fixes then indexer reclaim, unless capacity waits appear (then W43).
+
+## 2026-09-04: M0′ idle-box s2b re-bench + Window A soak — NEED-MORE-DATA (second opinion)
+
+Ran on the standing `b5ab8091-s2b` boot, no restart, `POST /reset_prefix_cache`
+(200) between arms. Idle pre/post every arm: running/waiting 0.0. Receipts
+`local/m0prime-structured-20260904.json`, `local/m0prime-prose-20260904.json`,
+`local/m0prime-prose-warmup-20260904.json`. Verdicts below are the
+**cuda-reviewer second opinion** (numbers-only, per-run judging), not a gate edit.
+
+### M0′ prefill vs S1 controls (60k 1044.3 / 240k 997.8)
+
+| Arm | Runs (tok/s) | Per-run Δ |
+|---|---|---|
+| 60k cold ×3 (salted) | 1124.8, 1048.4, 1049.3 | **+7.7%**, +0.4%, +0.5% |
+| 240k cold ×2 (salted) | 1014.5, 1063.5 | +1.7%, **+6.6%** |
+
+2 of 5 runs clear +5%; 3 sit in the 0…+5% band the gate never defined; 0 are
+≤ 0%. 60k spread 7.3% with the *first* run the outlier high (opposite of the
+known parked-swap fault-in pattern — unexplained variance, not warmup). The
+gate as written (≥+5% adopt / ≤0% revert) does not cover the measured middle,
+and n=2/3 cannot resolve a +5% threshold against 5–7% run-to-run spread. This
+matches the prior burst-contaminated +0.3% reading: the +41% isolated kernel
+win is Amdahl-eaten E2E (fat ≈ 25–30% of a prefill step). **Verdict:
+NEED-MORE-DATA — neither ADOPT (gate not met) nor REVERT (≤0% never seen).**
+
+### M0′ decode
+
+- **Structured n=9: PASS.** Median 71.54 (+1.6% vs 70.42), min 70.93, max
+  72.04 (±0.8%); every run finish=length, accept 1.0/7.0, all 7 positions
+  1.00, any_nan false. DFlash2 k=7 intact on s2b.
+- **Prose: NOT-BLOCKING but unmeasured this window.** 1 unscored warmup
+  (29.14), then n=9 median 29.14 (−1.2% vs 29.49) with a 26% spread
+  (25.73–32.57, σ ≈ 20× structured). Accept median 0.3405/2.383 and
+  coherent=true match the W44 closure — no behavioral regression signal, but
+  the median is meaningless at this spread. Do not cite −1.2% either way.
+
+### Log-audit veto: INCONCLUSIVE
+
+Prefill POSTs fully accounted (5 `/v1/completions` lines at expected TTFT
+spacing). Decode block 01:48:06–01:50:07 shows ~28 `/v1/chat/completions`
+lines at ~3 s cadence vs ~20 expected harness POSTs — gap ≈ 8, and all lines
+are 127.0.0.1 (tunnel vs any owner session indistinguishable). Structured is
+effectively exonerated (gauges 0.0 + bit-identical accept + ±0.8% spread is
+inconsistent with a co-batched foreign client); the prose phase cannot be
+certified clean. Future windows need a discriminative signal (harness-tagged
+requests, e.g. a unique per-window `user`/metadata field).
+
+### Window A soak (4×60k×3, `--rounds 3`)
+
+Pre: queries 3.1529896e+07 / hits 2.9370304e+07 / preemptions 0; head MemFree
+4824116 kB (spark2 hostname unresolvable — worker parity missing). Post:
+queries 3.2344855e+07 / hits 2.9906496e+07 / preemptions still 0.
+
+| Round | Wall | Usage hit% | Counter hit% | Notes |
+|---|---|---|---|---|
+| 1 cold | 237.5 s | 0.0 | 0.0 | as designed |
+| 2 | 10.9 s | 0.0 | **98.7** | −95% wall vs cold |
+| 3 | 15.6 s | 0.0 | **98.7** | cache served |
+
+**Retention PASSES at soak scale** (reproduces W3 95.0% under W25 per-group
+retention on the s2b image). Open: (a) **usage-vs-counter divergence** —
+usage cached_tokens reads 0/271,653 while counters read 98.7%; wall times prove
+a metric-semantics bug (usage field unpopulated on this path), not a retention
+failure — but per-request cache observability is broken until root-caused
+(one known-prefix request, compare `usage` vs counter deltas, then patch
+`cache-burst.py`); (b) the **1 h prefix-freeze watch never ran** (a 3-round
+soak cannot detect a #106-class `hits_total` freeze); (c) worker MemFree
+missing; (d) cosmetic: the script's quoted pool figure (929,670) is stale vs
+the pinned 1,396,551.
+
+### What closes M0′ (pre-register before the next window)
+
+1. Powered interleave: s2a/s2b ×5 runs each at 60k and 240k, salted,
+   reset between runs, exclusive loopback + harness-tagged requests — **plus a
+   defined middle-band rule** (non-inferiority adopt if median ≥ −1% and no
+   run < −3%, or keep the +5% bar and power to n=7+).
+2. Prose n≥9 re-run under exclusive access, median + spread reported separately.
+3. 1 h freeze watch: 60 s counter cadence ≥1 h under light traffic; fail = 0
+   counter delta over any 10-min window with traffic present.
+4. Fix spark2 mDNS resolution; capture worker MemFree pre/post soak.
+5. Usage-metric root cause (above).

--- a/docs/11-gb10-kernel-program.md
+++ b/docs/11-gb10-kernel-program.md
@@ -290,21 +290,30 @@ permanently below the incumbent). Automatic re-open triggers in docs/12 §8.
   (#49164 closed on correctness grounds).
 - **CUTLASS sm120 grouped GEMM** — FP8-path enablement only; subordinate to S3.
 
-## 7. Ranked queue (as of 2026-09-02)
+## 7. Ranked queue (rewritten 2026-09-02 night)
 
-1. ~~S1 row-tiling sweep~~ — **RUN 2026-09-02, REJECTED** (§6): TRF=128 + fat kernel
-   stands; row-tile kill-arm −20.9%.
-2. **S2a** `d5e4361` ticket-scheduler cherry-pick — **ADOPTED 2026-09-02**,
-   production image `b5ab8091-s2a`; re-bench verdict **PARITY** (§6; idle-box
-   protocol settled, structured −5.5% marginally investigated and exonerated,
-   prose parity); item closed.
-3. **S2b** fat-GEMM micro-opts — **ADOPTED 2026-09-02**, production image
-   `b5ab8091-s2b`; 3-stage `cp.async` pipeline (bit-exact ×56, sanitized,
-   kernel +41% → ~73.5 TFLOP/s); end-to-end prefill parity under ambient
-   bursts — verdict pending the idle re-bench (§6).
-4. **W28** indexer workspace — memory lane, unblocks a pin raise.
-5. **S3** Trellis study — **DONE 2026-09-02: FEASIBLE, PARKED with trigger**
-   (`docs/12-sparkinfer-trellis-study.md`; pilot = stopped-window `b12x`
-   microbench on rank-sliced shapes; trigger = clears the measured post-S2b
-   incumbent ~73.5 TFLOP/s with margin — only ≥ ~80 opens a real window).
-6. Watch: adaptive-K #52228/#52559, CUTLASS #43814, DeepGEMM sm120 port.
+Kernel program **closed** except parked S3. Live logs + CUDA review: fat is
+25–30% of prefill and already at 73.5 TFLOP/s; more fat ISA ≤ ~+4–5% e2e.
+Operator queue lives in `docs/06` (night rewrite) and `spec/TODO.md`.
+
+1. ~~S1 row-tiling sweep~~ — **REJECTED**. TRF=128 + fat kernel stands.
+2. ~~S2a ticket scheduler~~ — **ADOPTED** (kernel item closed). Clean
+   idle-box retained-image comparison vs s2b is still owed (`docs/06` M0′);
+   do not collect it on a swap-degraded / busy boot.
+3. ~~S2b cp.async pipeline~~ — **ADOPTED** (kernel +41%). End-to-end idle
+   numbers still owed; **do not collect them on a swap-degraded / busy boot**.
+4. **Stop fat-ISA work.** Dual-issue K16 / tail-tiles for 128–384 are below
+   the hist (37k of fat experts sit in 1024–2048 rows) and below Amdahl.
+5. **C1 (kernel-adjacent, overlay):** pass real `num_active` into fused
+   `exl3_moe` from the already-synced fat `counts_host`. Today hardcoded `-1`.
+   Stopped microbench. Decode stays `-1` (no new D2H).
+6. **C3 (later):** sub-16-row fused GEMM for decode-tail experts. Image
+   rebuild + full K4×M sweep. W44 (2026-09-03) showed the 2.71 vs 6.88
+   gap is traffic mix, not a GEMM problem — this is occupancy/GEMV work.
+7. **W28** indexer workspace — still the memory lane; still blocked on the
+   three Codex fail-opens. Do not raise the pin first.
+8. **S3** Trellis — **PARKED** (`docs/12`). Re-open only on the existing
+   trigger (≥ ~80 TFLOP/s rank-sliced, or s2b idle e2e < 5%).
+9. Watch (not EXL3 kernels): adaptive-K at **verification** #52228/#52559,
+   CUTLASS sm120 grouped GEMM #43814 (FP8 path only), DeepGEMM sm120, Marlin
+   sm121 W4A8 corruption #49546 (**do not adopt**).

--- a/local/cache-burst.py
+++ b/local/cache-burst.py
@@ -80,7 +80,7 @@ def main():
     prefixes = [make_prefix(1000 + i, a.ctx_tokens) for i in range(a.sessions)]
     total = a.sessions * a.ctx_tokens
     print(f"sessions={a.sessions} ctx~{a.ctx_tokens} tok each "
-          f"(~{total:,} total vs 929,670 pool) rounds={a.rounds} conc={a.concurrency}")
+          f"(~{total:,} total vs 1,396,551 pool) rounds={a.rounds} conc={a.concurrency}")
 
     for rnd in range(1, a.rounds + 1):
         m0, t0 = metrics(a.base), time.time()

--- a/local/m0prime-prose-20260904.json
+++ b/local/m0prime-prose-20260904.json
@@ -1,0 +1,363 @@
+{
+  "phase": "prose-s2b-rebench",
+  "health_code": 200,
+  "health_body": "",
+  "runs": [
+    {
+      "http": 200,
+      "ttft_s": 0.37381837500106485,
+      "wall_s": 7.339874041999792,
+      "decode_s": 6.966055666998727,
+      "tok_s": 28.567098730311706,
+      "completion_tokens": 200,
+      "prompt_tokens": 40,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "# How a Hash Map Works: A Complete Guide\n\nA hash map (also called a hash table or dictionary) is a data structure that stores key-value pairs and provides near-constant-time lookup, insertion, and deletion. Let's build up an understanding from the ground up.\n\n---\n\n## 1. The Core Idea\n\nA hash map lets you associate values with keys and retrieve them later:\n\n```\nmap.put(\"apple\", 3)\nmap.get(\"apple\") ",
+      "text_len": 808,
+      "usage": {
+        "prompt_tokens": 40,
+        "total_tokens": 240,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 60,
+        "draft_tokens": 420,
+        "accepted": 143,
+        "accept_ratio": 0.3405,
+        "accepted_per_step": 2.383,
+        "pos": [
+          0.7667,
+          0.5333,
+          0.3667,
+          0.2833,
+          0.2,
+          0.1333,
+          0.1
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.3718332080006803,
+      "wall_s": 8.098009750001438,
+      "decode_s": 7.726176542000758,
+      "tok_s": 25.756594988245933,
+      "completion_tokens": 200,
+      "prompt_tokens": 40,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "# How a Hash Map Works: A Complete Guide\n\nA hash map (also called a hash table or dictionary) is a data structure that stores key-value pairs and provides near-constant-time lookup, insertion, and deletion. Let's build up an understanding from the ground up.\n\n---\n\n## 1. The Core Concept\n\nA hash map stores data as **key-value pairs**. You provide a key (e.g., a username) and a value (e.g., the user",
+      "text_len": 852,
+      "usage": {
+        "prompt_tokens": 40,
+        "total_tokens": 240,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 67,
+        "draft_tokens": 469,
+        "accepted": 137,
+        "accept_ratio": 0.2921,
+        "accepted_per_step": 2.045,
+        "pos": [
+          0.7761,
+          0.4925,
+          0.2985,
+          0.194,
+          0.1642,
+          0.0597,
+          0.0597
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.365110167000239,
+      "wall_s": 6.475830084000336,
+      "decode_s": 6.110719917000097,
+      "tok_s": 32.56572101208232,
+      "completion_tokens": 200,
+      "prompt_tokens": 40,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "# How a Hash Map Works: A Complete Guide\n\nA hash map (also called a hash table or dictionary) is a data structure that stores key-value pairs and provides near-constant-time lookup, insertion, and deletion. Here's a thorough breakdown of how it works.\n\n---\n\n## 1. The Core Concept\n\nA hash map stores data as **key-value pairs**. Instead of searching through data linearly (like an array) or following",
+      "text_len": 863,
+      "usage": {
+        "prompt_tokens": 40,
+        "total_tokens": 240,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 53,
+        "draft_tokens": 371,
+        "accepted": 153,
+        "accept_ratio": 0.4124,
+        "accepted_per_step": 2.887,
+        "pos": [
+          0.8491,
+          0.6981,
+          0.5283,
+          0.3019,
+          0.2075,
+          0.1887,
+          0.1132
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.3654991669991432,
+      "wall_s": 7.19374820899975,
+      "decode_s": 6.828249042000607,
+      "tok_s": 29.14363532670669,
+      "completion_tokens": 200,
+      "prompt_tokens": 40,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "# How a Hash Map Works: A Complete Guide\n\nA hash map (also called a hash table or dictionary) is a data structure that stores key-value pairs and provides near-constant-time lookup, insertion, and deletion. Let's build up an understanding from the ground up.\n\n---\n\n## 1. The Core Concept\n\nA hash map stores data as **key-value pairs**. You provide a key (e.g., a username), and the map retrieves the ",
+      "text_len": 867,
+      "usage": {
+        "prompt_tokens": 40,
+        "total_tokens": 240,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 59,
+        "draft_tokens": 413,
+        "accepted": 140,
+        "accept_ratio": 0.339,
+        "accepted_per_step": 2.373,
+        "pos": [
+          0.7627,
+          0.5932,
+          0.4068,
+          0.2373,
+          0.1864,
+          0.1017,
+          0.0847
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.3674104999990959,
+      "wall_s": 7.331586999998763,
+      "decode_s": 6.964176499999667,
+      "tok_s": 28.57480708595044,
+      "completion_tokens": 200,
+      "prompt_tokens": 40,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "# How a Hash Map Works: A Complete Guide\n\nA hash map (also called a hash table or dictionary) is a data structure that stores key-value pairs and provides near-constant-time lookup, insertion, and deletion. Let's build up the full picture step by step.\n\n---\n\n## 1. The Core Idea\n\nA hash map lets you associate values with keys and retrieve them quickly. Instead of searching through data (like a list",
+      "text_len": 838,
+      "usage": {
+        "prompt_tokens": 40,
+        "total_tokens": 240,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 60,
+        "draft_tokens": 420,
+        "accepted": 139,
+        "accept_ratio": 0.331,
+        "accepted_per_step": 2.317,
+        "pos": [
+          0.7333,
+          0.5667,
+          0.3667,
+          0.25,
+          0.1833,
+          0.1333,
+          0.0833
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.3669726249991072,
+      "wall_s": 6.84307120899939,
+      "decode_s": 6.476098584000283,
+      "tok_s": 30.728377188643382,
+      "completion_tokens": 200,
+      "prompt_tokens": 40,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "# How a Hash Map Works: A Complete Guide\n\nA hash map (also called a hash table or dictionary) is a data structure that stores key-value pairs and provides near-constant-time lookup, insertion, and deletion. Let's build up an understanding from the ground up.\n\n---\n\n## 1. The Core Concept\n\nA hash map stores data as **key-value pairs**. You provide a key (e.g., a username) and a value (e.g., the user",
+      "text_len": 832,
+      "usage": {
+        "prompt_tokens": 40,
+        "total_tokens": 240,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 56,
+        "draft_tokens": 392,
+        "accepted": 150,
+        "accept_ratio": 0.3827,
+        "accepted_per_step": 2.679,
+        "pos": [
+          0.875,
+          0.6786,
+          0.4286,
+          0.2857,
+          0.2143,
+          0.125,
+          0.0714
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.3707230830004846,
+      "wall_s": 6.512096000000383,
+      "decode_s": 6.141372916999899,
+      "tok_s": 32.40317803355489,
+      "completion_tokens": 200,
+      "prompt_tokens": 40,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "# How a Hash Map Works: A Complete Guide\n\nA hash map (also called a hash table or dictionary) is a data structure that stores key-value pairs and provides near-constant-time lookup, insertion, and deletion. Let's build up an understanding from the ground up.\n\n---\n\n## 1. The Core Concept\n\nA hash map stores data as **key-value pairs**. You provide a key (e.g., a username) and a value (e.g., the user",
+      "text_len": 824,
+      "usage": {
+        "prompt_tokens": 40,
+        "total_tokens": 240,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 53,
+        "draft_tokens": 371,
+        "accepted": 146,
+        "accept_ratio": 0.3935,
+        "accepted_per_step": 2.755,
+        "pos": [
+          0.8491,
+          0.6604,
+          0.4528,
+          0.3019,
+          0.2453,
+          0.1509,
+          0.0943
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.361595792001026,
+      "wall_s": 7.037176667001404,
+      "decode_s": 6.675580875000378,
+      "tok_s": 29.810139930330593,
+      "completion_tokens": 200,
+      "prompt_tokens": 40,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "# How a Hash Map Works: A Complete Guide\n\nA hash map (also called a hash table or dictionary) is a data structure that stores key-value pairs and provides near-constant-time lookup, insertion, and deletion. Let's build up an understanding from the ground up.\n\n---\n\n## 1. The Core Concept\n\nA hash map stores data as **key-value pairs**. You provide a key (e.g., a username) and a value (e.g., the user",
+      "text_len": 828,
+      "usage": {
+        "prompt_tokens": 40,
+        "total_tokens": 240,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 57,
+        "draft_tokens": 399,
+        "accepted": 145,
+        "accept_ratio": 0.3634,
+        "accepted_per_step": 2.544,
+        "pos": [
+          0.8246,
+          0.5789,
+          0.4211,
+          0.2632,
+          0.2281,
+          0.1228,
+          0.1053
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.3682717089996004,
+      "wall_s": 8.101930541999536,
+      "decode_s": 7.733658832999936,
+      "tok_s": 25.73167556226509,
+      "completion_tokens": 200,
+      "prompt_tokens": 40,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "# How a Hash Map Works: A Complete Guide\n\nA hash map (also called a hash table or dictionary) is a data structure that stores key-value pairs and provides near-constant-time lookup, insertion, and deletion. Let's build up an understanding from the ground up.\n\n---\n\n## 1. The Core Idea\n\nA hash map lets you associate values with keys and retrieve them efficiently. Instead of searching through data li",
+      "text_len": 859,
+      "usage": {
+        "prompt_tokens": 40,
+        "total_tokens": 240,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 67,
+        "draft_tokens": 469,
+        "accepted": 133,
+        "accept_ratio": 0.2836,
+        "accepted_per_step": 1.985,
+        "pos": [
+          0.7463,
+          0.4776,
+          0.3134,
+          0.1642,
+          0.1194,
+          0.0896,
+          0.0746
+        ]
+      }
+    }
+  ],
+  "ts": 1788486538.4860952,
+  "prompt": "hashmap-prose",
+  "thinking": false,
+  "temperature": 0,
+  "tok_s_median": 29.14363532670669,
+  "tok_s_min": 25.73167556226509,
+  "tok_s_max": 32.56572101208232,
+  "ttft_median_s": 0.3674104999990959,
+  "completion_tokens_median": 200.0,
+  "accept_ratio_median": 0.3405,
+  "accepted_per_step_median": 2.383,
+  "any_nan": false,
+  "coherence": {
+    "paris": {
+      "ok": true,
+      "text": "Paris",
+      "http": 200
+    },
+    "cmp": {
+      "ok": true,
+      "text": "Yes. 9.9 is greater than 9.11 because 9.9 equals 9.90, and 90 hundredths is more than 11 hundredths.",
+      "http": 200
+    },
+    "sky": {
+      "ok": true,
+      "text": "The sky-blue paint on the nursery walls seemed to capture a perfect summer afternoon, bringing a sense of calm and endless possibility to the little room.",
+      "http": 200
+    },
+    "nan": false
+  },
+  "coherent": true,
+  "health_code_after": 200,
+  "short_after": {
+    "http": 200,
+    "ttft_s": 0.3808559579993016,
+    "wall_s": 0.4955357079998066,
+    "decode_s": 0.11467975000050501,
+    "tok_s": 61.03954708629182,
+    "completion_tokens": 8,
+    "prompt_tokens": 40,
+    "finish_reason": "length",
+    "nan": false,
+    "text_head": "# How a Hash Map Works: A",
+    "text_len": 25,
+    "usage": {
+      "prompt_tokens": 40,
+      "total_tokens": 48,
+      "completion_tokens": 8
+    }
+  }
+}

--- a/local/m0prime-prose-warmup-20260904.json
+++ b/local/m0prime-prose-warmup-20260904.json
@@ -1,0 +1,91 @@
+{
+  "phase": "prose-warmup",
+  "health_code": 200,
+  "health_body": "",
+  "runs": [
+    {
+      "http": 200,
+      "ttft_s": 0.37655029199959245,
+      "wall_s": 7.206430542000817,
+      "decode_s": 6.829880250001224,
+      "tok_s": 29.13667483408136,
+      "completion_tokens": 200,
+      "prompt_tokens": 40,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "# How a Hash Map Works: A Complete Guide\n\nA hash map (also called a hash table or dictionary) is a data structure that stores key-value pairs and provides near-constant-time lookup, insertion, and deletion. Let's build up an understanding from the ground up.\n\n---\n\n## 1. The Core Concept\n\nA hash map stores data as **key-value pairs**. You provide a key (e.g., a username) and a value (e.g., the user",
+      "text_len": 849,
+      "usage": {
+        "prompt_tokens": 40,
+        "total_tokens": 240,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 59,
+        "draft_tokens": 413,
+        "accepted": 144,
+        "accept_ratio": 0.3487,
+        "accepted_per_step": 2.441,
+        "pos": [
+          0.8305,
+          0.5932,
+          0.3729,
+          0.2203,
+          0.1864,
+          0.1186,
+          0.1186
+        ]
+      }
+    }
+  ],
+  "ts": 1788486525.206078,
+  "prompt": "hashmap-prose",
+  "thinking": false,
+  "temperature": 0,
+  "tok_s_median": 29.13667483408136,
+  "tok_s_min": 29.13667483408136,
+  "tok_s_max": 29.13667483408136,
+  "ttft_median_s": 0.37655029199959245,
+  "completion_tokens_median": 200.0,
+  "accept_ratio_median": 0.3487,
+  "accepted_per_step_median": 2.441,
+  "any_nan": false,
+  "coherence": {
+    "paris": {
+      "ok": true,
+      "text": "Paris",
+      "http": 200
+    },
+    "cmp": {
+      "ok": true,
+      "text": "Yes. 9.9 is greater than 9.11 because 9.90 > 9.11 when comparing the decimal values.",
+      "http": 200
+    },
+    "sky": {
+      "ok": true,
+      "text": "The sky-blue paint on the nursery walls seemed to capture a perfect summer afternoon, bringing a sense of calm and endless possibility to the little room.",
+      "http": 200
+    },
+    "nan": false
+  },
+  "coherent": true,
+  "health_code_after": 200,
+  "short_after": {
+    "http": 200,
+    "ttft_s": 0.372670749999088,
+    "wall_s": 0.4814069579988427,
+    "decode_s": 0.1087362079997547,
+    "tok_s": 64.37598044632742,
+    "completion_tokens": 8,
+    "prompt_tokens": 40,
+    "finish_reason": "length",
+    "nan": false,
+    "text_head": "# How a Hash Map Works: A",
+    "text_len": 25,
+    "usage": {
+      "prompt_tokens": 40,
+      "total_tokens": 48,
+      "completion_tokens": 8
+    }
+  }
+}

--- a/local/m0prime-structured-20260904.json
+++ b/local/m0prime-structured-20260904.json
@@ -1,0 +1,349 @@
+{
+  "phase": "structured-s2b-rebench",
+  "health_code": 200,
+  "health_body": "",
+  "runs": [
+    {
+      "http": 200,
+      "ttft_s": 0.3547084170004382,
+      "wall_s": 3.1396652920011547,
+      "decode_s": 2.7849568750007165,
+      "tok_s": 71.45532549761612,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.35381437500109314,
+      "wall_s": 3.1286403340000106,
+      "decode_s": 2.7748259589989175,
+      "tok_s": 71.71620957149825,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.3550949589989614,
+      "wall_s": 3.1404138750003767,
+      "decode_s": 2.7853189160014153,
+      "tok_s": 71.4460375997744,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.36122866599907866,
+      "wall_s": 3.127145874999769,
+      "decode_s": 2.7659172090006905,
+      "tok_s": 71.94720049914203,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.3520033750010043,
+      "wall_s": 3.1335270830004447,
+      "decode_s": 2.7815237079994404,
+      "tok_s": 71.54352106641834,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.35704854100004013,
+      "wall_s": 3.135715374999563,
+      "decode_s": 2.778666833999523,
+      "tok_s": 71.61707822076886,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.35799525000038557,
+      "wall_s": 3.141345458001524,
+      "decode_s": 2.7833502080011385,
+      "tok_s": 71.49657252182855,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.3588701669996226,
+      "wall_s": 3.164306167000177,
+      "decode_s": 2.8054360000005545,
+      "tok_s": 70.93371582882685,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.37150779200055695,
+      "wall_s": 3.133697666999069,
+      "decode_s": 2.762189874998512,
+      "tok_s": 72.04428696275168,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    }
+  ],
+  "ts": 1788486486.97934,
+  "prompt": "structured-count-1-200",
+  "thinking": false,
+  "temperature": 0,
+  "warmup": {
+    "tok_s": 88.90584154389387,
+    "ttft_s": 0.3638950409986137,
+    "completion_tokens": 32
+  },
+  "tok_s_median": 71.54352106641834,
+  "tok_s_min": 70.93371582882685,
+  "tok_s_max": 72.04428696275168,
+  "ttft_median_s": 0.35704854100004013,
+  "completion_tokens_median": 200.0,
+  "accept_ratio_median": 1.0,
+  "accepted_per_step_median": 7.0,
+  "any_nan": false,
+  "health_code_after": 200,
+  "short_after": {
+    "http": 200,
+    "ttft_s": 0.38963533300011477,
+    "wall_s": 0.50403520799955,
+    "decode_s": 0.11439987499943527,
+    "tok_s": 61.18887804759013,
+    "completion_tokens": 8,
+    "prompt_tokens": 40,
+    "finish_reason": "length",
+    "nan": false,
+    "text_head": "# How a Hash Map Works: A",
+    "text_len": 25,
+    "usage": {
+      "prompt_tokens": 40,
+      "total_tokens": 48,
+      "completion_tokens": 8
+    }
+  }
+}

--- a/local/w44-spec-accept-20260903.json
+++ b/local/w44-spec-accept-20260903.json
@@ -1,0 +1,159 @@
+{
+  "ts": 1788394290.637978,
+  "base": "http://127.0.0.1:18000",
+  "max_tokens": 200,
+  "pre": {
+    "running": 0.0,
+    "waiting": 0.0,
+    "kv": 0.0,
+    "hits": 5937024.0,
+    "queries": 8522704.0,
+    "drafts": 21717.0,
+    "acc": 55318.0
+  },
+  "arms": [
+    {
+      "name": "S0-struct-off-t0",
+      "thinking": false,
+      "temp": 0.0,
+      "effort": null,
+      "http": 200,
+      "ttft_s": 0.441,
+      "wall_s": 3.293,
+      "tok_s": 70.12,
+      "prompt_tokens": 34,
+      "completion_tokens": 200,
+      "finish_reason": "length",
+      "content_chars": 292,
+      "reasoning_chars": 0,
+      "content_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30",
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ],
+        "hit_delta": 0,
+        "query_delta": 34
+      }
+    },
+    {
+      "name": "P0-prose-off-t0",
+      "thinking": false,
+      "temp": 0.0,
+      "effort": null,
+      "http": 200,
+      "ttft_s": 0.388,
+      "wall_s": 6.954,
+      "tok_s": 30.46,
+      "prompt_tokens": 40,
+      "completion_tokens": 200,
+      "finish_reason": "length",
+      "content_chars": 860,
+      "reasoning_chars": 0,
+      "content_head": "# How a Hash Map Works: A Complete Guide\n\nA hash map (also called a hash table o",
+      "spec": {
+        "drafts": 54,
+        "draft_tokens": 378,
+        "accepted": 151,
+        "accept_ratio": 0.3995,
+        "accepted_per_step": 2.796,
+        "pos": [
+          0.8519,
+          0.7037,
+          0.5185,
+          0.2778,
+          0.2222,
+          0.1481,
+          0.0741
+        ],
+        "hit_delta": 0,
+        "query_delta": 40
+      }
+    },
+    {
+      "name": "S1-struct-on-t1-max",
+      "thinking": true,
+      "temp": 1.0,
+      "effort": "max",
+      "http": 200,
+      "ttft_s": 0.459,
+      "wall_s": 4.133,
+      "tok_s": 54.44,
+      "prompt_tokens": 33,
+      "completion_tokens": 200,
+      "finish_reason": "length",
+      "content_chars": 219,
+      "reasoning_chars": 195,
+      "content_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30",
+      "spec": {
+        "drafts": 29,
+        "draft_tokens": 203,
+        "accepted": 172,
+        "accept_ratio": 0.8473,
+        "accepted_per_step": 5.931,
+        "pos": [
+          0.9655,
+          0.931,
+          0.8621,
+          0.8621,
+          0.8621,
+          0.7586,
+          0.6897
+        ],
+        "hit_delta": 0,
+        "query_delta": 33
+      }
+    },
+    {
+      "name": "P1-prose-on-t1-max",
+      "thinking": true,
+      "temp": 1.0,
+      "effort": "max",
+      "http": 200,
+      "ttft_s": 0.457,
+      "wall_s": 7.608,
+      "tok_s": 27.97,
+      "prompt_tokens": 39,
+      "completion_tokens": 200,
+      "finish_reason": "length",
+      "content_chars": 0,
+      "reasoning_chars": 854,
+      "content_head": "",
+      "spec": {
+        "drafts": 60,
+        "draft_tokens": 420,
+        "accepted": 139,
+        "accept_ratio": 0.331,
+        "accepted_per_step": 2.317,
+        "pos": [
+          0.7333,
+          0.6,
+          0.4,
+          0.25,
+          0.1667,
+          0.1167,
+          0.05
+        ],
+        "hit_delta": 0,
+        "query_delta": 39
+      }
+    }
+  ],
+  "post": {
+    "running": 0.0,
+    "waiting": 0.0,
+    "kv": 0.0,
+    "hits": 5937024.0,
+    "queries": 8522850.0
+  }
+}

--- a/local/w44-spec-accept-probe.py
+++ b/local/w44-spec-accept-probe.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""W44: live spec-accept diagnostic (no restart, no-store).
+
+Why lifetime mean accept ~2.5–2.7 while the structured bench is 6.88–7.0.
+Four short arms, same max_tokens, W42 no-store so we do not evict the
+standing prefix cache:
+
+  S0  structured  thinking off  temp 0     (bench twin)
+  P0  prose       thinking off  temp 0     (bench twin)
+  S1  structured  thinking on   temp 1.0   effort=max (droid path)
+  P1  prose       thinking on   temp 1.0   effort=max (droid path)
+
+Aborts if num_requests_running>0. Run from the Mac through the tunnel:
+
+  uv run python local/w44-spec-accept-probe.py --base http://127.0.0.1:18000
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import time
+import urllib.error
+import urllib.request
+
+MODEL = "GLM-5.3-Flash-EXL3"
+STRUCTURED = (
+    "Count from 1 to 200. Output only the numbers, separated by spaces. No other text."
+)
+PROSE = (
+    "Write a detailed step-by-step explanation of how a hash map works, "
+    "including collision handling, resizing, and time complexity. Be thorough."
+)
+
+
+def get(url: str, timeout: float = 15) -> str:
+    with urllib.request.urlopen(url, timeout=timeout) as r:
+        return r.read().decode("utf-8", "replace")
+
+
+def metrics(base: str) -> dict:
+    txt = get(f"{base}/metrics")
+
+    def g(pat: str) -> float:
+        m = re.search(pat, txt, re.M)
+        return float(m.group(1)) if m else 0.0
+
+    pos = {}
+    for m in re.finditer(
+        r'^vllm:spec_decode_num_accepted_tokens_per_pos_total\{[^}]*position="(\d+)"[^}]*\} (\S+)',
+        txt,
+        re.M,
+    ):
+        pos[int(m.group(1))] = float(m.group(2))
+    return {
+        "running": g(r'^vllm:num_requests_running\{[^}]*\} (\S+)'),
+        "waiting": g(r'^vllm:num_requests_waiting\{[^}]*\} (\S+)'),
+        "kv": g(r'^vllm:kv_cache_usage_perc\{[^}]*\} (\S+)'),
+        "hits": g(r'^vllm:prefix_cache_hits_total\{[^}]*\} (\S+)'),
+        "queries": g(r'^vllm:prefix_cache_queries_total\{[^}]*\} (\S+)'),
+        "drafts": g(r'^vllm:spec_decode_num_drafts_total\{[^}]*\} (\S+)'),
+        "draft_tok": g(r'^vllm:spec_decode_num_draft_tokens_total\{[^}]*\} (\S+)'),
+        "acc": g(r'^vllm:spec_decode_num_accepted_tokens_total\{[^}]*\} (\S+)'),
+        "pos": pos,
+    }
+
+
+def spec_delta(a: dict, b: dict) -> dict:
+    drafts = b["drafts"] - a["drafts"]
+    dtok = b["draft_tok"] - a["draft_tok"]
+    acc = b["acc"] - a["acc"]
+    pos = []
+    for i in range(7):
+        d = b["pos"].get(i, 0) - a["pos"].get(i, 0)
+        pos.append(round(d / drafts, 4) if drafts else 0.0)
+    return {
+        "drafts": int(drafts),
+        "draft_tokens": int(dtok),
+        "accepted": int(acc),
+        "accept_ratio": round(acc / dtok, 4) if dtok else None,
+        "accepted_per_step": round(acc / drafts, 3) if drafts else None,
+        "pos": pos,
+        "hit_delta": int(b["hits"] - a["hits"]),
+        "query_delta": int(b["queries"] - a["queries"]),
+    }
+
+
+def stream_arm(
+    base: str,
+    prompt: str,
+    *,
+    thinking: bool,
+    temp: float,
+    effort: str | None,
+    max_tokens: int,
+    timeout: float,
+) -> dict:
+    kwargs: dict = {"enable_thinking": thinking}
+    if effort is not None:
+        kwargs["reasoning_effort"] = effort
+    body = {
+        "model": MODEL,
+        "messages": [{"role": "user", "content": prompt}],
+        "temperature": temp,
+        "max_tokens": max_tokens,
+        "stream": True,
+        "stream_options": {"include_usage": True},
+        "chat_template_kwargs": kwargs,
+        "vllm_xargs": {"skip_writing_prefix_cache": 1},
+    }
+    req = urllib.request.Request(
+        f"{base}/v1/chat/completions",
+        data=json.dumps(body).encode(),
+        headers={"Content-Type": "application/json"},
+    )
+    t0 = time.perf_counter()
+    first = None
+    content: list[str] = []
+    reasoning: list[str] = []
+    usage: dict = {}
+    finish = None
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        http = resp.status
+        buf = b""
+        while True:
+            piece = resp.read(256)
+            if not piece:
+                break
+            buf += piece
+            while b"\n" in buf:
+                line, buf = buf.split(b"\n", 1)
+                line = line.strip()
+                if not line.startswith(b"data:"):
+                    continue
+                payload = line[5:].strip()
+                if payload == b"[DONE]":
+                    continue
+                try:
+                    obj = json.loads(payload)
+                except json.JSONDecodeError:
+                    continue
+                if obj.get("usage"):
+                    usage = obj["usage"]
+                for ch in obj.get("choices") or []:
+                    finish = ch.get("finish_reason") or finish
+                    delta = ch.get("delta") or {}
+                    if delta.get("content"):
+                        if first is None:
+                            first = time.perf_counter()
+                        content.append(delta["content"])
+                    if delta.get("reasoning"):
+                        if first is None:
+                            first = time.perf_counter()
+                        reasoning.append(delta["reasoning"])
+    t1 = time.perf_counter()
+    ct = int(usage.get("completion_tokens") or 0)
+    ttft = (first - t0) if first else None
+    wall = t1 - t0
+    dec = ct / (wall - ttft) if ttft is not None and wall > ttft and ct else None
+    return {
+        "http": http,
+        "ttft_s": round(ttft, 3) if ttft is not None else None,
+        "wall_s": round(wall, 3),
+        "tok_s": round(dec, 2) if dec is not None else None,
+        "prompt_tokens": usage.get("prompt_tokens"),
+        "completion_tokens": ct,
+        "finish_reason": finish,
+        "content_chars": sum(len(x) for x in content),
+        "reasoning_chars": sum(len(x) for x in reasoning),
+        "content_head": "".join(content)[:80],
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--base", default=os.environ.get("GLM53_BASE", "http://127.0.0.1:18000"))
+    ap.add_argument("--max-tokens", type=int, default=200)
+    ap.add_argument("--out", default="")
+    a = ap.parse_args()
+
+    h = urllib.request.Request(f"{a.base}/health")
+    with urllib.request.urlopen(h, timeout=10) as resp:
+        if resp.status != 200:
+            print("health not 200", resp.status)
+            return 2
+
+    m0 = metrics(a.base)
+    if m0["running"] > 0 or m0["waiting"] > 0:
+        print(json.dumps({"abort": "server busy", **{k: m0[k] for k in ("running", "waiting", "kv")}}))
+        return 3
+
+    arms = [
+        ("S0-struct-off-t0", STRUCTURED, False, 0.0, None),
+        ("P0-prose-off-t0", PROSE, False, 0.0, None),
+        ("S1-struct-on-t1-max", STRUCTURED, True, 1.0, "max"),
+        ("P1-prose-on-t1-max", PROSE, True, 1.0, "max"),
+    ]
+    rec = {
+        "ts": time.time(),
+        "base": a.base,
+        "max_tokens": a.max_tokens,
+        "pre": {k: m0[k] for k in ("running", "waiting", "kv", "hits", "queries", "drafts", "acc")},
+        "arms": [],
+    }
+    print(
+        f"{'arm':<22} {'tok/s':>7} {'ttft':>6} {'acc/step':>8} {'ratio':>6}  pos",
+        flush=True,
+    )
+    for name, prompt, think, temp, effort in arms:
+        busy = metrics(a.base)
+        if busy["running"] > 0:
+            rec["arms"].append({"name": name, "abort": "became busy"})
+            print(f"{name:<22} ABORT busy")
+            break
+        before = metrics(a.base)
+        try:
+            run = stream_arm(
+                a.base,
+                prompt,
+                thinking=think,
+                temp=temp,
+                effort=effort,
+                max_tokens=a.max_tokens,
+                timeout=900,
+            )
+        except urllib.error.HTTPError as e:
+            rec["arms"].append({"name": name, "http": e.code, "err": e.read()[:300].decode("utf-8", "replace")})
+            print(f"{name:<22} HTTP {e.code}")
+            continue
+        after = metrics(a.base)
+        spec = spec_delta(before, after)
+        row = {"name": name, "thinking": think, "temp": temp, "effort": effort, **run, "spec": spec}
+        rec["arms"].append(row)
+        pos = " ".join(f"{p:.2f}" for p in spec["pos"])
+        print(
+            f"{name:<22} {str(run['tok_s'] or '-'):>7} {str(run['ttft_s'] or '-'):>6} "
+            f"{str(spec['accepted_per_step'] or '-'):>8} {str(spec['accept_ratio'] or '-'):>6}  {pos}",
+            flush=True,
+        )
+
+    m1 = metrics(a.base)
+    rec["post"] = {k: m1[k] for k in ("running", "waiting", "kv", "hits", "queries")}
+    out = a.out or f"/tmp/w44-spec-accept-{int(time.time())}.json"
+    with open(out, "w") as f:
+        json.dump(rec, f, indent=2)
+    print("wrote", out)
+    print(json.dumps({k: rec[k] for k in rec if k != "arms"}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Idle-box s2b re-bench (Window D) + soak/freeze watch part 1 (Window A), run 2026-09-04 on production image b5ab8091-s2b. No restart, POST /reset_prefix_cache between arms, idle pre/post every arm.

M0' prefill vs S1 controls (60k 1044.3 / 240k 997.8): 60k 1124.8/1048.4/1049.3 (+7.7/+0.4/+0.5%), 240k 1014.5/1063.5 (+1.7/+6.6%). 2/5 runs clear +5%, 3 sit in the undefined 0-5% band, 0 <= 0%. Gate covers neither adopt nor revert.

Structured n=9 PASS: median 71.54 (+1.6% vs 70.42), accept 1.0/7.0 bit-identical x9, all positions 1.00. Prose unmeasured this window (median 29.14, 26% spread, log-audit inconclusive -- ~28 POSTs vs ~20 expected, all 127.0.0.1).

Second-opinion verdict (numbers-only, per-run judging): NEED-MORE-DATA on adopt/revert; structured PASS; veto INCONCLUSIVE (structured exonerated, prose uncertified); retention PASSES at soak scale.

Window A 4x60k x3: cold 237.5s/0%, rounds 2-3 10.9s/15.6s at 98.7% global-counter hit, preemptions 0. Open: 1h freeze watch, usage-vs-counter divergence (usage cached_tokens 0 vs counters 98.7%), spark2 parity.

Closes the M0' re-bench half and the Window A soak half of the idle-box session; the powered M0' re-window (pre-registered middle-band rule), prose re-run, 1h freeze watch, usage-metric root cause, and spark2 parity remain open per the docs/06 dated entry.

Validation: pytest 68 passed / 1 skipped; python compileall OK; secret scan OK; receipts are valid JSON in local/m0prime-*-20260904.json.