### PR TITLE
M0' powered re-window: ADOPT s2b (+5.3-5.6%), usage-vs-counter root cause, receipts

### DIFF
--- a/docs/06-improvement-plan.md
+++ b/docs/06-improvement-plan.md
@@ -1500,3 +1500,94 @@ traffic, no unexplained gap.
 lower it). 400k+ sessions pay a ~3–4% drafting tax and, dominating,
 structured decode ~31 tok/s at ~519k. Compaction or a fresh session remains
 the remedy; the 1M-window serving contract is unchanged.
+
+## 2026-09-04: M0′ powered re-window — ADOPT s2b (second opinion)
+
+Powered interleave per the pre-registered plan: s2b arms on the settled s2b
+boot (no restart, converged immediately), s2a arms on a fresh s2a boot
+(`IMAGE=glm53-selfbuild:b5ab8091-s2a`, `reset-failed`, watchdog timer stopped
+then re-armed, `SKIP_DOWNLOAD=1` — weights intact in HF cache; the first
+restart attempt without it hit the known `download.sh` 0/120 failure, issue
+#29, and was retried with the skip). Salted unique prompts, `POST
+/reset_prefix_cache` (200) between arms, running/waiting 0.0 idle guards.
+Receipts `local/m0prime2-s2b-structured-20260904.json`,
+`local/m0prime2-s2b-prose-20260904.json` (s2a prefill arms logged inline —
+no receipt file, s2a was a temporary boot).
+
+### Prefill: complete per-run separation at 60k, consistent +5–6% at 240k
+
+| Arm | Runs (tok/s) | Median |
+|---|---|---|
+| s2b 60k ×5 | 1121.8, 1114.7, 1116.6, 1116.2, 1116.3 | **1116.3** (spread 0.6%) |
+| s2b 240k ×5 | 1073.7, 1081.4, 1083.0, 1084.9, 1086.0 | **1083.0** (spread 1.1%, mild warmup slope) |
+| s2a 60k ×5 | 976.7, 996.4, 1057.6, 1061.1, 1059.5 | 1057.6 (first two fault-in low; converged last-three med 1059.5) |
+| s2a 240k ×2 | 1026.4, 1024.2 | 1025.3 (thin sample; see caveat) |
+
+- **60k: s2b min (1114.7) > s2a max (1061.1)** — every s2b run beats every
+  s2a run by ≥ +5.1%. Full-x5 medians +5.6%; converged-only (s2a last three)
+  +5.4%. The conservative read is the headline: dropping s2a's fault-in runs
+  raises the s2a median and shrinks the delta.
+- **240k: +5.6%** (1083.0 vs 1025.3), worst-case pairing +4.6%. The s2a 240k
+  ×5 batch timed out at the harness (1500s client cap vs 5 × ~300s runs) —
+  the server logged all 5 completions; the loss is client-side collection,
+  corroborated by the two direct singles agreeing within 0.2% and sitting
+  above the S1 control (997.8).
+- **Gate verdict (cuda-reviewer second opinion): ADOPT s2b.** Non-inferiority
+  (median ≥ −1%, no run < −3%, both lengths) passes trivially; the legacy
+  ≥ +5% bar also clears on both lengths. The first window's middle-band
+  ambiguity is retired. Amdahl note: isolated +41% on 25–30% of a prefill
+  step predicts +8–9.5% E2E; measured +5.5% is below the ceiling — calibrate
+  future windows against the measured number, not the isolated one.
+
+### Decode
+
+- **Structured n=9: 71.86–74.04, median 73.53 (+4.4% vs 70.42 baseline)** —
+  all finish=length, nan=false, accept 1.0/7.0 every run. DFlash2 k=7 intact.
+- **Prose n=9: median 30.21, 30.2% spread (25.07–34.20)** — second window
+  running with ~30% spread. RETIRED as a gate variable (monitoring only);
+  a prose gate would need n≥30 or variance-normalized scoring.
+
+### Log-audit veto: PASS (one accounted intruder)
+
+- Prefill: 10 completions + 2 resets = exactly issued. No veto.
+- Decode: 24 chat POSTs — 18 are this harness (9 structured + 9 prose
+  stream_bench, incl. structured 32-token warmup + prose 3×coherence +
+  2×short_after; +1 pre-window `/health` 404 from a wrong `GLM53_BASE`
+  → fixed to `http://127.0.0.1:18000` without `/v1`).
+  The 6 extras at 09:49:17–19 are the prose `short_after` tail of the
+  window (script appends it post-coherence), NOT an intruder — the prose
+  receipt `ts` marks bench *start* (09:48:13); 9 × ~7s walls + coherence +
+  short_after land exactly in the 09:49:17–19 cluster. No veto.
+
+### s2a boot bistability — new wrinkle, recorded
+
+The fresh s2a boot oscillated 15.7/15.7/25.4/25.7 → 64.7–70.3 → back to
+25.5/26.0 → settled 67–73 over 22 probes (~10 min). Probes 1–4 are the known
+parked-swap fault-in class; the dip *after* convergence (probes 10–11) is
+not monotone fault-in — no POST overlap in the audit, so not cross-traffic.
+Prefill arms ran only post-settling (probes 12–22), and s2a 60k's first-two
+low runs are the residual tail of the same class. Track: if a dip-after-settle
+recurs on s2b boots it becomes a boot-health finding, not an A/B finding.
+
+### Usage-vs-counter root cause — CLOSED
+
+The Window A divergence is a metric-semantics bug, not a retention failure:
+the chat path (`/v1/chat/completions`) returns `prompt_tokens_details: null`
+— it never populates `cached_tokens` — while `/v1/completions` replays hit
+4160/4217 on the counters. `cache-burst.py`'s usage-based hit% is therefore
+blind on the chat path; on that path the counters are the trustworthy number
+(the script's header comment says the reverse — fix the comment, not the
+server). One-line doc fix queued with this entry.
+
+### Freeze watch — open, T0 recorded
+
+T0 q=1984/h=64 at 1788520243 on the restored s2b boot; mid-window samples
+moved only under our own traffic (10450/4224), flat at idle since. The 1 h
+no-traffic-idle cadence never ran — keep the watch item open in TODO.
+
+### Production state after the window
+
+Restored `IMAGE=glm53-selfbuild:b5ab8091-s2b`, clean pair restart
+(`SKIP_DOWNLOAD=1`), pool **1,396,551 byte-identical**, watchdog timer
+re-armed (active/active), serving spot-check OK, 6/6 converge probes
+69.7–71.1 on the fresh boot. **M0′ is CLOSED as ADOPT s2b.**

--- a/local/cache-burst.py
+++ b/local/cache-burst.py
@@ -6,10 +6,13 @@ LOCAL to this cluster; not part of the vendored upstream kit.
 Simulates N long-lived agent sessions (openclaw-shaped: big stable prompt
 prefix, tiny new suffix per turn, short answers) hitting the server
 concurrently for R rounds, and reports the prefix-cache hit rate per round.
-Primary ledger: per-request usage.prompt_tokens_details.cached_tokens (exact,
-per-request). Secondary: the global prefix_cache_queries/hits counter delta —
-kept for continuity, but it over-counts 1.3–2x under queue pressure (vLLM RFC
-#37003 thread), so trust the usage-based number when they disagree.
+Primary ledger: the global prefix_cache_queries/hits counter delta. (The old
+comment here said per-request usage.prompt_tokens_details.cached_tokens —
+measured 2026-09-04: the chat path returns prompt_tokens_details null and
+never populates cached_tokens, so usage-based hit% is blind on this path;
+a /v1/completions replay hit 4160/4217 on the counters. The counters stay
+the trustworthy number here; usage-based applies only where the endpoint
+populates the field.)
 Round 1 is cold by construction; rounds 2+ measure whether each session's
 cached prefix SURVIVED the other sessions' traffic — the eviction churn probe.
 If N*ctx_tokens exceeds the KV pool (1,396,551 tok at the 2026-08-29 1M

--- a/local/m0prime2-s2b-prose-20260904.json
+++ b/local/m0prime2-s2b-prose-20260904.json
@@ -1,0 +1,363 @@
+{
+  "phase": "prose",
+  "health_code": 200,
+  "health_body": "",
+  "runs": [
+    {
+      "http": 200,
+      "ttft_s": 0.3670256250043167,
+      "wall_s": 6.448973958998977,
+      "decode_s": 6.08194833399466,
+      "tok_s": 32.71977811578935,
+      "completion_tokens": 200,
+      "prompt_tokens": 40,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "# How a Hash Map Works: A Complete Guide\n\nA hash map (also called a hash table or dictionary) is a data structure that stores key-value pairs and provides near-constant-time lookup, insertion, and deletion. Here's a thorough breakdown of how it works.\n\n---\n\n## 1. The Core Concept\n\nA hash map stores data as **key-value pairs**. Instead of searching through data linearly (like an array) or following",
+      "text_len": 860,
+      "usage": {
+        "prompt_tokens": 40,
+        "total_tokens": 240,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 53,
+        "draft_tokens": 371,
+        "accepted": 148,
+        "accept_ratio": 0.3989,
+        "accepted_per_step": 2.792,
+        "pos": [
+          0.8679,
+          0.717,
+          0.5283,
+          0.283,
+          0.2075,
+          0.1509,
+          0.0377
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.36554079099732917,
+      "wall_s": 6.18348804100242,
+      "decode_s": 5.817947250005091,
+      "tok_s": 34.204504002649024,
+      "completion_tokens": 200,
+      "prompt_tokens": 40,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "# How a Hash Map Works: A Complete Guide\n\nA hash map (also called a hash table or dictionary) is a data structure that stores key-value pairs and provides near-constant-time lookup, insertion, and deletion. Here's a thorough breakdown of how it works.\n\n---\n\n## 1. The Core Concept\n\nA hash map stores data as **key-value pairs**. Instead of searching through data linearly (like an array) or following",
+      "text_len": 870,
+      "usage": {
+        "prompt_tokens": 40,
+        "total_tokens": 240,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 51,
+        "draft_tokens": 357,
+        "accepted": 150,
+        "accept_ratio": 0.4202,
+        "accepted_per_step": 2.941,
+        "pos": [
+          0.8627,
+          0.6863,
+          0.5098,
+          0.2745,
+          0.2745,
+          0.1961,
+          0.1373
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.3671328339987667,
+      "wall_s": 6.989457542003947,
+      "decode_s": 6.622324708005181,
+      "tok_s": 30.0498705174401,
+      "completion_tokens": 200,
+      "prompt_tokens": 40,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "# How a Hash Map Works: A Complete Guide\n\nA hash map (also called a hash table or dictionary) is a data structure that stores key-value pairs and provides near-constant-time lookup, insertion, and deletion. Let's build up an understanding from the ground up.\n\n---\n\n## 1. The Core Concept\n\nA hash map stores data as **key-value pairs**. You provide a key (e.g., a username) and a value (e.g., the user",
+      "text_len": 845,
+      "usage": {
+        "prompt_tokens": 40,
+        "total_tokens": 240,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 57,
+        "draft_tokens": 399,
+        "accepted": 147,
+        "accept_ratio": 0.3684,
+        "accepted_per_step": 2.579,
+        "pos": [
+          0.8246,
+          0.6667,
+          0.4035,
+          0.2807,
+          0.2281,
+          0.1228,
+          0.0526
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.4572546249983134,
+      "wall_s": 6.56033095800376,
+      "decode_s": 6.103076333005447,
+      "tok_s": 32.60650680769101,
+      "completion_tokens": 200,
+      "prompt_tokens": 40,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "# How a Hash Map Works: A Complete Guide\n\nA hash map (also called a hash table or dictionary) is a data structure that stores key-value pairs and provides near-constant-time lookup, insertion, and deletion. Here's a thorough breakdown of how it works.\n\n---\n\n## 1. The Core Concept\n\nA hash map stores data as **key-value pairs**. Instead of searching through data linearly (like an array) or following",
+      "text_len": 866,
+      "usage": {
+        "prompt_tokens": 40,
+        "total_tokens": 240,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 54,
+        "draft_tokens": 378,
+        "accepted": 145,
+        "accept_ratio": 0.3836,
+        "accepted_per_step": 2.685,
+        "pos": [
+          0.7963,
+          0.6111,
+          0.463,
+          0.2778,
+          0.2593,
+          0.1667,
+          0.1111
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.4692019169960986,
+      "wall_s": 7.0559539169989876,
+      "decode_s": 6.586752000002889,
+      "tok_s": 30.21215919468544,
+      "completion_tokens": 200,
+      "prompt_tokens": 40,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "# How a Hash Map Works: A Complete Guide\n\nA hash map (also called a hash table or dictionary) is a data structure that stores key-value pairs and provides near-constant-time lookup, insertion, and deletion. Let's build up an understanding from the ground up.\n\n---\n\n## 1. The Core Idea\n\nA hash map lets you associate values with keys so you can retrieve them quickly. The naive alternatives are slow:\n",
+      "text_len": 849,
+      "usage": {
+        "prompt_tokens": 40,
+        "total_tokens": 240,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 58,
+        "draft_tokens": 406,
+        "accepted": 142,
+        "accept_ratio": 0.3498,
+        "accepted_per_step": 2.448,
+        "pos": [
+          0.7414,
+          0.5172,
+          0.4138,
+          0.3103,
+          0.2241,
+          0.1379,
+          0.1034
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.3655630840003141,
+      "wall_s": 8.302309833998152,
+      "decode_s": 7.9367467499978375,
+      "tok_s": 25.073245533512107,
+      "completion_tokens": 200,
+      "prompt_tokens": 40,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "# How a Hash Map Works: A Complete Guide\n\nA hash map (also called a hash table or dictionary) is a data structure that stores key-value pairs and provides near-constant-time lookup, insertion, and deletion. Let's build up the full picture step by step.\n\n---\n\n## 1. The Core Idea\n\nA hash map lets you associate values with keys and retrieve them instantly. Instead of searching through data (like a li",
+      "text_len": 831,
+      "usage": {
+        "prompt_tokens": 40,
+        "total_tokens": 240,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 69,
+        "draft_tokens": 483,
+        "accepted": 131,
+        "accept_ratio": 0.2712,
+        "accepted_per_step": 1.899,
+        "pos": [
+          0.7246,
+          0.4203,
+          0.2754,
+          0.2029,
+          0.1449,
+          0.0725,
+          0.058
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.3956976669942378,
+      "wall_s": 7.327325624995865,
+      "decode_s": 6.931627958001627,
+      "tok_s": 28.7089845568358,
+      "completion_tokens": 200,
+      "prompt_tokens": 40,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "# How a Hash Map Works: A Complete Guide\n\nA hash map (also called a hash table or dictionary) is a data structure that stores key-value pairs and provides near-constant-time lookup, insertion, and deletion. Let's build up an understanding from the ground up.\n\n---\n\n## 1. The Core Idea\n\nA hash map lets you associate values with keys and retrieve them later:\n\n```\nmap.put(\"apple\", 3)\nmap.get(\"apple\") ",
+      "text_len": 810,
+      "usage": {
+        "prompt_tokens": 40,
+        "total_tokens": 240,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 60,
+        "draft_tokens": 420,
+        "accepted": 140,
+        "accept_ratio": 0.3333,
+        "accepted_per_step": 2.333,
+        "pos": [
+          0.7333,
+          0.5333,
+          0.3667,
+          0.3,
+          0.2167,
+          0.1,
+          0.0833
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.39120191700203577,
+      "wall_s": 7.135866208998777,
+      "decode_s": 6.744664291996742,
+      "tok_s": 29.504804299323624,
+      "completion_tokens": 200,
+      "prompt_tokens": 40,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "# How a Hash Map Works: A Complete Guide\n\nA hash map (also called a hash table or dictionary) is a data structure that stores key-value pairs and provides near-constant-time lookup, insertion, and deletion. Let's build up an understanding from the ground up.\n\n---\n\n## 1. The Core Concept\n\nA hash map stores data as **key-value pairs**. You provide a key (e.g., a username), and the map retrieves the ",
+      "text_len": 860,
+      "usage": {
+        "prompt_tokens": 40,
+        "total_tokens": 240,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 59,
+        "draft_tokens": 413,
+        "accepted": 140,
+        "accept_ratio": 0.339,
+        "accepted_per_step": 2.373,
+        "pos": [
+          0.7797,
+          0.6102,
+          0.3729,
+          0.2373,
+          0.1864,
+          0.1017,
+          0.0847
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.3724614169987035,
+      "wall_s": 6.44440654200298,
+      "decode_s": 6.071945125004277,
+      "tok_s": 32.77368222260735,
+      "completion_tokens": 200,
+      "prompt_tokens": 40,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "# How a Hash Map Works: A Complete Guide\n\nA hash map (also called a hash table or dictionary) is a data structure that stores key-value pairs and provides near-constant-time lookup, insertion, and deletion. Here's a thorough breakdown of how it works.\n\n---\n\n## 1. The Core Concept\n\nA hash map stores data as **key-value pairs**. Instead of searching through data linearly (like an array) or following",
+      "text_len": 847,
+      "usage": {
+        "prompt_tokens": 40,
+        "total_tokens": 240,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 53,
+        "draft_tokens": 371,
+        "accepted": 148,
+        "accept_ratio": 0.3989,
+        "accepted_per_step": 2.792,
+        "pos": [
+          0.8491,
+          0.717,
+          0.5094,
+          0.3208,
+          0.2264,
+          0.1132,
+          0.0566
+        ]
+      }
+    }
+  ],
+  "ts": 1788515293.757956,
+  "prompt": "hashmap-prose",
+  "thinking": false,
+  "temperature": 0,
+  "tok_s_median": 30.21215919468544,
+  "tok_s_min": 25.073245533512107,
+  "tok_s_max": 34.204504002649024,
+  "ttft_median_s": 0.3724614169987035,
+  "completion_tokens_median": 200.0,
+  "accept_ratio_median": 0.3684,
+  "accepted_per_step_median": 2.579,
+  "any_nan": false,
+  "coherence": {
+    "paris": {
+      "ok": true,
+      "text": "Paris",
+      "http": 200
+    },
+    "cmp": {
+      "ok": true,
+      "text": "Yes. 9.9 is greater than 9.11 because 9.90 > 9.11 when comparing the decimal values.",
+      "http": 200
+    },
+    "sky": {
+      "ok": true,
+      "text": "The sky-blue paint on the nursery walls seemed to glow softly in the morning light, like a piece of clear summer sky brought indoors.",
+      "http": 200
+    },
+    "nan": false
+  },
+  "coherent": true,
+  "health_code_after": 200,
+  "short_after": {
+    "http": 200,
+    "ttft_s": 0.41773504199954914,
+    "wall_s": 0.47842141699948115,
+    "decode_s": 0.06068637499993201,
+    "tok_s": 115.34714340752504,
+    "completion_tokens": 8,
+    "prompt_tokens": 40,
+    "finish_reason": "length",
+    "nan": false,
+    "text_head": "# How a Hash Map Works: A",
+    "text_len": 25,
+    "usage": {
+      "prompt_tokens": 40,
+      "total_tokens": 48,
+      "completion_tokens": 8
+    }
+  }
+}

--- a/local/m0prime2-s2b-structured-20260904.json
+++ b/local/m0prime2-s2b-structured-20260904.json
@@ -1,0 +1,349 @@
+{
+  "phase": "structured",
+  "health_code": 200,
+  "health_body": "",
+  "runs": [
+    {
+      "http": 200,
+      "ttft_s": 0.3486404580035014,
+      "wall_s": 3.1181030000007013,
+      "decode_s": 2.7694625419972,
+      "tok_s": 71.8550971469327,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.36385400000290247,
+      "wall_s": 3.116529459002777,
+      "decode_s": 2.7526754589998745,
+      "tok_s": 72.29330263012639,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.35391900000104215,
+      "wall_s": 3.1070308749985998,
+      "decode_s": 2.7531118749975576,
+      "tok_s": 72.28184288739685,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.35248225000395905,
+      "wall_s": 3.108960333003779,
+      "decode_s": 2.75647808299982,
+      "tok_s": 72.19357238038776,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.43936945899622515,
+      "wall_s": 3.127273541998875,
+      "decode_s": 2.6879040830026497,
+      "tok_s": 74.0353799298142,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.4059218330003205,
+      "wall_s": 3.106040499995288,
+      "decode_s": 2.7001186669949675,
+      "tok_s": 73.70046451383276,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.40271670799847925,
+      "wall_s": 3.109012832996086,
+      "decode_s": 2.706296124997607,
+      "tok_s": 73.53223402342047,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.4166276670002844,
+      "wall_s": 3.1068159170026775,
+      "decode_s": 2.690188250002393,
+      "tok_s": 73.9725184658817,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.39915691599890124,
+      "wall_s": 3.1010532079963014,
+      "decode_s": 2.7018962919974,
+      "tok_s": 73.65197568441369,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    }
+  ],
+  "ts": 1788515253.50591,
+  "prompt": "structured-count-1-200",
+  "thinking": false,
+  "temperature": 0,
+  "warmup": {
+    "tok_s": 78.64572906923239,
+    "ttft_s": 0.3600437499990221,
+    "completion_tokens": 32
+  },
+  "tok_s_median": 73.53223402342047,
+  "tok_s_min": 71.8550971469327,
+  "tok_s_max": 74.0353799298142,
+  "ttft_median_s": 0.39915691599890124,
+  "completion_tokens_median": 200.0,
+  "accept_ratio_median": 1.0,
+  "accepted_per_step_median": 7.0,
+  "any_nan": false,
+  "health_code_after": 200,
+  "short_after": {
+    "http": 200,
+    "ttft_s": 0.40885762499965494,
+    "wall_s": 0.4837232080026297,
+    "decode_s": 0.07486558300297474,
+    "tok_s": 93.50090815056978,
+    "completion_tokens": 8,
+    "prompt_tokens": 40,
+    "finish_reason": "length",
+    "nan": false,
+    "text_head": "# How a Hash Map Works: A",
+    "text_len": 25,
+    "usage": {
+      "prompt_tokens": 40,
+      "total_tokens": 48,
+      "completion_tokens": 8
+    }
+  }
+}


### PR DESCRIPTION
Powered s2a/s2b interleave (salted, reset between arms, idle guards, log-audited). s2b 60k x5 med 1116.3 with complete per-run separation vs s2a; 240k x5 med 1083.0 (+5.6%, n=2 s2a caveat recorded). Structured n=9 med 73.53 (+4.4%, 1.0/7.0 every run). Prose retired as gate (30% spread, second window running). Second-opinion verdict ADOPT s2b: non-inferiority gate and legacy +5% bar both clear, first-window middle-band ambiguity retired. Usage-vs-counter divergence root-caused (chat path omits cached_tokens; counters trustworthy there) with cache-burst.py comment fix. Production restored b5ab8091-s2b, pool byte-identical, watchdog re-armed. M0' CLOSED. Receipts local/m0prime2-s2b-*-20260904.json. Detail in docs/06 dated entry.