### PR TITLE
W28: right-size GLM indexer workspace and backport correctness fixes

### DIFF
--- a/docs/06-improvement-plan.md
+++ b/docs/06-improvement-plan.md
@@ -672,6 +672,20 @@ pool bytes unmoved at 14.36 GiB, no `keeping stock sizing` warning, and free mem
 sampled *after* the workspace allocation point (it may be lazy — re-measure after the
 first long prefill).
 
+**Resolution prepared locally 2026-09-04, not deployed.** The W28 overlay is
+GLM-5.3-only: the shared stock helper stays unchanged and only
+`models/glm5next/nvidia/attention.py` calls the rightsize helper with its
+authoritative `self.index_kpool`. This leaves DeepSeek-V4 and the rank-0
+DFlash2 drafter outside the experiment. The MNBT multiplier is removed. The
+`end == start` path raises on an oversized N row, and every emitted metadata
+chunk is checked again. The kpool operator then compares the chunk with its
+actual GLM allocation immediately before gather-buffer slicing, closing the
+stock-metadata-bound versus rightsized-allocation gap. A rightsize result that
+does not narrow stock fails boot. Host tests pass against checked-in pinned
+anchors and full authoritative source from `b5ab8091-s2b`. Deployment remains
+blocked on the required reviews; the post-A/B adopt/revert decision also gets
+a CUDA-reviewer second opinion.
+
 ### Watchlist — new
 
 - **vLLM #54521** — greedy decoding non-deterministic above `indexer_budget` on
@@ -1242,7 +1256,7 @@ Fat kernel: `FAT_TILE_M/K/N = 128/16/128`, 3-stage `cp.async`, 23,552 B SMEM, 2 
 Remaining candidates the review would still run, in order:
 
 1. ~~**Spec-accept recovery (not a kernel).**~~ **W44 CLOSED 2026-09-03.** Lifetime 2.55 vs bench 7.0 is production prose/thinking-on mix; structured path still 7.0/1.000. Do not chase with a kernel or k-window. Adaptive verification remains W40, not next.
-2. **W28 indexer workspace reclaim** (~5,035 MiB locked: `max_model_len × 40 × 132 B`). Only credible basis for a pin raise, which is the only way to grow the 14-segment prefix. Blocked on the three Codex fail-opens.
+2. **W28 indexer workspace reclaim** (~5,035 MiB locked: `max_model_len × 40 × 132 B`). Candidate prepared with the reviewed fail-closed row, metadata and actual-allocation guards. Reclaim first; do not raise the pin in the same window.
 3. **`num_active` widening on the fused thin launch**, using the `counts_host` D2H **already paid** by the fat path. Today dispatch hardcodes `n_active_host = -1`, so `MOE_SMS_PER_EXPERT` stays 8. Overlay + stopped microbench; no rebuild. Targets the *complement* of the spent fat path.
 4. **KDA/GDN profile-first.** P0 traces (2026-08-29) already put KDA at ~6% of a 1024-token chunk. Confirm on MNBT=3584 before any Triton/CuTe work. Do not guess.
 5. **Sub-16-row fused GEMM** — decode-tail kernel, moderate risk. W44 showed the accept gap is traffic mix, so this is occupancy/GEMV work, not "fix 2.71".

--- a/docs/11-gb10-kernel-program.md
+++ b/docs/11-gb10-kernel-program.md
@@ -285,7 +285,8 @@ permanently below the incumbent). Automatic re-open triggers in docs/12 §8.
 
 - **W28 indexer workspace right-sizing** — `glm5next` omits `// compress_ratio`;
   5,035 MiB locked at the 1M window; the reclaim is the only credible basis for a
-  KV-pin raise. Blocked on the three Codex fixes (docs/06 §W28).
+  KV-pin raise. Candidate prepared with the three Codex fixes; blocked on CUDA
+  review, final review and the guarded W28 window (docs/06 §W28).
 - **Adaptive-K at verification** — vLLM #52228/#52559 only; drafting stays fixed-K
   (#49164 closed on correctness grounds).
 - **CUTLASS sm120 grouped GEMM** — FP8-path enablement only; subordinate to S3.
@@ -310,8 +311,9 @@ Operator queue lives in `docs/06` (night rewrite) and `spec/TODO.md`.
 6. **C3 (later):** sub-16-row fused GEMM for decode-tail experts. Image
    rebuild + full K4×M sweep. W44 (2026-09-03) showed the 2.71 vs 6.88
    gap is traffic mix, not a GEMM problem — this is occupancy/GEMV work.
-7. **W28** indexer workspace — still the memory lane; still blocked on the
-   three Codex fail-opens. Do not raise the pin first.
+7. **W28** indexer workspace — still the memory lane; candidate prepared with
+   the three Codex fail-opens closed. Review and reclaim first. Do not raise
+   the pin in the same window.
 8. **S3** Trellis — **PARKED** (`docs/12`). Re-open only on the existing
    trigger (≥ ~80 TFLOP/s rank-sliced, or s2b idle e2e < 5%).
 9. Watch (not EXL3 kernels): adaptive-K at **verification** #52228/#52559,

--- a/docs/DESIGN-indexer-workspace.md
+++ b/docs/DESIGN-indexer-workspace.md
@@ -1,0 +1,234 @@
+# W28: GLM-5.3 indexer prefill-workspace reclaim
+
+`GLM53_INDEXER_WORKSPACE=rightsize` ·
+`overlay/patch_indexer_workspace.py` ·
+`tests/test_indexer_workspace.py`
+
+This is a GLM-5.3-Flash deployment change. It does not target or modify a
+DeepSeek deployment. Some reused vLLM classes retain `DeepseekV32...` names,
+but activation is scoped to `models/glm5next/nvidia/attention.py`.
+
+## Purpose
+
+The pinned preview build sizes the sparse-indexer prefill gather workspace as:
+
+```text
+max_model_len * 40 entries
+```
+
+At the production 1M-token window that is 40,000,000 entries. The measured
+profile allocation is:
+
+```text
+40,000,000 * 132 B + 1 MiB radix scratch
+= 5,281,048,576 B
+= 5036.40 MiB
+```
+
+The allocation happens during memory profiling and remains locked. Production
+uses a byte-pinned KV pool, so W28 tests the reclaim as **free memory
+headroom**. It does not raise the KV pin.
+
+## Safe GLM-only sizing
+
+GLM-5.3 uses a kpool-compressed indexer. The safe per-step upper bound is:
+
+```text
+max_num_seqs
+* cdiv(max_model_len + num_speculative_tokens, index_kpool)
+```
+
+At the production geometry:
+
+```text
+max_model_len          = 1,000,000
+num_speculative_tokens = 7
+index_kpool             = 4
+max_num_seqs            = 4
+
+cdiv(1,000,007, 4) * 4 = 1,000,008 entries
+```
+
+This predicts about 126.9 MiB including the radix scratch, reclaiming about
+4.79 GiB relative to stock.
+
+`max_num_batched_tokens` is deliberately absent from the multiplier. The
+earlier proposal used `min(max_num_seqs, max_num_batched_tokens)`, but the
+review found that invariant insufficiently established. `max_num_seqs` is the
+direct scheduler admission bound and is conservative at the deployed shape.
+
+## Scope boundary
+
+The shared `get_max_prefill_buffer_size()` implementation remains unchanged.
+The overlay adds `_glm53_glm5next_workspace_entries()` and changes the GLM
+allocation call site:
+
+```text
+vllm/models/glm5next/nvidia/attention.py
+```
+
+It also adds a guard immediately before gather-buffer slicing in:
+
+```text
+vllm/model_executor/layers/sparse_attn_indexer_kpool.py
+```
+
+The helper receives `self.index_kpool`, the same instance value used to create
+GLM's compressed indexer KV-cache spec. The runtime guard activates only when
+`index_kpool > 1`; GLM is the only such caller in the pinned source. This
+avoids:
+
+- changing the existing DeepSeek-V4 call site, which already applies its own
+  compression adjustment;
+- process-wide model-type inference;
+- an unscoped cross-check firing in the rank-0-only DFlash2 drafter;
+- one-rank startup failure followed by an apparent NCCL hang.
+
+`rightsize` must compute fewer entries than stock. If it cannot reclaim memory,
+boot fails instead of silently retaining stock sizing and producing a false
+positive receipt.
+
+## Splitter hardening
+
+The pinned splitter has a fail-open:
+
+```python
+if end == start:
+    chunk_m, chunk_n = query_lens_cpu[end].item(), seq_lens_cpu[end].item()
+    end += 1
+```
+
+If one compressed row is wider than the workspace, the packing loop rejects
+it, then this branch admits it anyway. Query sub-chunking reduces M only; it
+cannot reduce N.
+
+W28 adds three guards:
+
+1. The `end == start` branch raises when the row exceeds the metadata
+   builder's bound.
+2. Every emitted metadata chunk is checked against that bound again.
+3. The kpool operator compares `chunk.total_seq_lens` with the actual
+   `total_seq_lens` allocation argument immediately before slicing
+   `k_quant_full`/`k_scale_full` or invoking the gather kernel.
+
+The rightsize formula leaves room for every admitted GLM request at
+`max_model_len + draft_k`, so any guard firing is a correctness failure and
+an automatic revert.
+
+## Bundled correctness backports
+
+The next restart also carries `overlay/patch_w28_correctness.py`.
+
+### vLLM #53798
+
+The pinned V2 worker seeds a resumed align-mode request with:
+
+```python
+(num_computed_tokens - 1) // cache_config.block_size
+```
+
+The align table is indexed in `MambaSpec.block_size` units. Page unification
+can make those block sizes differ, so the old divisor can select a neighbour's
+row or run past the table.
+
+The port:
+
+1. adds a default no-op `ModelState.set_kv_cache_config()` hook;
+2. calls it after `init_attn_backend()` resolves the KV groups and before any
+   request is admitted;
+3. validates the align-mode Mamba groups share scheduling parameters;
+4. seeds resumed state with `mamba_spec.block_size`.
+
+### vLLM #54057
+
+`FlashInferMLASparseSM120Impl` is sparse-MQA-only, but the generic prefill
+dispatcher reads `masked_mha_available` for sparse implementations. The pinned
+SM120 class defines neither that flag nor an explicit dense-prefill capability.
+
+W28 declares:
+
+```python
+supports_dense_mha_prefill = False
+masked_mha_available = False
+```
+
+next to the existing `is_sparse` capability flag. The overlay anchor matches
+the deployed preview, not the later upstream file that already contains the
+dense-prefill flag.
+
+## Activation and rollback
+
+```text
+GLM53_INDEXER_WORKSPACE=stock      # production/control
+GLM53_INDEXER_WORKSPACE=rightsize  # W28 arm
+```
+
+The launcher validates the literal enum before a restart. Caller exports are
+captured with setness semantics so an explicitly empty value is rejected
+rather than overwritten by `.env`.
+
+Rollback is:
+
+```text
+GLM53_INDEXER_WORKSPACE=stock
+```
+
+The correctness backports stay in both arms because they are not the W28
+decision variable.
+
+## Pre-deployment gates
+
+Before any cluster A/B:
+
+1. Host tests pass against checked-in anchor snapshots from the pinned
+   production source. Optional environment overrides can re-run the same tests
+   against full container-source copies.
+2. `bash -n start.sh` passes.
+3. Full repository tests and lint pass.
+4. `cuda-kernel-reviewer` reviews the complete candidate, including the
+   Python-to-GPU gather safety contract.
+5. `final-reviewer` approves the complete candidate change-set.
+
+No deployment occurs before both reviews.
+
+## Restart protocol
+
+The W28 restart must:
+
+1. stop the watchdog timer;
+2. wait for any in-flight watchdog service;
+3. run `systemctl --user reset-failed`;
+4. stop the pair through `local/prod-start.sh` hygiene;
+5. require the both-node `MemFree` tripwire;
+6. perform the planned one-time JIT wipe;
+7. boot the stock/control arm first;
+8. boot the rightsize arm with no other decision variable changed;
+9. re-arm the watchdog only after the selected production arm is healthy.
+
+W43 remains conditional on observed capacity waits. It is not combined with
+W28.
+
+## Live A/B gates
+
+The standing pool remains exactly 15,414,698,763 bytes. A pin raise is out of
+scope.
+
+Required receipts:
+
+- both ranks log the GLM target line with identical mode, kpool, entry count
+  and byte count;
+- no row/chunk guard, workspace lock assertion, IMA, Xid, or cross-row-state
+  symptom;
+- memory sampled after the workspace is actually allocated and again after
+  the first long prefill;
+- pool bytes remain unchanged;
+- acceptance 7/7 and serving 6/6;
+- structured acceptance remains 1.0000/7.0;
+- cache retention standing gates remain green;
+- temperature-0 determinism probes run below and above `indexer_budget`
+  because vLLM #54521 is a direct GB10/TP=2 hazard;
+- prefill and decode show no unexplained regression beyond the pre-registered
+  non-inferiority bounds.
+
+After the A/B, `cuda-kernel-reviewer` provides a second opinion on adopt versus
+revert before the production decision is finalized.

--- a/env.example
+++ b/env.example
@@ -103,6 +103,16 @@ GLM53_KV_CAPACITY_LOG=1
 # 0 = kill switch: a valid 1 becomes a logged no-op (malformed values are still
 # rejected with HTTP 400 at the API boundary). Exactly 0 or 1. Not in the JIT hash.
 GLM53_APC_NO_STORE=1
+# W28 sparse-indexer workspace experiment. The overlay is GLM-5.3-only:
+# it is activated from models/glm5next/nvidia/attention.py with that model
+# instance's index_kpool, so the DFlash2 drafter and other model paths retain
+# the generic stock allocation. `stock` is production before the window;
+# `rightsize` uses MAX_NUM_SEQS * cdiv((MAX_MODEL_LEN + draft k), index_kpool).
+# At the current 1M / seqs=4 / kpool=4 / k=7 geometry this predicts 1,000,008
+# entries (~126.9 MiB including radix scratch) instead of 40,000,000
+# (5036.40 MiB). The arm must produce matching lines on both ranks and no
+# row/chunk guard failure. Reclaim first; never raise the KV pin in this window.
+GLM53_INDEXER_WORKSPACE=stock
 # W23 mixed-prefill gate v2 (defaults shown; MAX_WAIT_MS=0 restores the v1 hold-forever gate).
 # Cached follow-ups whose uncached remainder is <= WARM_TOKENS skip the mixing hold entirely;
 # a cold prefill held while others decode proceeds after MAX_WAIT_MS at LATE_CAP tokens/step.

--- a/overlay/patch_indexer_workspace.py
+++ b/overlay/patch_indexer_workspace.py
@@ -1,0 +1,476 @@
+#!/usr/bin/env python3
+"""Right-size the GLM-5.3 sparse-indexer prefill workspace (opt-in).
+
+The pinned vLLM preview sizes the shared sparse-indexer gather workspace as
+``max_model_len * 40`` entries. At the production 1M-token window, with
+132 bytes per FP8 entry plus the radix scratch, that locks 5036.40 MiB during
+memory profiling.
+
+GLM-5.3's kpool indexer consumes compressed sequence lengths. Its safe
+per-step upper bound is:
+
+    max_num_seqs * cdiv(max_model_len + num_speculative_tokens, index_kpool)
+
+The patch is deliberately GLM-scoped. It adds a helper to the shared indexer
+module, then changes only ``models/glm5next/nvidia/attention.py`` to call it
+with that model instance's authoritative ``self.index_kpool``. The generic
+``get_max_prefill_buffer_size`` function stays byte-for-byte stock, so other
+models and the rank-0 DFlash2 drafter cannot enter the experiment.
+
+Safety hardening required by the local review:
+
+* a single row wider than the workspace raises instead of the stock
+  ``if end == start`` fail-open;
+* every emitted chunk is checked again before metadata construction and GPU
+  gather;
+* the GLM kpool operator compares each chunk against its actual allocation
+  argument immediately before slicing the gather buffers;
+* the disputed ``max_num_batched_tokens`` request multiplier is not used;
+* rightsize mode must actually narrow the workspace, otherwise boot fails
+  rather than reporting a successful experiment that kept stock sizing.
+
+``GLM53_INDEXER_WORKSPACE``:
+
+* ``stock`` (default) keeps the exact stock allocation;
+* ``rightsize`` activates the GLM-only bound;
+* any other value fails at process import.
+
+All three target files are preflighted before any is written. Re-application is
+idempotent, drift fails closed, writes use atomic replacement, and stale pyc
+files are removed.
+"""
+from __future__ import annotations
+
+import os
+import stat
+import sys
+from pathlib import Path
+
+
+INDEXER_TARGET = Path(
+    os.environ.get(
+        "GLM53_INDEXER_BACKEND_PY",
+        "/usr/local/lib/python3.12/dist-packages/vllm/v1/attention/backends/mla/"
+        "indexer.py",
+    )
+)
+GLM_TARGET = Path(
+    os.environ.get(
+        "GLM53_GLM5NEXT_ATTENTION_PY",
+        "/usr/local/lib/python3.12/dist-packages/vllm/models/glm5next/nvidia/"
+        "attention.py",
+    )
+)
+KPOOL_TARGET = Path(
+    os.environ.get(
+        "GLM53_INDEXER_KPOOL_PY",
+        "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/"
+        "sparse_attn_indexer_kpool.py",
+    )
+)
+
+ENV_NAME = "GLM53_INDEXER_WORKSPACE"
+STOCK_MULTIPLIER = 40
+BYTES_PER_ENTRY = 132
+
+
+HELPERS_SRC = '''
+
+# [glm53-indexer-workspace] GLM-5.3-only prefill gather sizing.
+_GLM53_WORKSPACE_ENV = "GLM53_INDEXER_WORKSPACE"
+
+
+def _glm53_workspace_mode() -> str:
+    """Return the literal workspace mode; only an unset value defaults."""
+    raw = os.environ.get(_GLM53_WORKSPACE_ENV)
+    if raw is None:
+        return "stock"
+    if raw not in ("stock", "rightsize"):
+        raise ValueError(
+            f"{_GLM53_WORKSPACE_ENV} must be exactly one of: stock rightsize "
+            f"(got: {raw!r})"
+        )
+    return raw
+
+
+def _glm53_glm5next_workspace_entries(
+    vllm_config: VllmConfig,
+    index_kpool: int,
+) -> int:
+    """Return the GLM kpool workspace, never a generic model workspace."""
+    stock = get_max_prefill_buffer_size(vllm_config)
+    if _glm53_workspace_mode() == "stock":
+        return stock
+
+    ratio = int(index_kpool)
+    if ratio <= 1:
+        raise ValueError(
+            "[glm53-indexer-workspace] rightsize requires GLM index_kpool > 1 "
+            f"(got {ratio})"
+        )
+    max_model_len = int(vllm_config.model_config.max_model_len)
+    max_num_seqs = int(vllm_config.scheduler_config.max_num_seqs)
+    if max_model_len <= 0 or max_num_seqs <= 0:
+        raise ValueError(
+            "[glm53-indexer-workspace] rightsize requires positive "
+            f"max_model_len/max_num_seqs (got {max_model_len}/{max_num_seqs})"
+        )
+    spec_cfg = getattr(vllm_config, "speculative_config", None)
+    num_spec = int(getattr(spec_cfg, "num_speculative_tokens", 0) or 0)
+    span = max_model_len + max(0, num_spec)
+    per_req = -(-span // ratio)
+    entries = per_req * max_num_seqs
+
+    # A rightsize arm that silently kept stock would produce a false-positive
+    # deployment receipt. Fail readiness instead.
+    if entries >= stock:
+        raise ValueError(
+            "[glm53-indexer-workspace] rightsize does not narrow the stock "
+            f"workspace: computed={entries}, stock={stock}, "
+            f"index_kpool={ratio}, max_num_seqs={max_num_seqs}"
+        )
+
+    rank = (
+        torch.distributed.get_rank()
+        if torch.distributed.is_available()
+        and torch.distributed.is_initialized()
+        else -1
+    )
+    logger.info(
+        "[glm53-indexer-workspace] role=target rank=%d mode=rightsize "
+        "index_kpool=%d max_num_seqs=%d entries=%d stock=%d bytes=%d "
+        "reclaimed_mib=%.1f",
+        rank,
+        ratio,
+        max_num_seqs,
+        entries,
+        stock,
+        entries * 132,
+        (stock - entries) * 132 / (1024 * 1024),
+    )
+    return entries
+'''
+
+class _HostDistributed:
+    @staticmethod
+    def is_available() -> bool:
+        return False
+
+    @staticmethod
+    def is_initialized() -> bool:
+        return False
+
+
+class _HostTorch:
+    distributed = _HostDistributed()
+
+
+_HELPER_NS: dict = {"os": os, "torch": _HostTorch()}
+
+
+def _stock_size(config) -> int:
+    return int(config.model_config.max_model_len) * STOCK_MULTIPLIER
+
+
+_HELPER_NS["get_max_prefill_buffer_size"] = _stock_size
+_HELPER_NS["logger"] = type(
+    "_NullLogger",
+    (),
+    {"info": staticmethod(lambda *_args, **_kwargs: None)},
+)()
+_HELPER_NS["VllmConfig"] = object
+exec(
+    compile(HELPERS_SRC, "<glm53-indexer-workspace helpers>", "exec"),
+    _HELPER_NS,
+)
+workspace_mode = _HELPER_NS["_glm53_workspace_mode"]
+glm5next_workspace_entries = _HELPER_NS["_glm53_glm5next_workspace_entries"]
+
+
+def split_prefill_chunks(
+    compressed_seq_lens: list[int],
+    query_lens: list[int],
+    workspace_size: int,
+    max_logits_bytes: int,
+) -> list[tuple[tuple[int, int], tuple[int, int]]]:
+    """Host replica of the patched splitter used by CPU-only tests."""
+    chunks: list[tuple[tuple[int, int], tuple[int, int]]] = []
+    n = len(compressed_seq_lens)
+    max_logits_elems = max_logits_bytes // 4
+    end = 0
+    while end < n:
+        start, chunk_m, chunk_n = end, 0, 0
+        while end < n:
+            q, s = query_lens[end], compressed_seq_lens[end]
+            new_m, new_n = chunk_m + q, chunk_n + s
+            if new_n <= workspace_size and new_m * new_n <= max_logits_elems:
+                chunk_m, chunk_n = new_m, new_n
+                end += 1
+            else:
+                break
+        if end == start:
+            chunk_m, chunk_n = query_lens[end], compressed_seq_lens[end]
+            if chunk_n > workspace_size:
+                raise ValueError(
+                    "sparse-indexer row exceeds workspace: "
+                    f"row={chunk_n}, workspace={workspace_size}"
+                )
+            end += 1
+        if chunk_n > workspace_size:
+            raise AssertionError(
+                "sparse-indexer chunk exceeds workspace: "
+                f"chunk={chunk_n}, workspace={workspace_size}"
+            )
+        req_slice = (start, end)
+        max_q = (
+            max(1, max_logits_elems // chunk_n)
+            if chunk_n > 0
+            else max(1, chunk_m)
+        )
+        for q_off in range(0, chunk_m, max_q):
+            sub_m = min(max_q, chunk_m - q_off)
+            chunks.append((req_slice, (q_off, q_off + sub_m)))
+    return chunks
+
+
+MARK_HELPERS = "# [glm53-indexer-workspace] GLM-5.3-only prefill gather sizing.\n"
+ANCHOR_HELPERS = """def get_max_prefill_buffer_size(vllm_config: VllmConfig):
+    max_model_len = vllm_config.model_config.max_model_len
+    # NOTE(Chen): 40 is a magic number for controlling the prefill buffer size.
+    # Each entry is 128 fp8 bytes and 4 scale bytes for a total of 132 bytes.
+    # The flashmla_sparse backend uses a workspace size of 5 * max_model_len.
+    # The memory usage of the workspace there is 576 * 2 bytes; so we size this as
+    # (576 * 2 // 132) * 5 = 40 to maximize this workspace size while still fitting
+    # within the flashmla_sparse workspace.
+    # For DeepSeek-V3.2, the max_model_len is 163840.
+    #   40 * 163840 * 132 = 865075200 bytes = 825 MB
+    return max_model_len * 40
+"""
+PATCHED_HELPERS = ANCHOR_HELPERS + HELPERS_SRC
+
+MARK_SPLITTER = "            # [glm53-indexer-workspace] N cannot be sub-chunked.\n"
+ANCHOR_SPLITTER = """        # A single request can exceed the budget, requiring sub-chunking
+        # on the query dimension.
+        if end == start:
+            chunk_m, chunk_n = query_lens_cpu[end].item(), seq_lens_cpu[end].item()
+            end += 1
+
+        req_slice = slice(start + request_offset, end + request_offset)
+"""
+PATCHED_SPLITTER = """        # A single request can exceed the logits budget, requiring
+        # sub-chunking on the query dimension. N cannot be sub-chunked: the
+        # stock fail-open admitted the oversized row anyway, so right-sizing
+        # could overrun the locked gather workspace.
+        if end == start:
+            chunk_m, chunk_n = query_lens_cpu[end].item(), seq_lens_cpu[end].item()
+            # [glm53-indexer-workspace] N cannot be sub-chunked.
+            if chunk_n > workspace_size:
+                raise ValueError(
+                    "[glm53-indexer-workspace] sparse-indexer row exceeds "
+                    f"workspace: row={chunk_n}, workspace={workspace_size}, "
+                    f"request={end + request_offset}"
+                )
+            end += 1
+
+        if chunk_n > workspace_size:
+            raise AssertionError(
+                "[glm53-indexer-workspace] emitted chunk exceeds workspace: "
+                f"chunk={chunk_n}, workspace={workspace_size}, "
+                f"requests={start + request_offset}:{end + request_offset}"
+            )
+        req_slice = slice(start + request_offset, end + request_offset)
+"""
+
+MARK_CHUNK_ASSERT = (
+    "                # [glm53-indexer-workspace] Final guard before GPU gather.\n"
+)
+ANCHOR_CHUNK_ASSERT = """                # Skip when total_seq_lens is 0 (i.e., no compressed token).
+                if metadata is not None:
+                    chunks.append(metadata)
+"""
+PATCHED_CHUNK_ASSERT = """                # Skip when total_seq_lens is 0 (i.e., no compressed token).
+                if metadata is not None:
+                    # [glm53-indexer-workspace] Final guard before GPU gather.
+                    if metadata.total_seq_lens > self.max_prefill_buffer_size:
+                        raise AssertionError(
+                            "[glm53-indexer-workspace] metadata chunk exceeds "
+                            f"workspace: chunk={metadata.total_seq_lens}, "
+                            f"workspace={self.max_prefill_buffer_size}"
+                        )
+                    chunks.append(metadata)
+"""
+
+INDEXER_SITES = (
+    ("helpers", MARK_HELPERS, ANCHOR_HELPERS, PATCHED_HELPERS),
+    ("splitter fail-closed", MARK_SPLITTER, ANCHOR_SPLITTER, PATCHED_SPLITTER),
+    (
+        "pre-gather chunk assertion",
+        MARK_CHUNK_ASSERT,
+        ANCHOR_CHUNK_ASSERT,
+        PATCHED_CHUNK_ASSERT,
+    ),
+)
+
+MARK_GLM_IMPORT = (
+    "            _glm53_glm5next_workspace_entries,  "
+    "# [glm53-indexer-workspace]\n"
+)
+ANCHOR_GLM_IMPORT = """        from vllm.v1.attention.backends.mla.indexer import get_max_prefill_buffer_size
+
+        self.max_total_seq_len = get_max_prefill_buffer_size(vllm_config)
+"""
+PATCHED_GLM_IMPORT = """        from vllm.v1.attention.backends.mla.indexer import (
+            _glm53_glm5next_workspace_entries,  # [glm53-indexer-workspace]
+        )
+
+        # GLM-scoped by construction: the generic helper remains untouched,
+        # and the authoritative kpool value is the same instance value used
+        # to build the compressed KV-cache spec above.
+        self.max_total_seq_len = _glm53_glm5next_workspace_entries(
+            vllm_config,
+            self.index_kpool,
+        )
+"""
+
+MARK_KPOOL_CAP = (
+    "            # [glm53-indexer-workspace] Guard the actual GLM allocation.\n"
+)
+ANCHOR_KPOOL_CAP = """        for chunk in prefill_metadata.chunks if not short_prefill else ():
+            k_quant = k_quant_full[: chunk.total_seq_lens]
+            k_scale = k_scale_full[: chunk.total_seq_lens]
+"""
+PATCHED_KPOOL_CAP = """        for chunk in prefill_metadata.chunks if not short_prefill else ():
+            # [glm53-indexer-workspace] Guard the actual GLM allocation.
+            if index_kpool > 1 and chunk.total_seq_lens > total_seq_lens:
+                raise ValueError(
+                    "[glm53-indexer-workspace] gather chunk exceeds allocated "
+                    f"workspace: chunk={chunk.total_seq_lens}, "
+                    f"allocated={total_seq_lens}"
+                )
+            k_quant = k_quant_full[: chunk.total_seq_lens]
+            k_scale = k_scale_full[: chunk.total_seq_lens]
+"""
+
+
+def _verified(text: str, sites) -> bool:
+    return all(
+        text.count(mark) == 1
+        and text.count(patched) == 1
+        and text.count(anchor) == patched.count(anchor)
+        for _name, mark, anchor, patched in sites
+    )
+
+
+def _prepare(text: str, sites, label: str) -> tuple[str, str]:
+    marks = sum(text.count(mark) for _name, mark, _anchor, _patched in sites)
+    if marks:
+        if marks != len(sites) or not _verified(text, sites):
+            raise ValueError(
+                f"partial/inconsistent {label} patch "
+                f"(marks={marks}, expected={len(sites)})"
+            )
+        return text, "already present"
+
+    out = text
+    for name, _mark, anchor, patched in sites:
+        count = out.count(anchor)
+        if count != 1:
+            raise ValueError(
+                f"pinned {label} anchor {name!r} drifted "
+                f"(found {count}, expected 1)"
+            )
+        out = out.replace(anchor, patched, 1)
+    if not _verified(out, sites):
+        raise ValueError(f"{label} post-patch verification failed")
+    return out, "patched"
+
+
+def prepare_indexer(text: str) -> tuple[str, str]:
+    return _prepare(text, INDEXER_SITES, "indexer")
+
+
+def prepare_glm(text: str) -> tuple[str, str]:
+    sites = (("GLM call site", MARK_GLM_IMPORT, ANCHOR_GLM_IMPORT, PATCHED_GLM_IMPORT),)
+    return _prepare(text, sites, "GLM attention")
+
+
+def prepare_kpool(text: str) -> tuple[str, str]:
+    sites = (
+        (
+            "actual allocation guard",
+            MARK_KPOOL_CAP,
+            ANCHOR_KPOOL_CAP,
+            PATCHED_KPOOL_CAP,
+        ),
+    )
+    return _prepare(text, sites, "kpool operator")
+
+
+def replace_file(target: Path, source: str) -> None:
+    tmp = target.with_name(f".{target.name}.glm53-indexer-workspace.tmp")
+    try:
+        tmp.write_text(source)
+        os.chmod(tmp, stat.S_IMODE(target.stat().st_mode))
+        os.replace(tmp, target)
+    finally:
+        if tmp.exists():
+            tmp.unlink()
+
+
+def clear_pyc(target: Path) -> None:
+    cache = target.parent / "__pycache__"
+    if not cache.is_dir():
+        return
+    for pyc in cache.glob(f"{target.stem}*.pyc"):
+        pyc.unlink(missing_ok=True)
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = sys.argv if argv is None else argv
+    preflight_only = "--preflight" in argv[1:]
+
+    for target in (INDEXER_TARGET, GLM_TARGET, KPOOL_TARGET):
+        if not target.is_file():
+            raise SystemExit(f"missing {target}")
+
+    indexer_source = INDEXER_TARGET.read_text()
+    glm_source = GLM_TARGET.read_text()
+    kpool_source = KPOOL_TARGET.read_text()
+    try:
+        indexer_patched, indexer_action = prepare_indexer(indexer_source)
+        glm_patched, glm_action = prepare_glm(glm_source)
+        kpool_patched, kpool_action = prepare_kpool(kpool_source)
+    except ValueError as exc:
+        raise SystemExit(f"indexer workspace preflight failed: {exc}") from exc
+
+    compile(indexer_patched, str(INDEXER_TARGET), "exec")
+    compile(glm_patched, str(GLM_TARGET), "exec")
+    compile(kpool_patched, str(KPOOL_TARGET), "exec")
+    if preflight_only:
+        print(
+            "indexer workspace preflight OK "
+            f"(indexer={indexer_action}, glm={glm_action}, "
+            f"kpool={kpool_action})"
+        )
+        return 0
+
+    if indexer_patched != indexer_source:
+        replace_file(INDEXER_TARGET, indexer_patched)
+        clear_pyc(INDEXER_TARGET)
+    if glm_patched != glm_source:
+        replace_file(GLM_TARGET, glm_patched)
+        clear_pyc(GLM_TARGET)
+    if kpool_patched != kpool_source:
+        replace_file(KPOOL_TARGET, kpool_patched)
+        clear_pyc(KPOOL_TARGET)
+    print(
+        "indexer workspace "
+        f"(indexer={indexer_action}, glm={glm_action}, "
+        f"kpool={kpool_action}, "
+        f"{ENV_NAME}={os.environ.get(ENV_NAME, 'stock (unset)')!r})"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/overlay/patch_w28_correctness.py
+++ b/overlay/patch_w28_correctness.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+"""Backport the two correctness fixes bundled with the GLM W28 restart.
+
+This overlay ports:
+
+* vLLM #53798: seed resumed align-mode Mamba state indices in
+  ``MambaSpec.block_size`` units, not the generic scheduler block size;
+* vLLM #54057: declare ``masked_mha_available = False`` on the SM120 sparse
+  MLA implementation used by GLM-5.3 on GB10, while also pinning its missing
+  dense-prefill capability to ``False``.
+
+The #53798 port is adapted to the pinned preview build. The runner binds the
+resolved KV cache config to ``ModelState`` immediately after attention backend
+initialization and before any request can be admitted. The hybrid model state
+then resolves and validates its Mamba groups once and uses the Mamba block size
+for resumed-request state indexing.
+
+All five Python targets are preflighted and compiled before any write.
+Re-application is idempotent, anchor drift fails closed, writes use atomic
+replacement, and stale pyc files are removed.
+"""
+from __future__ import annotations
+
+import os
+import stat
+import sys
+from pathlib import Path
+
+
+SITE = Path(
+    os.environ.get(
+        "GLM53_VLLM_SITE",
+        "/usr/local/lib/python3.12/dist-packages/vllm",
+    )
+)
+
+TARGETS = {
+    "interface": SITE / "v1/worker/gpu/model_states/interface.py",
+    "runner": SITE / "v1/worker/gpu/model_runner.py",
+    "mamba": SITE / "v1/worker/gpu/model_states/mamba_hybrid.py",
+    "sm120": SITE / "v1/attention/backends/mla/flashinfer_mla_sparse_sm120.py",
+}
+
+
+INTERFACE_MARK = "    def set_kv_cache_config(  # [glm53-w28-correctness]\n"
+INTERFACE_ANCHOR = """    def apply_staged_writes(self) -> None:
+        return None
+
+    def get_additional_cg_support(self) -> tuple[AttentionCGSupport, str | None]:
+"""
+INTERFACE_PATCHED = """    def apply_staged_writes(self) -> None:
+        return None
+
+    def set_kv_cache_config(  # [glm53-w28-correctness]
+        self, kv_cache_config: KVCacheConfig
+    ) -> None:
+        \"\"\"Bind the resolved KV cache config before requests are admitted.\"\"\"
+        return None
+
+    def get_additional_cg_support(self) -> tuple[AttentionCGSupport, str | None]:
+"""
+
+RUNNER_MARK = (
+    "        self.model_state.set_kv_cache_config(  "
+    "# [glm53-w28-correctness]\n"
+)
+RUNNER_ANCHOR = """        self.attn_groups, attn_cg_support, self.kernel_block_sizes = init_attn_backend(
+            self.kv_cache_config, self.vllm_config, self.device
+        )
+        attn_cg_support = attn_cg_support.narrow(
+"""
+RUNNER_PATCHED = """        self.attn_groups, attn_cg_support, self.kernel_block_sizes = init_attn_backend(
+            self.kv_cache_config, self.vllm_config, self.device
+        )
+        self.model_state.set_kv_cache_config(  # [glm53-w28-correctness]
+            self.kv_cache_config
+        )
+        attn_cg_support = attn_cg_support.narrow(
+"""
+
+MAMBA_BIND_MARK = "    def set_kv_cache_config(  # [glm53-w28-correctness]\n"
+MAMBA_BIND_ANCHOR = """    def add_request(self, req_index: int, new_req_data: NewRequestData) -> None:
+        super().add_request(req_index, new_req_data)
+"""
+MAMBA_BIND_PATCHED = """    def set_kv_cache_config(  # [glm53-w28-correctness]
+        self, kv_cache_config: KVCacheConfig
+    ) -> None:
+        if not self._align_mode:
+            return
+        group_ids: list[int] = []
+        specs: list[MambaSpec] = []
+        for group_id, group in enumerate(kv_cache_config.kv_cache_groups):
+            spec = group.kv_cache_spec
+            if isinstance(spec, MambaSpec):
+                group_ids.append(group_id)
+                specs.append(spec)
+        assert specs, "no mamba layers in the model"
+        representative = specs[0]
+        assert all(
+            spec.block_size == representative.block_size
+            and spec.num_speculative_blocks
+            == representative.num_speculative_blocks
+            and spec.mamba_cache_mode == representative.mamba_cache_mode
+            for spec in specs
+        ), "all mamba groups must share cache scheduling parameters"
+        self._mamba_group_ids = group_ids
+        self._mamba_spec = representative
+
+    def add_request(self, req_index: int, new_req_data: NewRequestData) -> None:
+        super().add_request(req_index, new_req_data)
+"""
+
+MAMBA_SEED_MARK = (
+    "            # [glm53-w28-correctness] The align table is in Mamba blocks.\n"
+)
+MAMBA_SEED_ANCHOR = """        if self._align_mode:
+            # Seed the running state block from the resumed/prefilled position.
+            self._mamba_state_idx_gpu[req_index].fill_(
+                (new_req_data.num_computed_tokens - 1) // self.cache_config.block_size
+            )
+
+    def _get_mamba_group_info(
+        self, kv_cache_config: KVCacheConfig
+    ) -> tuple[list[int], MambaSpec]:
+        if self._mamba_spec is None:
+            group_ids: list[int] = []
+            specs: list[MambaSpec] = []
+            for i, group in enumerate(kv_cache_config.kv_cache_groups):
+                spec = group.kv_cache_spec
+                if isinstance(spec, MambaSpec):
+                    group_ids.append(i)
+                    specs.append(spec)
+            assert specs, "no mamba layers in the model"
+            assert all(specs[0] == s for s in specs)
+            self._mamba_group_ids = group_ids
+            self._mamba_spec = specs[0]
+        return self._mamba_group_ids, self._mamba_spec
+"""
+MAMBA_SEED_PATCHED = """        if self._align_mode:
+            # Seed the running state block from the resumed/prefilled position.
+            # [glm53-w28-correctness] The align table is in Mamba blocks.
+            _, mamba_spec = self._get_mamba_group_info()
+            self._mamba_state_idx_gpu[req_index].fill_(
+                (new_req_data.num_computed_tokens - 1) // mamba_spec.block_size
+            )
+
+    def _get_mamba_group_info(self) -> tuple[list[int], MambaSpec]:
+        assert self._mamba_spec is not None, "KV cache config not bound"
+        return self._mamba_group_ids, self._mamba_spec
+"""
+
+MAMBA_CALLS_MARK = (
+    "        mamba_group_ids, mamba_spec = self._get_mamba_group_info()  "
+    "# [glm53-w28-correctness]\n"
+)
+MAMBA_CALLS_ANCHOR = """        mamba_group_ids, mamba_spec = self._get_mamba_group_info(kv_cache_config)
+        ctx = self._ensure_align_ctx(kv_cache_config, mamba_group_ids, block_tables)
+"""
+MAMBA_CALLS_PATCHED = """        mamba_group_ids, mamba_spec = self._get_mamba_group_info()  # [glm53-w28-correctness]
+        ctx = self._ensure_align_ctx(kv_cache_config, mamba_group_ids, block_tables)
+"""
+
+SM120_MARK = "    masked_mha_available = False  # [glm53-w28-correctness]\n"
+SM120_ANCHOR = """    is_sparse = True
+
+    def __init__(
+"""
+SM120_PATCHED = """    is_sparse = True
+    supports_dense_mha_prefill = False
+    # The sparse-MQA-only SM120 implementation does not inherit the generic
+    # initializer that sets this capability, but the prefill dispatcher reads
+    # it for every sparse backend once num_mha_tokens > 0.
+    masked_mha_available = False  # [glm53-w28-correctness]
+
+    def __init__(
+"""
+
+SITES = {
+    "interface": (
+        ("KV config hook", INTERFACE_MARK, INTERFACE_ANCHOR, INTERFACE_PATCHED),
+    ),
+    "runner": (
+        ("bind KV config", RUNNER_MARK, RUNNER_ANCHOR, RUNNER_PATCHED),
+    ),
+    "mamba": (
+        ("resolve Mamba groups", MAMBA_BIND_MARK, MAMBA_BIND_ANCHOR, MAMBA_BIND_PATCHED),
+        ("Mamba-block seed", MAMBA_SEED_MARK, MAMBA_SEED_ANCHOR, MAMBA_SEED_PATCHED),
+        ("bound group lookup", MAMBA_CALLS_MARK, MAMBA_CALLS_ANCHOR, MAMBA_CALLS_PATCHED),
+    ),
+    "sm120": (
+        ("masked MHA capability", SM120_MARK, SM120_ANCHOR, SM120_PATCHED),
+    ),
+}
+
+
+def verified_state(text: str, sites) -> bool:
+    return all(
+        text.count(mark) == 1
+        and text.count(patched) == 1
+        and text.count(anchor) == patched.count(anchor)
+        for _name, mark, anchor, patched in sites
+    )
+
+
+def prepare(text: str, sites, label: str) -> tuple[str, str]:
+    marks = sum(text.count(mark) for _name, mark, _anchor, _patched in sites)
+    if marks:
+        if marks != len(sites) or not verified_state(text, sites):
+            raise ValueError(
+                f"partial/inconsistent {label} patch "
+                f"(marks={marks}, expected={len(sites)})"
+            )
+        return text, "already present"
+
+    out = text
+    for name, _mark, anchor, patched in sites:
+        count = out.count(anchor)
+        if count != 1:
+            raise ValueError(
+                f"pinned {label} anchor {name!r} drifted "
+                f"(found {count}, expected 1)"
+            )
+        out = out.replace(anchor, patched, 1)
+    if not verified_state(out, sites):
+        raise ValueError(f"{label} post-patch verification failed")
+    return out, "patched"
+
+
+def replace_file(target: Path, source: str) -> None:
+    tmp = target.with_name(f".{target.name}.glm53-w28-correctness.tmp")
+    try:
+        tmp.write_text(source)
+        os.chmod(tmp, stat.S_IMODE(target.stat().st_mode))
+        os.replace(tmp, target)
+    finally:
+        if tmp.exists():
+            tmp.unlink()
+
+
+def clear_pyc(target: Path) -> None:
+    cache = target.parent / "__pycache__"
+    if not cache.is_dir():
+        return
+    for pyc in cache.glob(f"{target.stem}*.pyc"):
+        pyc.unlink(missing_ok=True)
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = sys.argv if argv is None else argv
+    preflight_only = "--preflight" in argv[1:]
+
+    original: dict[str, str] = {}
+    patched: dict[str, str] = {}
+    actions: dict[str, str] = {}
+    for label, target in TARGETS.items():
+        if not target.is_file():
+            raise SystemExit(f"missing {target}")
+        original[label] = target.read_text()
+        try:
+            patched[label], actions[label] = prepare(
+                original[label], SITES[label], label
+            )
+        except ValueError as exc:
+            raise SystemExit(f"W28 correctness preflight failed: {exc}") from exc
+        compile(patched[label], str(target), "exec")
+
+    if preflight_only:
+        print(
+            "W28 correctness preflight OK "
+            + " ".join(f"{name}={actions[name]}" for name in TARGETS)
+        )
+        return 0
+
+    for label, target in TARGETS.items():
+        if patched[label] != original[label]:
+            replace_file(target, patched[label])
+            clear_pyc(target)
+    print(
+        "W28 correctness "
+        + " ".join(f"{name}={actions[name]}" for name in TARGETS)
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/start.sh
+++ b/start.sh
@@ -83,6 +83,8 @@ _glm53_cli_kvlog_set="${GLM53_KV_CAPACITY_LOG+a}"
 _glm53_cli_kvlog_val="${GLM53_KV_CAPACITY_LOG-}"
 _glm53_cli_apcns_set="${GLM53_APC_NO_STORE+a}"
 _glm53_cli_apcns_val="${GLM53_APC_NO_STORE-}"
+_glm53_cli_indexer_workspace_set="${GLM53_INDEXER_WORKSPACE+a}"
+_glm53_cli_indexer_workspace_val="${GLM53_INDEXER_WORKSPACE-}"
 # LOCAL: W41/W42 caller-wins capture (end)
 set -a
 # shellcheck disable=SC1091
@@ -111,6 +113,7 @@ set +a
 # LOCAL: W41/W42 caller-wins restore (begin)
 [ -n "${_glm53_cli_kvlog_set}" ] && GLM53_KV_CAPACITY_LOG="$_glm53_cli_kvlog_val"
 [ -n "${_glm53_cli_apcns_set}" ] && GLM53_APC_NO_STORE="$_glm53_cli_apcns_val"
+[ -n "${_glm53_cli_indexer_workspace_set}" ] && GLM53_INDEXER_WORKSPACE="$_glm53_cli_indexer_workspace_val"
 # LOCAL: W41/W42 caller-wins restore (end)
 
 # ----------------------------- configuration -------------------------------
@@ -224,6 +227,9 @@ ALIGN_FLOOR_PATCH_HOST="${ALIGN_FLOOR_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_alig
 # LOCAL: W41 (kit PR #94) block-level KV capacity boot log, log-only; W42 (kit PR #95) per-request APC no-store
 KV_CAPACITY_LOG_PATCH_HOST="${KV_CAPACITY_LOG_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_kv_capacity_log.py}"
 APC_NO_STORE_PATCH_HOST="${APC_NO_STORE_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_apc_no_store.py}"
+# LOCAL: W28 GLM-only indexer-workspace reclaim + bundled correctness backports
+INDEXER_WORKSPACE_PATCH_HOST="${INDEXER_WORKSPACE_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_indexer_workspace.py}"
+W28_CORRECTNESS_PATCH_HOST="${W28_CORRECTNESS_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_w28_correctness.py}"
 KV_CACHE_DTYPE="${KV_CACHE_DTYPE:-fp8}"
 QUANTIZATION="${QUANTIZATION:-exl3}"
 LANGUAGE_MODEL_ONLY="${LANGUAGE_MODEL_ONLY:-0}"
@@ -303,6 +309,9 @@ GLM53_ALIGN_FLOOR="${GLM53_ALIGN_FLOOR:-1}"
 # running pair; the overlays re-validate in-process and fail closed at boot.
 GLM53_KV_CAPACITY_LOG="${GLM53_KV_CAPACITY_LOG-1}"
 GLM53_APC_NO_STORE="${GLM53_APC_NO_STORE-1}"
+# W28: stock is the shipped allocation; rightsize enables the GLM-5.3-only
+# reclaim. Default stays stock until the guarded A/B produces live receipts.
+GLM53_INDEXER_WORKSPACE="${GLM53_INDEXER_WORKSPACE-stock}"
 # LOCAL: W41/W42 knob defaults (end)
 # EngineCore stock timeout is 300s; mid-serve Triton/TileLang JIT on TP=2 can
 # exceed that without being a true hang. NCCL watchdog is still 600s.
@@ -398,6 +407,10 @@ validate_numeric_config() {
         case "${!_v}" in 0|1) ;; *) echo "$_v must be exactly 0 or 1 (got: '${!_v}')" >&2; return 2 ;; esac
     done
     unset _v
+    case "${GLM53_INDEXER_WORKSPACE-stock}" in
+        stock|rightsize) ;;
+        *) echo "GLM53_INDEXER_WORKSPACE must be exactly one of: stock rightsize (got: '${GLM53_INDEXER_WORKSPACE-<unset>}')" >&2; return 2 ;;
+    esac
     # LOCAL: W41/W42 strict-bool validation (end)
     # LOCAL: DEFAULT_MAX_NEW_TOKENS is spliced into generated shell + JSON; empty = off.
     if [ -n "${DEFAULT_MAX_NEW_TOKENS:-}" ]; then
@@ -593,6 +606,8 @@ preflight() {
     [ -f "$ALIGN_FLOOR_PATCH_HOST" ] || die "$ALIGN_FLOOR_PATCH_HOST missing"  # LOCAL: align-floor
     [ -f "$KV_CAPACITY_LOG_PATCH_HOST" ] || die "$KV_CAPACITY_LOG_PATCH_HOST missing"  # LOCAL: W41
     [ -f "$APC_NO_STORE_PATCH_HOST" ] || die "$APC_NO_STORE_PATCH_HOST missing"  # LOCAL: W42
+    [ -f "$INDEXER_WORKSPACE_PATCH_HOST" ] || die "$INDEXER_WORKSPACE_PATCH_HOST missing"  # LOCAL: W28
+    [ -f "$W28_CORRECTNESS_PATCH_HOST" ] || die "$W28_CORRECTNESS_PATCH_HOST missing"  # LOCAL: W28
 
     local need_kb=$((180 * 1024 * 1024)) avail
     mkdir -p "$HF_CACHE_DIR"
@@ -1109,6 +1124,12 @@ fi
 if [ -f /opt/glm53/patch_apc_no_store.py ]; then  # LOCAL: W42
     python3 /opt/glm53/patch_apc_no_store.py
 fi
+if [ -f /opt/glm53/patch_w28_correctness.py ]; then  # LOCAL: W28 correctness first
+    python3 /opt/glm53/patch_w28_correctness.py
+fi
+if [ -f /opt/glm53/patch_indexer_workspace.py ]; then  # LOCAL: W28 decision variable
+    python3 /opt/glm53/patch_indexer_workspace.py
+fi
 say "launching: vllm serve ${MODEL_DIR} ${ARGS[*]}"
 exec vllm serve "${MODEL_DIR}" "${ARGS[@]}"
 EOF
@@ -1233,6 +1254,12 @@ fi
 if [ -f /opt/glm53/patch_apc_no_store.py ]; then  # LOCAL: W42
     python3 /opt/glm53/patch_apc_no_store.py
 fi
+if [ -f /opt/glm53/patch_w28_correctness.py ]; then  # LOCAL: W28 correctness first
+    python3 /opt/glm53/patch_w28_correctness.py
+fi
+if [ -f /opt/glm53/patch_indexer_workspace.py ]; then  # LOCAL: W28 decision variable
+    python3 /opt/glm53/patch_indexer_workspace.py
+fi
 say "joining TP2 at ${HEAD_IP}:${MASTER_PORT} as rank 1"
 exec vllm serve "${MODEL_DIR}" "${ARGS[@]}"
 EOF
@@ -1279,6 +1306,10 @@ launch_cluster() {
     scp -q -o BatchMode=yes "$KV_CAPACITY_LOG_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_kv_capacity_log.py"
     [ -f "$APC_NO_STORE_PATCH_HOST" ] || die "missing $APC_NO_STORE_PATCH_HOST"  # LOCAL: W42
     scp -q -o BatchMode=yes "$APC_NO_STORE_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_apc_no_store.py"
+    [ -f "$W28_CORRECTNESS_PATCH_HOST" ] || die "missing $W28_CORRECTNESS_PATCH_HOST"  # LOCAL: W28
+    scp -q -o BatchMode=yes "$W28_CORRECTNESS_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_w28_correctness.py"
+    [ -f "$INDEXER_WORKSPACE_PATCH_HOST" ] || die "missing $INDEXER_WORKSPACE_PATCH_HOST"  # LOCAL: W28
+    scp -q -o BatchMode=yes "$INDEXER_WORKSPACE_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_indexer_workspace.py"
 
 
     local -a nccl_common=(
@@ -1314,6 +1345,7 @@ launch_cluster() {
         -e "GLM53_ALIGN_FLOOR=$GLM53_ALIGN_FLOOR"
         -e "GLM53_KV_CAPACITY_LOG=$GLM53_KV_CAPACITY_LOG"  # LOCAL: W41
         -e "GLM53_APC_NO_STORE=$GLM53_APC_NO_STORE"  # LOCAL: W42
+        -e "GLM53_INDEXER_WORKSPACE=$GLM53_INDEXER_WORKSPACE"  # LOCAL: W28
         # LOCAL: W9 ablation — 0 restores stock router-GEMM eligibility exactly
         -e "GLM53_ROUTER_GEMM_CUBLAS=${GLM53_ROUTER_GEMM_CUBLAS:-1}"
         # LOCAL: W17/W18 opt-in overlays (both ranks read these at patch time)
@@ -1419,6 +1451,8 @@ launch_cluster() {
         -v '/tmp/patch_align_floor.py:/opt/glm53/patch_align_floor.py:ro' \
         -v '/tmp/patch_kv_capacity_log.py:/opt/glm53/patch_kv_capacity_log.py:ro' \
         -v '/tmp/patch_apc_no_store.py:/opt/glm53/patch_apc_no_store.py:ro' \
+        -v '/tmp/patch_w28_correctness.py:/opt/glm53/patch_w28_correctness.py:ro' \
+        -v '/tmp/patch_indexer_workspace.py:/opt/glm53/patch_indexer_workspace.py:ro' \
         ${worker_preload} \
         ${worker_nccl} \
         -e NCCL_SOCKET_IFNAME='$WORKER_CX7_IF' \
@@ -1455,6 +1489,8 @@ launch_cluster() {
         -v "$ALIGN_FLOOR_PATCH_HOST:/opt/glm53/patch_align_floor.py:ro" \
         -v "$KV_CAPACITY_LOG_PATCH_HOST:/opt/glm53/patch_kv_capacity_log.py:ro" \
         -v "$APC_NO_STORE_PATCH_HOST:/opt/glm53/patch_apc_no_store.py:ro" \
+        -v "$W28_CORRECTNESS_PATCH_HOST:/opt/glm53/patch_w28_correctness.py:ro" \
+        -v "$INDEXER_WORKSPACE_PATCH_HOST:/opt/glm53/patch_indexer_workspace.py:ro" \
         "${head_preload[@]}" \
         "${nccl_common[@]}" \
         -e NCCL_SOCKET_IFNAME="$HEAD_CX7_IF" \

--- a/tests/fixtures/w28-pinned-preview/README.md
+++ b/tests/fixtures/w28-pinned-preview/README.md
@@ -1,0 +1,17 @@
+# W28 pinned-preview anchor snapshots
+
+These minimal, syntax-valid snapshots preserve the exact patch anchors from
+the deployed GLM-5.3 preview source at vLLM commit `933876c388`:
+
+- `vllm/v1/attention/backends/mla/indexer.py`
+- `vllm/models/glm5next/nvidia/attention.py`
+- `vllm/v1/worker/gpu/model_states/interface.py`
+- `vllm/v1/worker/gpu/model_runner.py`
+- `vllm/v1/worker/gpu/model_states/mamba_hybrid.py`
+- `vllm/v1/attention/backends/mla/flashinfer_mla_sparse_sm120.py`
+- `vllm/model_executor/layers/sparse_attn_indexer_kpool.py`
+
+They are deliberately independent of the overlay constants. Tests apply the
+overlays to these files by default, so an anchor copied from a different vLLM
+revision fails in CI. Environment overrides still allow the same tests to run
+against complete files copied from a container.

--- a/tests/fixtures/w28-pinned-preview/glm-attention.py
+++ b/tests/fixtures/w28-pinned-preview/glm-attention.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+
+class Glm5NextIndexer:
+    def __init__(self, vllm_config):
+        self.index_kpool = 4
+        from vllm.v1.attention.backends.mla.indexer import get_max_prefill_buffer_size
+
+        self.max_total_seq_len = get_max_prefill_buffer_size(vllm_config)

--- a/tests/fixtures/w28-pinned-preview/gpu-model-runner.py
+++ b/tests/fixtures/w28-pinned-preview/gpu-model-runner.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+
+class GPUModelRunner:
+    def initialize_kv_cache(self):
+        self.attn_groups, attn_cg_support, self.kernel_block_sizes = init_attn_backend(
+            self.kv_cache_config, self.vllm_config, self.device
+        )
+        attn_cg_support = attn_cg_support.narrow(
+            *self.model_state.get_additional_cg_support()
+        )
+        return attn_cg_support

--- a/tests/fixtures/w28-pinned-preview/indexer.py
+++ b/tests/fixtures/w28-pinned-preview/indexer.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+
+def split_indexer_prefill_chunks(
+    seq_lens_cpu,
+    query_lens_cpu,
+    workspace_size,
+    max_logits_bytes,
+    request_offset=0,
+):
+    chunks = []
+    n = len(seq_lens_cpu)
+    max_logits_elems = max_logits_bytes // 4
+    end = 0
+    while end < n:
+        start, chunk_m, chunk_n = end, 0, 0
+        while end < n:
+            q, s = query_lens_cpu[end].item(), seq_lens_cpu[end].item()
+            new_m, new_n = chunk_m + q, chunk_n + s
+            if new_n <= workspace_size and new_m * new_n <= max_logits_elems:
+                chunk_m, chunk_n = new_m, new_n
+                end += 1
+            else:
+                break
+
+        # A single request can exceed the budget, requiring sub-chunking
+        # on the query dimension.
+        if end == start:
+            chunk_m, chunk_n = query_lens_cpu[end].item(), seq_lens_cpu[end].item()
+            end += 1
+
+        req_slice = slice(start + request_offset, end + request_offset)
+        max_q = max(1, max_logits_elems // chunk_n) if chunk_n > 0 else max(1, chunk_m)
+        for q_off in range(0, chunk_m, max_q):
+            sub_m = min(max_q, chunk_m - q_off)
+            chunks.append((req_slice, slice(q_off, q_off + sub_m)))
+    return chunks
+
+
+def get_max_prefill_buffer_size(vllm_config: VllmConfig):
+    max_model_len = vllm_config.model_config.max_model_len
+    # NOTE(Chen): 40 is a magic number for controlling the prefill buffer size.
+    # Each entry is 128 fp8 bytes and 4 scale bytes for a total of 132 bytes.
+    # The flashmla_sparse backend uses a workspace size of 5 * max_model_len.
+    # The memory usage of the workspace there is 576 * 2 bytes; so we size this as
+    # (576 * 2 // 132) * 5 = 40 to maximize this workspace size while still fitting
+    # within the flashmla_sparse workspace.
+    # For DeepSeek-V3.2, the max_model_len is 163840.
+    #   40 * 163840 * 132 = 865075200 bytes = 825 MB
+    return max_model_len * 40
+
+
+class Builder:
+    def build(self):
+        chunks = []
+        for metadata in (None,):
+                # Skip when total_seq_lens is 0 (i.e., no compressed token).
+                if metadata is not None:
+                    chunks.append(metadata)
+        return chunks

--- a/tests/fixtures/w28-pinned-preview/mamba-hybrid.py
+++ b/tests/fixtures/w28-pinned-preview/mamba-hybrid.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+
+class MambaHybridModelState:
+    def add_request(self, req_index: int, new_req_data: NewRequestData) -> None:
+        super().add_request(req_index, new_req_data)
+        # Must reset the speculative acceptance count in this idx which could be stale.
+        self.num_accepted_tokens_gpu[req_index].fill_(1)
+        if self._align_mode:
+            # Seed the running state block from the resumed/prefilled position.
+            self._mamba_state_idx_gpu[req_index].fill_(
+                (new_req_data.num_computed_tokens - 1) // self.cache_config.block_size
+            )
+
+    def _get_mamba_group_info(
+        self, kv_cache_config: KVCacheConfig
+    ) -> tuple[list[int], MambaSpec]:
+        if self._mamba_spec is None:
+            group_ids: list[int] = []
+            specs: list[MambaSpec] = []
+            for i, group in enumerate(kv_cache_config.kv_cache_groups):
+                spec = group.kv_cache_spec
+                if isinstance(spec, MambaSpec):
+                    group_ids.append(i)
+                    specs.append(spec)
+            assert specs, "no mamba layers in the model"
+            assert all(specs[0] == s for s in specs)
+            self._mamba_group_ids = group_ids
+            self._mamba_spec = specs[0]
+        return self._mamba_group_ids, self._mamba_spec
+
+    def preprocess_state(self, kv_cache_config, block_tables):
+        mamba_group_ids, mamba_spec = self._get_mamba_group_info(kv_cache_config)
+        ctx = self._ensure_align_ctx(kv_cache_config, mamba_group_ids, block_tables)
+        return mamba_spec, ctx

--- a/tests/fixtures/w28-pinned-preview/model-state-interface.py
+++ b/tests/fixtures/w28-pinned-preview/model-state-interface.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+
+class ModelState:
+    def apply_staged_writes(self) -> None:
+        return None
+
+    def get_additional_cg_support(self) -> tuple[AttentionCGSupport, str | None]:
+        return AttentionCGSupport.ALWAYS, None

--- a/tests/fixtures/w28-pinned-preview/sm120-mla.py
+++ b/tests/fixtures/w28-pinned-preview/sm120-mla.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+
+class FlashInferMLASparseSM120Impl:
+    """SM120 FlashInfer sparse-MLA implementation."""
+
+    is_sparse = True
+
+    def __init__(
+        self,
+        num_heads: int,
+    ) -> None:
+        self.num_heads = num_heads

--- a/tests/fixtures/w28-pinned-preview/sparse-attn-indexer-kpool.py
+++ b/tests/fixtures/w28-pinned-preview/sparse-attn-indexer-kpool.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+
+class Buffer:
+    def __init__(self, size):
+        self.size = size
+
+    def __getitem__(self, item):
+        return range(min(item.stop, self.size))
+
+
+def gather(prefill_metadata, short_prefill, total_seq_lens, index_kpool):
+    k_quant_full = Buffer(total_seq_lens)
+    k_scale_full = Buffer(total_seq_lens)
+    if True:
+        for chunk in prefill_metadata.chunks if not short_prefill else ():
+            k_quant = k_quant_full[: chunk.total_seq_lens]
+            k_scale = k_scale_full[: chunk.total_seq_lens]
+        return len(k_quant), len(k_scale)

--- a/tests/test_indexer_workspace.py
+++ b/tests/test_indexer_workspace.py
@@ -1,0 +1,502 @@
+#!/usr/bin/env python3
+"""CPU-only tests for the GLM-5.3 W28 indexer-workspace overlay."""
+from __future__ import annotations
+
+import os
+import random
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parent
+PINNED_FIXTURE_ROOT = HERE / "fixtures" / "w28-pinned-preview"
+PATCH = next(
+    path
+    for path in (
+        HERE / "patch_indexer_workspace.py",
+        ROOT / "overlay" / "patch_indexer_workspace.py",
+    )
+    if path.is_file()
+)
+sys.path.insert(0, str(PATCH.parent))
+import patch_indexer_workspace as P  # noqa: E402
+
+
+LIVE_MAX_MODEL_LEN = 1_000_000
+LIVE_KPOOL = 4
+LIVE_MAX_NUM_SEQS = 4
+LIVE_SPEC = 7
+MAX_LOGITS_BYTES = 512 * 1024 * 1024
+RADIX_BYTES = 1024 * 1024
+
+
+class Ns:
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+
+def cfg(
+    *,
+    max_model_len: int = LIVE_MAX_MODEL_LEN,
+    max_num_seqs: int = LIVE_MAX_NUM_SEQS,
+    spec: int | None = LIVE_SPEC,
+    mnbt: int = 3584,
+):
+    return Ns(
+        model_config=Ns(max_model_len=max_model_len),
+        scheduler_config=Ns(
+            max_num_seqs=max_num_seqs,
+            max_num_batched_tokens=mnbt,
+        ),
+        speculative_config=(
+            Ns(num_speculative_tokens=spec) if spec is not None else None
+        ),
+    )
+
+
+def set_mode(value: str | None) -> None:
+    if value is None:
+        os.environ.pop(P.ENV_NAME, None)
+    else:
+        os.environ[P.ENV_NAME] = value
+
+
+def cdiv(a: int, b: int) -> int:
+    return -(-a // b)
+
+
+def test_mode_is_literal_and_fail_closed() -> None:
+    saved = os.environ.get(P.ENV_NAME)
+    try:
+        set_mode(None)
+        assert P.workspace_mode() == "stock"
+        for good in ("stock", "rightsize"):
+            set_mode(good)
+            assert P.workspace_mode() == good
+        for bad in ("", "RIGHTSIZE", " rightsize ", "1", "on"):
+            set_mode(bad)
+            try:
+                P.workspace_mode()
+            except ValueError as exc:
+                assert P.ENV_NAME in str(exc)
+                assert repr(bad) in str(exc)
+            else:
+                raise AssertionError(f"{bad!r} must fail")
+    finally:
+        set_mode(saved)
+
+
+def test_stock_receipt_and_rightsize_formula() -> None:
+    saved = os.environ.get(P.ENV_NAME)
+    try:
+        stock = LIVE_MAX_MODEL_LEN * P.STOCK_MULTIPLIER
+        total_bytes = stock * P.BYTES_PER_ENTRY + RADIX_BYTES
+        assert stock == 40_000_000
+        assert total_bytes == 5_281_048_576
+        assert f"{total_bytes / 1024**2:.2f}" == "5036.40"
+
+        for mode in (None, "stock"):
+            set_mode(mode)
+            assert P.glm5next_workspace_entries(cfg(), LIVE_KPOOL) == stock
+
+        set_mode("rightsize")
+        per_req = cdiv(LIVE_MAX_MODEL_LEN + LIVE_SPEC, LIVE_KPOOL)
+        assert per_req == 250_002
+        assert (
+            P.glm5next_workspace_entries(cfg(), LIVE_KPOOL)
+            == per_req * LIVE_MAX_NUM_SEQS
+            == 1_000_008
+        )
+        assert (
+            P.glm5next_workspace_entries(
+                cfg(max_num_seqs=16),
+                LIVE_KPOOL,
+            )
+            == 4_000_032
+        )
+    finally:
+        set_mode(saved)
+
+
+def test_formula_does_not_depend_on_mnbt() -> None:
+    """Codex finding: do not use the unproven MNBT request multiplier."""
+    saved = os.environ.get(P.ENV_NAME)
+    try:
+        set_mode("rightsize")
+        values = {
+            P.glm5next_workspace_entries(cfg(mnbt=mnbt), LIVE_KPOOL)
+            for mnbt in (1, 4, 64, 3584, 8192)
+        }
+        assert values == {1_000_008}
+        assert "max_num_batched_tokens" not in P.HELPERS_SRC
+    finally:
+        set_mode(saved)
+
+
+def test_rightsize_must_be_glm_kpool_and_must_reclaim() -> None:
+    saved = os.environ.get(P.ENV_NAME)
+    try:
+        set_mode("rightsize")
+        for ratio in (0, 1):
+            try:
+                P.glm5next_workspace_entries(cfg(), ratio)
+            except ValueError as exc:
+                assert "index_kpool > 1" in str(exc)
+            else:
+                raise AssertionError("non-kpool rightsize must fail")
+
+        # 160 * cdiv(1_000_007, 4) exceeds the stock 40M entries.
+        try:
+            P.glm5next_workspace_entries(
+                cfg(max_num_seqs=160),
+                LIVE_KPOOL,
+            )
+        except ValueError as exc:
+            assert "does not narrow" in str(exc)
+        else:
+            raise AssertionError("a no-reclaim arm must fail readiness")
+    finally:
+        set_mode(saved)
+
+
+def test_splitter_rejects_a_row_wider_than_workspace() -> None:
+    try:
+        P.split_prefill_chunks(
+            [250_003],
+            [1],
+            250_002,
+            MAX_LOGITS_BYTES,
+        )
+    except ValueError as exc:
+        assert "row exceeds workspace" in str(exc)
+    else:
+        raise AssertionError("the stock end==start fail-open must be closed")
+
+
+def legal_batches(seed: int = 20260904, count: int = 400):
+    rng = random.Random(seed)
+    for _ in range(count):
+        count_reqs = rng.randint(1, LIVE_MAX_NUM_SEQS)
+        query_lens = [rng.randint(1, 896) for _ in range(count_reqs)]
+        seq_lens = [
+            rng.randint(query_len, LIVE_MAX_MODEL_LEN) // LIVE_KPOOL
+            for query_len in query_lens
+        ]
+        yield seq_lens, query_lens
+    yield [LIVE_MAX_MODEL_LEN // LIVE_KPOOL] * LIVE_MAX_NUM_SEQS, [1] * 4
+    yield [LIVE_MAX_MODEL_LEN // LIVE_KPOOL], [3584]
+
+
+def test_rightsize_keeps_legal_chunking_identical_to_stock() -> None:
+    saved = os.environ.get(P.ENV_NAME)
+    try:
+        set_mode("rightsize")
+        rightsize = P.glm5next_workspace_entries(cfg(), LIVE_KPOOL)
+        stock = LIVE_MAX_MODEL_LEN * P.STOCK_MULTIPLIER
+        assert rightsize < stock
+        for seq_lens, query_lens in legal_batches():
+            assert P.split_prefill_chunks(
+                seq_lens,
+                query_lens,
+                rightsize,
+                MAX_LOGITS_BYTES,
+            ) == P.split_prefill_chunks(
+                seq_lens,
+                query_lens,
+                stock,
+                MAX_LOGITS_BYTES,
+            )
+    finally:
+        set_mode(saved)
+
+
+PINNED_INDEXER = (
+    """# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from dataclasses import dataclass
+
+import torch
+
+from vllm.config import VllmConfig
+
+
+class Logger:
+    def info(self, *args):
+        return None
+
+
+logger = Logger()
+
+def split():
+    while True:
+"""
+    + P.ANCHOR_SPLITTER
+    + "\n"
+    + P.ANCHOR_HELPERS
+    + """
+
+class Builder:
+    def build(self):
+        for metadata in (None,):
+            if metadata is not None:
+"""
+    + P.ANCHOR_CHUNK_ASSERT
+)
+
+PINNED_GLM = (
+    """class Indexer:
+    def __init__(self, vllm_config):
+        self.index_kpool = 4
+"""
+    + P.ANCHOR_GLM_IMPORT.replace("        ", "        ", 1)
+)
+
+PINNED_KPOOL = """from __future__ import annotations
+
+
+class Buffer:
+    def __init__(self, size):
+        self.size = size
+
+    def __getitem__(self, item):
+        return range(min(item.stop, self.size))
+
+
+def gather(prefill_metadata, short_prefill, total_seq_lens, index_kpool):
+    k_quant_full = Buffer(total_seq_lens)
+    k_scale_full = Buffer(total_seq_lens)
+    if True:
+        for chunk in prefill_metadata.chunks if not short_prefill else ():
+            k_quant = k_quant_full[: chunk.total_seq_lens]
+            k_scale = k_scale_full[: chunk.total_seq_lens]
+        return len(k_quant), len(k_scale)
+"""
+
+
+def run_patch(
+    indexer: Path,
+    glm: Path,
+    kpool: Path,
+    *args: str,
+) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["GLM53_INDEXER_BACKEND_PY"] = str(indexer)
+    env["GLM53_GLM5NEXT_ATTENTION_PY"] = str(glm)
+    env["GLM53_INDEXER_KPOOL_PY"] = str(kpool)
+    return subprocess.run(
+        [sys.executable, str(PATCH), *args],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def write_fixture(tmp: Path) -> tuple[Path, Path, Path]:
+    indexer = tmp / "indexer.py"
+    glm = tmp / "attention.py"
+    kpool = tmp / "sparse_attn_indexer_kpool.py"
+    indexer.write_text(PINNED_INDEXER)
+    glm.write_text(PINNED_GLM)
+    kpool.write_text(PINNED_KPOOL)
+    return indexer, glm, kpool
+
+
+def test_apply_preflight_idempotence_and_glm_scope() -> None:
+    with tempfile.TemporaryDirectory() as raw:
+        indexer, glm, kpool = write_fixture(Path(raw))
+        before_indexer = indexer.read_text()
+        before_glm = glm.read_text()
+        before_kpool = kpool.read_text()
+
+        preflight = run_patch(indexer, glm, kpool, "--preflight")
+        assert preflight.returncode == 0, preflight.stderr
+        assert indexer.read_text() == before_indexer
+        assert glm.read_text() == before_glm
+        assert kpool.read_text() == before_kpool
+
+        first = run_patch(indexer, glm, kpool)
+        assert first.returncode == 0, first.stderr
+        patched_indexer = indexer.read_text()
+        patched_glm = glm.read_text()
+        patched_kpool = kpool.read_text()
+        assert P._verified(patched_indexer, P.INDEXER_SITES)
+        assert P._verified(
+            patched_glm,
+            ((
+                "GLM call site",
+                P.MARK_GLM_IMPORT,
+                P.ANCHOR_GLM_IMPORT,
+                P.PATCHED_GLM_IMPORT,
+            ),),
+        )
+        assert P._verified(
+            patched_kpool,
+            ((
+                "actual allocation guard",
+                P.MARK_KPOOL_CAP,
+                P.ANCHOR_KPOOL_CAP,
+                P.PATCHED_KPOOL_CAP,
+            ),),
+        )
+        # The generic helper remains stock. Only the GLM call site opts in.
+        assert P.ANCHOR_HELPERS in patched_indexer
+        assert "_glm53_glm5next_workspace_entries(" in patched_glm
+        assert "role=target rank=%d mode=rightsize" in patched_indexer
+        assert "deepseek_v4" not in patched_glm
+
+        second = run_patch(indexer, glm, kpool)
+        assert second.returncode == 0, second.stderr
+        assert "already present" in second.stdout
+        assert indexer.read_text() == patched_indexer
+        assert glm.read_text() == patched_glm
+        assert kpool.read_text() == patched_kpool
+
+
+def test_runtime_operator_uses_actual_glm_allocation_bound() -> None:
+    with tempfile.TemporaryDirectory() as raw:
+        indexer, glm, kpool = write_fixture(Path(raw))
+        result = run_patch(indexer, glm, kpool)
+        assert result.returncode == 0, result.stderr
+        namespace: dict = {}
+        exec(compile(kpool.read_text(), str(kpool), "exec"), namespace)
+        gather = namespace["gather"]
+
+        saved = os.environ.get(P.ENV_NAME)
+        try:
+            set_mode("rightsize")
+            rightsize = P.glm5next_workspace_entries(cfg(), LIVE_KPOOL)
+            stock = LIVE_MAX_MODEL_LEN * P.STOCK_MULTIPLIER
+            assert gather(
+                Ns(chunks=[Ns(total_seq_lens=rightsize)]),
+                False,
+                rightsize,
+                LIVE_KPOOL,
+            ) == (rightsize, rightsize)
+            try:
+                gather(
+                    Ns(chunks=[Ns(total_seq_lens=rightsize + 1)]),
+                    False,
+                    rightsize,
+                    LIVE_KPOOL,
+                )
+            except ValueError as exc:
+                assert "gather chunk exceeds allocated workspace" in str(exc)
+            else:
+                raise AssertionError("rightsize + 1 must fail before gather slicing")
+
+            # The same chunk remains legal under the stock GLM allocation.
+            assert gather(
+                Ns(chunks=[Ns(total_seq_lens=rightsize + 1)]),
+                False,
+                stock,
+                LIVE_KPOOL,
+            ) == (rightsize + 1, rightsize + 1)
+
+            # Non-kpool callers retain the pinned source behavior.
+            assert gather(
+                Ns(chunks=[Ns(total_seq_lens=9)]),
+                False,
+                8,
+                1,
+            ) == (8, 8)
+        finally:
+            set_mode(saved)
+
+
+def test_each_anchor_drift_fails_without_writing_any_file() -> None:
+    drifts = (
+        ("indexer", "return max_model_len * 40", "return max_model_len * 48"),
+        ("indexer", "if end == start:", "if end <= start:"),
+        ("indexer", "chunks.append(metadata)", "chunks += [metadata]"),
+        (
+            "glm",
+            "self.max_total_seq_len = get_max_prefill_buffer_size(vllm_config)",
+            "self.max_total_seq_len = 1",
+        ),
+        (
+            "kpool",
+            "k_quant = k_quant_full[: chunk.total_seq_lens]",
+            "k_quant = k_quant_full",
+        ),
+    )
+    for label, old, new in drifts:
+        with tempfile.TemporaryDirectory() as raw:
+            indexer, glm, kpool = write_fixture(Path(raw))
+            targets = {"indexer": indexer, "glm": glm, "kpool": kpool}
+            target = targets[label]
+            changed = target.read_text().replace(old, new, 1)
+            assert changed != target.read_text()
+            target.write_text(changed)
+            before_indexer = indexer.read_text()
+            before_glm = glm.read_text()
+            before_kpool = kpool.read_text()
+            result = run_patch(indexer, glm, kpool)
+            assert result.returncode != 0, (old, result.stdout, result.stderr)
+            assert "preflight failed" in result.stderr
+            assert indexer.read_text() == before_indexer
+            assert glm.read_text() == before_glm
+            assert kpool.read_text() == before_kpool
+
+
+def test_pinned_container_sources_apply() -> None:
+    indexer_src = Path(
+        os.environ.get(
+            "GLM53_INDEXER_BACKEND_PY_SRC",
+            PINNED_FIXTURE_ROOT / "indexer.py",
+        )
+    )
+    glm_src = Path(
+        os.environ.get(
+            "GLM53_GLM5NEXT_ATTENTION_PY_SRC",
+            PINNED_FIXTURE_ROOT / "glm-attention.py",
+        )
+    )
+    kpool_src = Path(
+        os.environ.get(
+            "GLM53_INDEXER_KPOOL_PY_SRC",
+            PINNED_FIXTURE_ROOT / "sparse-attn-indexer-kpool.py",
+        )
+    )
+    with tempfile.TemporaryDirectory() as raw:
+        tmp = Path(raw)
+        indexer = tmp / "indexer.py"
+        glm = tmp / "attention.py"
+        kpool = tmp / "sparse_attn_indexer_kpool.py"
+        indexer.write_text(indexer_src.read_text())
+        glm.write_text(glm_src.read_text())
+        kpool.write_text(kpool_src.read_text())
+        result = run_patch(indexer, glm, kpool)
+        assert result.returncode == 0, result.stderr
+        compile(indexer.read_text(), str(indexer), "exec")
+        compile(glm.read_text(), str(glm), "exec")
+        compile(kpool.read_text(), str(kpool), "exec")
+
+
+def test_recipe_wiring() -> None:
+    start = (ROOT / "start.sh").read_text()
+    env_example = (ROOT / "env.example").read_text()
+    assert '_glm53_cli_indexer_workspace_set="${GLM53_INDEXER_WORKSPACE+a}"' in start
+    assert 'GLM53_INDEXER_WORKSPACE="${GLM53_INDEXER_WORKSPACE-stock}"' in start
+    assert "GLM53_INDEXER_WORKSPACE must be exactly one of: stock rightsize" in start
+    assert start.count("python3 /opt/glm53/patch_indexer_workspace.py") == 2
+    assert start.count(
+        "-v \"$INDEXER_WORKSPACE_PATCH_HOST:"
+        "/opt/glm53/patch_indexer_workspace.py:ro\""
+    ) == 1
+    assert "GLM53_INDEXER_WORKSPACE=stock" in env_example
+
+
+def main() -> int:
+    tests = [value for name, value in sorted(globals().items()) if name.startswith("test_")]
+    for test in tests:
+        test()
+    print(f"indexer workspace tests: PASS ({len(tests)})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_w28_correctness.py
+++ b/tests/test_w28_correctness.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""CPU-only tests for the W28 correctness backport overlay."""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parent
+PINNED_FIXTURE_ROOT = HERE / "fixtures" / "w28-pinned-preview"
+PATCH = next(
+    path
+    for path in (
+        HERE / "patch_w28_correctness.py",
+        ROOT / "overlay" / "patch_w28_correctness.py",
+    )
+    if path.is_file()
+)
+sys.path.insert(0, str(PATCH.parent))
+import patch_w28_correctness as P  # noqa: E402
+
+
+FIXTURES = {
+    "interface": (
+        """class ModelState:
+"""
+        + P.INTERFACE_ANCHOR
+        + "        return None\n"
+    ),
+    "runner": (
+        """class Runner:
+    def initialize_kv_cache(self):
+"""
+        + P.RUNNER_ANCHOR
+        + "            0, None\n        )\n"
+    ),
+    "mamba": (
+        """class MambaHybridModelState:
+"""
+        + P.MAMBA_BIND_ANCHOR
+        + P.MAMBA_SEED_ANCHOR
+        + """
+    def preprocess_state(self, kv_cache_config, block_tables):
+"""
+        + P.MAMBA_CALLS_ANCHOR
+        + "        return ctx\n"
+    ),
+    "sm120": (
+        """class FlashInferMLASparseSM120Impl:
+"""
+        + P.SM120_ANCHOR
+        + "        self,\n    ):\n        pass\n"
+    ),
+}
+
+
+def write_tree(root: Path) -> dict[str, Path]:
+    paths = {
+        "interface": root / "v1/worker/gpu/model_states/interface.py",
+        "runner": root / "v1/worker/gpu/model_runner.py",
+        "mamba": root / "v1/worker/gpu/model_states/mamba_hybrid.py",
+        "sm120": (
+            root
+            / "v1/attention/backends/mla/flashinfer_mla_sparse_sm120.py"
+        ),
+    }
+    for label, path in paths.items():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(FIXTURES[label])
+    return paths
+
+
+def run_patch(
+    root: Path,
+    *args: str,
+) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["GLM53_VLLM_SITE"] = str(root)
+    return subprocess.run(
+        [sys.executable, str(PATCH), *args],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def test_apply_preflight_and_idempotence() -> None:
+    with tempfile.TemporaryDirectory() as raw:
+        root = Path(raw)
+        paths = write_tree(root)
+        before = {label: path.read_text() for label, path in paths.items()}
+
+        preflight = run_patch(root, "--preflight")
+        assert preflight.returncode == 0, preflight.stderr
+        assert {label: path.read_text() for label, path in paths.items()} == before
+
+        first = run_patch(root)
+        assert first.returncode == 0, first.stderr
+        after = {label: path.read_text() for label, path in paths.items()}
+        for label, path in paths.items():
+            assert P.verified_state(after[label], P.SITES[label])
+            compile(after[label], str(path), "exec")
+
+        mamba = after["mamba"]
+        assert "// mamba_spec.block_size" in mamba
+        assert "// self.cache_config.block_size" not in mamba
+        assert '"KV cache config not bound"' in mamba
+        assert "all mamba groups must share cache scheduling parameters" in mamba
+
+        sm120 = after["sm120"]
+        assert "supports_dense_mha_prefill = False" in sm120
+        assert "masked_mha_available = False" in sm120
+
+        second = run_patch(root)
+        assert second.returncode == 0, second.stderr
+        assert "already present" in second.stdout
+        assert {label: path.read_text() for label, path in paths.items()} == after
+
+
+def test_mamba_divisor_regression_arithmetic() -> None:
+    """The resumed request must select Mamba column 121, not scheduler 6709."""
+    num_computed_tokens = 107_360
+    scheduler_block_size = 16
+    mamba_block_size = 880
+    assert (num_computed_tokens - 1) // mamba_block_size == 121
+    assert (num_computed_tokens - 1) // scheduler_block_size == 6709
+
+
+def test_each_anchor_drift_fails_before_any_write() -> None:
+    for label, sites in P.SITES.items():
+        for name, _mark, anchor, _patched in sites:
+            with tempfile.TemporaryDirectory() as raw:
+                root = Path(raw)
+                paths = write_tree(root)
+                target = paths[label]
+                drifted_anchor = anchor.replace("\n", "\n# drift\n", 1)
+                drifted = target.read_text().replace(anchor, drifted_anchor, 1)
+                target.write_text(drifted)
+                before = {
+                    item_label: path.read_text()
+                    for item_label, path in paths.items()
+                }
+                result = run_patch(root)
+                assert result.returncode != 0, (
+                    label,
+                    name,
+                    result.stdout,
+                    result.stderr,
+                )
+                assert "preflight failed" in result.stderr
+                assert {
+                    item_label: path.read_text()
+                    for item_label, path in paths.items()
+                } == before
+
+
+def test_pinned_container_sources_apply() -> None:
+    source_root_path = Path(
+        os.environ.get("GLM53_W28_PINNED_SOURCE_ROOT", PINNED_FIXTURE_ROOT)
+    )
+    source_names = {
+        "interface": "model-state-interface.py",
+        "runner": "gpu-model-runner.py",
+        "mamba": "mamba-hybrid.py",
+        "sm120": "sm120-mla.py",
+    }
+    with tempfile.TemporaryDirectory() as raw:
+        root = Path(raw)
+        paths = write_tree(root)
+        for label, name in source_names.items():
+            paths[label].write_text((source_root_path / name).read_text())
+        result = run_patch(root)
+        assert result.returncode == 0, result.stderr
+        for path in paths.values():
+            compile(path.read_text(), str(path), "exec")
+
+
+def test_recipe_wiring() -> None:
+    start = (ROOT / "start.sh").read_text()
+    assert start.count("python3 /opt/glm53/patch_w28_correctness.py") == 2
+    assert start.count(
+        "-v \"$W28_CORRECTNESS_PATCH_HOST:"
+        "/opt/glm53/patch_w28_correctness.py:ro\""
+    ) == 1
+
+
+def main() -> int:
+    tests = [
+        value
+        for name, value in sorted(globals().items())
+        if name.startswith("test_")
+    ]
+    for test in tests:
+        test()
+    print(f"W28 correctness tests: PASS ({len(tests)})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Add a stock-versus-rightsize switch for the GLM-5.3 sparse-indexer prefill workspace.
- Keep the generic vLLM workspace helper unchanged and scope right-sizing to the GLM call site.
- Add fail-closed row, metadata, and actual-allocation guards before gather-buffer slicing and GPU gather.
- Backport `vllm-project/vllm#53798` for resumed align-mode Mamba state indexing.
- Backport `vllm-project/vllm#54057` for SM120 sparse-MLA capability handling.
- Wire both overlays symmetrically to both TP ranks and document the guarded A/B protocol.

## Safety

- `GLM53_INDEXER_WORKSPACE=stock` remains the default and control.
- The KV pool remains pinned at `15,414,698,763` bytes. This change does not raise it.
- The rightsize prediction is `1,000,008` entries versus `40,000,000` stock entries.
- Any source-anchor drift, non-narrowing configuration, oversized compressed row, or chunk exceeding the actual operator allocation fails closed.
- Checked-in snapshots exercise the deployed preview anchors by default.

## Validation

- `84 passed, 1 skipped`
- Indexer overlay tests: `11 passed`
- Correctness overlay tests: `5 passed`
- Full authoritative-source overlay application at vLLM `933876c388`: passed
- Python compile checks, `bash -n`, ShellCheck, secret scan, and `git diff --check`: passed
- Independent CUDA/GPU-path and final reviews: approved

## Deployment

This PR prepares the candidate only. The guarded cluster A/B runs stock first, then rightsize with no other decision variable changed. A post-A/B CUDA/GPU-path review is required before adopt or revert.
