### PR TITLE
Fix snapshot validation and benchmark harnesses

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,23 @@ gain as a matching tok/s jump. The 500k/111× replay row is from the
 suite runs with `pip install -r requirements-dev.txt && pytest tests/ -q`.
 
 ## The serving image: preview vLLM, pinned and completed
+`download.sh` validates the selected snapshot's
+`model.safetensors.index.json` and every referenced safetensors payload. Valid
+Hub blob symlinks count as files; dangling links, missing/unindexed shards,
+truncated payloads, and a wrong explicit revision fail closed. An explicit
+`MODEL_REVISION` always wins over `refs/main`.
+
+For concurrency work, `tests/bench_concurrency.py` runs simultaneous streaming
+lanes and records usage-token goodput, per-stream decode, TTFT/ITL percentiles,
+cache hits, preemptions, and unique request IDs for log audit. It refuses a busy
+server unless `--force` is explicit and honors `VLLM_API_KEY`:
+
+```bash
+GLM53_BASE=http://127.0.0.1:8000 uv run python tests/bench_concurrency.py \
+  --levels 1,2,3,4 --modes code,data,chat --ctx 0,60000 --reps 3 \
+  --out local/concurrency-baseline-$(date +%F).json
+```
+
 
 The base is `vllm/vllm-openai:glm53-flash-arm64-cu130` — the **day-0 GLM-5.3 preview
 image**, carrying a *pre-release* vLLM dev build (`0.1.dev20051+g487ecf187`) cut from

--- a/docs/06-improvement-plan.md
+++ b/docs/06-improvement-plan.md
@@ -20,12 +20,76 @@ fusions, and all of EXL3 — zero EXL3 code exists in vLLM mainline). Consequenc
   container start, or as a rebuilt upstream image.
 - Upstream "merged" ≠ "in this build" — date every candidate against `b908a21f9a`.
 
-## Current queue (updated through W28 adoption, 2026-09-04)
+## Current queue (research refresh, 2026-09-05)
 
 The S1/S2 kernel program is closed. Production is `glm53-selfbuild:b5ab8091-s2b`
-(fat GEMM pipelined, ticket scheduler live). Further fat-kernel ISA is below the
-Amdahl noise floor: isolated **+41%** landed as **+0.3%** end-to-end prefill
-because the fat path is only ~25–30% of a prefill step.
+(fat GEMM pipelined, ticket scheduler live). The initial contended **+0.3%**
+end-to-end result is superseded by PR #32's powered re-window:
+**+5.3–5.6% cold prefill**. Further kernel work needs a new current-stack
+profile, not extrapolation from the isolated +41% kernel result.
+
+**Current research and proposed windows:**
+[docs/13-upstream-review-20260905.md](13-upstream-review-20260905.md).
+At the survey freeze the owner selected research/plan only; the later R0
+implementation below still made no runtime/config change or performance claim.
+Mainline GLM support (#53906) has merged, so model resolution is no longer the
+mainline blocker described in the historical section above; EXL3 integration
+and overlay compatibility still block a stock-image replacement.
+
+### 2026-09-05: R0 harness foundation implemented
+
+The first priority block from the September 5 survey is implemented without a
+production restart or model/image/config change:
+
+- `scripts/validate_hf_snapshot.py` replaces the filename count with selected-
+  revision validation of `model.safetensors.index.json` and each referenced
+  safetensors header/payload extent. Hub blob symlinks are followed; dangling,
+  missing, unindexed, zero/truncated and wrong-revision snapshots fail closed.
+  `MODEL_REVISION` is threaded into validation, resolution and the worker sync
+  marker, while an unpinned non-default `MODEL` still follows its own
+  `refs/main`.
+- `tests/bench_decode.py` now sends `VLLM_API_KEY` bearer auth to health,
+  metrics and completion requests. NaN detection is token-aware, so words such
+  as `banana` no longer poison `nan`/`any_nan`, while standalone NaN and the
+  known `locklock` marker still fail.
+- `tests/bench_concurrency.py` ports the upstream ladder to this kit's
+  `GLM53_BASE=:8000` tunnel path. It sums labeled metrics, refuses a busy
+  server, warms a reusable system-prefix with a distinct measured suffix,
+  records usage-token goodput/TTFT/ITL/cache hits/preemptions, and emits unique
+  `X-Request-Id` values plus expected/successful request counts for log audit.
+
+Local validation after review repair: **98 passed, 1 skipped**, shellcheck,
+bash syntax and Python
+compileall clean. Exact candidate validator SHA256
+`ba1506011856e9055c7886367304650a0926c3a7a8d7c0f935da1cb170542078`
+ran in read-only containers on both target nodes: each selected
+`1ae6d70430a12d762917786696db06a7b4f9bbae`, validated 120 Hub-symlink
+shards and reported **175,642,157,752 bytes**. No cache files changed.
+Exact launcher SHA256
+`46ba36bd5fa25c2f96611b992ef4667b3a87b261800679a5aa251e1e49017a87`
+also passed `bash -n` and the `--help` path on both nodes with a sanitized
+non-default-model/no-revision fixture; both resolved
+`MODEL_REVISION_EXPLICIT=0` and an empty selected revision, preserving that
+model's `refs/main`.
+
+Live no-restart smokes through `127.0.0.1:8000` also passed: concurrency
+run `02dab5c7f7` completed its one measured request with usage, zero errors and
+zero preemptions; `bench_decode.py` returned HTTP 200 before/during/after with
+`any_nan=false`. Post-smoke service/health stayed active/200, recent head and
+worker logs contained zero CUDA/IMA/Xid/Traceback matches, and MemFree was
+6,441,380 / 6,091,752 kB. These are correctness smokes, not performance
+samples. The full canonical baseline is prepared, not yet a performance claim:
+
+```bash
+GLM53_BASE=http://127.0.0.1:8000 uv run python tests/bench_concurrency.py \
+  --levels 1,2,3,4 --modes code,data,chat --ctx 0,60000 --reps 3 \
+  --out local/concurrency-baseline-20260905.json
+```
+
+For a future C4 tail decision, `--levels 4 --reps 25` yields 100 measured
+requests per mode/context cell before any spread-triggered rerun. C1 still
+needs its dedicated incumbent/newcomer arrival harness; this ladder is the
+concurrency baseline and audit substrate, not a substitute for that workload.
 
 **W44 CLOSED 2026-09-03:** the 2.71 lifetime spec-accept vs bench 6.88 is
 **traffic mix, not a broken drafter.** Same-boot no-store four-arm: structured

--- a/docs/07-rebase-plan.md
+++ b/docs/07-rebase-plan.md
@@ -1,5 +1,14 @@
 # Rebase plan — riding GLM-5.3-Flash into vLLM mainline
 
+> **2026-09-05 update:** #53906 merged on September 3; the source-rebase trigger
+> below has fired. Mainline now resolves GLM-5.3-Flash, but still needs our EXL3
+> integration and qualification of every retained overlay. This is preparation,
+> not approval to rebase production. See [the current survey](13-upstream-review-20260905.md)
+> for #54374, packed-MLA alignment, GDN/null-gap tests and proposed gates.
+> The August hardware claims below are historical and superseded: SM121 lacks
+> tcgen05/TMEM, not all FP4 warp MMA; verify native sm_121a code generation rather
+> than assuming architecture-specific sm_120a binaries are portable.
+
 > **Status (2026-08-30): the first stage of this plan was executed.** The day-0
 > base was field-tested on the pair (`09-rebase-draft-test.md`) and production now
 > runs an image this repo builds from it (`10-selfbuild-production.md`). What

--- a/docs/13-upstream-review-20260905.md
+++ b/docs/13-upstream-review-20260905.md
@@ -1,0 +1,333 @@
+# 13 — Upstream review and next A/B windows, 2026-09-05
+
+**Scope: research and planning only, explicitly selected by the owner.** No
+template, model pin, launcher, kernel, service, or GPU workload was changed.
+No PR, issue reply, or other external post was published. The windows below
+are proposals, not deployment receipts or authorization to run maintenance.
+**Subsequent update:** R0 was implemented later on September 5; its exact-node
+correctness receipts are recorded in `docs/06-improvement-plan.md`. The survey
+evidence and all later performance-window gates remain unchanged.
+
+## 1. Evidence boundary and current baseline
+
+Read the local changelog through PR #34 and the existing TODO in full. Queried
+GitHub's public issue/PR API for recent updates, then inspected relevant bodies,
+patches and local source. Used Exa for upstream research and NVIDIA guidance.
+Search excerpts sometimes had stale PR states; the GitHub API and checked-out
+merge commits take precedence. This is a targeted survey, not an exhaustive
+review of every vLLM PR.
+
+| Repository | Checked revision / status |
+|---|---|
+| This kit | `5e0dcf8`, clean `main` before this documentation change; PRs #33/#34 adopted W28 |
+| vLLM | Local and remote main `e473e9036f979d546830aece9855027049faf0ba`, 2026-09-05 |
+| ExLlamaV3 | Local and remote master `499890c75d20d8e7c9d061f37189ae611a5c9f0b`, v1.4.6; no newer master commit at inspection |
+| Live pair | Both containers use `glm53-selfbuild:b5ab8091-s2b`; head unit active, watchdog active |
+
+Live read-only checks found `rightsize`, 1M context, MNBT 3584, C4 admission,
+k=7, the original Flash drafter revision, the unchanged 15,414,698,763-byte
+KV pin and async-OFF. Both nodes reserve `vm.min_free_kbytes=1048576`;
+the API binds only to `127.0.0.1:8000`. One head metrics sample showed
+running=0, waiting=0, preemptions=0. These samples are **not a concurrency soak**.
+Direct Mac→worker authentication failed; the normal head→worker fabric SSH
+route succeeded. Both mounted templates had SHA256
+`a872eaf2948cdfec4d50e144fc65a1ce013c5e8dcf4e0c9d0234cf9e106cb767`.
+
+Use **same-day controls**, not the old ~893 tok/s prefill or the noisy S2b
+initial +0.3% receipt. PR #32's powered re-window established +5.3–5.6%
+cold prefill for s2b, and PR #34 subsequently measured another +8.1% at 240k
+for W28. Do not add these percentages or call them a new combined benchmark.
+W29r's ~324k acceptance plateau and 300k client compaction still stand.
+W44 already explained lifetime-vs-structured acceptance as traffic mix.
+
+Public metadata and exact small upstream files are retained locally under
+`/Users/reederey/Developer/dgx-spark/for_review/glm53-upstream-20260905T085834Z/`.
+These research artifacts are outside the public kit; no downloaded code ran.
+
+## 2. Template and drafter intake
+
+### Template: port the Flash update, not a raw replacement
+
+The [full-GLM template supplied initially](https://huggingface.co/zai-org/GLM-5.3/blob/main/chat_template.jinja)
+was resolved at `aca966e4e02791568aa6a4ced368624b3d897f42`.
+Its multimedia fallback says the model cannot process media. It must not
+replace this deployment's vision-enabled template.
+
+The corresponding [Flash template](https://huggingface.co/zai-org/GLM-5.3-Flash/blob/690b705278a3a58e538fcb37c2ca8b5f9511213c/chat_template.jinja)
+was resolved at `690b705278a3a58e538fcb37c2ca8b5f9511213c`, SHA256
+`0c4099f3382d6c92700dfb99725025360966fd73032f0ecf32377c0d9e6309c5`.
+Compared directly with `files/chat_template.jinja`, it adds early exits once
+tool-result sorting is impossible, suppresses rendering `None` content, and
+uses Jinja string coercion for tool names. It also lacks our thinking toggle.
+
+**Pick first:** selectively port those changes while retaining
+`thinking`/`enable_thinking`, the unconditional effort prefix (W16), and all
+image/video/audio placeholders. [MiaAI-Lab PR #127](https://github.com/MiaAI-Lab/GLM-5.3-Flash-EXL3-2x-DGX-Sparks/pull/127)
+already proposes this class of port; review/reuse it rather than duplicate
+upstream work.
+
+The expected benefit is CPU rendering latency for tool-heavy conversations,
+especially invalid/duplicate-ID fallback blocks. It does not make all sorting
+linear-time, nor directly accelerate GPU prefill or prose token generation.
+Check `content=None` and malformed-name behavior separately from output-equivalent
+early-exit cases. A changed prompt can change tokenization and APC reuse.
+
+### Drafter: compatible latest revision was already tested and rejected
+
+The owner-confirmed repository is
+[incoai/GLM-5.3-Flash-DFlash2](https://huggingface.co/incoai/GLM-5.3-Flash-DFlash2).
+The initial `inca_ai` URL returned HTTP 401; that is not evidence of a usable
+checkpoint. Direct Hub metadata, not cached search results, resolved:
+
+| Artifact | Incumbent | Candidate |
+|---|---|---|
+| Revision | `7d74cdd881ed7e32c31175984a67823127b66cfe` | `bf582e4eacc1810f76656d1811693ff6c6737d2a` |
+| Model file bytes | 2,342,169,800 | 2,342,169,800 |
+| Weight SHA256, Hub LFS metadata | `8931dc522be0aa31760a7463f8d2f8044fa3e6d40be2e87aa08e9fd17bfd6683` | `b038e1d9d1e7833fa3880c2c0135ba9b673013f03da1b29fb831931584759dac` |
+| `config.json` | Byte-identical | SHA256 `c4aeac0101196a6e26705b34c45230bcd0c7c68ee2d2d1efdb242087f3712573` |
+
+Both configurations specify BF16, hidden size 4096, five draft layers, 45 target
+layers, taps `[5,14,24,33,42]`, block size 8 and a 2048 sliding window.
+Both snapshots already exist on spark1 with the expected model-file sizes.
+**Existence/size is not a local SHA256 verification**, and candidate parity
+on spark2 remains to be established. No multi-GB file was downloaded here.
+The latest card explicitly withdraws the old benchmark table pending remeasurement;
+do not reuse the old GB300 speedups as evidence for these new weights.
+
+The separately supplied [full-GLM drafter](https://huggingface.co/incoai/GLM-5.3-DFlash2),
+revision `425aa615ce320caac34400208b30808c8f14f76c`, is **not compatible**:
+hidden size 6144, 78 target layers, six draft layers and taps
+`[5,19,33,47,61,75]`; its weights are 4,918,859,112 bytes.
+Matching vocabulary or the DFlash2 name does not fix that mismatch.
+
+**W19 already tested these exact newer weights on August 31.** The existing
+docs/06 W19 ledger records incumbent `7d74cdd` prose **28.3–30.0 tok/s** versus
+`bf582e4` **28.1–28.8**, with structured acceptance 1.0000/7.0 on both:
+**rejected as a wash; original pin retained**. `dc77ff1` was also rejected,
+with a ~26.6 tok/s prose median. The cached candidate is not fresh intake.
+
+**Keep the current pin.** D1 is only a conditional post-W28 re-window, below
+template/concurrency work: reopen if current profiling identifies changed
+draft/verify or memory costs, or a predeclared representative agentic workload
+exposes a limitation of W19's workload coverage. The s2b/rightsize changes alone
+do not prove draft acceptance will improve. Record the reopening reason before
+booking a window; otherwise skip D1.
+
+If reopened, keep k, draft TP and target weights fixed. Different draft weights
+may change acceptance without changing the target distribution under a correct
+rejection sampler; identical acceptance is not the correctness gate for this
+arm. Verify target-output behavior instead.
+
+Both drafter cards specify **CC BY-NC-ND 4.0**, with commercial licensing via
+the publisher. Confirm permitted use before adoption or distributing modified/
+quantized drafts. A model's advertised speculative correctness does not grant
+permission to redistribute a derived checkpoint.
+
+## 3. Your open issues and the weight audit
+
+### Issue #29: reproducible download-validation defect, P0 for reproducibility
+
+[Issue #29](https://github.com/Reederey87/glm53-flash-exl3-2x-dgx-spark/issues/29)
+reports a completed download followed by `0 / 120 shards`.
+`start.sh:count_shards` uses `find ... -type f` without following snapshot
+symlinks. An isolated fixture containing a valid Hub-style safetensors symlink
+returned **0**, while resolving that symlink confirmed a regular file.
+This proves a local defect matching the symptom; the reporter's exact filesystem
+has not been inspected, so it is not a complete incident RCA.
+
+Proposed fix: validate the **selected revision's index and referenced files**,
+support regular files and valid Hub blob symlinks, reject dangling links,
+zero/truncated files and missing shards, and test a stale `refs/main` against an
+explicit pin. `count_shards` currently chooses `refs/main`/newest snapshot,
+not `MODEL_REVISION`. Counting 120 arbitrary filenames is insufficient.
+Do not suggest deleting or re-downloading the 164 GiB cache as the first remedy.
+At the research freeze no code was changed and no issue reply was posted.
+
+### Issue #28: independent evidence, not a reason to erase W20
+
+[Issue #28](https://github.com/Reederey87/glm53-flash-exl3-2x-dgx-spark/issues/28)
+confirms W18/W25/W41/LPTT and reports ~7.5% structured benefit for draft TP=2.
+Its geometry is 300k context/C3 on an older image. Our W20 already tested
+C1 **and C4**, with no meaningful gain, and reverted TP=2.
+Keep that rejection. Re-open only as a new **post-W28/current-checkpoint**
+experiment after measuring C4 bottlenecks, not as an untested easy win.
+
+### BF16 byte audit: the dense-quantization premise is real
+
+A standard-library CPU audit read only safetensors headers from all 120
+incumbent target shards and the original drafter. No tensors were loaded:
+
+| On-disk category | Payload bytes | Dtype |
+|---|---:|---|
+| Routed-expert trellis | 155,826,782,208 | I16 packed representation, not 16-bit weights |
+| Routed-expert scales / metadata | 456,672,384 | F16 + I32 |
+| Shared-expert tensors | 2,164,269,056 | BF16 |
+| `lm_head.weight` | 1,268,776,960 | BF16 |
+| Embedding-named tensors | 1,271,187,456 | BF16 |
+| Other dense/attention/norm/vision | 14,634,109,440 | BF16 |
+| Other auxiliary | 1,182,072 | F32 |
+| Original drafter tensors | 2,342,160,896 | BF16 |
+
+Target payload total: **175,622,979,576 bytes**. The ~164 GiB checkpoint does
+**not** imply every dense tensor is ~4 bpw. The old TODO's proposed inference
+from aggregate model size was invalid.
+
+This is a name-bucketed disk audit, **not runtime bytes per generated token**.
+Vision, embeddings, unused tensors, TP slicing/replication and routed-expert
+reuse differ. Next split the broad bucket by live module and profile traffic.
+[Kit issue #124](https://github.com/MiaAI-Lab/GLM-5.3-Flash-EXL3-2x-DGX-Sparks/issues/124)'s
+claimed +22–26% from dense K6/K5 + draft 5bpw + head K6 is a credible candidate,
+not a transferable receipt. Test drafter-only quantization separately from
+target dense/head quantization. The latter changes target numerics and needs
+an owner-approved quality contract, not the existing bit-exact contract.
+
+## 4. Upstream decisions
+
+| Candidate and verified state | Applicability and decision |
+|---|---|
+| vLLM [#53906](https://github.com/vllm-project/vllm/pull/53906), merged Sep 3; [#55119](https://github.com/vllm-project/vllm/pull/55119), merged Sep 5 | Mainline GLM support now exists: the docs/07 source-rebase trigger **has fired**. Prepare a separate pinned-image compatibility matrix. EXL3 remains external. EPLB needs EP-compatible packed-expert loading, redistribution and redundant-weight memory; no benefit from merely setting EPLB on our current TP-only EXL3 path. |
+| vLLM [#54374](https://github.com/vllm-project/vllm/pull/54374), merged Sep 4 | Important **MRV2 rebase prerequisite**, not a direct patch to the live legacy `v1/spec_decode/dflash.py` proposer. It disables inappropriate FA AOT schedules for windowed draft groups. FA AOT is version-gated; prove actual builder/version/engagement before diagnosing this stack. Upstream “acceptance length 1” means collapsed speculation, not our accepted fraction 1.0. |
+| vLLM [#55178](https://github.com/vllm-project/vllm/pull/55178), merged Sep 4 | Padded one-token prompt-tail state corruption deserves a mixed-hit regression. But its patch is in `BaseMambaAttentionMetadataBuilder`; live GLM KDA uses `GatedDeltaNetAttention` and a separate `GDNAttentionMetadataBuilder` already classifying speculative rows by draft-count tags. **Do not blindly port** an unused Mamba fix. Trace the actual GDN path first. |
+| vLLM [#55450](https://github.com/vllm-project/vllm/pull/55450), open, head `8fd4dad11257` | Null-gap Mamba-state retirement: **high-value CPU reproducer/soak candidate** for capacity and concurrency. The fork's retirement code differs and includes per-step state tracking; establish a leak on exact fork bytes before patching. Include W25 retention and CoW ownership in the test. |
+| vLLM [#55449](https://github.com/vllm-project/vllm/pull/55449), open, head `f229587db190` | Mainline packed-MLA alignment fix. Live `MLAAttentionSpec.real_page_size_bytes` already special-cases `fp8_ds_mla` to 656 B/token. **Rebase regression test, not an immediate capacity gain**; it is also not the same fix as kit #108's drafter divisibility loss. |
+| vLLM [#55442](https://github.com/vllm-project/vllm/pull/55442), open | Defers disposable GLM **MTP** lm_head at load. DFlash2 is not native MTP; reject for current runtime, retain for an MTP fallback evaluation. Combined predecessor #55435 closed unmerged and was split; do not treat it as a shipped optimization. |
+| vLLM [#54394](https://github.com/vllm-project/vllm/pull/54394), open | TP row-sharded DSA prefill indexer: promising concept, **not drop-in**. Patch touches generic `sparse_attn_indexer.py`; live GLM uses `SparseAttnIndexerKpool`. It requires ≥1024 rows/rank, so solo LPTT=1792 at TP2 misses the gate. Do not raise LPTT merely to enable it, given the rejected HoL window. Profile and prove a reachable shape before any port. |
+| vLLM [#52228](https://github.com/vllm-project/vllm/pull/52228) / [#52559](https://github.com/vllm-project/vllm/pull/52559), experimental open PRs | Best strategic speculation lane: adapt **verification** work to acceptance and graph cost. Requires MRV2/backend compatibility; published H200/GB200 results are not GB10 promises. Keep the DFlash2 native draft block intact unless its implementation explicitly supports changing it. |
+| vLLM [#55222](https://github.com/vllm-project/vllm/pull/55222), open; #54915 merged | Indexer-workspace work is already addressed locally by W28 at fixed 1M geometry, or targets a different QSA path. Do not queue the same reclaim again. |
+| ExLlamaV3 [#330](https://github.com/turboderp-org/exllamav3/pull/330), open, head `d0094bc922bc` | Native BF16 I/O/grouped-Hadamard for **K5/K6 dense** decode; useful if dense quantization lands. Not the current K4 fused-MoE path, not bit-exact (reported relative RMS ~0.0013). RTX5090 C4 +11.6% is not a Spark receipt. Kernel review required only when actually implementing it. |
+| ExLlamaV3 [#334](https://github.com/turboderp-org/exllamav3/pull/334), open | New native-generator DFlash2 integration explicitly excludes TP targets and dynamic draft truncation. We use ExLlamaV3 as a CUDA library inside vLLM, not its generator. **Not applicable as a serving upgrade**; its BF16 residual and fixed-block checks are useful correctness references. |
+| ExLlamaV3 master fixes / other recent PRs | QSA/autosplit/loader, recurrent-slot and P2P fixes mostly belong to its native runtime; AVX2 CPU kernels and Turing support do not accelerate ARM64/SM121 serving. Ticket scheduler `d5e4361` is already in s2b. Keep remaining autotune fixes as qualified rebuild ride-alongs, not a wholesale master bump. |
+
+Watch, without asserting local reproduction: kit
+[#128](https://github.com/MiaAI-Lab/GLM-5.3-Flash-EXL3-2x-DGX-Sparks/issues/128)
+TP4 EXL3 sort/synchronize stalls, #106 hour-scale APC freeze, #121 long-form
+corruption, #123 thinking-SSE hang; vLLM
+[#55279](https://github.com/vllm-project/vllm/issues/55279) sampling-only cumulative
+IMA on a different SM80/Qwen stack. All strengthen the **mixed-workload soak**
+requirement, not the case for speculative unproven fixes.
+
+## 5. GB10 kernel priorities
+
+NVIDIA's [CUDA tuning recommendations](https://docs.nvidia.com/cuda/blackwell-tuning-guide/index.html)
+emphasize coalescing, avoiding redundant memory traffic, reducing host/device
+transfers and matching launch geometry to utilization.
+[CUTLASS #2947](https://github.com/NVIDIA/cutlass/issues/2947) explicitly distinguishes
+unsupported `tcgen05` from supported FP4 warp MMA. Do not repeat old documentation's
+claim that NVFP4 can *never* compile on GB10. That does not make NVFP4 a replacement
+for the existing packed EXL3 trellis format.
+
+Hard intake gates remain CUDA 13, native `sm_121a` build verification,
+≤101,376 B shared memory per CTA, no tcgen05/TMEM/WGMMA assumptions.
+Do not assume SM120a cubins or SM100 cluster/multicast features transfer to GB10.
+Check actual device properties and generated SASS, not a generic “Blackwell” label.
+[Measured GB10 CUTLASS work](https://forums.developer.nvidia.com/t/sm121-cutlass-kernel-optimization-results-nvfp4-356-tflops-moe-grouped-gemm-on-dgx-spark/359960)
+is evidence for that method, not an EXL3 benchmark.
+
+Order of work:
+
+1. **Profile current s2b/rightsize at the shapes users actually run.** Separate
+   cold prefill, warm follow-up, C1 prose, and C4 mixed decode. Record both-rank
+   critical time, DRAM traffic, cache hit rates, registers/spills, achieved
+   occupancy, launch gaps, synchronization and NCCL time. An inferred
+   `18B × 4bit / 273GB/s` roofline is not proof that each TP rank streams those
+   bytes per emitted token. Acceptance and verify-block cost matter too.
+2. **Prefill:** preserve the adopted ticket scheduler and three-stage cp.async
+   fat GEMM. Profile per-expert launch/index-select/count-staging overhead before
+   grouping launches, reusing transformed inputs or retuning pipeline stages.
+   Do not retry rejected row-tiling/TRF arms without a new mechanism.
+3. **Prose:** preserve W19's checkpoint rejection; prioritize live-byte
+   attribution, then permission/quality-gated draft/target traffic reduction
+   in separate arms. Reopen the checkpoint only on new workload/profile evidence.
+   Consider BF16 I/O fusion only for actual K5/K6 dense callers.
+   Preserve BF16 range through drafter residuals; do not globally cast to FP16.
+4. **Concurrency:** prevent avoidable prefill blocking and cache churn before
+   adding lanes. A larger MAX_NUM_SEQS is neither more physical capacity nor
+   automatically faster service. Do not scale KV pins using advertised pool tokens.
+5. **Trellis/S3 stays conditional:** rank-sliced microbench ≥~80 TFLOP/s versus
+   the measured ~73.5 incumbent, correct K4/MCG packing and rotations, then a
+   separately measured end-to-end gain. Profile outside production, use a working
+   set larger than L2 and changing graph inputs, run sanitizer/oracles, and retain
+   the scatter's synchronization/ownership contract. Isolated TFLOPS alone cannot
+   justify an image cutover.
+
+## 6. Prioritized A/B plan
+
+### Measurement and safety contract for every future window
+
+- Obtain a dedicated maintenance slot. Save exact `.env`, image ID/digest, model
+  and drafter revisions, template/overlay hashes, both-node source parity and
+  rollback files. Audit actual PID-1 arguments; duplicate `.env` assignments mean
+  a grep is not an effective-config parser. Change one independent variable.
+- Stop the watchdog timer and wait for any in-flight watchdog/start job to exit.
+  Use `systemctl --user reset-failed` and the unit's `local/prod-start.sh`, never
+  bare `start.sh restart`. Never overwrite an executing script; stage + atomic
+  rename. Keep existing memory guards and the KV pin; no automatic pin increase.
+- Configuration-shape changes (draft revision/TP/k, admission/graph geometry,
+  image) require the existing both-node shape-cache invalidation procedure.
+  `/reset_prefix_cache` clears APC, **not configuration or JIT state**.
+  Do not erase unrelated caches. Warm until the unit is active and the
+  predeclared stability criterion holds, with a finite retry limit.
+- Predeclare at most four warmup passes, then an A-B-B-A sequence with at least
+  nine measured observations per arm for noisy prose, at least five per arm for
+  60k/240k prefill. Record every observation, including exclusions and their
+  predeclared reason. If variance/traffic prevents a decision, report
+  **INCONCLUSIVE**, not “keep rerunning until it wins.”
+- Use identical saved payloads/token IDs, temperature, top-p, effort, thinking
+  mode, output limits and timing definitions. Prose: multiple fixed essay/
+  explanation/agentic prompts, both temp-0 diagnostic and temp-1 production
+  cells; keep effort fixed per session. Measure first-to-last-token decode,
+  TTFT separately, and end-to-end goodput. Do not compare token counts from
+  different prompts as if they were deterministic parity.
+- Cold rounds: reset APC only on a drained engine; confirm reset success and
+  windowed hit/prompt counters. Warm replay rounds: deliberately retain cache.
+  Log-audit for unrelated requests. Capture engine age and cumulative tokens:
+  the [mixed-state prefill report](https://forums.developer.nvidia.com/t/glm-5-3-flash-on-2x-gb10-speculative-decoding-makes-long-prefill-ttft-alternate-2x-after-a-mixed-workload-plus-3-knobs-that-measurably-helped/382099)
+  warns that APC reset may not reset a degraded engine state.
+- Collect delta acceptance by position, accepted drafts/step, output tokens/step,
+  preemptions, waiting-by-reason, cache hits, per-stream ITL/TTFT and aggregate
+  throughput. These acceptance measures are different quantities. For C4 tails,
+  collect ≥100 requests per cell; small-n “p99” is descriptive only.
+- Every adopted arm passes acceptance 7/7, serving 6/6, toolcall 23/23, vision,
+  thinking-SSE, long-form output and mixed cache-hit correctness. Exact-weight/
+  geometry-preserving optimization arms require the standing parity gates.
+  Draft-change arms compare target greedy output on saved prompts and test
+  stochastic/structured correctness; target-quantization arms require an
+  explicitly approved quality contract.
+- Abort on any CUDA/Xid/IMA, lost forward progress, output corruption,
+  preemption regression, worker failure or either-node MemFree <2.5 GiB.
+  A transient `/health` 200 does not exonerate a stall. Preserve diagnostics.
+  Restore the tested control through the guarded unit, recheck gates and both
+  nodes, then re-arm the watchdog. Off-the-bus/Xid hardware faults may require
+  an owner-operated cold power cycle, not repeated restarts.
+- Before publication: local validation + one final-reviewer pass for the exact
+  candidate, CUDA reviewer additionally for actual device-kernel edits, and
+  exact-byte cluster receipts. No publication without per-post owner approval;
+  if cluster testing is unsafe/unavailable, obtain a waiver rather than bypass it.
+
+### Windows, in execution order
+
+| Window | Control → candidate | Required observations / decision |
+|---|---|---|
+| **R0: issue #29 + harness foundation** | Current helper/bench behavior → focused fixes | **IMPLEMENTED locally 2026-09-05.** CPU fixtures cover linked/regular/dangling/missing/unindexed/zero/truncated/mixed-revision shards; decode auth/NaN checks and the tunnel-aware concurrency harness are present. Publication still requires exact-node validation and final review. |
+| **T1: template** | Current template → selective Flash update | Offline golden rendering for 1/10/100/500 tool results, shuffled valid IDs, duplicates, missing/unknown IDs, list outputs, null content, tool references, reasoning and media. Same bytes for unaffected valid cases; explicit expected outputs for intentional fixes. ≥15% render-latency improvement on fallback stress cases, no >5% ordinary-render regression; correctness-only adoption can be considered if performance is immaterial. Then template-only guarded restart, toolcall/vision/SSE/APC tests. No automatic JIT wipe for template-only change. |
+| **C1: actual mixed-prefill policy** | W26 v3 `CHUNK=skip` → `512`, then `2048` | Preserve LPTT=1792, wait=1500 ms, warm tail=3584, late cap=512, escalation=10000 ms/max=1792. Test 9.5k/38k newcomers 2 s into a fixed decode, C4 simultaneous arrival, and short request behind 240k. `2048` is **not unlimited** at MNBT=3584 and may be capped by LPTT; require engagement logs. Target ≥20% newcomer p95 improvement with incumbent decode ≥−5%, ITL p99 ≤+10%, aggregate ≥−5%; otherwise retain v3. Scheduler-policy changes require restart even when hash-neutral. |
+| **C2: admission / state retention** | C4 → C3 only after capacity evidence | Measure fixed/marginal block cost at 2k/9k/30k/70k, with W41 geometry and preemption counters; do not transfer the other kit's “90k tokens/request.” Test 4×60k×3 plus unequal-length shared-prefix forks. Zero preemptions, aggregate ≥−5%, ≥20% tail improvement to justify reduction. Reproduce #55450 on exact fork CPU fixtures first; if positive, isolate that repair before the admission comparison. |
+| **D1: conditional post-W28 checkpoint re-window** | W19 incumbent `7d74cdd` → previously rejected `bf582e4`, k=7/TP1 unchanged | **Skip unless new profiling/workload evidence justifies reopening W19; record that reason first.** Verify hashes/config/tensor dimensions on both nodes before boot. Checkpoint-only restart and shape-cache handling. Prose/agentic gain ≥5% with paired evidence, structured throughput ≥−3%, prefill ≥−3%, no worse preemptions/tail latency (>5%). No win means keep `7d74cdd`, as W19 already decided. |
+| **D2: verification-length study** | k=7 → verified-supported k=4/3 path | First prove draft block/mask/selector/cache correctness and graph coverage; the fixed eight-row draft is not automatically safe to truncate. If the legacy path lacks support, PARK for MRV2 adaptive verification. A supported static k arm needs restart + both-node shape-cache handling. Compare prose gain ≥5%, target-output correctness and structured speed ≥−3%; acceptance positions only over the chosen k, not impossible “7/7” at k=3. No per-request k routing is assumed to exist. |
+| **D3: draft TP re-window, conditional** | TP1 → TP2 at the same chosen revision and k | Re-open W20 only after post-W28 profiling or checkpoint change gives a new reason. Same 1M/C4 geometry, plus C1 control; C4 per-stream ≥15%, C1 ≥−3%, no memory/preemption regression. Record actual allocated bytes and usable blocks, not a promised identical token count. |
+| **Q1: selective quantization, permission-gated** | Current chosen draft → draft-only quant; later target dense/head quant separately | Finish live-module byte attribution and permissions first. Draft-only: preserve target-output/distribution tests and require ≥5% prose gain. Target changes: proposed offline KL ≤0.005, top-1 ≥97%, toolcall 23/23 plus a predeclared task-quality set require owner approval; no silent waiver. Quantization is not a lossless kernel optimization. Keep all original artifacts and original KV pin. |
+| **K1 / rebase: profile-led** | Current exact image → one qualified kernel change, or a separately staged mainline image | K1 requires representative microkernel parity and ≥5% end-to-end prefill gain with prose/concurrency non-inferior. Rebase is its own multi-component qualification, not a one-knob A/B: include #54374, packed-MLA/GDN/null-gap regressions and every retained overlay. No stock-vLLM drop-in assumption. |
+
+Before adopting a concurrency/checkpoint/allocator change, add an hour-long
+mixed agentic soak after the short gates: cached follow-ups of unequal lengths,
+cold bursts, thinking/tool/SSE traffic, long-form output and repeated 24k cold
+probes after mixed shapes. Track global APC-hit progress, pending-token progress,
+preemptions and latency drift. A single short successful benchmark does not
+close #106/#128-style failures.
+
+**First choices:** repair reproducibility/measurement, port the template, then
+measure concurrency policy/capacity and attribute live BF16 traffic. Retain
+W19's original drafter pin; the latest checkpoint is a conditional re-window,
+not the next default optimization. For larger prose gains, selective byte
+reduction has a real artifact basis but higher quality/licensing cost.
+Another generic fat-GEMM rewrite or EPLB flag is not the first move.

--- a/scripts/validate_hf_snapshot.py
+++ b/scripts/validate_hf_snapshot.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Validate one selected Hugging Face safetensors snapshot.
+
+The Hub cache stores snapshot files as symlinks into ``../../blobs``. Counting
+only regular files therefore reports zero for a healthy cache. This validator
+instead reads the selected snapshot's index, follows valid symlinks, and checks
+that every referenced safetensors file contains its complete declared payload.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+
+class SnapshotError(ValueError):
+    """The selected snapshot is absent, inconsistent, or incomplete."""
+
+
+@dataclass(frozen=True)
+class SnapshotReport:
+    revision: str
+    snapshot: str
+    index: str
+    shard_count: int
+    total_bytes: int
+
+
+def _read_ref(repo: Path) -> str:
+    try:
+        return (repo / "refs" / "main").read_text(encoding="utf-8").strip()
+    except OSError:
+        return ""
+
+
+def select_revision(repo: Path, explicit_revision: str = "") -> str:
+    """Select an explicit revision, refs/main, or finally the newest snapshot."""
+    if explicit_revision:
+        return explicit_revision
+    ref = _read_ref(repo)
+    if ref:
+        return ref
+    snapshots = repo / "snapshots"
+    try:
+        candidates = [path for path in snapshots.iterdir() if path.is_dir()]
+    except OSError as exc:
+        raise SnapshotError(f"no snapshots under {repo}: {exc}") from exc
+    if not candidates:
+        raise SnapshotError(f"no snapshots under {repo}")
+    return max(candidates, key=lambda path: path.stat().st_mtime_ns).name
+
+
+def _safe_snapshot_member(snapshot: Path, name: str) -> Path:
+    relative = PurePosixPath(name)
+    if relative.is_absolute() or not relative.parts or ".." in relative.parts:
+        raise SnapshotError(f"unsafe shard path in index: {name!r}")
+    return snapshot.joinpath(*relative.parts)
+
+
+def _validate_safetensors_file(path: Path) -> int:
+    if not path.exists():
+        kind = "dangling symlink" if path.is_symlink() else "missing file"
+        raise SnapshotError(f"{kind}: {path}")
+    if not path.is_file():
+        raise SnapshotError(f"not a regular file: {path}")
+    size = path.stat().st_size
+    if size < 9:
+        raise SnapshotError(f"zero/truncated safetensors file ({size} bytes): {path}")
+    with path.open("rb") as handle:
+        raw_len = handle.read(8)
+        header_len = int.from_bytes(raw_len, "little", signed=False)
+        if header_len <= 0 or header_len > size - 8:
+            raise SnapshotError(
+                f"invalid safetensors header length {header_len} for {size}-byte file: {path}"
+            )
+        raw_header = handle.read(header_len)
+    try:
+        header: Any = json.loads(raw_header)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise SnapshotError(f"invalid safetensors JSON header: {path}: {exc}") from exc
+    if not isinstance(header, dict):
+        raise SnapshotError(f"safetensors header is not an object: {path}")
+
+    max_payload_end = 0
+    tensor_count = 0
+    for name, metadata in header.items():
+        if name == "__metadata__":
+            continue
+        tensor_count += 1
+        if not isinstance(metadata, dict):
+            raise SnapshotError(f"invalid tensor metadata for {name!r}: {path}")
+        offsets = metadata.get("data_offsets")
+        if (
+            not isinstance(offsets, list)
+            or len(offsets) != 2
+            or not all(isinstance(value, int) for value in offsets)
+            or offsets[0] < 0
+            or offsets[1] < offsets[0]
+        ):
+            raise SnapshotError(f"invalid data_offsets for {name!r}: {path}")
+        max_payload_end = max(max_payload_end, offsets[1])
+    if tensor_count == 0:
+        raise SnapshotError(f"safetensors file declares no tensors: {path}")
+    payload_bytes = size - 8 - header_len
+    if max_payload_end > payload_bytes:
+        raise SnapshotError(
+            f"truncated safetensors payload ({payload_bytes} < {max_payload_end} bytes): {path}"
+        )
+    return size
+
+
+def validate_snapshot(
+    repo: Path, explicit_revision: str = "", expected_shards: int | None = None
+) -> SnapshotReport:
+    revision = select_revision(repo, explicit_revision)
+    snapshot = repo / "snapshots" / revision
+    if not snapshot.is_dir():
+        source = "explicit revision" if explicit_revision else "selected revision"
+        raise SnapshotError(f"{source} {revision} is missing under {repo / 'snapshots'}")
+
+    index = snapshot / "model.safetensors.index.json"
+    if not index.is_file():
+        raise SnapshotError(f"safetensors index missing: {index}")
+    try:
+        index_data = json.loads(index.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise SnapshotError(f"invalid safetensors index {index}: {exc}") from exc
+    weight_map = index_data.get("weight_map") if isinstance(index_data, dict) else None
+    if not isinstance(weight_map, dict) or not weight_map:
+        raise SnapshotError(f"safetensors index has no non-empty weight_map: {index}")
+    if not all(isinstance(name, str) and name for name in weight_map.values()):
+        raise SnapshotError(f"safetensors index contains an invalid shard name: {index}")
+
+    shard_names = sorted(set(weight_map.values()))
+    if expected_shards is not None and len(shard_names) != expected_shards:
+        raise SnapshotError(
+            f"index references {len(shard_names)} shards, expected {expected_shards}: {index}"
+        )
+
+    indexed = {PurePosixPath(name).as_posix() for name in shard_names}
+    present = {
+        path.relative_to(snapshot).as_posix()
+        for path in snapshot.rglob("*.safetensors")
+    }
+    unindexed = sorted(present - indexed)
+    if unindexed:
+        sample = ", ".join(unindexed[:3])
+        raise SnapshotError(f"safetensors files missing from index: {sample}")
+
+    total_bytes = 0
+    for name in shard_names:
+        total_bytes += _validate_safetensors_file(_safe_snapshot_member(snapshot, name))
+    return SnapshotReport(
+        revision=revision,
+        snapshot=str(snapshot),
+        index=str(index),
+        shard_count=len(shard_names),
+        total_bytes=total_bytes,
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", type=Path, required=True)
+    parser.add_argument("--revision", default="")
+    parser.add_argument("--expected-shards", type=int)
+    parser.add_argument(
+        "--field",
+        choices=("count", "revision", "snapshot", "json"),
+        default="json",
+    )
+    args = parser.parse_args()
+    try:
+        report = validate_snapshot(args.repo, args.revision, args.expected_shards)
+    except SnapshotError as exc:
+        print(f"snapshot validation failed: {exc}", file=sys.stderr)
+        return 1
+    if args.field == "count":
+        print(report.shard_count)
+    elif args.field == "revision":
+        print(report.revision)
+    elif args.field == "snapshot":
+        print(report.snapshot)
+    else:
+        print(json.dumps(asdict(report), sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/start.sh
+++ b/start.sh
@@ -117,13 +117,25 @@ set +a
 # LOCAL: W41/W42 caller-wins restore (end)
 
 # ----------------------------- configuration -------------------------------
+_glm53_model_revision_set="${MODEL_REVISION+x}"
 MODEL="${MODEL:-Mia-AiLab/GLM-5.3-Flash-EXL3-TR3-4bpw}"
 # If the durable mirror is empty/moved, download.sh falls back to this id.
 MODEL_FALLBACK="${MODEL_FALLBACK:-brandonmusic/GLM-5.3-Flash-tr3-4bpw}"
 MODEL_CACHE_NAME="${MODEL_CACHE_NAME:-models--${MODEL//\//--}}"
 MODEL_FALLBACK_CACHE_NAME="${MODEL_FALLBACK_CACHE_NAME:-models--${MODEL_FALLBACK//\//--}}"
 # Hub commit on the Mia-AiLab mirror (the 5ab363a8-byte-identical upload).
-MODEL_REVISION="${MODEL_REVISION:-25a44fdbf16862a46b7cc9921142c6c81350af2f}"
+# The default belongs only to the default MODEL. A caller/.env MODEL override
+# without MODEL_REVISION intentionally follows that repository's refs/main.
+if [ -n "$_glm53_model_revision_set" ]; then
+    MODEL_REVISION="${MODEL_REVISION:-}"
+    MODEL_REVISION_EXPLICIT=1
+elif [ "$MODEL" = "Mia-AiLab/GLM-5.3-Flash-EXL3-TR3-4bpw" ]; then
+    MODEL_REVISION="25a44fdbf16862a46b7cc9921142c6c81350af2f"
+    MODEL_REVISION_EXPLICIT=0
+else
+    MODEL_REVISION=""
+    MODEL_REVISION_EXPLICIT=0
+fi
 IMAGE="${IMAGE:-ghcr.io/miaai-lab/glm-5.3-flash-2x-dgx-sparks:exl3}"
 SERVED_MODEL_NAME="${SERVED_MODEL_NAME:-GLM-5.3-Flash-EXL3}"
 GHCR_USER="${GHCR_USER:-MiaAI-Lab}"
@@ -340,6 +352,7 @@ HF_CACHE_DIR="${HF_HOME:-$HOME/.cache/huggingface}"
 MODEL_PATH="$HF_CACHE_DIR/hub/$MODEL_CACHE_NAME"
 FALLBACK_MODEL_PATH="$HF_CACHE_DIR/hub/$MODEL_FALLBACK_CACHE_NAME"
 DFLASH_PATH="$HF_CACHE_DIR/hub/$DFLASH_CACHE_NAME"
+MODEL_SELECTED_REVISION="${MODEL_REVISION:-}"
 WORKER_CACHE_DIR="$WORKER_HOME/.cache/huggingface"
 CACHE_ROOT="${CACHE_ROOT:-$HOME/.cache/vllm-glm53-flash}"
 WORKER_VLLM_CACHE="${WORKER_VLLM_CACHE:-$WORKER_HOME/.cache/vllm-glm53-flash}"
@@ -460,16 +473,14 @@ worker_ssh() { ssh -T -o BatchMode=yes -o ConnectTimeout=15 "$WORKER_SSH" "$@"; 
 usage() { sed -n '2,40p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; }
 
 count_shards() {
-    local repo_path="$1" ref
-    ref="$(cat "$repo_path/refs/main" 2>/dev/null || true)"
-    # shellcheck disable=SC2012  # newest-snapshot fallback; snapshot dirnames are hex shas
-    [ -n "$ref" ] || ref="$(ls -1t "$repo_path/snapshots" 2>/dev/null | head -n 1 || true)"
-    if [ -z "$ref" ]; then
+    local repo_path="$1" revision="${2:-}" count
+    if count="$(python3 "$SCRIPT_DIR/scripts/validate_hf_snapshot.py" \
+        --repo "$repo_path" --revision "$revision" \
+        --expected-shards "$EXPECTED_SHARDS" --field count)"; then
+        printf '%s' "$count"
+    else
         printf '0'
-        return
     fi
-    find "$repo_path/snapshots/$ref" -maxdepth 1 -type f -name '*.safetensors' 2>/dev/null \
-        | wc -l | tr -d '[:space:]' || true
 }
 
 ensure_refs_main() {
@@ -485,8 +496,14 @@ ensure_refs_main() {
 
 resolve_model_dir() {
     local ref="$MODEL_PATH/refs/main" hash dir
-    ensure_refs_main
-    hash="$(<"$ref")"
+    if [ -n "${MODEL_SELECTED_REVISION:-}" ]; then
+        hash="$MODEL_SELECTED_REVISION"
+        [ -d "$MODEL_PATH/snapshots/$hash" ] \
+            || die "target pinned snapshot $hash missing under $MODEL_PATH/snapshots — run without SKIP_DOWNLOAD (or REFRESH_WEIGHTS=1)"
+    else
+        ensure_refs_main
+        hash="$(<"$ref")"
+    fi
     dir="$MODEL_PATH/snapshots/$hash"
     [ -f "$dir/config.json" ] || die "config.json missing in $dir — re-run with REFRESH_WEIGHTS=1"
     printf '/root/.cache/huggingface/hub/%s/snapshots/%s' "$MODEL_CACHE_NAME" "$hash"
@@ -811,17 +828,24 @@ ensure_image() {
 # brandonmusic cache folder without a second 164 GiB pull.
 adopt_complete_weights() {
     local have
-    have="$(count_shards "$MODEL_PATH")"
+    have="$(count_shards "$MODEL_PATH" "$MODEL_SELECTED_REVISION")"
     if [ "${have:-0}" -ge "$EXPECTED_SHARDS" ]; then
-        ensure_refs_main
-        log "weights already present: $MODEL_PATH ($have shards)"
+        [ -n "${MODEL_SELECTED_REVISION:-}" ] || ensure_refs_main
+        log "weights already present: $MODEL_PATH ($have validated shards)"
         return 0
+    fi
+    # An explicit MODEL_REVISION is a fail-closed request for that model and
+    # revision. Never turn it into the fallback model's refs/main selection.
+    if [ "${MODEL_REVISION_EXPLICIT:-0}" = "1" ] \
+       && [ -n "${MODEL_SELECTED_REVISION:-}" ]; then
+        return 1
     fi
     have="$(count_shards "$FALLBACK_MODEL_PATH")"
     if [ "${have:-0}" -ge "$EXPECTED_SHARDS" ]; then
-        log "primary cache incomplete — using fallback ${MODEL_FALLBACK} at $FALLBACK_MODEL_PATH ($have shards)"
+        log "primary cache incomplete — using fallback ${MODEL_FALLBACK} at $FALLBACK_MODEL_PATH ($have validated shards)"
         MODEL_PATH="$FALLBACK_MODEL_PATH"
         MODEL_CACHE_NAME="$MODEL_FALLBACK_CACHE_NAME"
+        MODEL_SELECTED_REVISION=""
         ensure_refs_main
         return 0
     fi
@@ -882,6 +906,10 @@ download_weights() {
     if adopt_complete_weights; then
         return
     fi
+    if [ "${MODEL_REVISION_EXPLICIT:-0}" = "1" ] \
+       && [ -n "${MODEL_SELECTED_REVISION:-}" ]; then
+        die "explicit MODEL_REVISION ${MODEL_SELECTED_REVISION} for ${MODEL} is unavailable or incomplete — refusing fallback model ${MODEL_FALLBACK}"
+    fi
 
     if [ "$MODEL_FALLBACK" != "$MODEL" ]; then
         log "falling back to ${MODEL_FALLBACK} ..."
@@ -889,7 +917,7 @@ download_weights() {
             || die "download of ${MODEL} and ${MODEL_FALLBACK} both failed"
     fi
     adopt_complete_weights \
-        || die "download finished with $(count_shards "$MODEL_PATH") / $EXPECTED_SHARDS shards"
+        || die "download finished with $(count_shards "$MODEL_PATH" "$MODEL_SELECTED_REVISION") / $EXPECTED_SHARDS validated shards"
 }
 
 download_dflash() {
@@ -934,7 +962,7 @@ download_only() {
     download_weights
     download_dflash
 
-    have="$(count_shards "$MODEL_PATH")"
+    have="$(count_shards "$MODEL_PATH" "$MODEL_SELECTED_REVISION")"
     log "======================================================================"
     log "head HF cache : ${HF_CACHE_DIR}"
     log "  target      : ${MODEL}  (${have} / ${EXPECTED_SHARDS} shards)"
@@ -950,8 +978,8 @@ download_only() {
 }
 
 # ------------------------------ weight sync --------------------------------
-# Keyed on the snapshot commit (refs/main, with the same repair fallback as
-# ensure_refs_main), not on MODEL_REVISION: the marker lives inside each
+# Keyed on the explicitly selected revision when set, otherwise refs/main with
+# the same repair fallback as ensure_refs_main. The marker lives inside each
 # synced repo folder, so a MODEL / revision switch re-syncs automatically.
 # Without it, every ./start.sh pays a full size+mtime re-verification walk
 # over ~164 GiB / 120 shards on both ends for zero bytes of difference
@@ -993,7 +1021,7 @@ sync_repo_to_worker() {
 sync_weights() {
     [ "${SKIP_SYNC:-0}" = "1" ] && { log "SKIP_SYNC=1 — not syncing to worker"; return; }
     [ -d "$MODEL_PATH" ] || die "weights missing at $MODEL_PATH — run without SKIP_DOWNLOAD first"
-    sync_repo_to_worker "$MODEL_PATH" "$MODEL_CACHE_NAME" "weights"
+    sync_repo_to_worker "$MODEL_PATH" "$MODEL_CACHE_NAME" "weights" "$MODEL_SELECTED_REVISION"
     if [ "$SPEC_METHOD" = "dflash" ]; then
         [ -d "$DFLASH_PATH" ] || die "DFlash2 weights missing at $DFLASH_PATH"
         sync_repo_to_worker "$DFLASH_PATH" "$DFLASH_CACHE_NAME" "DFlash2 draft" "$DFLASH_REVISION"

--- a/tests/bench_concurrency.py
+++ b/tests/bench_concurrency.py
@@ -1,0 +1,563 @@
+#!/usr/bin/env python3
+"""Concurrency and long-context ladder for GLM-5.3-Flash EXL3.
+
+Runs simultaneous streaming chat completions for each mode/context/concurrency
+cell. Tokens come from the server usage block, not SSE chunk counts. Every cell
+records aggregate and per-stream throughput, TTFT/ITL percentiles, prefix-cache
+hit ratio, preemptions, request IDs, and enough counts for a server-log audit.
+
+Canonical current-stack baseline, through the Mac tunnel:
+
+  GLM53_BASE=http://127.0.0.1:8000 uv run python tests/bench_concurrency.py \
+    --levels 1,2,3,4 --modes code,data,chat --ctx 0,60000 \
+    --reps 3 --out local/concurrency-baseline-$(date +%F).json
+
+The server must be idle unless ``--force`` is given. Long-context cells warm a
+distinct system-message prefix per lane, then measure that cached prefix with a
+different user suffix. Set ``VLLM_API_KEY`` for authenticated deployments.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import statistics
+import sys
+import threading
+import time
+import urllib.error
+import urllib.request
+import uuid
+from pathlib import Path
+from typing import Any
+
+BASE = os.environ.get("GLM53_BASE", "http://127.0.0.1:8000").rstrip("/")
+MODEL = os.environ.get("GLM53_MODEL", "GLM-5.3-Flash-EXL3")
+API_KEY = os.environ.get("VLLM_API_KEY", "")
+
+CHAT_TOPICS = [
+    "why sourdough needs a long cold proof",
+    "how tides work for a curious ten-year-old",
+    "what makes a good cup of pour-over coffee",
+    "how to plan a first vegetable garden in a small yard",
+]
+CODE_TASKS = [
+    "a typed Python module implementing an LRU cache with tests",
+    "a Go file implementing a thread-safe key-value store with TTL expiry",
+    "a Rust tokenizer and recursive-descent parser for arithmetic expressions",
+    "a bash log-rotation script with dry-run, verbose mode, and help text",
+]
+DATA_TASKS = [
+    "a JSON array of 40 fictional customers with realistic fields",
+    "a CSV with 60 fictional weather readings and a header",
+    "an OpenAPI 3 YAML snippet for a four-endpoint notes API",
+    "a markdown table comparing 45 fictional laptops",
+]
+FILLER = "Ledger row %d reconciled to the cent under audit rule seven. "
+METRIC_NAMES = (
+    "prefix_cache_queries_total",
+    "prefix_cache_hits_total",
+    "num_preemptions_total",
+    "num_requests_running",
+    "num_requests_waiting",
+)
+
+
+def _headers(*, json_content: bool = False, request_id: str = "") -> dict[str, str]:
+    headers = {"Content-Type": "application/json"} if json_content else {}
+    if API_KEY:
+        headers["Authorization"] = f"Bearer {API_KEY}"
+    if request_id:
+        headers["X-Request-Id"] = request_id
+    return headers
+
+
+def _open(path: str, body: dict | None, timeout: float, request_id: str = ""):
+    data = json.dumps(body).encode() if body is not None else None
+    request = urllib.request.Request(
+        BASE + path,
+        data=data,
+        headers=_headers(json_content=body is not None, request_id=request_id),
+        method="POST" if body is not None else "GET",
+    )
+    return urllib.request.urlopen(request, timeout=timeout)
+
+
+def parse_metrics(text: str) -> dict[str, float]:
+    """Sum all label series for the counters and gauges used by the ladder."""
+    out: dict[str, float] = {}
+    for key in METRIC_NAMES:
+        pattern = re.compile(rf"^vllm:{re.escape(key)}(?:\{{[^}}]*\}})?\s+(\S+)$", re.M)
+        values = [float(match.group(1)) for match in pattern.finditer(text)]
+        if values:
+            out[key] = sum(values)
+    return out
+
+
+def metrics() -> dict[str, float]:
+    with _open("/metrics", None, 20) as response:
+        return parse_metrics(response.read().decode("utf-8", "replace"))
+
+
+def server_is_busy(snapshot: dict[str, float]) -> bool:
+    return (
+        snapshot.get("num_requests_running", 0) > 0
+        or snapshot.get("num_requests_waiting", 0) > 0
+    )
+
+
+def percentiles(values: list[float]) -> dict[str, float | None]:
+    if not values:
+        return {"p50": None, "p95": None, "p99": None}
+    ordered = sorted(values)
+
+    def quantile(p: float) -> float:
+        index = min(len(ordered) - 1, max(0, int(round(p * (len(ordered) - 1)))))
+        return ordered[index]
+
+    return {
+        "p50": round(quantile(0.50), 3),
+        "p95": round(quantile(0.95), 3),
+        "p99": round(quantile(0.99), 3),
+    }
+
+
+def make_prefix(lane_tag: int, context_tokens: int) -> str:
+    # Approximately fourteen tokens per sentence on this model's tokenizer.
+    rows = max(0, int(context_tokens / 14))
+    return "".join(FILLER % (lane_tag * 1_000_000 + row) for row in range(rows))
+
+
+def task_text(mode: str, index: int) -> str:
+    if mode == "chat":
+        return (
+            f"Chat with me about {CHAT_TOPICS[index % len(CHAT_TOPICS)]}. "
+            "Be warm and conversational, about 250 words."
+        )
+    if mode == "code":
+        return f"Write {CODE_TASKS[index % len(CODE_TASKS)]}. Output only code."
+    return f"Write {DATA_TASKS[index % len(DATA_TASKS)]}. Output only the data."
+
+
+def build_messages(
+    mode: str,
+    index: int,
+    context_tokens: int,
+    lane_tag: int,
+    shared_prefix: bool,
+    *,
+    warmup: bool = False,
+) -> list[dict[str, str]]:
+    messages: list[dict[str, str]] = []
+    if context_tokens:
+        prefix_lane = 0 if shared_prefix else lane_tag
+        messages.append(
+            {
+                "role": "system",
+                "content": (
+                    make_prefix(prefix_lane, context_tokens)
+                    + "\nThis ledger is immutable reference context."
+                ),
+            }
+        )
+    user = "Acknowledge the reference context with OK." if warmup else task_text(mode, index)
+    messages.append({"role": "user", "content": user})
+    return messages
+
+
+def stream_one(
+    messages: list[dict[str, str]],
+    max_tokens: int,
+    temperature: float,
+    thinking: bool,
+    request_id: str,
+    out: dict[str, Any],
+) -> None:
+    body = {
+        "model": MODEL,
+        "messages": messages,
+        "max_tokens": max_tokens,
+        "temperature": temperature,
+        "stream": True,
+        "stream_options": {"include_usage": True},
+        "chat_template_kwargs": {"enable_thinking": thinking},
+    }
+    started = time.perf_counter()
+    first = None
+    last = None
+    itl: list[float] = []
+    usage = None
+    finish_reason = None
+    http_status = None
+    try:
+        with _open(
+            "/v1/chat/completions", body, timeout=3600, request_id=request_id
+        ) as response:
+            http_status = response.status
+            for raw in response:
+                line = raw.decode("utf-8", "replace").strip()
+                if not line.startswith("data:"):
+                    continue
+                payload = line[5:].strip()
+                if payload == "[DONE]":
+                    break
+                try:
+                    event = json.loads(payload)
+                except json.JSONDecodeError:
+                    continue
+                if event.get("usage"):
+                    usage = event["usage"]
+                choices = event.get("choices") or []
+                if not choices:
+                    continue
+                choice = choices[0]
+                delta = choice.get("delta") or {}
+                content = (
+                    delta.get("content")
+                    or delta.get("reasoning")
+                    or delta.get("reasoning_content")
+                    or ""
+                )
+                if content:
+                    now = time.perf_counter()
+                    if first is None:
+                        first = now
+                    elif last is not None:
+                        itl.append(now - last)
+                    last = now
+                if choice.get("finish_reason"):
+                    finish_reason = choice["finish_reason"]
+    except urllib.error.HTTPError as exc:
+        http_status = exc.code
+        out["error"] = f"HTTP {exc.code}: {exc.read(200)!r}"
+    except (urllib.error.URLError, OSError, TimeoutError) as exc:
+        out["error"] = f"{type(exc).__name__}: {exc}"[:240]
+    ended = time.perf_counter()
+    out.update(
+        {
+            "request_id": request_id,
+            "http": http_status,
+            "start": started,
+            "first": first,
+            "end": ended,
+            "ttft": (first - started) if first is not None else None,
+            "itl": itl,
+            "completion_tokens": (usage or {}).get("completion_tokens"),
+            "prompt_tokens": (usage or {}).get("prompt_tokens"),
+            "usage_seen": usage is not None,
+            "finish_reason": finish_reason,
+        }
+    )
+
+
+def _request_id(run_id: str, mode: str, ctx: int, level: int, rep: int, lane: int, kind: str) -> str:
+    return f"glm53-ladder-{run_id}-{mode}-c{ctx}-n{level}-r{rep}-l{lane}-{kind}"
+
+
+def run_cell(
+    mode: str,
+    ctx: int,
+    level: int,
+    rep: int,
+    args: argparse.Namespace,
+    run_id: str,
+    status_cb,
+) -> dict[str, Any]:
+    temperature = 0.0 if mode in ("code", "data") or args.chat_temp0 else 0.7
+    measured_messages = [
+        build_messages(
+            mode,
+            rep * 31 + lane,
+            ctx,
+            lane + 1,
+            args.shared_prefix,
+        )
+        for lane in range(level)
+    ]
+    warm_request_ids: list[str] = []
+    if ctx:
+        for lane in range(level):
+            request_id = _request_id(run_id, mode, ctx, level, rep, lane, "warm")
+            warm_request_ids.append(request_id)
+            warm_out: dict[str, Any] = {}
+            stream_one(
+                build_messages(
+                    mode,
+                    rep * 31 + lane,
+                    ctx,
+                    lane + 1,
+                    args.shared_prefix,
+                    warmup=True,
+                ),
+                1,
+                0.0,
+                False,
+                request_id,
+                warm_out,
+            )
+            if warm_out.get("error") or warm_out.get("http") != 200:
+                return {
+                    "mode": mode,
+                    "ctx": ctx,
+                    "level": level,
+                    "rep": rep,
+                    "errors": 1,
+                    "error_samples": [warm_out.get("error") or f"warmup HTTP {warm_out.get('http')}"],
+                    "audit": {
+                        "warm_request_ids": warm_request_ids,
+                        "measured_request_ids": [],
+                    },
+                }
+        time.sleep(1)
+
+    before = metrics()
+    cell_started = time.perf_counter()
+    outputs: list[dict[str, Any]] = [dict() for _ in range(level)]
+    request_ids = [
+        _request_id(run_id, mode, ctx, level, rep, lane, "measure")
+        for lane in range(level)
+    ]
+    threads = []
+    for lane, messages in enumerate(measured_messages):
+        thread = threading.Thread(
+            target=stream_one,
+            args=(
+                messages,
+                args.max_tokens,
+                temperature,
+                args.thinking,
+                request_ids[lane],
+                outputs[lane],
+            ),
+        )
+        threads.append(thread)
+        thread.start()
+        if args.stagger and lane < level - 1:
+            time.sleep(args.stagger)
+    while any(thread.is_alive() for thread in threads):
+        time.sleep(0.5)
+        status_cb(mode, ctx, level, rep, outputs, cell_started)
+    for thread in threads:
+        thread.join()
+    after = metrics()
+
+    wall = max((item.get("end") or cell_started) for item in outputs) - cell_started
+    tokens = [int(item.get("completion_tokens") or 0) for item in outputs]
+    stream_rates = [
+        (int(item["completion_tokens"]) - 1) / max(item["end"] - item["first"], 1e-3)
+        for item in outputs
+        if item.get("first") is not None and int(item.get("completion_tokens") or 0) > 1
+    ]
+    ttfts = [item["ttft"] for item in outputs if item.get("ttft") is not None]
+    itls = [gap for item in outputs for gap in item.get("itl", [])]
+    queries = after.get("prefix_cache_queries_total", 0) - before.get(
+        "prefix_cache_queries_total", 0
+    )
+    hits = after.get("prefix_cache_hits_total", 0) - before.get(
+        "prefix_cache_hits_total", 0
+    )
+    errors = [item.get("error") for item in outputs if item.get("error")]
+    successful = sum(
+        item.get("http") == 200 and item.get("usage_seen") for item in outputs
+    )
+    cell = {
+        "mode": mode,
+        "ctx": ctx,
+        "level": level,
+        "rep": rep,
+        "temperature": temperature,
+        "thinking": args.thinking,
+        "agg_tps": round(sum(tokens) / max(wall, 1e-3), 1),
+        "stream_tps_median": (
+            round(statistics.median(stream_rates), 1) if stream_rates else None
+        ),
+        "ttft": percentiles(ttfts),
+        "itl": percentiles(itls),
+        "starvation_age_s": round(max(ttfts), 2) if ttfts else None,
+        "tokens": sum(tokens),
+        "prompt_tokens": sum(int(item.get("prompt_tokens") or 0) for item in outputs),
+        "wall": round(wall, 1),
+        "cache_hit_ratio": round(hits / queries, 3) if queries else None,
+        "preemptions": int(
+            after.get("num_preemptions_total", 0)
+            - before.get("num_preemptions_total", 0)
+        ),
+        "errors": level - successful,
+        "error_samples": errors[:2],
+        "audit": {
+            "warm_request_ids": warm_request_ids,
+            "measured_request_ids": request_ids,
+            "expected_measured_requests": level,
+            "http_200_with_usage": successful,
+            "metric_queries_delta": queries,
+            "metric_hits_delta": hits,
+        },
+    }
+    if ctx and cell["cache_hit_ratio"] is not None and cell["cache_hit_ratio"] < args.min_hit_ratio:
+        cell["warning"] = (
+            f"cache hit ratio {cell['cache_hit_ratio']} < {args.min_hit_ratio}"
+        )
+    return cell
+
+
+def _positive_csv(raw: str, *, allow_zero: bool = False) -> list[int]:
+    values = [int(part) for part in raw.split(",")]
+    floor = 0 if allow_zero else 1
+    if not values or any(value < floor for value in values):
+        raise argparse.ArgumentTypeError(f"values must be >= {floor}: {raw}")
+    return values
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("--levels", default="1,2,3,4")
+    parser.add_argument("--modes", default="code,data,chat")
+    parser.add_argument("--ctx", default="0,60000", help="context tokens per lane")
+    parser.add_argument("--reps", type=int, default=3)
+    parser.add_argument("--max-tokens", type=int, default=400)
+    parser.add_argument("--stagger", type=float, default=0.0)
+    parser.add_argument("--shared-prefix", action="store_true")
+    parser.add_argument("--chat-temp0", action="store_true")
+    parser.add_argument("--thinking", action="store_true")
+    parser.add_argument("--min-hit-ratio", type=float, default=0.8)
+    parser.add_argument("--spread-tolerance", type=float, default=0.10)
+    parser.add_argument("--status", default="status.json")
+    parser.add_argument("--out", default="local/concurrency-ladder.json")
+    parser.add_argument("--force", action="store_true")
+    args = parser.parse_args()
+
+    if args.reps < 1 or args.max_tokens < 1 or args.stagger < 0:
+        parser.error("--reps/--max-tokens must be positive and --stagger non-negative")
+    levels = _positive_csv(args.levels)
+    contexts = _positive_csv(args.ctx, allow_zero=True)
+    modes = [mode.strip() for mode in args.modes.split(",") if mode.strip()]
+    if not modes or any(mode not in {"code", "data", "chat"} for mode in modes):
+        parser.error("--modes must be a comma-separated subset of code,data,chat")
+
+    initial = metrics()
+    if not args.force and server_is_busy(initial):
+        print(
+            "server busy "
+            f"(running={initial.get('num_requests_running', 0):g} "
+            f"waiting={initial.get('num_requests_waiting', 0):g}); refusing. "
+            "Use --force only when the overlap is intentional.",
+            file=sys.stderr,
+        )
+        return 2
+
+    run_id = uuid.uuid4().hex[:10]
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    status_path = Path(args.status)
+    state: dict[str, Any] = {
+        "schema_version": 1,
+        "phase": "running",
+        "run_id": run_id,
+        "started": time.time(),
+        "cells": [],
+        "live": {},
+    }
+
+    def dump_status() -> None:
+        status_path.parent.mkdir(parents=True, exist_ok=True)
+        temporary = status_path.with_name(status_path.name + ".tmp")
+        temporary.write_text(json.dumps(state), encoding="utf-8")
+        os.replace(temporary, status_path)
+
+    def status_cb(mode, ctx, level, rep, outputs, cell_started) -> None:
+        state["live"] = {
+            "mode": mode,
+            "ctx": ctx,
+            "level": level,
+            "rep": rep,
+            "elapsed": round(time.perf_counter() - cell_started, 1),
+            "streams": [
+                {
+                    "request_id": item.get("request_id"),
+                    "ttft": item.get("ttft"),
+                    "done": "end" in item,
+                }
+                for item in outputs
+            ],
+        }
+        dump_status()
+
+    warm: dict[str, Any] = {}
+    stream_one(
+        build_messages("code", 0, 0, 1, False),
+        64,
+        0.0,
+        False,
+        f"glm53-ladder-{run_id}-global-warm",
+        warm,
+    )
+    if warm.get("error") or warm.get("http") != 200:
+        print(f"global warmup failed: {warm}", file=sys.stderr)
+        return 2
+
+    for mode in modes:
+        for ctx in contexts:
+            for level in levels:
+                measured: list[dict[str, Any]] = []
+                for rep in range(args.reps):
+                    cell = run_cell(
+                        mode, ctx, level, rep, args, run_id, status_cb
+                    )
+                    measured.append(cell)
+                    state["cells"].append(cell)
+                    dump_status()
+                    print(
+                        f"{mode:5s} ctx={ctx:6d} x{level:2d} rep{rep}: "
+                        f"agg {cell.get('agg_tps')} | "
+                        f"stream {cell.get('stream_tps_median')} | "
+                        f"TTFT p50/p95 {cell.get('ttft', {}).get('p50')}/"
+                        f"{cell.get('ttft', {}).get('p95')} | "
+                        f"hit {cell.get('cache_hit_ratio')} | "
+                        f"pre {cell.get('preemptions')} | err {cell.get('errors')}",
+                        flush=True,
+                    )
+                    time.sleep(2)
+                aggregates = [
+                    cell["agg_tps"] for cell in measured if cell.get("agg_tps")
+                ]
+                if (
+                    len(aggregates) >= 2
+                    and (max(aggregates) - min(aggregates))
+                    / max(statistics.median(aggregates), 1e-3)
+                    > args.spread_tolerance
+                ):
+                    cell = run_cell(
+                        mode, ctx, level, args.reps, args, run_id, status_cb
+                    )
+                    cell["rerun"] = True
+                    state["cells"].append(cell)
+                    dump_status()
+                    print(
+                        f"  spread > {args.spread_tolerance:.0%}; "
+                        f"re-ran once: agg {cell.get('agg_tps')}",
+                        flush=True,
+                    )
+
+    state["phase"] = "done"
+    state["finished"] = time.time()
+    state["live"] = {}
+    dump_status()
+    result = {
+        "schema_version": 1,
+        "run_id": run_id,
+        "base": BASE,
+        "model": MODEL,
+        "args": vars(args),
+        "initial_metrics": initial,
+        "cells": state["cells"],
+    }
+    out_path.write_text(json.dumps(result, indent=2), encoding="utf-8")
+    print(f"wrote {out_path}")
+    return 1 if any(cell.get("errors", 0) for cell in state["cells"]) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/bench_decode.py
+++ b/tests/bench_decode.py
@@ -19,6 +19,7 @@ from pathlib import Path
 
 BASE = os.environ.get("GLM53_BASE", "http://127.0.0.1:8000")  # LOCAL: this cluster serves :8000
 MODEL = "GLM-5.3-Flash-EXL3"
+API_KEY = os.environ.get("VLLM_API_KEY", "")
 BENCH_PROMPT = (
     "Write a detailed step-by-step explanation of how a hash map works, "
     "including collision handling, resizing, and time complexity. Be thorough."
@@ -33,19 +34,31 @@ SPEC_RE = re.compile(
 )
 
 
+def _headers(*, json_content: bool = False) -> dict[str, str]:
+    headers = {"Content-Type": "application/json"} if json_content else {}
+    if API_KEY:
+        headers["Authorization"] = f"Bearer {API_KEY}"
+    return headers
+
+
+def contains_nan(text: str) -> bool:
+    """Detect standalone NaN tokens and the known locklock corruption marker."""
+    return bool(NAN_RE.search(text))
+
+
 def _post(path: str, body: dict, timeout: float = 600.0, stream: bool = False):
     data = json.dumps(body).encode()
     req = urllib.request.Request(
         BASE + path,
         data=data,
-        headers={"Content-Type": "application/json"},
+        headers=_headers(json_content=True),
         method="POST",
     )
     return urllib.request.urlopen(req, timeout=timeout)
 
 
 def health() -> tuple[int, str]:
-    req = urllib.request.Request(BASE + "/health")
+    req = urllib.request.Request(BASE + "/health", headers=_headers())
     try:
         with urllib.request.urlopen(req, timeout=10) as resp:
             return resp.status, resp.read().decode("utf-8", "replace")
@@ -71,7 +84,7 @@ def chat_nonstream(prompt: str, max_tokens: int = 64) -> dict:
 
 def spec_snapshot() -> dict[str, float]:
     """vLLM spec-decode counters. per-pos keys are pos:{n}."""
-    req = urllib.request.Request(BASE + "/metrics")
+    req = urllib.request.Request(BASE + "/metrics", headers=_headers())
     with urllib.request.urlopen(req, timeout=10) as resp:
         raw = resp.read().decode("utf-8", "replace")
     out: dict[str, float] = {}
@@ -181,7 +194,7 @@ def stream_bench(max_tokens: int = 200, prompt: str | None = None) -> dict:
     tps = None
     if decode_s and decode_s > 0 and decode_toks > 0:
         tps = decode_toks / decode_s
-    nan = bool(NAN_RE.search(text)) or ("nan" in text.lower())
+    nan = contains_nan(text)
     return {
         "http": http,
         "ttft_s": ttft,
@@ -230,8 +243,8 @@ def coherence() -> dict:
     return {
         "paris": {"ok": "paris" in (pcontent + ptxt).lower(), "text": pcontent[:400] or ptxt[:400], "http": paris.get("_http")},
         "cmp": {"ok": cmp_ok and bool((ccontent or ctxt).strip()), "text": ccontent[:400] or ctxt[:400], "http": cmp_.get("_http")},
-        "sky": {"ok": bool(scontent.strip()) and "nan" not in scontent.lower(), "text": scontent[:400], "http": sky.get("_http")},
-        "nan": any(NAN_RE.search(t) for t in (ptxt, ctxt, stxt, pcontent, ccontent, scontent)),
+        "sky": {"ok": bool(scontent.strip()) and not contains_nan(scontent), "text": scontent[:400], "http": sky.get("_http")},
+        "nan": any(contains_nan(t) for t in (ptxt, ctxt, stxt, pcontent, ccontent, scontent)),
     }
 
 

--- a/tests/test_bench_concurrency.py
+++ b/tests/test_bench_concurrency.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+BENCH = ROOT / "tests" / "bench_concurrency.py"
+
+
+def _module(monkeypatch, api_key: str = ""):
+    monkeypatch.setenv("VLLM_API_KEY", api_key)
+    spec = importlib.util.spec_from_file_location("bench_concurrency_under_test", BENCH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_auth_and_request_id_headers(monkeypatch) -> None:
+    module = _module(monkeypatch, "test-key")
+    assert module._headers(json_content=True, request_id="req-1") == {
+        "Content-Type": "application/json",
+        "Authorization": "Bearer test-key",
+        "X-Request-Id": "req-1",
+    }
+
+
+def test_metrics_sum_labeled_series_and_busy_veto(monkeypatch) -> None:
+    module = _module(monkeypatch)
+    parsed = module.parse_metrics(
+        "\n".join(
+            [
+                'vllm:num_requests_running{model_name="a"} 1',
+                'vllm:num_requests_running{model_name="b"} 2',
+                'vllm:num_requests_waiting{model_name="a"} 0',
+                'vllm:prefix_cache_hits_total{model_name="a"} 10',
+                'vllm:prefix_cache_hits_total{model_name="b"} 5',
+                'vllm:prefix_cache_queries_total{model_name="a"} 20',
+                "vllm:num_preemptions_total 3",
+            ]
+        )
+    )
+    assert parsed["num_requests_running"] == 3
+    assert parsed["prefix_cache_hits_total"] == 15
+    assert parsed["num_preemptions_total"] == 3
+    assert module.server_is_busy(parsed)
+    assert not module.server_is_busy(
+        {"num_requests_running": 0, "num_requests_waiting": 0}
+    )
+
+
+def test_cached_prefix_warmup_and_measurement_use_different_suffixes(monkeypatch) -> None:
+    module = _module(monkeypatch)
+    warm = module.build_messages("code", 0, 100, 2, False, warmup=True)
+    measured = module.build_messages("code", 0, 100, 2, False, warmup=False)
+    assert warm[0] == measured[0]
+    assert warm[-1] != measured[-1]
+    shared = module.build_messages("chat", 1, 100, 99, True)
+    other_shared = module.build_messages("chat", 1, 100, 3, True)
+    assert shared[0] == other_shared[0]
+
+
+def test_percentiles_and_request_ids_are_stable(monkeypatch) -> None:
+    module = _module(monkeypatch)
+    assert module.percentiles([]) == {"p50": None, "p95": None, "p99": None}
+    assert module.percentiles([4.0, 1.0, 3.0, 2.0]) == {
+        "p50": 3.0,
+        "p95": 4.0,
+        "p99": 4.0,
+    }
+    assert (
+        module._request_id("abc", "code", 60000, 4, 2, 3, "measure")
+        == "glm53-ladder-abc-code-c60000-n4-r2-l3-measure"
+    )

--- a/tests/test_bench_decode.py
+++ b/tests/test_bench_decode.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+BENCH = ROOT / "tests" / "bench_decode.py"
+
+
+def _module(monkeypatch, api_key: str = ""):
+    monkeypatch.setenv("VLLM_API_KEY", api_key)
+    spec = importlib.util.spec_from_file_location("bench_decode_under_test", BENCH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_bearer_header_is_used_for_json_and_metrics(monkeypatch) -> None:
+    module = _module(monkeypatch, "secret-for-test")
+    assert module._headers(json_content=True) == {
+        "Content-Type": "application/json",
+        "Authorization": "Bearer secret-for-test",
+    }
+    assert module._headers() == {"Authorization": "Bearer secret-for-test"}
+
+
+def test_nan_detection_is_token_aware(monkeypatch) -> None:
+    module = _module(monkeypatch)
+    for text in ("nan", "value: NaN", "locklock", "the result is (NAN)."):
+        assert module.contains_nan(text), text
+    for text in ("banana", "finance", "Nanjing", "nanosecond", "canonical"):
+        assert not module.contains_nan(text), text
+
+
+def test_aggregate_any_nan_semantics(monkeypatch) -> None:
+    module = _module(monkeypatch)
+    clean_runs = [{"nan": module.contains_nan("banana")}, {"nan": False}]
+    bad_runs = clean_runs + [{"nan": module.contains_nan("value NaN")}]
+    assert not any(run["nan"] for run in clean_runs)
+    assert any(run["nan"] for run in bad_runs)

--- a/tests/test_snapshot_validation.py
+++ b/tests/test_snapshot_validation.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import re
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+VALIDATOR = ROOT / "scripts" / "validate_hf_snapshot.py"
+START = ROOT / "start.sh"
+
+
+def _module():
+    spec = importlib.util.spec_from_file_location("validate_hf_snapshot", VALIDATOR)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _shell_function(name: str) -> str:
+    source = START.read_text(encoding="utf-8")
+    match = re.search(rf"(?ms)^{re.escape(name)}\(\) \{{\n.*?^\}}\n", source)
+    assert match, f"missing function {name}"
+    return match.group(0)
+
+
+def _safetensors(path: Path, payload_bytes: int = 8, truncate: int = 0) -> None:
+    header = json.dumps(
+        {"tensor": {"dtype": "U8", "shape": [payload_bytes], "data_offsets": [0, payload_bytes]}}
+    ).encode()
+    raw = len(header).to_bytes(8, "little") + header + (b"x" * payload_bytes)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(raw[:-truncate] if truncate else raw)
+
+
+def _snapshot(repo: Path, revision: str, *, symlinks: bool = False) -> Path:
+    snap = repo / "snapshots" / revision
+    snap.mkdir(parents=True)
+    names = ["model-00001-of-00002.safetensors", "model-00002-of-00002.safetensors"]
+    weight_map = {"a": names[0], "b": names[1]}
+    (snap / "model.safetensors.index.json").write_text(json.dumps({"weight_map": weight_map}))
+    (snap / "config.json").write_text("{}")
+    if symlinks:
+        blobs = repo / "blobs"
+        blobs.mkdir(parents=True)
+        for index, name in enumerate(names):
+            blob = blobs / f"blob-{index}"
+            _safetensors(blob)
+            (snap / name).symlink_to(os.path.relpath(blob, snap))
+    else:
+        for name in names:
+            _safetensors(snap / name)
+    return snap
+
+
+def test_regular_and_hub_symlink_snapshots_validate(tmp_path: Path) -> None:
+    module = _module()
+    regular = tmp_path / "regular"
+    linked = tmp_path / "linked"
+    _snapshot(regular, "regular-rev")
+    _snapshot(linked, "linked-rev", symlinks=True)
+    assert module.validate_snapshot(regular, "regular-rev", 2).shard_count == 2
+    assert module.validate_snapshot(linked, "linked-rev", 2).shard_count == 2
+
+
+def test_explicit_revision_wins_over_stale_refs_main(tmp_path: Path) -> None:
+    module = _module()
+    _snapshot(tmp_path, "wanted")
+    refs = tmp_path / "refs"
+    refs.mkdir()
+    (refs / "main").write_text("missing")
+    report = module.validate_snapshot(tmp_path, "wanted", 2)
+    assert report.revision == "wanted"
+    assert module.select_revision(tmp_path, "wanted") == "wanted"
+
+
+def test_dangling_missing_unindexed_and_truncated_shards_fail(tmp_path: Path) -> None:
+    module = _module()
+
+    dangling = tmp_path / "dangling"
+    snap = _snapshot(dangling, "rev", symlinks=True)
+    (dangling / "blobs" / "blob-1").unlink()
+    try:
+        module.validate_snapshot(dangling, "rev", 2)
+    except module.SnapshotError as exc:
+        assert "dangling symlink" in str(exc)
+    else:
+        raise AssertionError("dangling symlink accepted")
+
+    missing = tmp_path / "missing"
+    snap = _snapshot(missing, "rev")
+    (snap / "model-00002-of-00002.safetensors").unlink()
+    try:
+        module.validate_snapshot(missing, "rev", 2)
+    except module.SnapshotError as exc:
+        assert "missing file" in str(exc)
+    else:
+        raise AssertionError("missing shard accepted")
+
+    unindexed = tmp_path / "unindexed"
+    snap = _snapshot(unindexed, "rev")
+    _safetensors(snap / "model-00003-of-00003.safetensors")
+    try:
+        module.validate_snapshot(unindexed, "rev", 2)
+    except module.SnapshotError as exc:
+        assert "missing from index" in str(exc)
+    else:
+        raise AssertionError("unindexed shard accepted")
+
+    truncated = tmp_path / "truncated"
+    snap = _snapshot(truncated, "rev")
+    _safetensors(snap / "model-00002-of-00002.safetensors", truncate=4)
+    try:
+        module.validate_snapshot(truncated, "rev", 2)
+    except module.SnapshotError as exc:
+        assert "truncated safetensors payload" in str(exc)
+    else:
+        raise AssertionError("truncated shard accepted")
+
+
+def test_zero_file_and_incomplete_index_fail(tmp_path: Path) -> None:
+    module = _module()
+    zero = tmp_path / "zero"
+    snap = _snapshot(zero, "rev")
+    (snap / "model-00001-of-00002.safetensors").write_bytes(b"")
+    try:
+        module.validate_snapshot(zero, "rev", 2)
+    except module.SnapshotError as exc:
+        assert "zero/truncated" in str(exc)
+    else:
+        raise AssertionError("zero shard accepted")
+
+    incomplete = tmp_path / "incomplete"
+    snap = _snapshot(incomplete, "rev")
+    index = snap / "model.safetensors.index.json"
+    index.write_text(json.dumps({"weight_map": {"a": "model-00001-of-00002.safetensors"}}))
+    try:
+        module.validate_snapshot(incomplete, "rev", 2)
+    except module.SnapshotError as exc:
+        assert "references 1 shards, expected 2" in str(exc)
+    else:
+        raise AssertionError("incomplete index accepted")
+
+
+def test_cli_count_and_start_wiring(tmp_path: Path) -> None:
+    _snapshot(tmp_path, "wanted", symlinks=True)
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(VALIDATOR),
+            "--repo",
+            str(tmp_path),
+            "--revision",
+            "wanted",
+            "--expected-shards",
+            "2",
+            "--field",
+            "count",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "2"
+    source = START.read_text(encoding="utf-8")
+    assert 'MODEL_SELECTED_REVISION="${MODEL_REVISION:-}"' in source
+    assert "MODEL_REVISION_EXPLICIT=1" in source
+    assert 'count_shards "$MODEL_PATH" "$MODEL_SELECTED_REVISION"' in source
+    assert 'sync_repo_to_worker "$MODEL_PATH" "$MODEL_CACHE_NAME" "weights" "$MODEL_SELECTED_REVISION"' in source
+    assert '_glm53_model_revision_set="${MODEL_REVISION+x}"' in source
+    assert 'elif [ "$MODEL" = "Mia-AiLab/GLM-5.3-Flash-EXL3-TR3-4bpw" ]' in source
+
+
+def test_explicit_revision_cannot_fall_through_to_fallback(tmp_path: Path) -> None:
+    primary = tmp_path / "primary"
+    fallback = tmp_path / "fallback"
+    _snapshot(fallback, "fallback-main")
+    (fallback / "refs").mkdir()
+    (fallback / "refs" / "main").write_text("fallback-main")
+    script = f"""
+set -euo pipefail
+SCRIPT_DIR={shlex.quote(str(ROOT))}
+EXPECTED_SHARDS=2
+MODEL_PATH={shlex.quote(str(primary))}
+FALLBACK_MODEL_PATH={shlex.quote(str(fallback))}
+MODEL_CACHE_NAME=primary
+MODEL_FALLBACK_CACHE_NAME=fallback
+MODEL_FALLBACK=example/fallback
+MODEL_SELECTED_REVISION=wrong-explicit-pin
+MODEL_REVISION_EXPLICIT=1
+log() {{ :; }}
+{_shell_function("ensure_refs_main")}
+{_shell_function("count_shards")}
+{_shell_function("adopt_complete_weights")}
+if adopt_complete_weights; then
+    echo "unexpected-success:$MODEL_PATH:$MODEL_SELECTED_REVISION"
+    exit 9
+fi
+printf '%s|%s\\n' "$MODEL_PATH" "$MODEL_SELECTED_REVISION"
+"""
+    result = subprocess.run(["bash", "-c", script], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == f"{primary}|wrong-explicit-pin"
+
+
+def test_implicit_default_may_adopt_valid_fallback(tmp_path: Path) -> None:
+    primary = tmp_path / "primary"
+    fallback = tmp_path / "fallback"
+    _snapshot(fallback, "fallback-main")
+    (fallback / "refs").mkdir()
+    (fallback / "refs" / "main").write_text("fallback-main")
+    script = f"""
+set -euo pipefail
+SCRIPT_DIR={shlex.quote(str(ROOT))}
+EXPECTED_SHARDS=2
+MODEL_PATH={shlex.quote(str(primary))}
+FALLBACK_MODEL_PATH={shlex.quote(str(fallback))}
+MODEL_CACHE_NAME=primary
+MODEL_FALLBACK_CACHE_NAME=fallback
+MODEL_FALLBACK=example/fallback
+MODEL_SELECTED_REVISION=implicit-default-pin
+MODEL_REVISION_EXPLICIT=0
+log() {{ :; }}
+{_shell_function("ensure_refs_main")}
+{_shell_function("count_shards")}
+{_shell_function("adopt_complete_weights")}
+adopt_complete_weights
+printf '%s|%s|%s\\n' "$MODEL_PATH" "$MODEL_CACHE_NAME" "$MODEL_SELECTED_REVISION"
+"""
+    result = subprocess.run(["bash", "-c", script], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == f"{fallback}|fallback|"


### PR DESCRIPTION
## Summary
- validate the selected Hugging Face snapshot through its safetensors index, including Hub symlinks and payload extents
- make `bench_decode.py` bearer-auth aware and remove false-positive substring NaN failures
- add an audited concurrency ladder with busy-server refusal, usage-token accounting, cache/preemption metrics, and request IDs
- publish the September 5 upstream survey, ordered TODO, A/B gates, and R0 receipts

## Validation
- 98 passed, 1 skipped
- shellcheck, bash syntax, Python compileall, and diff checks passed
- exact validator bytes passed on both DGX Spark nodes: 120 shards and 175,642,157,752 bytes on each
- exact launcher bytes parsed safely on both nodes
- live no-restart concurrency and decode smokes passed; service remained healthy with zero recent GPU-error matches
- independent final review: approved

No production restart, model/image/config change, issue reply, or performance claim is included.
