### PR TITLE
P0: harden runtime diagnostics and Mamba retirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,9 @@ Key local hardening, all marked `# LOCAL:` in-file: **loopback bind hardcoded**
 with `ss -ltn | grep 8000` after any update), **KV pool pinned to the byte** (never
 raise it — `docs/02`), and **`MAX_NUM_BATCHED_TOKENS` = the 3,584-token page size
 with async scheduling OFF** — get either wrong and cache hits silently read 0%
-(`docs/04`).
+(`docs/04`). Patch installers run under `python3 -S` so a persisted `.pth` import
+hook cannot re-enter later installers, and the API bearer credential is passed
+only to rank 0, never to the headless worker.
 
 ## Quickstart
 
@@ -165,6 +167,18 @@ local/acceptance.sh         # 7 checks: tools, thinking, vision, long-context ne
 
 Then install the units in `local/` (`systemctl --user enable ...`) so the pair
 survives reboots and heals itself. Full drill: `docs/03-bringup.md`.
+
+**Shared-head starting point.** The production 1M profile assumes a dedicated,
+headless Spark. If the head also runs a desktop, IDE, agents, or other memory
+consumers, start conservatively at `GPU_MEM_UTIL=0.78`,
+`MAX_MODEL_LEN=262144`, `GLM53_INDEXER_WORKSPACE=rightsize`,
+`MAX_NUM_BATCHED_TOKENS=2048`, and
+`CG_ESTIMATE=0`. Treat that as a bring-up baseline, not a performance
+recommendation. Lowering `GPU_MEM_UTIL` changes only the boot gate when
+`KV_CACHE_MEMORY_BYTES` is pinned; it does not shrink the KV allocation. Watch
+CUDA device-free/host `MemFree`, then raise one dimension at a time.
+`MemAvailable` and `nvidia-smi` are not reliable admission signals on unified
+memory.
 
 This release is reproduce-tested: this exact tree was rebuilt on the production head
 and booted **as production**, passing acceptance 7/7, serving 6/6, a byte-identical

--- a/docs/05-known-issues.md
+++ b/docs/05-known-issues.md
@@ -58,3 +58,29 @@ Check `--no-async-scheduling` is present before touching the pin or max-len.
 `tests/bench_decode.py`'s coherence probe marks "9.9 vs 9.11" wrong even when the
 model answers correctly ("9.9 is greater") — string-match artifact, not a model
 regression. Read the text, not just the flag.
+
+## 5. GB10 unified-memory livelock: health and `nvidia-smi` can mislead
+
+On Grace Blackwell, a driver/unified-memory livelock can leave `/health` at 200
+or make `nvidia-smi` look merely stale while CUDA work no longer completes. The
+watchdog's pending-token progress check covers a wedged serving request, but it
+does not prove the CUDA runtime itself can still launch work.
+
+**Prevent it:** keep both nodes symmetric, preserve the `MemFree` tripwire, never
+raise the pinned KV reservation, and avoid reclaim shocks such as `swapoff` or
+starting the engine while desktop/IDE workloads are consuming the shared head.
+Use host `MemFree` and a CUDA device-free probe for admission, not
+`MemAvailable`.
+
+**Detect it:** while requests are pending, alert if prompt plus generation token
+counters stop advancing even though `/health` is 200. Confirm with a bounded
+CUDA matrix multiply in an isolated helper process. If the matmul times out
+while SSH and host commands still work, classify it as a CUDA/driver stall, not
+an API-only failure. Record both nodes' kernel logs and Xid monitor state before
+recovery.
+
+**Recover it:** stop the user unit and containers through the guarded procedure.
+If bounded CUDA work still cannot launch after the containers are gone, a warm
+service restart is not evidence of recovery. Preserve diagnostics and cold
+power-cycle both nodes together when the driver remains stuck. Never automate a
+bounce for Xid/off-the-bus classes.

--- a/docs/06-improvement-plan.md
+++ b/docs/06-improvement-plan.md
@@ -80,6 +80,42 @@ worker logs contained zero CUDA/IMA/Xid/Traceback matches, and MemFree was
 6,441,380 / 6,091,752 kB. These are correctness smokes, not performance
 samples. The full canonical baseline is prepared, not yet a performance claim:
 
+### 2026-09-05: P0 runtime diagnostics and null-gap repair candidate
+
+The next priority block combines tasks 18, 9 and the task-27 null-gap
+reproducer:
+
+- The exact production fork positively reproduces vLLM #55450's align-mode
+  retirement leak in a CPU-only container probe. Given
+  `[old, null, committed, in-flight]`, retirement through block 2 leaves
+  `old.ref_cnt=1` and the free pool one block short because the generic helper
+  stops at the null gap.
+- `overlay/patch_mamba_null_gap_retirement.py` adapts the upstream repair to
+  this fork. It installs a Mamba-only range-removal override, skips null gaps,
+  tracks the already-retired prefix, clears that state on request free, validates
+  the patched AST, and is idempotent/fail-closed.
+- `local/p0-runtime-probe.py` adds the missing live gates: three >1k-token
+  temp-0.7, thinking-off essay streams plus a thinking-on SSE request. It uses
+  APC no-store and fails on incomplete SSE, UTF-8/mojibake markers, repeated
+  16-gram loops, missing reasoning deltas, preemptions, or leftover requests.
+- Every runtime patch installer now runs with `python3 -S`. This prevents the
+  persisted video `.pth` hook from importing during later installer processes,
+  the re-entry class reported in upstream issue #97. Normal vLLM startup still
+  uses site initialization, so the intended video import hook remains active.
+- `VLLM_API_KEY` is now passed only to the rank-0 API container. The worker is
+  headless and never needs the bearer secret.
+- `docs/05-known-issues.md` records the UVM livelock prevention/detection/
+  recovery distinction, and README adds the conservative shared-head starting
+  profile requested by upstream issue #118.
+
+Decision contract: exact source bytes and overlay test must fail before/pass
+after on both nodes; restart with no image/model/config change; pool bytes,
+shape stamp and bind stay unchanged; acceptance 7/7, serving 6/6, toolcall
+23/23, vision, structured/prose gates, P0 probe, cache burst and mixed-shape
+soak pass with zero CUDA/IMA/Xid/preemption regressions. Rollback is the saved
+pre-window `start.sh` plus removal of the null-gap mount, followed by the guarded
+unit restart.
+
 ```bash
 GLM53_BASE=http://127.0.0.1:8000 uv run python tests/bench_concurrency.py \
   --levels 1,2,3,4 --modes code,data,chat --ctx 0,60000 --reps 3 \

--- a/docs/06-improvement-plan.md
+++ b/docs/06-improvement-plan.md
@@ -80,7 +80,7 @@ worker logs contained zero CUDA/IMA/Xid/Traceback matches, and MemFree was
 6,441,380 / 6,091,752 kB. These are correctness smokes, not performance
 samples. The full canonical baseline is prepared, not yet a performance claim:
 
-### 2026-09-05: P0 runtime diagnostics and null-gap repair candidate
+### 2026-09-05: P0 runtime diagnostics and null-gap repair adopted
 
 The next priority block combines tasks 18, 9 and the task-27 null-gap
 reproducer:
@@ -115,6 +115,48 @@ shape stamp and bind stay unchanged; acceptance 7/7, serving 6/6, toolcall
 soak pass with zero CUDA/IMA/Xid/preemption regressions. Rollback is the saved
 pre-window `start.sh` plus removal of the null-gap mount, followed by the guarded
 unit restart.
+
+**Executed and ADOPTED on candidate `39d3ee5`.** Exact published-candidate
+hashes installed atomically on spark1:
+`start.sh d8fe5a644ebd2a6d6e79f38b89c10f206a2596db01df6513d8a9dbcad51a5fe1`;
+null-gap overlay
+`181b2d5ad93b1ae3a7eb8a878bba33e3a5934c1bf21893de9863c66119ba3dd8`.
+The overlay applied and passed the upstream-style CPU regression on both
+nodes' exact installed source; before the patch the same fixture left
+`old.ref_cnt=1` / free blocks 4, after it produced
+`[null,null,committed,in-flight]`, refs `[0,1,1]`, free blocks 5 and cleared
+per-request tracking.
+
+Guarded restart changed no `.env`, image, model, pool pin or JIT shape:
+shape stamp stayed `91fbe73a55b2590a3009762603dff284`; the boot reported
+82.03 GiB model load, 1,396,551 pool tokens / 1.40×, rightsize workspace and
+`127.0.0.1:8000`. Both ranks logged the overlay install. The head retained one
+empty API-key environment entry; the headless worker had **zero** API-key
+entries. No patch-helper re-entry/segfault appeared.
+
+Short gates: acceptance **7/7**, serving **6/6**, tool calls **23/23** with
+zero blank required arguments; structured n=3 median **71.94 tok/s** at
+**1.0000 / 7.0** (every position 1.0); prose n=3 median **29.42 tok/s**,
+coherent/no NaN. The P0 control and candidate batteries each completed three
+1,800-token temp-0.7 essays plus thinking-SSE with no mojibake/repetition,
+zero preemptions and a final answer after reasoning. Candidate wall times
+111.1/92.3/89.3 s versus control 105.6/90.2/86.9 s are descriptive small-n,
+not a throughput regression claim. The established 4×60k×3 cache burst held
+**98.7%** counter hits on rounds 2–3 with zero errors.
+
+The required mixed-state soak ran **3,949 s / 8 cycles**:
+96 24k/60k concurrency cells (thinking/SSE, C1/C4, code/data/chat),
+8 cached unequal-length shared-prefix forks, 128 quick tool turns and
+32 long-form/thinking streams. Results: zero errors/preemptions, concurrency
+hit ratio 0.98–1.00, unequal-fork hit ratio 0.572 every cycle, all 8 cache
+resets succeeded, MemFree floor 3,946,516 / 3,387,340 kB. Post-soak:
+health 200, running/waiting/preemptions 0, prefix hits still advancing, zero
+head/worker CUDA/IMA/Traceback/segfault matches and zero kernel Xids. Production
+kept the candidate and the watchdog was re-armed. Receipts:
+`local/p0-runtime-{control,candidate}-20260905.json`,
+`local/p0-candidate-{structured,prose}-20260905.json`,
+`local/p0-cache-burst-candidate-20260905.txt` and
+`local/p0-soak-summary-20260905.json`.
 
 ```bash
 GLM53_BASE=http://127.0.0.1:8000 uv run python tests/bench_concurrency.py \

--- a/local/p0-cache-burst-candidate-20260905.txt
+++ b/local/p0-cache-burst-candidate-20260905.txt
@@ -1,0 +1,4 @@
+sessions=4 ctx~60000 tok each (~240,000 total vs 1,396,551 pool) rounds=3 conc=4
+round 1: wall  244.9s  hit%   0.0 (usage: 0/271,653)  [counters   0.0]  prefill_tps    1109  lat p50/max 244.5/244.9s  errors 0
+round 2: wall    5.9s  hit%   0.0 (usage: 0/271,653)  [counters  98.7]  prefill_tps   46102  lat p50/max 5.5/5.9s  errors 0
+round 3: wall    9.8s  hit%   0.0 (usage: 0/271,653)  [counters  98.7]  prefill_tps   27721  lat p50/max 9.7/9.8s  errors 0

--- a/local/p0-candidate-prose-20260905.json
+++ b/local/p0-candidate-prose-20260905.json
@@ -1,0 +1,159 @@
+{
+  "phase": "p0-candidate-prose",
+  "health_code": 200,
+  "health_body": "",
+  "runs": [
+    {
+      "http": 200,
+      "ttft_s": 0.3816934999995283,
+      "wall_s": 7.210853042000963,
+      "decode_s": 6.829159542001435,
+      "tok_s": 29.139749741690572,
+      "completion_tokens": 200,
+      "prompt_tokens": 40,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "# How a Hash Map Works: A Complete Guide\n\nA hash map (also called a hash table or dictionary) is a data structure that stores key-value pairs and provides near-constant-time lookup, insertion, and deletion. Let's build up an understanding from the ground up.\n\n---\n\n## 1. The Core Idea\n\nA hash map lets you associate values with keys and retrieve them quickly. Instead of searching through data (like ",
+      "text_len": 872,
+      "usage": {
+        "prompt_tokens": 40,
+        "total_tokens": 240,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 59,
+        "draft_tokens": 413,
+        "accepted": 141,
+        "accept_ratio": 0.3414,
+        "accepted_per_step": 2.39,
+        "pos": [
+          0.7458,
+          0.5085,
+          0.3559,
+          0.2542,
+          0.2034,
+          0.1864,
+          0.1356
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.3643798749999405,
+      "wall_s": 7.129478374999962,
+      "decode_s": 6.765098500000022,
+      "tok_s": 29.415684043624694,
+      "completion_tokens": 200,
+      "prompt_tokens": 40,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "# How a Hash Map Works: A Complete Guide\n\nA hash map (also called a hash table or dictionary) is a data structure that stores key-value pairs and provides near-constant-time lookup, insertion, and deletion. Let's build up an understanding from the ground up.\n\n---\n\n## 1. The Core Concept\n\nA hash map stores data as **key-value pairs**. You provide a key (e.g., a username) and a value (e.g., the user",
+      "text_len": 850,
+      "usage": {
+        "prompt_tokens": 40,
+        "total_tokens": 240,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 59,
+        "draft_tokens": 413,
+        "accepted": 140,
+        "accept_ratio": 0.339,
+        "accepted_per_step": 2.373,
+        "pos": [
+          0.8305,
+          0.5932,
+          0.4068,
+          0.2712,
+          0.1525,
+          0.0678,
+          0.0508
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.36511554200114915,
+      "wall_s": 6.934680083000785,
+      "decode_s": 6.569564540999636,
+      "tok_s": 30.291201000929632,
+      "completion_tokens": 200,
+      "prompt_tokens": 40,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "# How a Hash Map Works: A Complete Guide\n\nA hash map (also called a hash table or dictionary) is a data structure that stores key-value pairs and provides near-constant-time lookup, insertion, and deletion. Here's a thorough breakdown of how it works.\n\n---\n\n## 1. The Core Concept\n\nA hash map stores data as **key-value pairs**. Instead of searching through data linearly (like an array) or following",
+      "text_len": 861,
+      "usage": {
+        "prompt_tokens": 40,
+        "total_tokens": 240,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 52,
+        "draft_tokens": 364,
+        "accepted": 154,
+        "accept_ratio": 0.4231,
+        "accepted_per_step": 2.962,
+        "pos": [
+          0.8654,
+          0.7115,
+          0.5192,
+          0.3269,
+          0.2692,
+          0.1923,
+          0.0769
+        ]
+      }
+    }
+  ],
+  "ts": 1788605814.203147,
+  "prompt": "hashmap-prose",
+  "thinking": false,
+  "temperature": 0,
+  "tok_s_median": 29.415684043624694,
+  "tok_s_min": 29.139749741690572,
+  "tok_s_max": 30.291201000929632,
+  "ttft_median_s": 0.36511554200114915,
+  "completion_tokens_median": 200.0,
+  "accept_ratio_median": 0.3414,
+  "accepted_per_step_median": 2.39,
+  "any_nan": false,
+  "coherence": {
+    "paris": {
+      "ok": true,
+      "text": "Paris",
+      "http": 200
+    },
+    "cmp": {
+      "ok": true,
+      "text": "Yes. 9.9 is greater than 9.11 because 9.9 equals 9.90, and 90 hundredths is more than 11 hundredths.",
+      "http": 200
+    },
+    "sky": {
+      "ok": true,
+      "text": "The sky-blue paint on the nursery walls seemed to capture a perfect summer afternoon, bringing a sense of calm and endless possibility to the little room.",
+      "http": 200
+    },
+    "nan": false
+  },
+  "coherent": true,
+  "health_code_after": 200,
+  "short_after": {
+    "http": 200,
+    "ttft_s": 0.3617778339994402,
+    "wall_s": 0.47696787499990023,
+    "decode_s": 0.11519004100046004,
+    "tok_s": 60.76914235990283,
+    "completion_tokens": 8,
+    "prompt_tokens": 40,
+    "finish_reason": "length",
+    "nan": false,
+    "text_head": "# How a Hash Map Works: A",
+    "text_len": 25,
+    "usage": {
+      "prompt_tokens": 40,
+      "total_tokens": 48,
+      "completion_tokens": 8
+    }
+  }
+}

--- a/local/p0-candidate-structured-20260905.json
+++ b/local/p0-candidate-structured-20260905.json
@@ -1,0 +1,145 @@
+{
+  "phase": "p0-candidate-structured",
+  "health_code": 200,
+  "health_body": "",
+  "runs": [
+    {
+      "http": 200,
+      "ttft_s": 0.36590549999891664,
+      "wall_s": 3.132367874999545,
+      "decode_s": 2.7664623750006285,
+      "tok_s": 71.93302240373133,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.35177316699991934,
+      "wall_s": 3.098427291999542,
+      "decode_s": 2.7466541249996226,
+      "tok_s": 72.45178713574916,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.3503325420006149,
+      "wall_s": 3.1165612499989948,
+      "decode_s": 2.76622870799838,
+      "tok_s": 71.93909868139383,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    }
+  ],
+  "ts": 1788605803.366869,
+  "prompt": "structured-count-1-200",
+  "thinking": false,
+  "temperature": 0,
+  "warmup": {
+    "tok_s": 88.27552673561895,
+    "ttft_s": 0.3487585829989257,
+    "completion_tokens": 32
+  },
+  "tok_s_median": 71.93909868139383,
+  "tok_s_min": 71.93302240373133,
+  "tok_s_max": 72.45178713574916,
+  "ttft_median_s": 0.35177316699991934,
+  "completion_tokens_median": 200.0,
+  "accept_ratio_median": 1.0,
+  "accepted_per_step_median": 7.0,
+  "any_nan": false,
+  "health_code_after": 200,
+  "short_after": {
+    "http": 200,
+    "ttft_s": 0.37873299999955634,
+    "wall_s": 0.512145499998951,
+    "decode_s": 0.13341249999939464,
+    "tok_s": 52.46884662255608,
+    "completion_tokens": 8,
+    "prompt_tokens": 40,
+    "finish_reason": "length",
+    "nan": false,
+    "text_head": "# How a Hash Map Works: A",
+    "text_len": 25,
+    "usage": {
+      "prompt_tokens": 40,
+      "total_tokens": 48,
+      "completion_tokens": 8
+    }
+  }
+}

--- a/local/p0-runtime-candidate-20260905.json
+++ b/local/p0-runtime-candidate-20260905.json
@@ -1,0 +1,133 @@
+{
+  "schema_version": 1,
+  "run_id": "d6e33b2a75",
+  "started": 1788605489.300683,
+  "base": "http://127.0.0.1:18000",
+  "model": "GLM-5.3-Flash-EXL3",
+  "before": {
+    "num_requests_running": 0.0,
+    "num_requests_waiting": 0.0,
+    "num_preemptions_total": 0.0,
+    "prefix_cache_queries_total": 351874.0,
+    "prefix_cache_hits_total": 64.0
+  },
+  "runs": [
+    {
+      "request_id": "glm53-p0-d6e33b2a75-essay-1",
+      "http": 200,
+      "sse_chunks": 669,
+      "done": true,
+      "ttfb_s": 0.364,
+      "wall_s": 111.051,
+      "finish_reason": "length",
+      "usage": {
+        "prompt_tokens": 58,
+        "total_tokens": 1858,
+        "completion_tokens": 1800
+      },
+      "content_sha256": "473037ed3d33e9333e837c32f1bd12bb6933876dccf6c8a8077a25e712d25d5e",
+      "content_head": "# How Ocean Tides Work\n\n## Introduction\n\nOcean tides are among the most familiar yet most misunderstood phenomena in nature. Billions of people live near coastlines and witness the rhythmic rise and fall of the sea twice daily, yet the unde",
+      "content_tail": " tidal cycle, the incoming wave arrives roughly in phase with water still sloshing from the previous cycle, and the oscillation builds. Combined with the bay's dramatic narrowing and shallowing toward its head, the tide grows from about 6 m",
+      "diagnostics": {
+        "replacement_or_mojibake": [],
+        "max_16gram_repeats": 1,
+        "content_chars": 8025,
+        "reasoning_chars": 0
+      },
+      "name": "essay-1",
+      "thinking": false
+    },
+    {
+      "request_id": "glm53-p0-d6e33b2a75-essay-2",
+      "http": 200,
+      "sse_chunks": 756,
+      "done": true,
+      "ttfb_s": 0.409,
+      "wall_s": 92.298,
+      "finish_reason": "length",
+      "usage": {
+        "prompt_tokens": 54,
+        "total_tokens": 1854,
+        "completion_tokens": 1800
+      },
+      "content_sha256": "7d5aff09042c0b0a79be148922e7b43d3f52fa630087ee57e19afcd6e07246fa",
+      "content_head": "# Virtual Memory in Modern Operating Systems\n\n## Introduction\n\nVirtual memory is one of the most consequential abstractions in computer science. By decoupling the *addresses* programs use from the *physical locations* where their data actua",
+      "content_tail": "ls or permissions are insufficient. The OS's page fault handler is where nearly all the interesting memory management decisions happen. The handler must first determine *why* the fault occurred, using the faulting address and error code (on",
+      "diagnostics": {
+        "replacement_or_mojibake": [],
+        "max_16gram_repeats": 1,
+        "content_chars": 8180,
+        "reasoning_chars": 0
+      },
+      "name": "essay-2",
+      "thinking": false
+    },
+    {
+      "request_id": "glm53-p0-d6e33b2a75-essay-3",
+      "http": 200,
+      "sse_chunks": 730,
+      "done": true,
+      "ttfb_s": 0.371,
+      "wall_s": 89.256,
+      "finish_reason": "length",
+      "usage": {
+        "prompt_tokens": 51,
+        "total_tokens": 1851,
+        "completion_tokens": 1800
+      },
+      "content_sha256": "1b3e25fce28ab80a37800384e0b94b4abcdbb844b13b4687ff1e1ab4501cd758",
+      "content_head": "# The Scientific Method in Practice\n\n## Introduction\n\nThe scientific method is often taught as a clean, linear procedure: observe, hypothesize, experiment, conclude. In reality, science operates as a messier, iterative, and self-correcting ",
+      "content_tail": "diction might indict the hypothesis, the measurement, or an auxiliary assumption. When Uranus's orbit misbehaved, the hypothesis rejected was not Newton's laws but the assumption that no further planet existed.\n\nScientists therefore respond",
+      "diagnostics": {
+        "replacement_or_mojibake": [],
+        "max_16gram_repeats": 1,
+        "content_chars": 9867,
+        "reasoning_chars": 0
+      },
+      "name": "essay-3",
+      "thinking": false
+    },
+    {
+      "request_id": "glm53-p0-d6e33b2a75-thinking-sse",
+      "http": 200,
+      "sse_chunks": 43,
+      "done": true,
+      "ttfb_s": 0.264,
+      "wall_s": 4.973,
+      "finish_reason": "stop",
+      "usage": {
+        "prompt_tokens": 24,
+        "total_tokens": 164,
+        "completion_tokens": 140
+      },
+      "content_sha256": "550115119cb73967fbde945339c84051cc742e78b0ddcff2cb12a005a9049ecf",
+      "content_head": "THINKING_STREAM_OK",
+      "content_tail": "THINKING_STREAM_OK",
+      "diagnostics": {
+        "replacement_or_mojibake": [],
+        "max_16gram_repeats": 0,
+        "content_chars": 18,
+        "reasoning_chars": 621
+      },
+      "name": "thinking-sse",
+      "thinking": true
+    }
+  ],
+  "after": {
+    "num_requests_running": 0.0,
+    "num_requests_waiting": 0.0,
+    "num_preemptions_total": 0.0,
+    "prefix_cache_queries_total": 352061.0,
+    "prefix_cache_hits_total": 64.0
+  },
+  "metric_delta": {
+    "num_requests_running": 0.0,
+    "num_requests_waiting": 0.0,
+    "num_preemptions_total": 0.0,
+    "prefix_cache_queries_total": 187.0,
+    "prefix_cache_hits_total": 0.0
+  },
+  "failures": [],
+  "passed": true,
+  "finished": 1788605786.934251
+}

--- a/local/p0-runtime-control-20260905.json
+++ b/local/p0-runtime-control-20260905.json
@@ -1,0 +1,133 @@
+{
+  "schema_version": 1,
+  "run_id": "5b3c437a88",
+  "started": 1788604007.231663,
+  "base": "http://127.0.0.1:18000",
+  "model": "GLM-5.3-Flash-EXL3",
+  "before": {
+    "num_requests_running": 0.0,
+    "num_requests_waiting": 0.0,
+    "num_preemptions_total": 0.0,
+    "prefix_cache_queries_total": 291790.0,
+    "prefix_cache_hits_total": 220800.0
+  },
+  "runs": [
+    {
+      "request_id": "glm53-p0-5b3c437a88-essay-1",
+      "http": 200,
+      "sse_chunks": 675,
+      "done": true,
+      "ttfb_s": 0.387,
+      "wall_s": 105.622,
+      "finish_reason": "length",
+      "usage": {
+        "prompt_tokens": 58,
+        "total_tokens": 1858,
+        "completion_tokens": 1800
+      },
+      "content_sha256": "9f142013f3bc31120e5b6f5551c6027e26d276986dec28bffae6a47d46afa05b",
+      "content_head": "# How Ocean Tides Work\n\n## Introduction\n\nTides are among the most familiar yet most misunderstood phenomena in nature. Nearly everyone who has spent time near the ocean has seen the water advance and retreat, but the underlying physics invo",
+      "content_tail": "ours), so near-resonance amplifies the tide to a mean range of ~12 m and extremes above 16 m. Similar (if smaller) amplification occurs in Bristol Channel, England; Cook Inlet, Alaska; and the Severn Estuary.\n\n**Resonance.** Fundy's case is",
+      "diagnostics": {
+        "replacement_or_mojibake": [],
+        "max_16gram_repeats": 1,
+        "content_chars": 7931,
+        "reasoning_chars": 0
+      },
+      "name": "essay-1",
+      "thinking": false
+    },
+    {
+      "request_id": "glm53-p0-5b3c437a88-essay-2",
+      "http": 200,
+      "sse_chunks": 753,
+      "done": true,
+      "ttfb_s": 0.394,
+      "wall_s": 90.186,
+      "finish_reason": "length",
+      "usage": {
+        "prompt_tokens": 54,
+        "total_tokens": 1854,
+        "completion_tokens": 1800
+      },
+      "content_sha256": "d82063e14027653b1cca03169f054d6f8292b548d52adb6d9c190d30dc4e5c79",
+      "content_head": "# Virtual Memory in Modern Operating Systems\n\n## Introduction\n\nVirtual memory is one of the most consequential abstractions in computer science. By giving each process the illusion of a large, private, contiguous address space, it decouples",
+      "content_tail": "s allocating and zeroing memory for pages that are reserved but never used\u2014important because physical memory allocation usually includes security-driven zeroing (preventing information leaks from previous owners of a frame).\n\n## 4. Copy-on-",
+      "diagnostics": {
+        "replacement_or_mojibake": [],
+        "max_16gram_repeats": 1,
+        "content_chars": 8587,
+        "reasoning_chars": 0
+      },
+      "name": "essay-2",
+      "thinking": false
+    },
+    {
+      "request_id": "glm53-p0-5b3c437a88-essay-3",
+      "http": 200,
+      "sse_chunks": 729,
+      "done": true,
+      "ttfb_s": 0.434,
+      "wall_s": 86.938,
+      "finish_reason": "length",
+      "usage": {
+        "prompt_tokens": 51,
+        "total_tokens": 1851,
+        "completion_tokens": 1800
+      },
+      "content_sha256": "c644b2dffeced5ea07c6bb24229f212b821d1869480229749477a9f137f8296c",
+      "content_head": "# The Scientific Method in Practice\n\n## Introduction\n\nThe scientific method is often presented as a tidy flowchart: observe, hypothesize, experiment, conclude. Real science rarely works that way. In practice, it is a messy, iterative, self-",
+      "content_tail": "s, theories fall.\n\n## Peer Review: Quality Control by the Community\n\nIndividual scientists are fallible; the community is the corrective. **Peer review**\u2014evaluation of manuscripts and grant proposals by independent experts\u2014serves as quality",
+      "diagnostics": {
+        "replacement_or_mojibake": [],
+        "max_16gram_repeats": 1,
+        "content_chars": 9489,
+        "reasoning_chars": 0
+      },
+      "name": "essay-3",
+      "thinking": false
+    },
+    {
+      "request_id": "glm53-p0-5b3c437a88-thinking-sse",
+      "http": 200,
+      "sse_chunks": 42,
+      "done": true,
+      "ttfb_s": 0.52,
+      "wall_s": 9.99,
+      "finish_reason": "stop",
+      "usage": {
+        "prompt_tokens": 24,
+        "total_tokens": 169,
+        "completion_tokens": 145
+      },
+      "content_sha256": "550115119cb73967fbde945339c84051cc742e78b0ddcff2cb12a005a9049ecf",
+      "content_head": "THINKING_STREAM_OK",
+      "content_tail": "THINKING_STREAM_OK",
+      "diagnostics": {
+        "replacement_or_mojibake": [],
+        "max_16gram_repeats": 0,
+        "content_chars": 18,
+        "reasoning_chars": 657
+      },
+      "name": "thinking-sse",
+      "thinking": true
+    }
+  ],
+  "after": {
+    "num_requests_running": 0.0,
+    "num_requests_waiting": 0.0,
+    "num_preemptions_total": 0.0,
+    "prefix_cache_queries_total": 291977.0,
+    "prefix_cache_hits_total": 220800.0
+  },
+  "metric_delta": {
+    "num_requests_running": 0.0,
+    "num_requests_waiting": 0.0,
+    "num_preemptions_total": 0.0,
+    "prefix_cache_queries_total": 187.0,
+    "prefix_cache_hits_total": 0.0
+  },
+  "failures": [],
+  "passed": true,
+  "finished": 1788604300.026411
+}

--- a/local/p0-runtime-probe.py
+++ b/local/p0-runtime-probe.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+"""P0 long-form corruption and thinking-SSE probe.
+
+Runs three fixed English essay prompts with thinking disabled and one short
+thinking-enabled streaming request. Every request uses APC no-store. The probe
+fails on missing SSE termination, short/incomplete output, invalid UTF-8,
+replacement/mojibake markers, repeated-token loops, HTTP errors, preemptions, or
+requests left running/waiting.
+
+Run from the Mac through the production tunnel:
+
+  uv run python local/p0-runtime-probe.py \
+    --base http://127.0.0.1:18000 \
+    --out local/p0-runtime-$(date +%F).json
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import time
+import urllib.error
+import urllib.request
+import uuid
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+
+MODEL = os.environ.get("GLM53_MODEL", "GLM-5.3-Flash-EXL3")
+API_KEY = os.environ.get("VLLM_API_KEY", "")
+PROMPTS = (
+    "Write a detailed essay explaining how ocean tides work, including lunar and solar forcing, spring and neap tides, amphidromic systems, coastal geometry, and common misconceptions. Use clear sections and concrete examples.",
+    "Write a detailed essay on how a modern operating system manages virtual memory. Cover page tables, translation caches, page faults, copy-on-write, file-backed mappings, swapping, and failure modes under memory pressure.",
+    "Write a detailed essay explaining the scientific method in practice. Cover hypothesis formation, experimental design, measurement uncertainty, replication, falsification, peer review, and how scientists revise models after conflicting evidence.",
+)
+MOJIBAKE = ("�", "Ã", "Â", "â€", "\x00")
+METRICS = (
+    "num_requests_running",
+    "num_requests_waiting",
+    "num_preemptions_total",
+    "prefix_cache_queries_total",
+    "prefix_cache_hits_total",
+)
+
+
+def headers(request_id: str = "") -> dict[str, str]:
+    out = {"Content-Type": "application/json"}
+    if API_KEY:
+        out["Authorization"] = f"Bearer {API_KEY}"
+    if request_id:
+        out["X-Request-Id"] = request_id
+    return out
+
+
+def open_url(base: str, path: str, body: dict | None, timeout: float, request_id: str = ""):
+    request = urllib.request.Request(
+        base.rstrip("/") + path,
+        data=json.dumps(body).encode() if body is not None else None,
+        headers=headers(request_id),
+        method="POST" if body is not None else "GET",
+    )
+    return urllib.request.urlopen(request, timeout=timeout)
+
+
+def metrics(base: str) -> dict[str, float]:
+    with open_url(base, "/metrics", None, 30) as response:
+        text = response.read().decode("utf-8", "strict")
+    result: dict[str, float] = {}
+    for name in METRICS:
+        values = re.findall(
+            rf"^vllm:{re.escape(name)}(?:\{{[^}}]*\}})?\s+(\S+)$", text, re.MULTILINE
+        )
+        if values:
+            result[name] = sum(float(value) for value in values)
+    return result
+
+
+def max_ngram_repeats(text: str, width: int = 16) -> int:
+    words = re.findall(r"\w+|[^\w\s]", text.lower())
+    if len(words) < width:
+        return 0
+    counts = Counter(tuple(words[i : i + width]) for i in range(len(words) - width + 1))
+    return max(counts.values(), default=0)
+
+
+def stream_request(
+    base: str,
+    prompt: str,
+    *,
+    thinking: bool,
+    temperature: float,
+    max_tokens: int,
+    timeout: float,
+    request_id: str,
+) -> dict[str, Any]:
+    body = {
+        "model": MODEL,
+        "messages": [{"role": "user", "content": prompt}],
+        "temperature": temperature,
+        "max_tokens": max_tokens,
+        "stream": True,
+        "stream_options": {"include_usage": True},
+        "chat_template_kwargs": {
+            "enable_thinking": thinking,
+            "reasoning_effort": "max",
+        },
+        "vllm_xargs": {"skip_writing_prefix_cache": 1},
+    }
+    started = time.perf_counter()
+    first_byte = None
+    chunks = 0
+    done = False
+    usage: dict[str, Any] = {}
+    finish_reason = None
+    content: list[str] = []
+    reasoning: list[str] = []
+    with open_url(
+        base, "/v1/chat/completions", body, timeout, request_id=request_id
+    ) as response:
+        status = response.status
+        for raw in response:
+            if first_byte is None:
+                first_byte = time.perf_counter()
+            line = raw.decode("utf-8", "strict").strip()
+            if not line.startswith("data:"):
+                continue
+            payload = line[5:].strip()
+            if payload == "[DONE]":
+                done = True
+                continue
+            event = json.loads(payload)
+            chunks += 1
+            if event.get("usage"):
+                usage = event["usage"]
+            for choice in event.get("choices") or []:
+                finish_reason = choice.get("finish_reason") or finish_reason
+                delta = choice.get("delta") or {}
+                if delta.get("content"):
+                    content.append(delta["content"])
+                value = delta.get("reasoning") or delta.get("reasoning_content")
+                if value:
+                    reasoning.append(value)
+    ended = time.perf_counter()
+    text = "".join(content)
+    thought = "".join(reasoning)
+    diagnostics = {
+        "replacement_or_mojibake": [marker for marker in MOJIBAKE if marker in text],
+        "max_16gram_repeats": max_ngram_repeats(text),
+        "content_chars": len(text),
+        "reasoning_chars": len(thought),
+    }
+    return {
+        "request_id": request_id,
+        "http": status,
+        "sse_chunks": chunks,
+        "done": done,
+        "ttfb_s": round(first_byte - started, 3) if first_byte else None,
+        "wall_s": round(ended - started, 3),
+        "finish_reason": finish_reason,
+        "usage": usage,
+        "content_sha256": hashlib.sha256(text.encode()).hexdigest(),
+        "content_head": text[:240],
+        "content_tail": text[-240:],
+        "diagnostics": diagnostics,
+    }
+
+
+def validate_run(name: str, run: dict[str, Any], min_essay_tokens: int) -> list[str]:
+    failures: list[str] = []
+    if run.get("error"):
+        return [f"{name}: {run['error']}"]
+    if run.get("http") != 200 or not run.get("done") or run.get("sse_chunks", 0) < 2:
+        failures.append(f"{name}: incomplete SSE response")
+    diagnostics = run["diagnostics"]
+    if diagnostics["replacement_or_mojibake"]:
+        failures.append(f"{name}: mojibake markers {diagnostics['replacement_or_mojibake']}")
+    if diagnostics["max_16gram_repeats"] > 6:
+        failures.append(f"{name}: repeated 16-gram loop")
+
+    if name.startswith("essay"):
+        if run.get("finish_reason") not in {"stop", "length"}:
+            failures.append(f"{name}: finish_reason={run.get('finish_reason')!r}")
+        if int(run.get("usage", {}).get("completion_tokens") or 0) < min_essay_tokens:
+            failures.append(f"{name}: fewer than {min_essay_tokens} completion tokens")
+    elif name == "thinking-sse":
+        if run.get("finish_reason") != "stop":
+            failures.append(f"{name}: finish_reason={run.get('finish_reason')!r}")
+        if diagnostics["reasoning_chars"] == 0:
+            failures.append("thinking-sse: no reasoning deltas")
+        if "THINKING_STREAM_OK" not in (
+            str(run.get("content_head", "")) + str(run.get("content_tail", ""))
+        ):
+            failures.append("thinking-sse: missing final answer marker")
+    return failures
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base", default=os.environ.get("GLM53_BASE", "http://127.0.0.1:18000"))
+    parser.add_argument("--essay-max-tokens", type=int, default=1800)
+    parser.add_argument("--thinking-max-tokens", type=int, default=256)
+    parser.add_argument("--min-essay-tokens", type=int, default=1000)
+    parser.add_argument("--timeout", type=float, default=1800)
+    parser.add_argument("--out", required=True)
+    parser.add_argument("--force", action="store_true")
+    args = parser.parse_args()
+
+    before = metrics(args.base)
+    if not args.force and (
+        before.get("num_requests_running", 0) > 0
+        or before.get("num_requests_waiting", 0) > 0
+    ):
+        print("server busy; refusing (use --force only for an intentional overlap)")
+        return 2
+
+    run_id = uuid.uuid4().hex[:10]
+    result: dict[str, Any] = {
+        "schema_version": 1,
+        "run_id": run_id,
+        "started": time.time(),
+        "base": args.base,
+        "model": MODEL,
+        "before": before,
+        "runs": [],
+    }
+    failures: list[str] = []
+    cells = [
+        (f"essay-{index + 1}", prompt, False, 0.7, args.essay_max_tokens)
+        for index, prompt in enumerate(PROMPTS)
+    ]
+    cells.append(
+        (
+            "thinking-sse",
+            "Think briefly, then answer with exactly: THINKING_STREAM_OK",
+            True,
+            0.0,
+            args.thinking_max_tokens,
+        )
+    )
+
+    for name, prompt, thinking, temperature, max_tokens in cells:
+        request_id = f"glm53-p0-{run_id}-{name}"
+        try:
+            run = stream_request(
+                args.base,
+                prompt,
+                thinking=thinking,
+                temperature=temperature,
+                max_tokens=max_tokens,
+                timeout=args.timeout,
+                request_id=request_id,
+            )
+        except (urllib.error.URLError, OSError, TimeoutError, UnicodeError, json.JSONDecodeError) as exc:
+            run = {"request_id": request_id, "error": f"{type(exc).__name__}: {exc}"}
+        run["name"] = name
+        run["thinking"] = thinking
+        result["runs"].append(run)
+        failures.extend(validate_run(name, run, args.min_essay_tokens))
+
+    after = metrics(args.base)
+    result["after"] = after
+    result["metric_delta"] = {
+        key: after.get(key, 0) - before.get(key, 0) for key in METRICS
+    }
+    if result["metric_delta"].get("num_preemptions_total", 0) != 0:
+        failures.append("preemption counter increased")
+    if after.get("num_requests_running", 0) or after.get("num_requests_waiting", 0):
+        failures.append("requests remain running or waiting")
+    result["failures"] = failures
+    result["passed"] = not failures
+    result["finished"] = time.time()
+
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(result, indent=2), encoding="utf-8")
+    print(json.dumps({"passed": result["passed"], "failures": failures, "out": str(out)}))
+    return 0 if result["passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/local/p0-soak-summary-20260905.json
+++ b/local/p0-soak-summary-20260905.json
@@ -1,0 +1,6844 @@
+{
+  "schema_version": 1,
+  "candidate_commit": "39d3ee5",
+  "start_sha256": "d8fe5a644ebd2a6d6e79f38b89c10f206a2596db01df6513d8a9dbcad51a5fe1",
+  "overlay_sha256": "181b2d5ad93b1ae3a7eb8a878bba33e3a5934c1bf21893de9863c66119ba3dd8",
+  "duration_s": 3949,
+  "cycles": 8,
+  "min_memfree_kb": {
+    "head": 3946516,
+    "worker": 3387340
+  },
+  "cache_resets_successful": 8,
+  "tool_turns": 128,
+  "tool_errors": 0,
+  "concurrency_summary": {
+    "cells": 96,
+    "errors": 0,
+    "preemptions": 0,
+    "cache_hit_ratio_min": 0.98,
+    "cache_hit_ratio_max": 1.0
+  },
+  "unequal_fork_summary": {
+    "runs": 8,
+    "hit_ratio_min": 0.571960981917058,
+    "hit_ratio_max": 0.571960981917058,
+    "preemptions": 0
+  },
+  "runtime_summary": {
+    "runs": 32,
+    "failed_cycles": 0,
+    "preemptions": 0
+  },
+  "concurrency_cycles": [
+    {
+      "file": "p0-soak-concurrency-c1-20260905.json",
+      "run_id": "cae32315c1",
+      "cells": [
+        {
+          "mode": "code",
+          "ctx": 24000,
+          "level": 1,
+          "rep": 0,
+          "temperature": 0.0,
+          "thinking": true,
+          "agg_tps": 30.7,
+          "stream_tps_median": 36.6,
+          "ttft": {
+            "p50": 0.697,
+            "p95": 0.697,
+            "p99": 0.697
+          },
+          "itl": {
+            "p50": 0.118,
+            "p95": 0.128,
+            "p99": 0.13
+          },
+          "starvation_age_s": 0.7,
+          "tokens": 128,
+          "prompt_tokens": 25477,
+          "wall": 4.2,
+          "cache_hit_ratio": 0.997,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-cae32315c1-code-c24000-n1-r0-l0-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-cae32315c1-code-c24000-n1-r0-l0-measure"
+            ],
+            "expected_measured_requests": 1,
+            "http_200_with_usage": 1,
+            "metric_queries_delta": 25477.0,
+            "metric_hits_delta": 25408.0
+          }
+        },
+        {
+          "mode": "code",
+          "ctx": 24000,
+          "level": 4,
+          "rep": 0,
+          "temperature": 0.0,
+          "thinking": true,
+          "agg_tps": 54.7,
+          "stream_tps_median": 15.6,
+          "ttft": {
+            "p50": 1.0,
+            "p95": 1.001,
+            "p99": 1.001
+          },
+          "itl": {
+            "p50": 0.251,
+            "p95": 0.339,
+            "p99": 0.348
+          },
+          "starvation_age_s": 1.0,
+          "tokens": 512,
+          "prompt_tokens": 101915,
+          "wall": 9.4,
+          "cache_hit_ratio": 0.998,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-cae32315c1-code-c24000-n4-r0-l0-warm",
+              "glm53-ladder-cae32315c1-code-c24000-n4-r0-l1-warm",
+              "glm53-ladder-cae32315c1-code-c24000-n4-r0-l2-warm",
+              "glm53-ladder-cae32315c1-code-c24000-n4-r0-l3-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-cae32315c1-code-c24000-n4-r0-l0-measure",
+              "glm53-ladder-cae32315c1-code-c24000-n4-r0-l1-measure",
+              "glm53-ladder-cae32315c1-code-c24000-n4-r0-l2-measure",
+              "glm53-ladder-cae32315c1-code-c24000-n4-r0-l3-measure"
+            ],
+            "expected_measured_requests": 4,
+            "http_200_with_usage": 4,
+            "metric_queries_delta": 101915.0,
+            "metric_hits_delta": 101696.0
+          }
+        },
+        {
+          "mode": "code",
+          "ctx": 60000,
+          "level": 1,
+          "rep": 0,
+          "temperature": 0.0,
+          "thinking": true,
+          "agg_tps": 25.0,
+          "stream_tps_median": 38.5,
+          "ttft": {
+            "p50": 1.815,
+            "p95": 1.815,
+            "p99": 1.815
+          },
+          "itl": {
+            "p50": 0.119,
+            "p95": 0.123,
+            "p99": 0.124
+          },
+          "starvation_age_s": 1.82,
+          "tokens": 128,
+          "prompt_tokens": 65807,
+          "wall": 5.1,
+          "cache_hit_ratio": 0.98,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-cae32315c1-code-c60000-n1-r0-l0-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-cae32315c1-code-c60000-n1-r0-l0-measure"
+            ],
+            "expected_measured_requests": 1,
+            "http_200_with_usage": 1,
+            "metric_queries_delta": 65807.0,
+            "metric_hits_delta": 64512.0
+          }
+        },
+        {
+          "mode": "code",
+          "ctx": 60000,
+          "level": 4,
+          "rep": 0,
+          "temperature": 0.0,
+          "thinking": true,
+          "agg_tps": 41.1,
+          "stream_tps_median": 16.6,
+          "ttft": {
+            "p50": 4.365,
+            "p95": 4.368,
+            "p99": 4.368
+          },
+          "itl": {
+            "p50": 0.241,
+            "p95": 0.354,
+            "p99": 0.356
+          },
+          "starvation_age_s": 4.37,
+          "tokens": 512,
+          "prompt_tokens": 263235,
+          "wall": 12.5,
+          "cache_hit_ratio": 0.985,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-cae32315c1-code-c60000-n4-r0-l0-warm",
+              "glm53-ladder-cae32315c1-code-c60000-n4-r0-l1-warm",
+              "glm53-ladder-cae32315c1-code-c60000-n4-r0-l2-warm",
+              "glm53-ladder-cae32315c1-code-c60000-n4-r0-l3-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-cae32315c1-code-c60000-n4-r0-l0-measure",
+              "glm53-ladder-cae32315c1-code-c60000-n4-r0-l1-measure",
+              "glm53-ladder-cae32315c1-code-c60000-n4-r0-l2-measure",
+              "glm53-ladder-cae32315c1-code-c60000-n4-r0-l3-measure"
+            ],
+            "expected_measured_requests": 4,
+            "http_200_with_usage": 4,
+            "metric_queries_delta": 263235.0,
+            "metric_hits_delta": 259328.0
+          }
+        },
+        {
+          "mode": "data",
+          "ctx": 24000,
+          "level": 1,
+          "rep": 0,
+          "temperature": 0.0,
+          "thinking": true,
+          "agg_tps": 30.1,
+          "stream_tps_median": 34.4,
+          "ttft": {
+            "p50": 0.558,
+            "p95": 0.558,
+            "p99": 0.558
+          },
+          "itl": {
+            "p50": 0.117,
+            "p95": 0.175,
+            "p99": 0.187
+          },
+          "starvation_age_s": 0.56,
+          "tokens": 128,
+          "prompt_tokens": 25478,
+          "wall": 4.3,
+          "cache_hit_ratio": 0.997,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-cae32315c1-data-c24000-n1-r0-l0-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-cae32315c1-data-c24000-n1-r0-l0-measure"
+            ],
+            "expected_measured_requests": 1,
+            "http_200_with_usage": 1,
+            "metric_queries_delta": 25478.0,
+            "metric_hits_delta": 25408.0
+          }
+        },
+        {
+          "mode": "data",
+          "ctx": 24000,
+          "level": 4,
+          "rep": 0,
+          "temperature": 0.0,
+          "thinking": true,
+          "agg_tps": 51.8,
+          "stream_tps_median": 17.0,
+          "ttft": {
+            "p50": 1.515,
+            "p95": 1.516,
+            "p99": 1.516
+          },
+          "itl": {
+            "p50": 0.199,
+            "p95": 0.331,
+            "p99": 0.465
+          },
+          "starvation_age_s": 1.52,
+          "tokens": 512,
+          "prompt_tokens": 101912,
+          "wall": 9.9,
+          "cache_hit_ratio": 0.998,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-cae32315c1-data-c24000-n4-r0-l0-warm",
+              "glm53-ladder-cae32315c1-data-c24000-n4-r0-l1-warm",
+              "glm53-ladder-cae32315c1-data-c24000-n4-r0-l2-warm",
+              "glm53-ladder-cae32315c1-data-c24000-n4-r0-l3-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-cae32315c1-data-c24000-n4-r0-l0-measure",
+              "glm53-ladder-cae32315c1-data-c24000-n4-r0-l1-measure",
+              "glm53-ladder-cae32315c1-data-c24000-n4-r0-l2-measure",
+              "glm53-ladder-cae32315c1-data-c24000-n4-r0-l3-measure"
+            ],
+            "expected_measured_requests": 4,
+            "http_200_with_usage": 4,
+            "metric_queries_delta": 101912.0,
+            "metric_hits_delta": 101696.0
+          }
+        },
+        {
+          "mode": "data",
+          "ctx": 60000,
+          "level": 1,
+          "rep": 0,
+          "temperature": 0.0,
+          "thinking": true,
+          "agg_tps": 22.0,
+          "stream_tps_median": 32.6,
+          "ttft": {
+            "p50": 1.918,
+            "p95": 1.918,
+            "p99": 1.918
+          },
+          "itl": {
+            "p50": 0.116,
+            "p95": 0.14,
+            "p99": 0.153
+          },
+          "starvation_age_s": 1.92,
+          "tokens": 128,
+          "prompt_tokens": 65808,
+          "wall": 5.8,
+          "cache_hit_ratio": 0.98,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-cae32315c1-data-c60000-n1-r0-l0-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-cae32315c1-data-c60000-n1-r0-l0-measure"
+            ],
+            "expected_measured_requests": 1,
+            "http_200_with_usage": 1,
+            "metric_queries_delta": 65808.0,
+            "metric_hits_delta": 64512.0
+          }
+        },
+        {
+          "mode": "data",
+          "ctx": 60000,
+          "level": 4,
+          "rep": 0,
+          "temperature": 0.0,
+          "thinking": true,
+          "agg_tps": 29.7,
+          "stream_tps_median": 11.2,
+          "ttft": {
+            "p50": 5.274,
+            "p95": 5.277,
+            "p99": 5.277
+          },
+          "itl": {
+            "p50": 0.239,
+            "p95": 0.335,
+            "p99": 5.22
+          },
+          "starvation_age_s": 5.28,
+          "tokens": 512,
+          "prompt_tokens": 263232,
+          "wall": 17.2,
+          "cache_hit_ratio": 0.985,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-cae32315c1-data-c60000-n4-r0-l0-warm",
+              "glm53-ladder-cae32315c1-data-c60000-n4-r0-l1-warm",
+              "glm53-ladder-cae32315c1-data-c60000-n4-r0-l2-warm",
+              "glm53-ladder-cae32315c1-data-c60000-n4-r0-l3-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-cae32315c1-data-c60000-n4-r0-l0-measure",
+              "glm53-ladder-cae32315c1-data-c60000-n4-r0-l1-measure",
+              "glm53-ladder-cae32315c1-data-c60000-n4-r0-l2-measure",
+              "glm53-ladder-cae32315c1-data-c60000-n4-r0-l3-measure"
+            ],
+            "expected_measured_requests": 4,
+            "http_200_with_usage": 4,
+            "metric_queries_delta": 263232.0,
+            "metric_hits_delta": 259328.0
+          }
+        },
+        {
+          "mode": "chat",
+          "ctx": 24000,
+          "level": 1,
+          "rep": 0,
+          "temperature": 0.7,
+          "thinking": true,
+          "agg_tps": 19.8,
+          "stream_tps_median": 22.0,
+          "ttft": {
+            "p50": 0.693,
+            "p95": 0.693,
+            "p99": 0.693
+          },
+          "itl": {
+            "p50": 0.117,
+            "p95": 0.13,
+            "p99": 0.167
+          },
+          "starvation_age_s": 0.69,
+          "tokens": 128,
+          "prompt_tokens": 25485,
+          "wall": 6.5,
+          "cache_hit_ratio": 0.997,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-cae32315c1-chat-c24000-n1-r0-l0-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-cae32315c1-chat-c24000-n1-r0-l0-measure"
+            ],
+            "expected_measured_requests": 1,
+            "http_200_with_usage": 1,
+            "metric_queries_delta": 25485.0,
+            "metric_hits_delta": 25408.0
+          }
+        },
+        {
+          "mode": "chat",
+          "ctx": 24000,
+          "level": 4,
+          "rep": 0,
+          "temperature": 0.7,
+          "thinking": true,
+          "agg_tps": 36.9,
+          "stream_tps_median": 10.5,
+          "ttft": {
+            "p50": 1.108,
+            "p95": 1.11,
+            "p99": 1.11
+          },
+          "itl": {
+            "p50": 0.233,
+            "p95": 0.383,
+            "p99": 0.413
+          },
+          "starvation_age_s": 1.11,
+          "tokens": 512,
+          "prompt_tokens": 101943,
+          "wall": 13.9,
+          "cache_hit_ratio": 0.998,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-cae32315c1-chat-c24000-n4-r0-l0-warm",
+              "glm53-ladder-cae32315c1-chat-c24000-n4-r0-l1-warm",
+              "glm53-ladder-cae32315c1-chat-c24000-n4-r0-l2-warm",
+              "glm53-ladder-cae32315c1-chat-c24000-n4-r0-l3-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-cae32315c1-chat-c24000-n4-r0-l0-measure",
+              "glm53-ladder-cae32315c1-chat-c24000-n4-r0-l1-measure",
+              "glm53-ladder-cae32315c1-chat-c24000-n4-r0-l2-measure",
+              "glm53-ladder-cae32315c1-chat-c24000-n4-r0-l3-measure"
+            ],
+            "expected_measured_requests": 4,
+            "http_200_with_usage": 4,
+            "metric_queries_delta": 101943.0,
+            "metric_hits_delta": 101696.0
+          }
+        },
+        {
+          "mode": "chat",
+          "ctx": 60000,
+          "level": 1,
+          "rep": 0,
+          "temperature": 0.7,
+          "thinking": true,
+          "agg_tps": 16.7,
+          "stream_tps_median": 22.2,
+          "ttft": {
+            "p50": 1.917,
+            "p95": 1.917,
+            "p99": 1.917
+          },
+          "itl": {
+            "p50": 0.119,
+            "p95": 0.131,
+            "p99": 0.144
+          },
+          "starvation_age_s": 1.92,
+          "tokens": 128,
+          "prompt_tokens": 65815,
+          "wall": 7.6,
+          "cache_hit_ratio": 0.98,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-cae32315c1-chat-c60000-n1-r0-l0-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-cae32315c1-chat-c60000-n1-r0-l0-measure"
+            ],
+            "expected_measured_requests": 1,
+            "http_200_with_usage": 1,
+            "metric_queries_delta": 65815.0,
+            "metric_hits_delta": 64512.0
+          }
+        },
+        {
+          "mode": "chat",
+          "ctx": 60000,
+          "level": 4,
+          "rep": 0,
+          "temperature": 0.7,
+          "thinking": true,
+          "agg_tps": 28.9,
+          "stream_tps_median": 9.2,
+          "ttft": {
+            "p50": 0.786,
+            "p95": 0.947,
+            "p99": 0.947
+          },
+          "itl": {
+            "p50": 0.231,
+            "p95": 0.378,
+            "p99": 0.411
+          },
+          "starvation_age_s": 0.95,
+          "tokens": 512,
+          "prompt_tokens": 263263,
+          "wall": 17.7,
+          "cache_hit_ratio": 1.0,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-cae32315c1-chat-c60000-n4-r0-l0-warm",
+              "glm53-ladder-cae32315c1-chat-c60000-n4-r0-l1-warm",
+              "glm53-ladder-cae32315c1-chat-c60000-n4-r0-l2-warm",
+              "glm53-ladder-cae32315c1-chat-c60000-n4-r0-l3-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-cae32315c1-chat-c60000-n4-r0-l0-measure",
+              "glm53-ladder-cae32315c1-chat-c60000-n4-r0-l1-measure",
+              "glm53-ladder-cae32315c1-chat-c60000-n4-r0-l2-measure",
+              "glm53-ladder-cae32315c1-chat-c60000-n4-r0-l3-measure"
+            ],
+            "expected_measured_requests": 4,
+            "http_200_with_usage": 4,
+            "metric_queries_delta": 263263.0,
+            "metric_hits_delta": 263168.0
+          }
+        }
+      ]
+    },
+    {
+      "file": "p0-soak-concurrency-c2-20260905.json",
+      "run_id": "d858f72546",
+      "cells": [
+        {
+          "mode": "code",
+          "ctx": 24000,
+          "level": 1,
+          "rep": 0,
+          "temperature": 0.0,
+          "thinking": true,
+          "agg_tps": 25.2,
+          "stream_tps_median": 28.2,
+          "ttft": {
+            "p50": 0.583,
+            "p95": 0.583,
+            "p99": 0.583
+          },
+          "itl": {
+            "p50": 0.122,
+            "p95": 0.192,
+            "p99": 0.196
+          },
+          "starvation_age_s": 0.58,
+          "tokens": 128,
+          "prompt_tokens": 25477,
+          "wall": 5.1,
+          "cache_hit_ratio": 0.997,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-d858f72546-code-c24000-n1-r0-l0-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-d858f72546-code-c24000-n1-r0-l0-measure"
+            ],
+            "expected_measured_requests": 1,
+            "http_200_with_usage": 1,
+            "metric_queries_delta": 25477.0,
+            "metric_hits_delta": 25408.0
+          }
+        },
+        {
+          "mode": "code",
+          "ctx": 24000,
+          "level": 4,
+          "rep": 0,
+          "temperature": 0.0,
+          "thinking": true,
+          "agg_tps": 53.8,
+          "stream_tps_median": 16.7,
+          "ttft": {
+            "p50": 1.084,
+            "p95": 1.084,
+            "p99": 1.084
+          },
+          "itl": {
+            "p50": 0.238,
+            "p95": 0.316,
+            "p99": 0.341
+          },
+          "starvation_age_s": 1.08,
+          "tokens": 512,
+          "prompt_tokens": 101915,
+          "wall": 9.5,
+          "cache_hit_ratio": 0.998,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-d858f72546-code-c24000-n4-r0-l0-warm",
+              "glm53-ladder-d858f72546-code-c24000-n4-r0-l1-warm",
+              "glm53-ladder-d858f72546-code-c24000-n4-r0-l2-warm",
+              "glm53-ladder-d858f72546-code-c24000-n4-r0-l3-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-d858f72546-code-c24000-n4-r0-l0-measure",
+              "glm53-ladder-d858f72546-code-c24000-n4-r0-l1-measure",
+              "glm53-ladder-d858f72546-code-c24000-n4-r0-l2-measure",
+              "glm53-ladder-d858f72546-code-c24000-n4-r0-l3-measure"
+            ],
+            "expected_measured_requests": 4,
+            "http_200_with_usage": 4,
+            "metric_queries_delta": 101915.0,
+            "metric_hits_delta": 101696.0
+          }
+        },
+        {
+          "mode": "code",
+          "ctx": 60000,
+          "level": 1,
+          "rep": 0,
+          "temperature": 0.0,
+          "thinking": true,
+          "agg_tps": 12.0,
+          "stream_tps_median": 14.4,
+          "ttft": {
+            "p50": 1.854,
+            "p95": 1.854,
+            "p99": 1.854
+          },
+          "itl": {
+            "p50": 0.122,
+            "p95": 0.137,
+            "p99": 5.044
+          },
+          "starvation_age_s": 1.85,
+          "tokens": 128,
+          "prompt_tokens": 65807,
+          "wall": 10.7,
+          "cache_hit_ratio": 0.98,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-d858f72546-code-c60000-n1-r0-l0-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-d858f72546-code-c60000-n1-r0-l0-measure"
+            ],
+            "expected_measured_requests": 1,
+            "http_200_with_usage": 1,
+            "metric_queries_delta": 65807.0,
+            "metric_hits_delta": 64512.0
+          }
+        },
+        {
+          "mode": "code",
+          "ctx": 60000,
+          "level": 4,
+          "rep": 0,
+          "temperature": 0.0,
+          "thinking": true,
+          "agg_tps": 38.9,
+          "stream_tps_median": 15.3,
+          "ttft": {
+            "p50": 4.748,
+            "p95": 4.75,
+            "p99": 4.75
+          },
+          "itl": {
+            "p50": 0.243,
+            "p95": 0.355,
+            "p99": 1.26
+          },
+          "starvation_age_s": 4.75,
+          "tokens": 512,
+          "prompt_tokens": 263235,
+          "wall": 13.2,
+          "cache_hit_ratio": 0.985,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-d858f72546-code-c60000-n4-r0-l0-warm",
+              "glm53-ladder-d858f72546-code-c60000-n4-r0-l1-warm",
+              "glm53-ladder-d858f72546-code-c60000-n4-r0-l2-warm",
+              "glm53-ladder-d858f72546-code-c60000-n4-r0-l3-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-d858f72546-code-c60000-n4-r0-l0-measure",
+              "glm53-ladder-d858f72546-code-c60000-n4-r0-l1-measure",
+              "glm53-ladder-d858f72546-code-c60000-n4-r0-l2-measure",
+              "glm53-ladder-d858f72546-code-c60000-n4-r0-l3-measure"
+            ],
+            "expected_measured_requests": 4,
+            "http_200_with_usage": 4,
+            "metric_queries_delta": 263235.0,
+            "metric_hits_delta": 259328.0
+          }
+        },
+        {
+          "mode": "data",
+          "ctx": 24000,
+          "level": 1,
+          "rep": 0,
+          "temperature": 0.0,
+          "thinking": true,
+          "agg_tps": 30.5,
+          "stream_tps_median": 35.4,
+          "ttft": {
+            "p50": 0.601,
+            "p95": 0.601,
+            "p99": 0.601
+          },
+          "itl": {
+            "p50": 0.116,
+            "p95": 0.135,
+            "p99": 0.156
+          },
+          "starvation_age_s": 0.6,
+          "tokens": 128,
+          "prompt_tokens": 25478,
+          "wall": 4.2,
+          "cache_hit_ratio": 0.997,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-d858f72546-data-c24000-n1-r0-l0-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-d858f72546-data-c24000-n1-r0-l0-measure"
+            ],
+            "expected_measured_requests": 1,
+            "http_200_with_usage": 1,
+            "metric_queries_delta": 25478.0,
+            "metric_hits_delta": 25408.0
+          }
+        },
+        {
+          "mode": "data",
+          "ctx": 24000,
+          "level": 4,
+          "rep": 0,
+          "temperature": 0.0,
+          "thinking": true,
+          "agg_tps": 51.2,
+          "stream_tps_median": 15.5,
+          "ttft": {
+            "p50": 1.076,
+            "p95": 1.078,
+            "p99": 1.078
+          },
+          "itl": {
+            "p50": 0.204,
+            "p95": 0.438,
+            "p99": 0.549
+          },
+          "starvation_age_s": 1.08,
+          "tokens": 512,
+          "prompt_tokens": 101912,
+          "wall": 10.0,
+          "cache_hit_ratio": 0.998,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-d858f72546-data-c24000-n4-r0-l0-warm",
+              "glm53-ladder-d858f72546-data-c24000-n4-r0-l1-warm",
+              "glm53-ladder-d858f72546-data-c24000-n4-r0-l2-warm",
+              "glm53-ladder-d858f72546-data-c24000-n4-r0-l3-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-d858f72546-data-c24000-n4-r0-l0-measure",
+              "glm53-ladder-d858f72546-data-c24000-n4-r0-l1-measure",
+              "glm53-ladder-d858f72546-data-c24000-n4-r0-l2-measure",
+              "glm53-ladder-d858f72546-data-c24000-n4-r0-l3-measure"
+            ],
+            "expected_measured_requests": 4,
+            "http_200_with_usage": 4,
+            "metric_queries_delta": 101912.0,
+            "metric_hits_delta": 101696.0
+          }
+        },
+        {
+          "mode": "data",
+          "ctx": 60000,
+          "level": 1,
+          "rep": 0,
+          "temperature": 0.0,
+          "thinking": true,
+          "agg_tps": 24.3,
+          "stream_tps_median": 38.0,
+          "ttft": {
+            "p50": 1.92,
+            "p95": 1.92,
+            "p99": 1.92
+          },
+          "itl": {
+            "p50": 0.115,
+            "p95": 0.122,
+            "p99": 0.123
+          },
+          "starvation_age_s": 1.92,
+          "tokens": 128,
+          "prompt_tokens": 65808,
+          "wall": 5.3,
+          "cache_hit_ratio": 0.98,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-d858f72546-data-c60000-n1-r0-l0-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-d858f72546-data-c60000-n1-r0-l0-measure"
+            ],
+            "expected_measured_requests": 1,
+            "http_200_with_usage": 1,
+            "metric_queries_delta": 65808.0,
+            "metric_hits_delta": 64512.0
+          }
+        },
+        {
+          "mode": "data",
+          "ctx": 60000,
+          "level": 4,
+          "rep": 0,
+          "temperature": 0.0,
+          "thinking": true,
+          "agg_tps": 43.5,
+          "stream_tps_median": 17.6,
+          "ttft": {
+            "p50": 4.662,
+            "p95": 4.662,
+            "p99": 4.662
+          },
+          "itl": {
+            "p50": 0.201,
+            "p95": 0.348,
+            "p99": 1.261
+          },
+          "starvation_age_s": 4.66,
+          "tokens": 512,
+          "prompt_tokens": 263232,
+          "wall": 11.8,
+          "cache_hit_ratio": 0.985,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-d858f72546-data-c60000-n4-r0-l0-warm",
+              "glm53-ladder-d858f72546-data-c60000-n4-r0-l1-warm",
+              "glm53-ladder-d858f72546-data-c60000-n4-r0-l2-warm",
+              "glm53-ladder-d858f72546-data-c60000-n4-r0-l3-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-d858f72546-data-c60000-n4-r0-l0-measure",
+              "glm53-ladder-d858f72546-data-c60000-n4-r0-l1-measure",
+              "glm53-ladder-d858f72546-data-c60000-n4-r0-l2-measure",
+              "glm53-ladder-d858f72546-data-c60000-n4-r0-l3-measure"
+            ],
+            "expected_measured_requests": 4,
+            "http_200_with_usage": 4,
+            "metric_queries_delta": 263232.0,
+            "metric_hits_delta": 259328.0
+          }
+        },
+        {
+          "mode": "chat",
+          "ctx": 24000,
+          "level": 1,
+          "rep": 0,
+          "temperature": 0.7,
+          "thinking": true,
+          "agg_tps": 21.6,
+          "stream_tps_median": 23.8,
+          "ttft": {
+            "p50": 0.595,
+            "p95": 0.595,
+            "p99": 0.595
+          },
+          "itl": {
+            "p50": 0.117,
+            "p95": 0.125,
+            "p99": 0.128
+          },
+          "starvation_age_s": 0.59,
+          "tokens": 128,
+          "prompt_tokens": 25485,
+          "wall": 5.9,
+          "cache_hit_ratio": 0.997,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-d858f72546-chat-c24000-n1-r0-l0-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-d858f72546-chat-c24000-n1-r0-l0-measure"
+            ],
+            "expected_measured_requests": 1,
+            "http_200_with_usage": 1,
+            "metric_queries_delta": 25485.0,
+            "metric_hits_delta": 25408.0
+          }
+        },
+        {
+          "mode": "chat",
+          "ctx": 24000,
+          "level": 4,
+          "rep": 0,
+          "temperature": 0.7,
+          "thinking": true,
+          "agg_tps": 40.2,
+          "stream_tps_median": 11.6,
+          "ttft": {
+            "p50": 1.095,
+            "p95": 1.096,
+            "p99": 1.096
+          },
+          "itl": {
+            "p50": 0.226,
+            "p95": 0.328,
+            "p99": 0.339
+          },
+          "starvation_age_s": 1.1,
+          "tokens": 512,
+          "prompt_tokens": 101943,
+          "wall": 12.7,
+          "cache_hit_ratio": 0.998,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-d858f72546-chat-c24000-n4-r0-l0-warm",
+              "glm53-ladder-d858f72546-chat-c24000-n4-r0-l1-warm",
+              "glm53-ladder-d858f72546-chat-c24000-n4-r0-l2-warm",
+              "glm53-ladder-d858f72546-chat-c24000-n4-r0-l3-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-d858f72546-chat-c24000-n4-r0-l0-measure",
+              "glm53-ladder-d858f72546-chat-c24000-n4-r0-l1-measure",
+              "glm53-ladder-d858f72546-chat-c24000-n4-r0-l2-measure",
+              "glm53-ladder-d858f72546-chat-c24000-n4-r0-l3-measure"
+            ],
+            "expected_measured_requests": 4,
+            "http_200_with_usage": 4,
+            "metric_queries_delta": 101943.0,
+            "metric_hits_delta": 101696.0
+          }
+        },
+        {
+          "mode": "chat",
+          "ctx": 60000,
+          "level": 1,
+          "rep": 0,
+          "temperature": 0.7,
+          "thinking": true,
+          "agg_tps": 17.0,
+          "stream_tps_median": 25.5,
+          "ttft": {
+            "p50": 2.535,
+            "p95": 2.535,
+            "p99": 2.535
+          },
+          "itl": {
+            "p50": 0.118,
+            "p95": 0.124,
+            "p99": 0.165
+          },
+          "starvation_age_s": 2.53,
+          "tokens": 128,
+          "prompt_tokens": 65815,
+          "wall": 7.5,
+          "cache_hit_ratio": 0.98,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-d858f72546-chat-c60000-n1-r0-l0-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-d858f72546-chat-c60000-n1-r0-l0-measure"
+            ],
+            "expected_measured_requests": 1,
+            "http_200_with_usage": 1,
+            "metric_queries_delta": 65815.0,
+            "metric_hits_delta": 64512.0
+          }
+        },
+        {
+          "mode": "chat",
+          "ctx": 60000,
+          "level": 4,
+          "rep": 0,
+          "temperature": 0.7,
+          "thinking": true,
+          "agg_tps": 40.7,
+          "stream_tps_median": 11.4,
+          "ttft": {
+            "p50": 0.704,
+            "p95": 1.003,
+            "p99": 1.003
+          },
+          "itl": {
+            "p50": 0.224,
+            "p95": 0.339,
+            "p99": 0.366
+          },
+          "starvation_age_s": 1.0,
+          "tokens": 512,
+          "prompt_tokens": 263263,
+          "wall": 12.6,
+          "cache_hit_ratio": 1.0,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-d858f72546-chat-c60000-n4-r0-l0-warm",
+              "glm53-ladder-d858f72546-chat-c60000-n4-r0-l1-warm",
+              "glm53-ladder-d858f72546-chat-c60000-n4-r0-l2-warm",
+              "glm53-ladder-d858f72546-chat-c60000-n4-r0-l3-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-d858f72546-chat-c60000-n4-r0-l0-measure",
+              "glm53-ladder-d858f72546-chat-c60000-n4-r0-l1-measure",
+              "glm53-ladder-d858f72546-chat-c60000-n4-r0-l2-measure",
+              "glm53-ladder-d858f72546-chat-c60000-n4-r0-l3-measure"
+            ],
+            "expected_measured_requests": 4,
+            "http_200_with_usage": 4,
+            "metric_queries_delta": 263263.0,
+            "metric_hits_delta": 263168.0
+          }
+        }
+      ]
+    },
+    {
+      "file": "p0-soak-concurrency-c3-20260905.json",
+      "run_id": "53f093c49a",
+      "cells": [
+        {
+          "mode": "code",
+          "ctx": 24000,
+          "level": 1,
+          "rep": 0,
+          "temperature": 0.0,
+          "thinking": true,
+          "agg_tps": 30.1,
+          "stream_tps_median": 34.8,
+          "ttft": {
+            "p50": 0.596,
+            "p95": 0.596,
+            "p99": 0.596
+          },
+          "itl": {
+            "p50": 0.12,
+            "p95": 0.125,
+            "p99": 0.192
+          },
+          "starvation_age_s": 0.6,
+          "tokens": 128,
+          "prompt_tokens": 25477,
+          "wall": 4.3,
+          "cache_hit_ratio": 0.997,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-53f093c49a-code-c24000-n1-r0-l0-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-53f093c49a-code-c24000-n1-r0-l0-measure"
+            ],
+            "expected_measured_requests": 1,
+            "http_200_with_usage": 1,
+            "metric_queries_delta": 25477.0,
+            "metric_hits_delta": 25408.0
+          }
+        },
+        {
+          "mode": "code",
+          "ctx": 24000,
+          "level": 4,
+          "rep": 0,
+          "temperature": 0.0,
+          "thinking": true,
+          "agg_tps": 53.7,
+          "stream_tps_median": 16.2,
+          "ttft": {
+            "p50": 0.978,
+            "p95": 0.979,
+            "p99": 0.979
+          },
+          "itl": {
+            "p50": 0.235,
+            "p95": 0.344,
+            "p99": 0.352
+          },
+          "starvation_age_s": 0.98,
+          "tokens": 512,
+          "prompt_tokens": 101915,
+          "wall": 9.5,
+          "cache_hit_ratio": 0.998,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-53f093c49a-code-c24000-n4-r0-l0-warm",
+              "glm53-ladder-53f093c49a-code-c24000-n4-r0-l1-warm",
+              "glm53-ladder-53f093c49a-code-c24000-n4-r0-l2-warm",
+              "glm53-ladder-53f093c49a-code-c24000-n4-r0-l3-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-53f093c49a-code-c24000-n4-r0-l0-measure",
+              "glm53-ladder-53f093c49a-code-c24000-n4-r0-l1-measure",
+              "glm53-ladder-53f093c49a-code-c24000-n4-r0-l2-measure",
+              "glm53-ladder-53f093c49a-code-c24000-n4-r0-l3-measure"
+            ],
+            "expected_measured_requests": 4,
+            "http_200_with_usage": 4,
+            "metric_queries_delta": 101915.0,
+            "metric_hits_delta": 101696.0
+          }
+        },
+        {
+          "mode": "code",
+          "ctx": 60000,
+          "level": 1,
+          "rep": 0,
+          "temperature": 0.0,
+          "thinking": true,
+          "agg_tps": 20.4,
+          "stream_tps_median": 29.2,
+          "ttft": {
+            "p50": 1.921,
+            "p95": 1.921,
+            "p99": 1.921
+          },
+          "itl": {
+            "p50": 0.124,
+            "p95": 0.195,
+            "p99": 0.261
+          },
+          "starvation_age_s": 1.92,
+          "tokens": 128,
+          "prompt_tokens": 65807,
+          "wall": 6.3,
+          "cache_hit_ratio": 0.98,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-53f093c49a-code-c60000-n1-r0-l0-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-53f093c49a-code-c60000-n1-r0-l0-measure"
+            ],
+            "expected_measured_requests": 1,
+            "http_200_with_usage": 1,
+            "metric_queries_delta": 65807.0,
+            "metric_hits_delta": 64512.0
+          }
+        },
+        {
+          "mode": "code",
+          "ctx": 60000,
+          "level": 4,
+          "rep": 0,
+          "temperature": 0.0,
+          "thinking": true,
+          "agg_tps": 40.7,
+          "stream_tps_median": 16.0,
+          "ttft": {
+            "p50": 4.463,
+            "p95": 4.464,
+            "p99": 4.464
+          },
+          "itl": {
+            "p50": 0.23,
+            "p95": 0.405,
+            "p99": 0.442
+          },
+          "starvation_age_s": 4.46,
+          "tokens": 512,
+          "prompt_tokens": 263235,
+          "wall": 12.6,
+          "cache_hit_ratio": 0.985,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-53f093c49a-code-c60000-n4-r0-l0-warm",
+              "glm53-ladder-53f093c49a-code-c60000-n4-r0-l1-warm",
+              "glm53-ladder-53f093c49a-code-c60000-n4-r0-l2-warm",
+              "glm53-ladder-53f093c49a-code-c60000-n4-r0-l3-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-53f093c49a-code-c60000-n4-r0-l0-measure",
+              "glm53-ladder-53f093c49a-code-c60000-n4-r0-l1-measure",
+              "glm53-ladder-53f093c49a-code-c60000-n4-r0-l2-measure",
+              "glm53-ladder-53f093c49a-code-c60000-n4-r0-l3-measure"
+            ],
+            "expected_measured_requests": 4,
+            "http_200_with_usage": 4,
+            "metric_queries_delta": 263235.0,
+            "metric_hits_delta": 259328.0
+          }
+        },
+        {
+          "mode": "data",
+          "ctx": 24000,
+          "level": 1,
+          "rep": 0,
+          "temperature": 0.0,
+          "thinking": true,
+          "agg_tps": 32.1,
+          "stream_tps_median": 36.4,
+          "ttft": {
+            "p50": 0.502,
+            "p95": 0.502,
+            "p99": 0.502
+          },
+          "itl": {
+            "p50": 0.116,
+            "p95": 0.181,
+            "p99": 0.205
+          },
+          "starvation_age_s": 0.5,
+          "tokens": 128,
+          "prompt_tokens": 25478,
+          "wall": 4.0,
+          "cache_hit_ratio": 0.997,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-53f093c49a-data-c24000-n1-r0-l0-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-53f093c49a-data-c24000-n1-r0-l0-measure"
+            ],
+            "expected_measured_requests": 1,
+            "http_200_with_usage": 1,
+            "metric_queries_delta": 25478.0,
+            "metric_hits_delta": 25408.0
+          }
+        },
+        {
+          "mode": "data",
+          "ctx": 24000,
+          "level": 4,
+          "rep": 0,
+          "temperature": 0.0,
+          "thinking": true,
+          "agg_tps": 50.7,
+          "stream_tps_median": 15.3,
+          "ttft": {
+            "p50": 1.005,
+            "p95": 1.006,
+            "p99": 1.006
+          },
+          "itl": {
+            "p50": 0.225,
+            "p95": 0.386,
+            "p99": 0.411
+          },
+          "starvation_age_s": 1.01,
+          "tokens": 512,
+          "prompt_tokens": 101912,
+          "wall": 10.1,
+          "cache_hit_ratio": 0.998,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-53f093c49a-data-c24000-n4-r0-l0-warm",
+              "glm53-ladder-53f093c49a-data-c24000-n4-r0-l1-warm",
+              "glm53-ladder-53f093c49a-data-c24000-n4-r0-l2-warm",
+              "glm53-ladder-53f093c49a-data-c24000-n4-r0-l3-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-53f093c49a-data-c24000-n4-r0-l0-measure",
+              "glm53-ladder-53f093c49a-data-c24000-n4-r0-l1-measure",
+              "glm53-ladder-53f093c49a-data-c24000-n4-r0-l2-measure",
+              "glm53-ladder-53f093c49a-data-c24000-n4-r0-l3-measure"
+            ],
+            "expected_measured_requests": 4,
+            "http_200_with_usage": 4,
+            "metric_queries_delta": 101912.0,
+            "metric_hits_delta": 101696.0
+          }
+        },
+        {
+          "mode": "data",
+          "ctx": 60000,
+          "level": 1,
+          "rep": 0,
+          "temperature": 0.0,
+          "thinking": true,
+          "agg_tps": 25.3,
+          "stream_tps_median": 41.2,
+          "ttft": {
+            "p50": 1.983,
+            "p95": 1.983,
+            "p99": 1.983
+          },
+          "itl": {
+            "p50": 0.117,
+            "p95": 0.179,
+            "p99": 0.194
+          },
+          "starvation_age_s": 1.98,
+          "tokens": 128,
+          "prompt_tokens": 65808,
+          "wall": 5.1,
+          "cache_hit_ratio": 0.98,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-53f093c49a-data-c60000-n1-r0-l0-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-53f093c49a-data-c60000-n1-r0-l0-measure"
+            ],
+            "expected_measured_requests": 1,
+            "http_200_with_usage": 1,
+            "metric_queries_delta": 65808.0,
+            "metric_hits_delta": 64512.0
+          }
+        },
+        {
+          "mode": "data",
+          "ctx": 60000,
+          "level": 4,
+          "rep": 0,
+          "temperature": 0.0,
+          "thinking": true,
+          "agg_tps": 45.2,
+          "stream_tps_median": 18.6,
+          "ttft": {
+            "p50": 4.484,
+            "p95": 4.485,
+            "p99": 4.485
+          },
+          "itl": {
+            "p50": 0.231,
+            "p95": 0.357,
+            "p99": 0.391
+          },
+          "starvation_age_s": 4.49,
+          "tokens": 512,
+          "prompt_tokens": 263232,
+          "wall": 11.3,
+          "cache_hit_ratio": 0.985,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-53f093c49a-data-c60000-n4-r0-l0-warm",
+              "glm53-ladder-53f093c49a-data-c60000-n4-r0-l1-warm",
+              "glm53-ladder-53f093c49a-data-c60000-n4-r0-l2-warm",
+              "glm53-ladder-53f093c49a-data-c60000-n4-r0-l3-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-53f093c49a-data-c60000-n4-r0-l0-measure",
+              "glm53-ladder-53f093c49a-data-c60000-n4-r0-l1-measure",
+              "glm53-ladder-53f093c49a-data-c60000-n4-r0-l2-measure",
+              "glm53-ladder-53f093c49a-data-c60000-n4-r0-l3-measure"
+            ],
+            "expected_measured_requests": 4,
+            "http_200_with_usage": 4,
+            "metric_queries_delta": 263232.0,
+            "metric_hits_delta": 259328.0
+          }
+        },
+        {
+          "mode": "chat",
+          "ctx": 24000,
+          "level": 1,
+          "rep": 0,
+          "temperature": 0.7,
+          "thinking": true,
+          "agg_tps": 17.3,
+          "stream_tps_median": 18.7,
+          "ttft": {
+            "p50": 0.593,
+            "p95": 0.593,
+            "p99": 0.593
+          },
+          "itl": {
+            "p50": 0.118,
+            "p95": 0.175,
+            "p99": 0.185
+          },
+          "starvation_age_s": 0.59,
+          "tokens": 128,
+          "prompt_tokens": 25485,
+          "wall": 7.4,
+          "cache_hit_ratio": 0.997,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-53f093c49a-chat-c24000-n1-r0-l0-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-53f093c49a-chat-c24000-n1-r0-l0-measure"
+            ],
+            "expected_measured_requests": 1,
+            "http_200_with_usage": 1,
+            "metric_queries_delta": 25485.0,
+            "metric_hits_delta": 25408.0
+          }
+        },
+        {
+          "mode": "chat",
+          "ctx": 24000,
+          "level": 4,
+          "rep": 0,
+          "temperature": 0.7,
+          "thinking": true,
+          "agg_tps": 39.1,
+          "stream_tps_median": 11.7,
+          "ttft": {
+            "p50": 1.0,
+            "p95": 1.001,
+            "p99": 1.001
+          },
+          "itl": {
+            "p50": 0.231,
+            "p95": 0.372,
+            "p99": 0.434
+          },
+          "starvation_age_s": 1.0,
+          "tokens": 512,
+          "prompt_tokens": 101943,
+          "wall": 13.1,
+          "cache_hit_ratio": 0.998,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-53f093c49a-chat-c24000-n4-r0-l0-warm",
+              "glm53-ladder-53f093c49a-chat-c24000-n4-r0-l1-warm",
+              "glm53-ladder-53f093c49a-chat-c24000-n4-r0-l2-warm",
+              "glm53-ladder-53f093c49a-chat-c24000-n4-r0-l3-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-53f093c49a-chat-c24000-n4-r0-l0-measure",
+              "glm53-ladder-53f093c49a-chat-c24000-n4-r0-l1-measure",
+              "glm53-ladder-53f093c49a-chat-c24000-n4-r0-l2-measure",
+              "glm53-ladder-53f093c49a-chat-c24000-n4-r0-l3-measure"
+            ],
+            "expected_measured_requests": 4,
+            "http_200_with_usage": 4,
+            "metric_queries_delta": 101943.0,
+            "metric_hits_delta": 101696.0
+          }
+        },
+        {
+          "mode": "chat",
+          "ctx": 60000,
+          "level": 1,
+          "rep": 0,
+          "temperature": 0.7,
+          "thinking": true,
+          "agg_tps": 16.9,
+          "stream_tps_median": 22.4,
+          "ttft": {
+            "p50": 1.889,
+            "p95": 1.889,
+            "p99": 1.889
+          },
+          "itl": {
+            "p50": 0.12,
+            "p95": 0.173,
+            "p99": 0.197
+          },
+          "starvation_age_s": 1.89,
+          "tokens": 128,
+          "prompt_tokens": 65815,
+          "wall": 7.6,
+          "cache_hit_ratio": 0.98,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-53f093c49a-chat-c60000-n1-r0-l0-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-53f093c49a-chat-c60000-n1-r0-l0-measure"
+            ],
+            "expected_measured_requests": 1,
+            "http_200_with_usage": 1,
+            "metric_queries_delta": 65815.0,
+            "metric_hits_delta": 64512.0
+          }
+        },
+        {
+          "mode": "chat",
+          "ctx": 60000,
+          "level": 4,
+          "rep": 0,
+          "temperature": 0.7,
+          "thinking": true,
+          "agg_tps": 30.0,
+          "stream_tps_median": 9.6,
+          "ttft": {
+            "p50": 0.712,
+            "p95": 0.96,
+            "p99": 0.96
+          },
+          "itl": {
+            "p50": 0.234,
+            "p95": 0.323,
+            "p99": 0.343
+          },
+          "starvation_age_s": 0.96,
+          "tokens": 512,
+          "prompt_tokens": 263263,
+          "wall": 17.1,
+          "cache_hit_ratio": 1.0,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-53f093c49a-chat-c60000-n4-r0-l0-warm",
+              "glm53-ladder-53f093c49a-chat-c60000-n4-r0-l1-warm",
+              "glm53-ladder-53f093c49a-chat-c60000-n4-r0-l2-warm",
+              "glm53-ladder-53f093c49a-chat-c60000-n4-r0-l3-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-53f093c49a-chat-c60000-n4-r0-l0-measure",
+              "glm53-ladder-53f093c49a-chat-c60000-n4-r0-l1-measure",
+              "glm53-ladder-53f093c49a-chat-c60000-n4-r0-l2-measure",
+              "glm53-ladder-53f093c49a-chat-c60000-n4-r0-l3-measure"
+            ],
+            "expected_measured_requests": 4,
+            "http_200_with_usage": 4,
+            "metric_queries_delta": 263263.0,
+            "metric_hits_delta": 263168.0
+          }
+        }
+      ]
+    },
+    {
+      "file": "p0-soak-concurrency-c4-20260905.json",
+      "run_id": "83c1589dc8",
+      "cells": [
+        {
+          "mode": "code",
+          "ctx": 24000,
+          "level": 1,
+          "rep": 0,
+          "temperature": 0.0,
+          "thinking": true,
+          "agg_tps": 33.5,
+          "stream_tps_median": 38.4,
+          "ttft": {
+            "p50": 0.514,
+            "p95": 0.514,
+            "p99": 0.514
+          },
+          "itl": {
+            "p50": 0.113,
+            "p95": 0.305,
+            "p99": 0.324
+          },
+          "starvation_age_s": 0.51,
+          "tokens": 128,
+          "prompt_tokens": 25477,
+          "wall": 3.8,
+          "cache_hit_ratio": 0.997,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-83c1589dc8-code-c24000-n1-r0-l0-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-83c1589dc8-code-c24000-n1-r0-l0-measure"
+            ],
+            "expected_measured_requests": 1,
+            "http_200_with_usage": 1,
+            "metric_queries_delta": 25477.0,
+            "metric_hits_delta": 25408.0
+          }
+        },
+        {
+          "mode": "code",
+          "ctx": 24000,
+          "level": 4,
+          "rep": 0,
+          "temperature": 0.0,
+          "thinking": true,
+          "agg_tps": 52.2,
+          "stream_tps_median": 15.5,
+          "ttft": {
+            "p50": 1.304,
+            "p95": 1.306,
+            "p99": 1.306
+          },
+          "itl": {
+            "p50": 0.242,
+            "p95": 0.393,
+            "p99": 0.446
+          },
+          "starvation_age_s": 1.31,
+          "tokens": 512,
+          "prompt_tokens": 101915,
+          "wall": 9.8,
+          "cache_hit_ratio": 0.998,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-83c1589dc8-code-c24000-n4-r0-l0-warm",
+              "glm53-ladder-83c1589dc8-code-c24000-n4-r0-l1-warm",
+              "glm53-ladder-83c1589dc8-code-c24000-n4-r0-l2-warm",
+              "glm53-ladder-83c1589dc8-code-c24000-n4-r0-l3-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-83c1589dc8-code-c24000-n4-r0-l0-measure",
+              "glm53-ladder-83c1589dc8-code-c24000-n4-r0-l1-measure",
+              "glm53-ladder-83c1589dc8-code-c24000-n4-r0-l2-measure",
+              "glm53-ladder-83c1589dc8-code-c24000-n4-r0-l3-measure"
+            ],
+            "expected_measured_requests": 4,
+            "http_200_with_usage": 4,
+            "metric_queries_delta": 101915.0,
+            "metric_hits_delta": 101696.0
+          }
+        },
+        {
+          "mode": "code",
+          "ctx": 60000,
+          "level": 1,
+          "rep": 0,
+          "temperature": 0.0,
+          "thinking": true,
+          "agg_tps": 20.8,
+          "stream_tps_median": 30.3,
+          "ttft": {
+            "p50": 1.971,
+            "p95": 1.971,
+            "p99": 1.971
+          },
+          "itl": {
+            "p50": 0.117,
+            "p95": 0.327,
+            "p99": 0.355
+          },
+          "starvation_age_s": 1.97,
+          "tokens": 128,
+          "prompt_tokens": 65807,
+          "wall": 6.2,
+          "cache_hit_ratio": 0.98,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-83c1589dc8-code-c60000-n1-r0-l0-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-83c1589dc8-code-c60000-n1-r0-l0-measure"
+            ],
+            "expected_measured_requests": 1,
+            "http_200_with_usage": 1,
+            "metric_queries_delta": 65807.0,
+            "metric_hits_delta": 64512.0
+          }
+        },
+        {
+          "mode": "code",
+          "ctx": 60000,
+          "level": 4,
+          "rep": 0,
+          "temperature": 0.0,
+          "thinking": true,
+          "agg_tps": 41.6,
+          "stream_tps_median": 16.6,
+          "ttft": {
+            "p50": 4.446,
+            "p95": 4.45,
+            "p99": 4.45
+          },
+          "itl": {
+            "p50": 0.235,
+            "p95": 0.404,
+            "p99": 0.465
+          },
+          "starvation_age_s": 4.45,
+          "tokens": 512,
+          "prompt_tokens": 263235,
+          "wall": 12.3,
+          "cache_hit_ratio": 0.985,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-83c1589dc8-code-c60000-n4-r0-l0-warm",
+              "glm53-ladder-83c1589dc8-code-c60000-n4-r0-l1-warm",
+              "glm53-ladder-83c1589dc8-code-c60000-n4-r0-l2-warm",
+              "glm53-ladder-83c1589dc8-code-c60000-n4-r0-l3-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-83c1589dc8-code-c60000-n4-r0-l0-measure",
+              "glm53-ladder-83c1589dc8-code-c60000-n4-r0-l1-measure",
+              "glm53-ladder-83c1589dc8-code-c60000-n4-r0-l2-measure",
+              "glm53-ladder-83c1589dc8-code-c60000-n4-r0-l3-measure"
+            ],
+            "expected_measured_requests": 4,
+            "http_200_with_usage": 4,
+            "metric_queries_delta": 263235.0,
+            "metric_hits_delta": 259328.0
+          }
+        },
+        {
+          "mode": "data",
+          "ctx": 24000,
+          "level": 1,
+          "rep": 0,
+          "temperature": 0.0,
+          "thinking": true,
+          "agg_tps": 32.2,
+          "stream_tps_median": 36.6,
+          "ttft": {
+            "p50": 0.503,
+            "p95": 0.503,
+            "p99": 0.503
+          },
+          "itl": {
+            "p50": 0.111,
+            "p95": 0.311,
+            "p99": 0.351
+          },
+          "starvation_age_s": 0.5,
+          "tokens": 128,
+          "prompt_tokens": 25478,
+          "wall": 4.0,
+          "cache_hit_ratio": 0.997,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-83c1589dc8-data-c24000-n1-r0-l0-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-83c1589dc8-data-c24000-n1-r0-l0-measure"
+            ],
+            "expected_measured_requests": 1,
+            "http_200_with_usage": 1,
+            "metric_queries_delta": 25478.0,
+            "metric_hits_delta": 25408.0
+          }
+        },
+        {
+          "mode": "data",
+          "ctx": 24000,
+          "level": 4,
+          "rep": 0,
+          "temperature": 0.0,
+          "thinking": true,
+          "agg_tps": 54.5,
+          "stream_tps_median": 16.2,
+          "ttft": {
+            "p50": 1.064,
+            "p95": 1.065,
+            "p99": 1.065
+          },
+          "itl": {
+            "p50": 0.237,
+            "p95": 0.436,
+            "p99": 0.524
+          },
+          "starvation_age_s": 1.07,
+          "tokens": 512,
+          "prompt_tokens": 101912,
+          "wall": 9.4,
+          "cache_hit_ratio": 0.998,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-83c1589dc8-data-c24000-n4-r0-l0-warm",
+              "glm53-ladder-83c1589dc8-data-c24000-n4-r0-l1-warm",
+              "glm53-ladder-83c1589dc8-data-c24000-n4-r0-l2-warm",
+              "glm53-ladder-83c1589dc8-data-c24000-n4-r0-l3-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-83c1589dc8-data-c24000-n4-r0-l0-measure",
+              "glm53-ladder-83c1589dc8-data-c24000-n4-r0-l1-measure",
+              "glm53-ladder-83c1589dc8-data-c24000-n4-r0-l2-measure",
+              "glm53-ladder-83c1589dc8-data-c24000-n4-r0-l3-measure"
+            ],
+            "expected_measured_requests": 4,
+            "http_200_with_usage": 4,
+            "metric_queries_delta": 101912.0,
+            "metric_hits_delta": 101696.0
+          }
+        },
+        {
+          "mode": "data",
+          "ctx": 60000,
+          "level": 1,
+          "rep": 0,
+          "temperature": 0.0,
+          "thinking": true,
+          "agg_tps": 23.8,
+          "stream_tps_median": 36.2,
+          "ttft": {
+            "p50": 1.88,
+            "p95": 1.88,
+            "p99": 1.88
+          },
+          "itl": {
+            "p50": 0.116,
+            "p95": 0.239,
+            "p99": 0.317
+          },
+          "starvation_age_s": 1.88,
+          "tokens": 128,
+          "prompt_tokens": 65808,
+          "wall": 5.4,
+          "cache_hit_ratio": 0.98,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-83c1589dc8-data-c60000-n1-r0-l0-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-83c1589dc8-data-c60000-n1-r0-l0-measure"
+            ],
+            "expected_measured_requests": 1,
+            "http_200_with_usage": 1,
+            "metric_queries_delta": 65808.0,
+            "metric_hits_delta": 64512.0
+          }
+        },
+        {
+          "mode": "data",
+          "ctx": 60000,
+          "level": 4,
+          "rep": 0,
+          "temperature": 0.0,
+          "thinking": true,
+          "agg_tps": 40.8,
+          "stream_tps_median": 18.3,
+          "ttft": {
+            "p50": 4.388,
+            "p95": 4.391,
+            "p99": 4.391
+          },
+          "itl": {
+            "p50": 0.231,
+            "p95": 0.422,
+            "p99": 0.457
+          },
+          "starvation_age_s": 4.39,
+          "tokens": 512,
+          "prompt_tokens": 263232,
+          "wall": 12.6,
+          "cache_hit_ratio": 0.985,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-83c1589dc8-data-c60000-n4-r0-l0-warm",
+              "glm53-ladder-83c1589dc8-data-c60000-n4-r0-l1-warm",
+              "glm53-ladder-83c1589dc8-data-c60000-n4-r0-l2-warm",
+              "glm53-ladder-83c1589dc8-data-c60000-n4-r0-l3-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-83c1589dc8-data-c60000-n4-r0-l0-measure",
+              "glm53-ladder-83c1589dc8-data-c60000-n4-r0-l1-measure",
+              "glm53-ladder-83c1589dc8-data-c60000-n4-r0-l2-measure",
+              "glm53-ladder-83c1589dc8-data-c60000-n4-r0-l3-measure"
+            ],
+            "expected_measured_requests": 4,
+            "http_200_with_usage": 4,
+            "metric_queries_delta": 263232.0,
+            "metric_hits_delta": 259328.0
+          }
+        },
+        {
+          "mode": "chat",
+          "ctx": 24000,
+          "level": 1,
+          "rep": 0,
+          "temperature": 0.7,
+          "thinking": true,
+          "agg_tps": 20.3,
+          "stream_tps_median": 22.0,
+          "ttft": {
+            "p50": 0.534,
+            "p95": 0.534,
+            "p99": 0.534
+          },
+          "itl": {
+            "p50": 0.116,
+            "p95": 0.271,
+            "p99": 0.317
+          },
+          "starvation_age_s": 0.53,
+          "tokens": 128,
+          "prompt_tokens": 25485,
+          "wall": 6.3,
+          "cache_hit_ratio": 0.997,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-83c1589dc8-chat-c24000-n1-r0-l0-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-83c1589dc8-chat-c24000-n1-r0-l0-measure"
+            ],
+            "expected_measured_requests": 1,
+            "http_200_with_usage": 1,
+            "metric_queries_delta": 25485.0,
+            "metric_hits_delta": 25408.0
+          }
+        },
+        {
+          "mode": "chat",
+          "ctx": 24000,
+          "level": 4,
+          "rep": 0,
+          "temperature": 0.7,
+          "thinking": true,
+          "agg_tps": 39.4,
+          "stream_tps_median": 11.0,
+          "ttft": {
+            "p50": 1.23,
+            "p95": 1.231,
+            "p99": 1.231
+          },
+          "itl": {
+            "p50": 0.23,
+            "p95": 0.368,
+            "p99": 0.472
+          },
+          "starvation_age_s": 1.23,
+          "tokens": 512,
+          "prompt_tokens": 101943,
+          "wall": 13.0,
+          "cache_hit_ratio": 0.998,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-83c1589dc8-chat-c24000-n4-r0-l0-warm",
+              "glm53-ladder-83c1589dc8-chat-c24000-n4-r0-l1-warm",
+              "glm53-ladder-83c1589dc8-chat-c24000-n4-r0-l2-warm",
+              "glm53-ladder-83c1589dc8-chat-c24000-n4-r0-l3-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-83c1589dc8-chat-c24000-n4-r0-l0-measure",
+              "glm53-ladder-83c1589dc8-chat-c24000-n4-r0-l1-measure",
+              "glm53-ladder-83c1589dc8-chat-c24000-n4-r0-l2-measure",
+              "glm53-ladder-83c1589dc8-chat-c24000-n4-r0-l3-measure"
+            ],
+            "expected_measured_requests": 4,
+            "http_200_with_usage": 4,
+            "metric_queries_delta": 101943.0,
+            "metric_hits_delta": 101696.0
+          }
+        },
+        {
+          "mode": "chat",
+          "ctx": 60000,
+          "level": 1,
+          "rep": 0,
+          "temperature": 0.7,
+          "thinking": true,
+          "agg_tps": 17.9,
+          "stream_tps_median": 24.1,
+          "ttft": {
+            "p50": 1.876,
+            "p95": 1.876,
+            "p99": 1.876
+          },
+          "itl": {
+            "p50": 0.116,
+            "p95": 0.26,
+            "p99": 0.292
+          },
+          "starvation_age_s": 1.88,
+          "tokens": 128,
+          "prompt_tokens": 65815,
+          "wall": 7.1,
+          "cache_hit_ratio": 0.98,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-83c1589dc8-chat-c60000-n1-r0-l0-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-83c1589dc8-chat-c60000-n1-r0-l0-measure"
+            ],
+            "expected_measured_requests": 1,
+            "http_200_with_usage": 1,
+            "metric_queries_delta": 65815.0,
+            "metric_hits_delta": 64512.0
+          }
+        },
+        {
+          "mode": "chat",
+          "ctx": 60000,
+          "level": 4,
+          "rep": 0,
+          "temperature": 0.7,
+          "thinking": true,
+          "agg_tps": 41.7,
+          "stream_tps_median": 11.5,
+          "ttft": {
+            "p50": 0.751,
+            "p95": 0.965,
+            "p99": 0.965
+          },
+          "itl": {
+            "p50": 0.227,
+            "p95": 0.433,
+            "p99": 0.722
+          },
+          "starvation_age_s": 0.96,
+          "tokens": 512,
+          "prompt_tokens": 263263,
+          "wall": 12.3,
+          "cache_hit_ratio": 1.0,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-83c1589dc8-chat-c60000-n4-r0-l0-warm",
+              "glm53-ladder-83c1589dc8-chat-c60000-n4-r0-l1-warm",
+              "glm53-ladder-83c1589dc8-chat-c60000-n4-r0-l2-warm",
+              "glm53-ladder-83c1589dc8-chat-c60000-n4-r0-l3-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-83c1589dc8-chat-c60000-n4-r0-l0-measure",
+              "glm53-ladder-83c1589dc8-chat-c60000-n4-r0-l1-measure",
+              "glm53-ladder-83c1589dc8-chat-c60000-n4-r0-l2-measure",
+              "glm53-ladder-83c1589dc8-chat-c60000-n4-r0-l3-measure"
+            ],
+            "expected_measured_requests": 4,
+            "http_200_with_usage": 4,
+            "metric_queries_delta": 263263.0,
+            "metric_hits_delta": 263168.0
+          }
+        }
+      ]
+    },
+    {
+      "file": "p0-soak-concurrency-c5-20260905.json",
+      "run_id": "51ad19e5f0",
+      "cells": [
+        {
+          "mode": "code",
+          "ctx": 24000,
+          "level": 1,
+          "rep": 0,
+          "temperature": 0.0,
+          "thinking": true,
+          "agg_tps": 30.9,
+          "stream_tps_median": 34.8,
+          "ttft": {
+            "p50": 0.487,
+            "p95": 0.487,
+            "p99": 0.487
+          },
+          "itl": {
+            "p50": 0.118,
+            "p95": 0.123,
+            "p99": 0.127
+          },
+          "starvation_age_s": 0.49,
+          "tokens": 128,
+          "prompt_tokens": 25477,
+          "wall": 4.1,
+          "cache_hit_ratio": 0.997,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-51ad19e5f0-code-c24000-n1-r0-l0-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-51ad19e5f0-code-c24000-n1-r0-l0-measure"
+            ],
+            "expected_measured_requests": 1,
+            "http_200_with_usage": 1,
+            "metric_queries_delta": 25477.0,
+            "metric_hits_delta": 25408.0
+          }
+        },
+        {
+          "mode": "code",
+          "ctx": 24000,
+          "level": 4,
+          "rep": 0,
+          "temperature": 0.0,
+          "thinking": true,
+          "agg_tps": 51.0,
+          "stream_tps_median": 14.2,
+          "ttft": {
+            "p50": 1.005,
+            "p95": 1.006,
+            "p99": 1.006
+          },
+          "itl": {
+            "p50": 0.27,
+            "p95": 0.377,
+            "p99": 0.41
+          },
+          "starvation_age_s": 1.01,
+          "tokens": 512,
+          "prompt_tokens": 101915,
+          "wall": 10.0,
+          "cache_hit_ratio": 0.998,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-51ad19e5f0-code-c24000-n4-r0-l0-warm",
+              "glm53-ladder-51ad19e5f0-code-c24000-n4-r0-l1-warm",
+              "glm53-ladder-51ad19e5f0-code-c24000-n4-r0-l2-warm",
+              "glm53-ladder-51ad19e5f0-code-c24000-n4-r0-l3-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-51ad19e5f0-code-c24000-n4-r0-l0-measure",
+              "glm53-ladder-51ad19e5f0-code-c24000-n4-r0-l1-measure",
+              "glm53-ladder-51ad19e5f0-code-c24000-n4-r0-l2-measure",
+              "glm53-ladder-51ad19e5f0-code-c24000-n4-r0-l3-measure"
+            ],
+            "expected_measured_requests": 4,
+            "http_200_with_usage": 4,
+            "metric_queries_delta": 101915.0,
+            "metric_hits_delta": 101696.0
+          }
+        },
+        {
+          "mode": "code",
+          "ctx": 60000,
+          "level": 1,
+          "rep": 0,
+          "temperature": 0.0,
+          "thinking": true,
+          "agg_tps": 22.6,
+          "stream_tps_median": 33.6,
+          "ttft": {
+            "p50": 1.869,
+            "p95": 1.869,
+            "p99": 1.869
+          },
+          "itl": {
+            "p50": 0.118,
+            "p95": 0.127,
+            "p99": 0.13
+          },
+          "starvation_age_s": 1.87,
+          "tokens": 128,
+          "prompt_tokens": 65807,
+          "wall": 5.7,
+          "cache_hit_ratio": 0.98,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-51ad19e5f0-code-c60000-n1-r0-l0-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-51ad19e5f0-code-c60000-n1-r0-l0-measure"
+            ],
+            "expected_measured_requests": 1,
+            "http_200_with_usage": 1,
+            "metric_queries_delta": 65807.0,
+            "metric_hits_delta": 64512.0
+          }
+        },
+        {
+          "mode": "code",
+          "ctx": 60000,
+          "level": 4,
+          "rep": 0,
+          "temperature": 0.0,
+          "thinking": true,
+          "agg_tps": 42.4,
+          "stream_tps_median": 16.6,
+          "ttft": {
+            "p50": 4.403,
+            "p95": 4.406,
+            "p99": 4.406
+          },
+          "itl": {
+            "p50": 0.231,
+            "p95": 0.326,
+            "p99": 0.364
+          },
+          "starvation_age_s": 4.41,
+          "tokens": 512,
+          "prompt_tokens": 263235,
+          "wall": 12.1,
+          "cache_hit_ratio": 0.985,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-51ad19e5f0-code-c60000-n4-r0-l0-warm",
+              "glm53-ladder-51ad19e5f0-code-c60000-n4-r0-l1-warm",
+              "glm53-ladder-51ad19e5f0-code-c60000-n4-r0-l2-warm",
+              "glm53-ladder-51ad19e5f0-code-c60000-n4-r0-l3-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-51ad19e5f0-code-c60000-n4-r0-l0-measure",
+              "glm53-ladder-51ad19e5f0-code-c60000-n4-r0-l1-measure",
+              "glm53-ladder-51ad19e5f0-code-c60000-n4-r0-l2-measure",
+              "glm53-ladder-51ad19e5f0-code-c60000-n4-r0-l3-measure"
+            ],
+            "expected_measured_requests": 4,
+            "http_200_with_usage": 4,
+            "metric_queries_delta": 263235.0,
+            "metric_hits_delta": 259328.0
+          }
+        },
+        {
+          "mode": "data",
+          "ctx": 24000,
+          "level": 1,
+          "rep": 0,
+          "temperature": 0.0,
+          "thinking": true,
+          "agg_tps": 33.5,
+          "stream_tps_median": 38.1,
+          "ttft": {
+            "p50": 0.491,
+            "p95": 0.491,
+            "p99": 0.491
+          },
+          "itl": {
+            "p50": 0.114,
+            "p95": 0.123,
+            "p99": 0.126
+          },
+          "starvation_age_s": 0.49,
+          "tokens": 128,
+          "prompt_tokens": 25478,
+          "wall": 3.8,
+          "cache_hit_ratio": 0.997,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-51ad19e5f0-data-c24000-n1-r0-l0-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-51ad19e5f0-data-c24000-n1-r0-l0-measure"
+            ],
+            "expected_measured_requests": 1,
+            "http_200_with_usage": 1,
+            "metric_queries_delta": 25478.0,
+            "metric_hits_delta": 25408.0
+          }
+        },
+        {
+          "mode": "data",
+          "ctx": 24000,
+          "level": 4,
+          "rep": 0,
+          "temperature": 0.0,
+          "thinking": true,
+          "agg_tps": 56.0,
+          "stream_tps_median": 17.9,
+          "ttft": {
+            "p50": 0.995,
+            "p95": 0.997,
+            "p99": 0.997
+          },
+          "itl": {
+            "p50": 0.196,
+            "p95": 0.324,
+            "p99": 0.327
+          },
+          "starvation_age_s": 1.0,
+          "tokens": 512,
+          "prompt_tokens": 101912,
+          "wall": 9.1,
+          "cache_hit_ratio": 0.998,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-51ad19e5f0-data-c24000-n4-r0-l0-warm",
+              "glm53-ladder-51ad19e5f0-data-c24000-n4-r0-l1-warm",
+              "glm53-ladder-51ad19e5f0-data-c24000-n4-r0-l2-warm",
+              "glm53-ladder-51ad19e5f0-data-c24000-n4-r0-l3-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-51ad19e5f0-data-c24000-n4-r0-l0-measure",
+              "glm53-ladder-51ad19e5f0-data-c24000-n4-r0-l1-measure",
+              "glm53-ladder-51ad19e5f0-data-c24000-n4-r0-l2-measure",
+              "glm53-ladder-51ad19e5f0-data-c24000-n4-r0-l3-measure"
+            ],
+            "expected_measured_requests": 4,
+            "http_200_with_usage": 4,
+            "metric_queries_delta": 101912.0,
+            "metric_hits_delta": 101696.0
+          }
+        },
+        {
+          "mode": "data",
+          "ctx": 60000,
+          "level": 1,
+          "rep": 0,
+          "temperature": 0.0,
+          "thinking": true,
+          "agg_tps": 23.5,
+          "stream_tps_median": 35.0,
+          "ttft": {
+            "p50": 1.821,
+            "p95": 1.821,
+            "p99": 1.821
+          },
+          "itl": {
+            "p50": 0.115,
+            "p95": 0.125,
+            "p99": 0.129
+          },
+          "starvation_age_s": 1.82,
+          "tokens": 128,
+          "prompt_tokens": 65808,
+          "wall": 5.5,
+          "cache_hit_ratio": 0.98,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-51ad19e5f0-data-c60000-n1-r0-l0-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-51ad19e5f0-data-c60000-n1-r0-l0-measure"
+            ],
+            "expected_measured_requests": 1,
+            "http_200_with_usage": 1,
+            "metric_queries_delta": 65808.0,
+            "metric_hits_delta": 64512.0
+          }
+        },
+        {
+          "mode": "data",
+          "ctx": 60000,
+          "level": 4,
+          "rep": 0,
+          "temperature": 0.0,
+          "thinking": true,
+          "agg_tps": 30.2,
+          "stream_tps_median": 11.4,
+          "ttft": {
+            "p50": 4.317,
+            "p95": 4.546,
+            "p99": 4.546
+          },
+          "itl": {
+            "p50": 0.223,
+            "p95": 0.347,
+            "p99": 5.216
+          },
+          "starvation_age_s": 4.55,
+          "tokens": 512,
+          "prompt_tokens": 263232,
+          "wall": 17.0,
+          "cache_hit_ratio": 0.985,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-51ad19e5f0-data-c60000-n4-r0-l0-warm",
+              "glm53-ladder-51ad19e5f0-data-c60000-n4-r0-l1-warm",
+              "glm53-ladder-51ad19e5f0-data-c60000-n4-r0-l2-warm",
+              "glm53-ladder-51ad19e5f0-data-c60000-n4-r0-l3-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-51ad19e5f0-data-c60000-n4-r0-l0-measure",
+              "glm53-ladder-51ad19e5f0-data-c60000-n4-r0-l1-measure",
+              "glm53-ladder-51ad19e5f0-data-c60000-n4-r0-l2-measure",
+              "glm53-ladder-51ad19e5f0-data-c60000-n4-r0-l3-measure"
+            ],
+            "expected_measured_requests": 4,
+            "http_200_with_usage": 4,
+            "metric_queries_delta": 263232.0,
+            "metric_hits_delta": 259328.0
+          }
+        },
+        {
+          "mode": "chat",
+          "ctx": 24000,
+          "level": 1,
+          "rep": 0,
+          "temperature": 0.7,
+          "thinking": true,
+          "agg_tps": 21.7,
+          "stream_tps_median": 23.6,
+          "ttft": {
+            "p50": 0.518,
+            "p95": 0.518,
+            "p99": 0.518
+          },
+          "itl": {
+            "p50": 0.117,
+            "p95": 0.123,
+            "p99": 0.132
+          },
+          "starvation_age_s": 0.52,
+          "tokens": 128,
+          "prompt_tokens": 25485,
+          "wall": 5.9,
+          "cache_hit_ratio": 0.997,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-51ad19e5f0-chat-c24000-n1-r0-l0-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-51ad19e5f0-chat-c24000-n1-r0-l0-measure"
+            ],
+            "expected_measured_requests": 1,
+            "http_200_with_usage": 1,
+            "metric_queries_delta": 25485.0,
+            "metric_hits_delta": 25408.0
+          }
+        },
+        {
+          "mode": "chat",
+          "ctx": 24000,
+          "level": 4,
+          "rep": 0,
+          "temperature": 0.7,
+          "thinking": true,
+          "agg_tps": 40.0,
+          "stream_tps_median": 11.0,
+          "ttft": {
+            "p50": 1.107,
+            "p95": 1.107,
+            "p99": 1.107
+          },
+          "itl": {
+            "p50": 0.234,
+            "p95": 0.322,
+            "p99": 0.327
+          },
+          "starvation_age_s": 1.11,
+          "tokens": 512,
+          "prompt_tokens": 101943,
+          "wall": 12.8,
+          "cache_hit_ratio": 0.998,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-51ad19e5f0-chat-c24000-n4-r0-l0-warm",
+              "glm53-ladder-51ad19e5f0-chat-c24000-n4-r0-l1-warm",
+              "glm53-ladder-51ad19e5f0-chat-c24000-n4-r0-l2-warm",
+              "glm53-ladder-51ad19e5f0-chat-c24000-n4-r0-l3-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-51ad19e5f0-chat-c24000-n4-r0-l0-measure",
+              "glm53-ladder-51ad19e5f0-chat-c24000-n4-r0-l1-measure",
+              "glm53-ladder-51ad19e5f0-chat-c24000-n4-r0-l2-measure",
+              "glm53-ladder-51ad19e5f0-chat-c24000-n4-r0-l3-measure"
+            ],
+            "expected_measured_requests": 4,
+            "http_200_with_usage": 4,
+            "metric_queries_delta": 101943.0,
+            "metric_hits_delta": 101696.0
+          }
+        },
+        {
+          "mode": "chat",
+          "ctx": 60000,
+          "level": 1,
+          "rep": 0,
+          "temperature": 0.7,
+          "thinking": true,
+          "agg_tps": 17.4,
+          "stream_tps_median": 23.3,
+          "ttft": {
+            "p50": 1.919,
+            "p95": 1.919,
+            "p99": 1.919
+          },
+          "itl": {
+            "p50": 0.119,
+            "p95": 0.124,
+            "p99": 0.127
+          },
+          "starvation_age_s": 1.92,
+          "tokens": 128,
+          "prompt_tokens": 65815,
+          "wall": 7.4,
+          "cache_hit_ratio": 0.98,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-51ad19e5f0-chat-c60000-n1-r0-l0-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-51ad19e5f0-chat-c60000-n1-r0-l0-measure"
+            ],
+            "expected_measured_requests": 1,
+            "http_200_with_usage": 1,
+            "metric_queries_delta": 65815.0,
+            "metric_hits_delta": 64512.0
+          }
+        },
+        {
+          "mode": "chat",
+          "ctx": 60000,
+          "level": 4,
+          "rep": 0,
+          "temperature": 0.7,
+          "thinking": true,
+          "agg_tps": 39.0,
+          "stream_tps_median": 10.5,
+          "ttft": {
+            "p50": 0.693,
+            "p95": 0.996,
+            "p99": 0.996
+          },
+          "itl": {
+            "p50": 0.26,
+            "p95": 0.336,
+            "p99": 0.409
+          },
+          "starvation_age_s": 1.0,
+          "tokens": 512,
+          "prompt_tokens": 263263,
+          "wall": 13.1,
+          "cache_hit_ratio": 1.0,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-51ad19e5f0-chat-c60000-n4-r0-l0-warm",
+              "glm53-ladder-51ad19e5f0-chat-c60000-n4-r0-l1-warm",
+              "glm53-ladder-51ad19e5f0-chat-c60000-n4-r0-l2-warm",
+              "glm53-ladder-51ad19e5f0-chat-c60000-n4-r0-l3-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-51ad19e5f0-chat-c60000-n4-r0-l0-measure",
+              "glm53-ladder-51ad19e5f0-chat-c60000-n4-r0-l1-measure",
+              "glm53-ladder-51ad19e5f0-chat-c60000-n4-r0-l2-measure",
+              "glm53-ladder-51ad19e5f0-chat-c60000-n4-r0-l3-measure"
+            ],
+            "expected_measured_requests": 4,
+            "http_200_with_usage": 4,
+            "metric_queries_delta": 263263.0,
+            "metric_hits_delta": 263168.0
+          }
+        }
+      ]
+    },
+    {
+      "file": "p0-soak-concurrency-c6-20260905.json",
+      "run_id": "ebc80e4f16",
+      "cells": [
+        {
+          "mode": "code",
+          "ctx": 24000,
+          "level": 1,
+          "rep": 0,
+          "temperature": 0.0,
+          "thinking": true,
+          "agg_tps": 30.1,
+          "stream_tps_median": 34.7,
+          "ttft": {
+            "p50": 0.592,
+            "p95": 0.592,
+            "p99": 0.592
+          },
+          "itl": {
+            "p50": 0.119,
+            "p95": 0.126,
+            "p99": 0.137
+          },
+          "starvation_age_s": 0.59,
+          "tokens": 128,
+          "prompt_tokens": 25477,
+          "wall": 4.3,
+          "cache_hit_ratio": 0.997,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-ebc80e4f16-code-c24000-n1-r0-l0-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-ebc80e4f16-code-c24000-n1-r0-l0-measure"
+            ],
+            "expected_measured_requests": 1,
+            "http_200_with_usage": 1,
+            "metric_queries_delta": 25477.0,
+            "metric_hits_delta": 25408.0
+          }
+        },
+        {
+          "mode": "code",
+          "ctx": 24000,
+          "level": 4,
+          "rep": 0,
+          "temperature": 0.0,
+          "thinking": true,
+          "agg_tps": 52.1,
+          "stream_tps_median": 15.9,
+          "ttft": {
+            "p50": 0.987,
+            "p95": 0.988,
+            "p99": 0.988
+          },
+          "itl": {
+            "p50": 0.22,
+            "p95": 0.342,
+            "p99": 0.354
+          },
+          "starvation_age_s": 0.99,
+          "tokens": 512,
+          "prompt_tokens": 101915,
+          "wall": 9.8,
+          "cache_hit_ratio": 0.998,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-ebc80e4f16-code-c24000-n4-r0-l0-warm",
+              "glm53-ladder-ebc80e4f16-code-c24000-n4-r0-l1-warm",
+              "glm53-ladder-ebc80e4f16-code-c24000-n4-r0-l2-warm",
+              "glm53-ladder-ebc80e4f16-code-c24000-n4-r0-l3-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-ebc80e4f16-code-c24000-n4-r0-l0-measure",
+              "glm53-ladder-ebc80e4f16-code-c24000-n4-r0-l1-measure",
+              "glm53-ladder-ebc80e4f16-code-c24000-n4-r0-l2-measure",
+              "glm53-ladder-ebc80e4f16-code-c24000-n4-r0-l3-measure"
+            ],
+            "expected_measured_requests": 4,
+            "http_200_with_usage": 4,
+            "metric_queries_delta": 101915.0,
+            "metric_hits_delta": 101696.0
+          }
+        },
+        {
+          "mode": "code",
+          "ctx": 60000,
+          "level": 1,
+          "rep": 0,
+          "temperature": 0.0,
+          "thinking": true,
+          "agg_tps": 22.6,
+          "stream_tps_median": 33.2,
+          "ttft": {
+            "p50": 1.824,
+            "p95": 1.824,
+            "p99": 1.824
+          },
+          "itl": {
+            "p50": 0.119,
+            "p95": 0.125,
+            "p99": 0.127
+          },
+          "starvation_age_s": 1.82,
+          "tokens": 128,
+          "prompt_tokens": 65807,
+          "wall": 5.7,
+          "cache_hit_ratio": 0.98,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-ebc80e4f16-code-c60000-n1-r0-l0-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-ebc80e4f16-code-c60000-n1-r0-l0-measure"
+            ],
+            "expected_measured_requests": 1,
+            "http_200_with_usage": 1,
+            "metric_queries_delta": 65807.0,
+            "metric_hits_delta": 64512.0
+          }
+        },
+        {
+          "mode": "code",
+          "ctx": 60000,
+          "level": 4,
+          "rep": 0,
+          "temperature": 0.0,
+          "thinking": true,
+          "agg_tps": 41.8,
+          "stream_tps_median": 16.4,
+          "ttft": {
+            "p50": 4.333,
+            "p95": 4.632,
+            "p99": 4.632
+          },
+          "itl": {
+            "p50": 0.25,
+            "p95": 0.346,
+            "p99": 1.34
+          },
+          "starvation_age_s": 4.63,
+          "tokens": 512,
+          "prompt_tokens": 263235,
+          "wall": 12.3,
+          "cache_hit_ratio": 0.985,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-ebc80e4f16-code-c60000-n4-r0-l0-warm",
+              "glm53-ladder-ebc80e4f16-code-c60000-n4-r0-l1-warm",
+              "glm53-ladder-ebc80e4f16-code-c60000-n4-r0-l2-warm",
+              "glm53-ladder-ebc80e4f16-code-c60000-n4-r0-l3-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-ebc80e4f16-code-c60000-n4-r0-l0-measure",
+              "glm53-ladder-ebc80e4f16-code-c60000-n4-r0-l1-measure",
+              "glm53-ladder-ebc80e4f16-code-c60000-n4-r0-l2-measure",
+              "glm53-ladder-ebc80e4f16-code-c60000-n4-r0-l3-measure"
+            ],
+            "expected_measured_requests": 4,
+            "http_200_with_usage": 4,
+            "metric_queries_delta": 263235.0,
+            "metric_hits_delta": 259328.0
+          }
+        },
+        {
+          "mode": "data",
+          "ctx": 24000,
+          "level": 1,
+          "rep": 0,
+          "temperature": 0.0,
+          "thinking": true,
+          "agg_tps": 32.4,
+          "stream_tps_median": 37.7,
+          "ttft": {
+            "p50": 0.587,
+            "p95": 0.587,
+            "p99": 0.587
+          },
+          "itl": {
+            "p50": 0.115,
+            "p95": 0.124,
+            "p99": 0.129
+          },
+          "starvation_age_s": 0.59,
+          "tokens": 128,
+          "prompt_tokens": 25478,
+          "wall": 4.0,
+          "cache_hit_ratio": 0.997,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-ebc80e4f16-data-c24000-n1-r0-l0-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-ebc80e4f16-data-c24000-n1-r0-l0-measure"
+            ],
+            "expected_measured_requests": 1,
+            "http_200_with_usage": 1,
+            "metric_queries_delta": 25478.0,
+            "metric_hits_delta": 25408.0
+          }
+        },
+        {
+          "mode": "data",
+          "ctx": 24000,
+          "level": 4,
+          "rep": 0,
+          "temperature": 0.0,
+          "thinking": true,
+          "agg_tps": 55.0,
+          "stream_tps_median": 17.2,
+          "ttft": {
+            "p50": 0.981,
+            "p95": 0.983,
+            "p99": 0.983
+          },
+          "itl": {
+            "p50": 0.203,
+            "p95": 0.326,
+            "p99": 0.332
+          },
+          "starvation_age_s": 0.98,
+          "tokens": 512,
+          "prompt_tokens": 101912,
+          "wall": 9.3,
+          "cache_hit_ratio": 0.998,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-ebc80e4f16-data-c24000-n4-r0-l0-warm",
+              "glm53-ladder-ebc80e4f16-data-c24000-n4-r0-l1-warm",
+              "glm53-ladder-ebc80e4f16-data-c24000-n4-r0-l2-warm",
+              "glm53-ladder-ebc80e4f16-data-c24000-n4-r0-l3-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-ebc80e4f16-data-c24000-n4-r0-l0-measure",
+              "glm53-ladder-ebc80e4f16-data-c24000-n4-r0-l1-measure",
+              "glm53-ladder-ebc80e4f16-data-c24000-n4-r0-l2-measure",
+              "glm53-ladder-ebc80e4f16-data-c24000-n4-r0-l3-measure"
+            ],
+            "expected_measured_requests": 4,
+            "http_200_with_usage": 4,
+            "metric_queries_delta": 101912.0,
+            "metric_hits_delta": 101696.0
+          }
+        },
+        {
+          "mode": "data",
+          "ctx": 60000,
+          "level": 1,
+          "rep": 0,
+          "temperature": 0.0,
+          "thinking": true,
+          "agg_tps": 24.5,
+          "stream_tps_median": 37.4,
+          "ttft": {
+            "p50": 1.825,
+            "p95": 1.825,
+            "p99": 1.825
+          },
+          "itl": {
+            "p50": 0.115,
+            "p95": 0.123,
+            "p99": 0.124
+          },
+          "starvation_age_s": 1.82,
+          "tokens": 128,
+          "prompt_tokens": 65808,
+          "wall": 5.2,
+          "cache_hit_ratio": 0.98,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-ebc80e4f16-data-c60000-n1-r0-l0-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-ebc80e4f16-data-c60000-n1-r0-l0-measure"
+            ],
+            "expected_measured_requests": 1,
+            "http_200_with_usage": 1,
+            "metric_queries_delta": 65808.0,
+            "metric_hits_delta": 64512.0
+          }
+        },
+        {
+          "mode": "data",
+          "ctx": 60000,
+          "level": 4,
+          "rep": 0,
+          "temperature": 0.0,
+          "thinking": true,
+          "agg_tps": 45.7,
+          "stream_tps_median": 18.6,
+          "ttft": {
+            "p50": 4.472,
+            "p95": 4.475,
+            "p99": 4.475
+          },
+          "itl": {
+            "p50": 0.204,
+            "p95": 0.334,
+            "p99": 0.348
+          },
+          "starvation_age_s": 4.48,
+          "tokens": 512,
+          "prompt_tokens": 263232,
+          "wall": 11.2,
+          "cache_hit_ratio": 0.985,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-ebc80e4f16-data-c60000-n4-r0-l0-warm",
+              "glm53-ladder-ebc80e4f16-data-c60000-n4-r0-l1-warm",
+              "glm53-ladder-ebc80e4f16-data-c60000-n4-r0-l2-warm",
+              "glm53-ladder-ebc80e4f16-data-c60000-n4-r0-l3-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-ebc80e4f16-data-c60000-n4-r0-l0-measure",
+              "glm53-ladder-ebc80e4f16-data-c60000-n4-r0-l1-measure",
+              "glm53-ladder-ebc80e4f16-data-c60000-n4-r0-l2-measure",
+              "glm53-ladder-ebc80e4f16-data-c60000-n4-r0-l3-measure"
+            ],
+            "expected_measured_requests": 4,
+            "http_200_with_usage": 4,
+            "metric_queries_delta": 263232.0,
+            "metric_hits_delta": 259328.0
+          }
+        },
+        {
+          "mode": "chat",
+          "ctx": 24000,
+          "level": 1,
+          "rep": 0,
+          "temperature": 0.7,
+          "thinking": true,
+          "agg_tps": 20.7,
+          "stream_tps_median": 22.6,
+          "ttft": {
+            "p50": 0.575,
+            "p95": 0.575,
+            "p99": 0.575
+          },
+          "itl": {
+            "p50": 0.117,
+            "p95": 0.123,
+            "p99": 0.14
+          },
+          "starvation_age_s": 0.57,
+          "tokens": 128,
+          "prompt_tokens": 25485,
+          "wall": 6.2,
+          "cache_hit_ratio": 0.997,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-ebc80e4f16-chat-c24000-n1-r0-l0-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-ebc80e4f16-chat-c24000-n1-r0-l0-measure"
+            ],
+            "expected_measured_requests": 1,
+            "http_200_with_usage": 1,
+            "metric_queries_delta": 25485.0,
+            "metric_hits_delta": 25408.0
+          }
+        },
+        {
+          "mode": "chat",
+          "ctx": 24000,
+          "level": 4,
+          "rep": 0,
+          "temperature": 0.7,
+          "thinking": true,
+          "agg_tps": 38.4,
+          "stream_tps_median": 10.6,
+          "ttft": {
+            "p50": 1.014,
+            "p95": 1.016,
+            "p99": 1.016
+          },
+          "itl": {
+            "p50": 0.232,
+            "p95": 0.341,
+            "p99": 0.411
+          },
+          "starvation_age_s": 1.02,
+          "tokens": 512,
+          "prompt_tokens": 101943,
+          "wall": 13.3,
+          "cache_hit_ratio": 0.998,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-ebc80e4f16-chat-c24000-n4-r0-l0-warm",
+              "glm53-ladder-ebc80e4f16-chat-c24000-n4-r0-l1-warm",
+              "glm53-ladder-ebc80e4f16-chat-c24000-n4-r0-l2-warm",
+              "glm53-ladder-ebc80e4f16-chat-c24000-n4-r0-l3-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-ebc80e4f16-chat-c24000-n4-r0-l0-measure",
+              "glm53-ladder-ebc80e4f16-chat-c24000-n4-r0-l1-measure",
+              "glm53-ladder-ebc80e4f16-chat-c24000-n4-r0-l2-measure",
+              "glm53-ladder-ebc80e4f16-chat-c24000-n4-r0-l3-measure"
+            ],
+            "expected_measured_requests": 4,
+            "http_200_with_usage": 4,
+            "metric_queries_delta": 101943.0,
+            "metric_hits_delta": 101696.0
+          }
+        },
+        {
+          "mode": "chat",
+          "ctx": 60000,
+          "level": 1,
+          "rep": 0,
+          "temperature": 0.7,
+          "thinking": true,
+          "agg_tps": 16.5,
+          "stream_tps_median": 21.8,
+          "ttft": {
+            "p50": 1.911,
+            "p95": 1.911,
+            "p99": 1.911
+          },
+          "itl": {
+            "p50": 0.119,
+            "p95": 0.132,
+            "p99": 0.141
+          },
+          "starvation_age_s": 1.91,
+          "tokens": 128,
+          "prompt_tokens": 65815,
+          "wall": 7.7,
+          "cache_hit_ratio": 0.98,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-ebc80e4f16-chat-c60000-n1-r0-l0-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-ebc80e4f16-chat-c60000-n1-r0-l0-measure"
+            ],
+            "expected_measured_requests": 1,
+            "http_200_with_usage": 1,
+            "metric_queries_delta": 65815.0,
+            "metric_hits_delta": 64512.0
+          }
+        },
+        {
+          "mode": "chat",
+          "ctx": 60000,
+          "level": 4,
+          "rep": 0,
+          "temperature": 0.7,
+          "thinking": true,
+          "agg_tps": 42.9,
+          "stream_tps_median": 11.7,
+          "ttft": {
+            "p50": 0.739,
+            "p95": 0.947,
+            "p99": 0.947
+          },
+          "itl": {
+            "p50": 0.23,
+            "p95": 0.409,
+            "p99": 0.417
+          },
+          "starvation_age_s": 0.95,
+          "tokens": 512,
+          "prompt_tokens": 263263,
+          "wall": 11.9,
+          "cache_hit_ratio": 1.0,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-ebc80e4f16-chat-c60000-n4-r0-l0-warm",
+              "glm53-ladder-ebc80e4f16-chat-c60000-n4-r0-l1-warm",
+              "glm53-ladder-ebc80e4f16-chat-c60000-n4-r0-l2-warm",
+              "glm53-ladder-ebc80e4f16-chat-c60000-n4-r0-l3-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-ebc80e4f16-chat-c60000-n4-r0-l0-measure",
+              "glm53-ladder-ebc80e4f16-chat-c60000-n4-r0-l1-measure",
+              "glm53-ladder-ebc80e4f16-chat-c60000-n4-r0-l2-measure",
+              "glm53-ladder-ebc80e4f16-chat-c60000-n4-r0-l3-measure"
+            ],
+            "expected_measured_requests": 4,
+            "http_200_with_usage": 4,
+            "metric_queries_delta": 263263.0,
+            "metric_hits_delta": 263168.0
+          }
+        }
+      ]
+    },
+    {
+      "file": "p0-soak-concurrency-c7-20260905.json",
+      "run_id": "8110d1a55e",
+      "cells": [
+        {
+          "mode": "code",
+          "ctx": 24000,
+          "level": 1,
+          "rep": 0,
+          "temperature": 0.0,
+          "thinking": true,
+          "agg_tps": 27.7,
+          "stream_tps_median": 31.5,
+          "ttft": {
+            "p50": 0.6,
+            "p95": 0.6,
+            "p99": 0.6
+          },
+          "itl": {
+            "p50": 0.119,
+            "p95": 0.125,
+            "p99": 0.126
+          },
+          "starvation_age_s": 0.6,
+          "tokens": 128,
+          "prompt_tokens": 25477,
+          "wall": 4.6,
+          "cache_hit_ratio": 0.997,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-8110d1a55e-code-c24000-n1-r0-l0-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-8110d1a55e-code-c24000-n1-r0-l0-measure"
+            ],
+            "expected_measured_requests": 1,
+            "http_200_with_usage": 1,
+            "metric_queries_delta": 25477.0,
+            "metric_hits_delta": 25408.0
+          }
+        },
+        {
+          "mode": "code",
+          "ctx": 24000,
+          "level": 4,
+          "rep": 0,
+          "temperature": 0.0,
+          "thinking": true,
+          "agg_tps": 54.7,
+          "stream_tps_median": 15.8,
+          "ttft": {
+            "p50": 1.001,
+            "p95": 1.001,
+            "p99": 1.001
+          },
+          "itl": {
+            "p50": 0.217,
+            "p95": 0.339,
+            "p99": 0.35
+          },
+          "starvation_age_s": 1.0,
+          "tokens": 512,
+          "prompt_tokens": 101915,
+          "wall": 9.4,
+          "cache_hit_ratio": 0.998,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-8110d1a55e-code-c24000-n4-r0-l0-warm",
+              "glm53-ladder-8110d1a55e-code-c24000-n4-r0-l1-warm",
+              "glm53-ladder-8110d1a55e-code-c24000-n4-r0-l2-warm",
+              "glm53-ladder-8110d1a55e-code-c24000-n4-r0-l3-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-8110d1a55e-code-c24000-n4-r0-l0-measure",
+              "glm53-ladder-8110d1a55e-code-c24000-n4-r0-l1-measure",
+              "glm53-ladder-8110d1a55e-code-c24000-n4-r0-l2-measure",
+              "glm53-ladder-8110d1a55e-code-c24000-n4-r0-l3-measure"
+            ],
+            "expected_measured_requests": 4,
+            "http_200_with_usage": 4,
+            "metric_queries_delta": 101915.0,
+            "metric_hits_delta": 101696.0
+          }
+        },
+        {
+          "mode": "code",
+          "ctx": 60000,
+          "level": 1,
+          "rep": 0,
+          "temperature": 0.0,
+          "thinking": true,
+          "agg_tps": 23.0,
+          "stream_tps_median": 34.7,
+          "ttft": {
+            "p50": 1.897,
+            "p95": 1.897,
+            "p99": 1.897
+          },
+          "itl": {
+            "p50": 0.118,
+            "p95": 0.124,
+            "p99": 0.124
+          },
+          "starvation_age_s": 1.9,
+          "tokens": 128,
+          "prompt_tokens": 65807,
+          "wall": 5.6,
+          "cache_hit_ratio": 0.98,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-8110d1a55e-code-c60000-n1-r0-l0-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-8110d1a55e-code-c60000-n1-r0-l0-measure"
+            ],
+            "expected_measured_requests": 1,
+            "http_200_with_usage": 1,
+            "metric_queries_delta": 65807.0,
+            "metric_hits_delta": 64512.0
+          }
+        },
+        {
+          "mode": "code",
+          "ctx": 60000,
+          "level": 4,
+          "rep": 0,
+          "temperature": 0.0,
+          "thinking": true,
+          "agg_tps": 28.1,
+          "stream_tps_median": 9.4,
+          "ttft": {
+            "p50": 4.479,
+            "p95": 4.48,
+            "p99": 4.48
+          },
+          "itl": {
+            "p50": 0.267,
+            "p95": 0.41,
+            "p99": 5.221
+          },
+          "starvation_age_s": 4.48,
+          "tokens": 512,
+          "prompt_tokens": 263235,
+          "wall": 18.2,
+          "cache_hit_ratio": 0.985,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-8110d1a55e-code-c60000-n4-r0-l0-warm",
+              "glm53-ladder-8110d1a55e-code-c60000-n4-r0-l1-warm",
+              "glm53-ladder-8110d1a55e-code-c60000-n4-r0-l2-warm",
+              "glm53-ladder-8110d1a55e-code-c60000-n4-r0-l3-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-8110d1a55e-code-c60000-n4-r0-l0-measure",
+              "glm53-ladder-8110d1a55e-code-c60000-n4-r0-l1-measure",
+              "glm53-ladder-8110d1a55e-code-c60000-n4-r0-l2-measure",
+              "glm53-ladder-8110d1a55e-code-c60000-n4-r0-l3-measure"
+            ],
+            "expected_measured_requests": 4,
+            "http_200_with_usage": 4,
+            "metric_queries_delta": 263235.0,
+            "metric_hits_delta": 259328.0
+          }
+        },
+        {
+          "mode": "data",
+          "ctx": 24000,
+          "level": 1,
+          "rep": 0,
+          "temperature": 0.0,
+          "thinking": true,
+          "agg_tps": 32.2,
+          "stream_tps_median": 37.5,
+          "ttft": {
+            "p50": 0.585,
+            "p95": 0.585,
+            "p99": 0.585
+          },
+          "itl": {
+            "p50": 0.115,
+            "p95": 0.122,
+            "p99": 0.129
+          },
+          "starvation_age_s": 0.59,
+          "tokens": 128,
+          "prompt_tokens": 25478,
+          "wall": 4.0,
+          "cache_hit_ratio": 0.997,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-8110d1a55e-data-c24000-n1-r0-l0-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-8110d1a55e-data-c24000-n1-r0-l0-measure"
+            ],
+            "expected_measured_requests": 1,
+            "http_200_with_usage": 1,
+            "metric_queries_delta": 25478.0,
+            "metric_hits_delta": 25408.0
+          }
+        },
+        {
+          "mode": "data",
+          "ctx": 24000,
+          "level": 4,
+          "rep": 0,
+          "temperature": 0.0,
+          "thinking": true,
+          "agg_tps": 54.1,
+          "stream_tps_median": 17.6,
+          "ttft": {
+            "p50": 1.027,
+            "p95": 1.028,
+            "p99": 1.028
+          },
+          "itl": {
+            "p50": 0.22,
+            "p95": 0.312,
+            "p99": 0.327
+          },
+          "starvation_age_s": 1.03,
+          "tokens": 512,
+          "prompt_tokens": 101912,
+          "wall": 9.5,
+          "cache_hit_ratio": 0.998,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-8110d1a55e-data-c24000-n4-r0-l0-warm",
+              "glm53-ladder-8110d1a55e-data-c24000-n4-r0-l1-warm",
+              "glm53-ladder-8110d1a55e-data-c24000-n4-r0-l2-warm",
+              "glm53-ladder-8110d1a55e-data-c24000-n4-r0-l3-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-8110d1a55e-data-c24000-n4-r0-l0-measure",
+              "glm53-ladder-8110d1a55e-data-c24000-n4-r0-l1-measure",
+              "glm53-ladder-8110d1a55e-data-c24000-n4-r0-l2-measure",
+              "glm53-ladder-8110d1a55e-data-c24000-n4-r0-l3-measure"
+            ],
+            "expected_measured_requests": 4,
+            "http_200_with_usage": 4,
+            "metric_queries_delta": 101912.0,
+            "metric_hits_delta": 101696.0
+          }
+        },
+        {
+          "mode": "data",
+          "ctx": 60000,
+          "level": 1,
+          "rep": 0,
+          "temperature": 0.0,
+          "thinking": true,
+          "agg_tps": 25.5,
+          "stream_tps_median": 39.5,
+          "ttft": {
+            "p50": 1.807,
+            "p95": 1.807,
+            "p99": 1.807
+          },
+          "itl": {
+            "p50": 0.116,
+            "p95": 0.125,
+            "p99": 0.126
+          },
+          "starvation_age_s": 1.81,
+          "tokens": 128,
+          "prompt_tokens": 65808,
+          "wall": 5.0,
+          "cache_hit_ratio": 0.98,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-8110d1a55e-data-c60000-n1-r0-l0-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-8110d1a55e-data-c60000-n1-r0-l0-measure"
+            ],
+            "expected_measured_requests": 1,
+            "http_200_with_usage": 1,
+            "metric_queries_delta": 65808.0,
+            "metric_hits_delta": 64512.0
+          }
+        },
+        {
+          "mode": "data",
+          "ctx": 60000,
+          "level": 4,
+          "rep": 0,
+          "temperature": 0.0,
+          "thinking": true,
+          "agg_tps": 44.2,
+          "stream_tps_median": 19.0,
+          "ttft": {
+            "p50": 4.491,
+            "p95": 4.494,
+            "p99": 4.494
+          },
+          "itl": {
+            "p50": 0.204,
+            "p95": 0.331,
+            "p99": 0.391
+          },
+          "starvation_age_s": 4.49,
+          "tokens": 512,
+          "prompt_tokens": 263232,
+          "wall": 11.6,
+          "cache_hit_ratio": 0.985,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-8110d1a55e-data-c60000-n4-r0-l0-warm",
+              "glm53-ladder-8110d1a55e-data-c60000-n4-r0-l1-warm",
+              "glm53-ladder-8110d1a55e-data-c60000-n4-r0-l2-warm",
+              "glm53-ladder-8110d1a55e-data-c60000-n4-r0-l3-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-8110d1a55e-data-c60000-n4-r0-l0-measure",
+              "glm53-ladder-8110d1a55e-data-c60000-n4-r0-l1-measure",
+              "glm53-ladder-8110d1a55e-data-c60000-n4-r0-l2-measure",
+              "glm53-ladder-8110d1a55e-data-c60000-n4-r0-l3-measure"
+            ],
+            "expected_measured_requests": 4,
+            "http_200_with_usage": 4,
+            "metric_queries_delta": 263232.0,
+            "metric_hits_delta": 259328.0
+          }
+        },
+        {
+          "mode": "chat",
+          "ctx": 24000,
+          "level": 1,
+          "rep": 0,
+          "temperature": 0.7,
+          "thinking": true,
+          "agg_tps": 17.2,
+          "stream_tps_median": 18.5,
+          "ttft": {
+            "p50": 0.601,
+            "p95": 0.601,
+            "p99": 0.601
+          },
+          "itl": {
+            "p50": 0.121,
+            "p95": 0.189,
+            "p99": 0.193
+          },
+          "starvation_age_s": 0.6,
+          "tokens": 128,
+          "prompt_tokens": 25485,
+          "wall": 7.5,
+          "cache_hit_ratio": 0.997,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-8110d1a55e-chat-c24000-n1-r0-l0-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-8110d1a55e-chat-c24000-n1-r0-l0-measure"
+            ],
+            "expected_measured_requests": 1,
+            "http_200_with_usage": 1,
+            "metric_queries_delta": 25485.0,
+            "metric_hits_delta": 25408.0
+          }
+        },
+        {
+          "mode": "chat",
+          "ctx": 24000,
+          "level": 4,
+          "rep": 0,
+          "temperature": 0.7,
+          "thinking": true,
+          "agg_tps": 42.5,
+          "stream_tps_median": 11.7,
+          "ttft": {
+            "p50": 0.976,
+            "p95": 0.977,
+            "p99": 0.977
+          },
+          "itl": {
+            "p50": 0.204,
+            "p95": 0.329,
+            "p99": 0.335
+          },
+          "starvation_age_s": 0.98,
+          "tokens": 512,
+          "prompt_tokens": 101943,
+          "wall": 12.1,
+          "cache_hit_ratio": 0.998,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-8110d1a55e-chat-c24000-n4-r0-l0-warm",
+              "glm53-ladder-8110d1a55e-chat-c24000-n4-r0-l1-warm",
+              "glm53-ladder-8110d1a55e-chat-c24000-n4-r0-l2-warm",
+              "glm53-ladder-8110d1a55e-chat-c24000-n4-r0-l3-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-8110d1a55e-chat-c24000-n4-r0-l0-measure",
+              "glm53-ladder-8110d1a55e-chat-c24000-n4-r0-l1-measure",
+              "glm53-ladder-8110d1a55e-chat-c24000-n4-r0-l2-measure",
+              "glm53-ladder-8110d1a55e-chat-c24000-n4-r0-l3-measure"
+            ],
+            "expected_measured_requests": 4,
+            "http_200_with_usage": 4,
+            "metric_queries_delta": 101943.0,
+            "metric_hits_delta": 101696.0
+          }
+        },
+        {
+          "mode": "chat",
+          "ctx": 60000,
+          "level": 1,
+          "rep": 0,
+          "temperature": 0.7,
+          "thinking": true,
+          "agg_tps": 16.9,
+          "stream_tps_median": 22.4,
+          "ttft": {
+            "p50": 1.898,
+            "p95": 1.898,
+            "p99": 1.898
+          },
+          "itl": {
+            "p50": 0.119,
+            "p95": 0.13,
+            "p99": 0.142
+          },
+          "starvation_age_s": 1.9,
+          "tokens": 128,
+          "prompt_tokens": 65815,
+          "wall": 7.6,
+          "cache_hit_ratio": 0.98,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-8110d1a55e-chat-c60000-n1-r0-l0-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-8110d1a55e-chat-c60000-n1-r0-l0-measure"
+            ],
+            "expected_measured_requests": 1,
+            "http_200_with_usage": 1,
+            "metric_queries_delta": 65815.0,
+            "metric_hits_delta": 64512.0
+          }
+        },
+        {
+          "mode": "chat",
+          "ctx": 60000,
+          "level": 4,
+          "rep": 0,
+          "temperature": 0.7,
+          "thinking": true,
+          "agg_tps": 29.5,
+          "stream_tps_median": 11.3,
+          "ttft": {
+            "p50": 0.791,
+            "p95": 1.095,
+            "p99": 1.095
+          },
+          "itl": {
+            "p50": 0.233,
+            "p95": 0.33,
+            "p99": 0.384
+          },
+          "starvation_age_s": 1.09,
+          "tokens": 512,
+          "prompt_tokens": 263263,
+          "wall": 17.4,
+          "cache_hit_ratio": 1.0,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-8110d1a55e-chat-c60000-n4-r0-l0-warm",
+              "glm53-ladder-8110d1a55e-chat-c60000-n4-r0-l1-warm",
+              "glm53-ladder-8110d1a55e-chat-c60000-n4-r0-l2-warm",
+              "glm53-ladder-8110d1a55e-chat-c60000-n4-r0-l3-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-8110d1a55e-chat-c60000-n4-r0-l0-measure",
+              "glm53-ladder-8110d1a55e-chat-c60000-n4-r0-l1-measure",
+              "glm53-ladder-8110d1a55e-chat-c60000-n4-r0-l2-measure",
+              "glm53-ladder-8110d1a55e-chat-c60000-n4-r0-l3-measure"
+            ],
+            "expected_measured_requests": 4,
+            "http_200_with_usage": 4,
+            "metric_queries_delta": 263263.0,
+            "metric_hits_delta": 263168.0
+          }
+        }
+      ]
+    },
+    {
+      "file": "p0-soak-concurrency-c8-20260905.json",
+      "run_id": "ea7a6c507e",
+      "cells": [
+        {
+          "mode": "code",
+          "ctx": 24000,
+          "level": 1,
+          "rep": 0,
+          "temperature": 0.0,
+          "thinking": true,
+          "agg_tps": 31.6,
+          "stream_tps_median": 35.6,
+          "ttft": {
+            "p50": 0.489,
+            "p95": 0.489,
+            "p99": 0.489
+          },
+          "itl": {
+            "p50": 0.119,
+            "p95": 0.124,
+            "p99": 0.124
+          },
+          "starvation_age_s": 0.49,
+          "tokens": 128,
+          "prompt_tokens": 25477,
+          "wall": 4.1,
+          "cache_hit_ratio": 0.997,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-ea7a6c507e-code-c24000-n1-r0-l0-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-ea7a6c507e-code-c24000-n1-r0-l0-measure"
+            ],
+            "expected_measured_requests": 1,
+            "http_200_with_usage": 1,
+            "metric_queries_delta": 25477.0,
+            "metric_hits_delta": 25408.0
+          }
+        },
+        {
+          "mode": "code",
+          "ctx": 24000,
+          "level": 4,
+          "rep": 0,
+          "temperature": 0.0,
+          "thinking": true,
+          "agg_tps": 51.3,
+          "stream_tps_median": 14.9,
+          "ttft": {
+            "p50": 1.105,
+            "p95": 1.105,
+            "p99": 1.105
+          },
+          "itl": {
+            "p50": 0.206,
+            "p95": 0.355,
+            "p99": 0.409
+          },
+          "starvation_age_s": 1.11,
+          "tokens": 512,
+          "prompt_tokens": 101915,
+          "wall": 10.0,
+          "cache_hit_ratio": 0.998,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-ea7a6c507e-code-c24000-n4-r0-l0-warm",
+              "glm53-ladder-ea7a6c507e-code-c24000-n4-r0-l1-warm",
+              "glm53-ladder-ea7a6c507e-code-c24000-n4-r0-l2-warm",
+              "glm53-ladder-ea7a6c507e-code-c24000-n4-r0-l3-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-ea7a6c507e-code-c24000-n4-r0-l0-measure",
+              "glm53-ladder-ea7a6c507e-code-c24000-n4-r0-l1-measure",
+              "glm53-ladder-ea7a6c507e-code-c24000-n4-r0-l2-measure",
+              "glm53-ladder-ea7a6c507e-code-c24000-n4-r0-l3-measure"
+            ],
+            "expected_measured_requests": 4,
+            "http_200_with_usage": 4,
+            "metric_queries_delta": 101915.0,
+            "metric_hits_delta": 101696.0
+          }
+        },
+        {
+          "mode": "code",
+          "ctx": 60000,
+          "level": 1,
+          "rep": 0,
+          "temperature": 0.0,
+          "thinking": true,
+          "agg_tps": 24.0,
+          "stream_tps_median": 36.2,
+          "ttft": {
+            "p50": 1.827,
+            "p95": 1.827,
+            "p99": 1.827
+          },
+          "itl": {
+            "p50": 0.118,
+            "p95": 0.126,
+            "p99": 0.132
+          },
+          "starvation_age_s": 1.83,
+          "tokens": 128,
+          "prompt_tokens": 65807,
+          "wall": 5.3,
+          "cache_hit_ratio": 0.98,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-ea7a6c507e-code-c60000-n1-r0-l0-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-ea7a6c507e-code-c60000-n1-r0-l0-measure"
+            ],
+            "expected_measured_requests": 1,
+            "http_200_with_usage": 1,
+            "metric_queries_delta": 65807.0,
+            "metric_hits_delta": 64512.0
+          }
+        },
+        {
+          "mode": "code",
+          "ctx": 60000,
+          "level": 4,
+          "rep": 0,
+          "temperature": 0.0,
+          "thinking": true,
+          "agg_tps": 40.8,
+          "stream_tps_median": 16.3,
+          "ttft": {
+            "p50": 4.674,
+            "p95": 4.677,
+            "p99": 4.677
+          },
+          "itl": {
+            "p50": 0.243,
+            "p95": 0.343,
+            "p99": 1.261
+          },
+          "starvation_age_s": 4.68,
+          "tokens": 512,
+          "prompt_tokens": 263235,
+          "wall": 12.5,
+          "cache_hit_ratio": 0.985,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-ea7a6c507e-code-c60000-n4-r0-l0-warm",
+              "glm53-ladder-ea7a6c507e-code-c60000-n4-r0-l1-warm",
+              "glm53-ladder-ea7a6c507e-code-c60000-n4-r0-l2-warm",
+              "glm53-ladder-ea7a6c507e-code-c60000-n4-r0-l3-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-ea7a6c507e-code-c60000-n4-r0-l0-measure",
+              "glm53-ladder-ea7a6c507e-code-c60000-n4-r0-l1-measure",
+              "glm53-ladder-ea7a6c507e-code-c60000-n4-r0-l2-measure",
+              "glm53-ladder-ea7a6c507e-code-c60000-n4-r0-l3-measure"
+            ],
+            "expected_measured_requests": 4,
+            "http_200_with_usage": 4,
+            "metric_queries_delta": 263235.0,
+            "metric_hits_delta": 259328.0
+          }
+        },
+        {
+          "mode": "data",
+          "ctx": 24000,
+          "level": 1,
+          "rep": 0,
+          "temperature": 0.0,
+          "thinking": true,
+          "agg_tps": 27.4,
+          "stream_tps_median": 30.5,
+          "ttft": {
+            "p50": 0.497,
+            "p95": 0.497,
+            "p99": 0.497
+          },
+          "itl": {
+            "p50": 0.125,
+            "p95": 0.179,
+            "p99": 0.189
+          },
+          "starvation_age_s": 0.5,
+          "tokens": 128,
+          "prompt_tokens": 25478,
+          "wall": 4.7,
+          "cache_hit_ratio": 0.997,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-ea7a6c507e-data-c24000-n1-r0-l0-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-ea7a6c507e-data-c24000-n1-r0-l0-measure"
+            ],
+            "expected_measured_requests": 1,
+            "http_200_with_usage": 1,
+            "metric_queries_delta": 25478.0,
+            "metric_hits_delta": 25408.0
+          }
+        },
+        {
+          "mode": "data",
+          "ctx": 24000,
+          "level": 4,
+          "rep": 0,
+          "temperature": 0.0,
+          "thinking": true,
+          "agg_tps": 54.9,
+          "stream_tps_median": 16.6,
+          "ttft": {
+            "p50": 1.007,
+            "p95": 1.009,
+            "p99": 1.009
+          },
+          "itl": {
+            "p50": 0.195,
+            "p95": 0.346,
+            "p99": 0.423
+          },
+          "starvation_age_s": 1.01,
+          "tokens": 512,
+          "prompt_tokens": 101912,
+          "wall": 9.3,
+          "cache_hit_ratio": 0.998,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-ea7a6c507e-data-c24000-n4-r0-l0-warm",
+              "glm53-ladder-ea7a6c507e-data-c24000-n4-r0-l1-warm",
+              "glm53-ladder-ea7a6c507e-data-c24000-n4-r0-l2-warm",
+              "glm53-ladder-ea7a6c507e-data-c24000-n4-r0-l3-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-ea7a6c507e-data-c24000-n4-r0-l0-measure",
+              "glm53-ladder-ea7a6c507e-data-c24000-n4-r0-l1-measure",
+              "glm53-ladder-ea7a6c507e-data-c24000-n4-r0-l2-measure",
+              "glm53-ladder-ea7a6c507e-data-c24000-n4-r0-l3-measure"
+            ],
+            "expected_measured_requests": 4,
+            "http_200_with_usage": 4,
+            "metric_queries_delta": 101912.0,
+            "metric_hits_delta": 101696.0
+          }
+        },
+        {
+          "mode": "data",
+          "ctx": 60000,
+          "level": 1,
+          "rep": 0,
+          "temperature": 0.0,
+          "thinking": true,
+          "agg_tps": 25.3,
+          "stream_tps_median": 40.5,
+          "ttft": {
+            "p50": 1.922,
+            "p95": 1.922,
+            "p99": 1.922
+          },
+          "itl": {
+            "p50": 0.116,
+            "p95": 0.125,
+            "p99": 0.131
+          },
+          "starvation_age_s": 1.92,
+          "tokens": 128,
+          "prompt_tokens": 65808,
+          "wall": 5.1,
+          "cache_hit_ratio": 0.98,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-ea7a6c507e-data-c60000-n1-r0-l0-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-ea7a6c507e-data-c60000-n1-r0-l0-measure"
+            ],
+            "expected_measured_requests": 1,
+            "http_200_with_usage": 1,
+            "metric_queries_delta": 65808.0,
+            "metric_hits_delta": 64512.0
+          }
+        },
+        {
+          "mode": "data",
+          "ctx": 60000,
+          "level": 4,
+          "rep": 0,
+          "temperature": 0.0,
+          "thinking": true,
+          "agg_tps": 41.3,
+          "stream_tps_median": 17.9,
+          "ttft": {
+            "p50": 5.366,
+            "p95": 5.366,
+            "p99": 5.366
+          },
+          "itl": {
+            "p50": 0.234,
+            "p95": 0.336,
+            "p99": 1.247
+          },
+          "starvation_age_s": 5.37,
+          "tokens": 512,
+          "prompt_tokens": 263232,
+          "wall": 12.4,
+          "cache_hit_ratio": 0.985,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-ea7a6c507e-data-c60000-n4-r0-l0-warm",
+              "glm53-ladder-ea7a6c507e-data-c60000-n4-r0-l1-warm",
+              "glm53-ladder-ea7a6c507e-data-c60000-n4-r0-l2-warm",
+              "glm53-ladder-ea7a6c507e-data-c60000-n4-r0-l3-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-ea7a6c507e-data-c60000-n4-r0-l0-measure",
+              "glm53-ladder-ea7a6c507e-data-c60000-n4-r0-l1-measure",
+              "glm53-ladder-ea7a6c507e-data-c60000-n4-r0-l2-measure",
+              "glm53-ladder-ea7a6c507e-data-c60000-n4-r0-l3-measure"
+            ],
+            "expected_measured_requests": 4,
+            "http_200_with_usage": 4,
+            "metric_queries_delta": 263232.0,
+            "metric_hits_delta": 259328.0
+          }
+        },
+        {
+          "mode": "chat",
+          "ctx": 24000,
+          "level": 1,
+          "rep": 0,
+          "temperature": 0.7,
+          "thinking": true,
+          "agg_tps": 19.7,
+          "stream_tps_median": 21.6,
+          "ttft": {
+            "p50": 0.627,
+            "p95": 0.627,
+            "p99": 0.627
+          },
+          "itl": {
+            "p50": 0.118,
+            "p95": 0.135,
+            "p99": 0.144
+          },
+          "starvation_age_s": 0.63,
+          "tokens": 128,
+          "prompt_tokens": 25485,
+          "wall": 6.5,
+          "cache_hit_ratio": 0.997,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-ea7a6c507e-chat-c24000-n1-r0-l0-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-ea7a6c507e-chat-c24000-n1-r0-l0-measure"
+            ],
+            "expected_measured_requests": 1,
+            "http_200_with_usage": 1,
+            "metric_queries_delta": 25485.0,
+            "metric_hits_delta": 25408.0
+          }
+        },
+        {
+          "mode": "chat",
+          "ctx": 24000,
+          "level": 4,
+          "rep": 0,
+          "temperature": 0.7,
+          "thinking": true,
+          "agg_tps": 37.8,
+          "stream_tps_median": 10.4,
+          "ttft": {
+            "p50": 0.989,
+            "p95": 0.99,
+            "p99": 0.99
+          },
+          "itl": {
+            "p50": 0.226,
+            "p95": 0.379,
+            "p99": 0.409
+          },
+          "starvation_age_s": 0.99,
+          "tokens": 512,
+          "prompt_tokens": 101943,
+          "wall": 13.6,
+          "cache_hit_ratio": 0.998,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-ea7a6c507e-chat-c24000-n4-r0-l0-warm",
+              "glm53-ladder-ea7a6c507e-chat-c24000-n4-r0-l1-warm",
+              "glm53-ladder-ea7a6c507e-chat-c24000-n4-r0-l2-warm",
+              "glm53-ladder-ea7a6c507e-chat-c24000-n4-r0-l3-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-ea7a6c507e-chat-c24000-n4-r0-l0-measure",
+              "glm53-ladder-ea7a6c507e-chat-c24000-n4-r0-l1-measure",
+              "glm53-ladder-ea7a6c507e-chat-c24000-n4-r0-l2-measure",
+              "glm53-ladder-ea7a6c507e-chat-c24000-n4-r0-l3-measure"
+            ],
+            "expected_measured_requests": 4,
+            "http_200_with_usage": 4,
+            "metric_queries_delta": 101943.0,
+            "metric_hits_delta": 101696.0
+          }
+        },
+        {
+          "mode": "chat",
+          "ctx": 60000,
+          "level": 1,
+          "rep": 0,
+          "temperature": 0.7,
+          "thinking": true,
+          "agg_tps": 16.2,
+          "stream_tps_median": 21.2,
+          "ttft": {
+            "p50": 1.918,
+            "p95": 1.918,
+            "p99": 1.918
+          },
+          "itl": {
+            "p50": 0.12,
+            "p95": 0.13,
+            "p99": 0.141
+          },
+          "starvation_age_s": 1.92,
+          "tokens": 128,
+          "prompt_tokens": 65815,
+          "wall": 7.9,
+          "cache_hit_ratio": 0.98,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-ea7a6c507e-chat-c60000-n1-r0-l0-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-ea7a6c507e-chat-c60000-n1-r0-l0-measure"
+            ],
+            "expected_measured_requests": 1,
+            "http_200_with_usage": 1,
+            "metric_queries_delta": 65815.0,
+            "metric_hits_delta": 64512.0
+          }
+        },
+        {
+          "mode": "chat",
+          "ctx": 60000,
+          "level": 4,
+          "rep": 0,
+          "temperature": 0.7,
+          "thinking": true,
+          "agg_tps": 41.2,
+          "stream_tps_median": 11.3,
+          "ttft": {
+            "p50": 0.769,
+            "p95": 0.973,
+            "p99": 0.973
+          },
+          "itl": {
+            "p50": 0.205,
+            "p95": 0.324,
+            "p99": 0.347
+          },
+          "starvation_age_s": 0.97,
+          "tokens": 512,
+          "prompt_tokens": 263263,
+          "wall": 12.4,
+          "cache_hit_ratio": 1.0,
+          "preemptions": 0,
+          "errors": 0,
+          "error_samples": [],
+          "audit": {
+            "warm_request_ids": [
+              "glm53-ladder-ea7a6c507e-chat-c60000-n4-r0-l0-warm",
+              "glm53-ladder-ea7a6c507e-chat-c60000-n4-r0-l1-warm",
+              "glm53-ladder-ea7a6c507e-chat-c60000-n4-r0-l2-warm",
+              "glm53-ladder-ea7a6c507e-chat-c60000-n4-r0-l3-warm"
+            ],
+            "measured_request_ids": [
+              "glm53-ladder-ea7a6c507e-chat-c60000-n4-r0-l0-measure",
+              "glm53-ladder-ea7a6c507e-chat-c60000-n4-r0-l1-measure",
+              "glm53-ladder-ea7a6c507e-chat-c60000-n4-r0-l2-measure",
+              "glm53-ladder-ea7a6c507e-chat-c60000-n4-r0-l3-measure"
+            ],
+            "expected_measured_requests": 4,
+            "http_200_with_usage": 4,
+            "metric_queries_delta": 263263.0,
+            "metric_hits_delta": 263168.0
+          }
+        }
+      ]
+    }
+  ],
+  "unequal_fork_cycles": [
+    {
+      "file": "p0-soak-unequal-c1-20260905.json",
+      "cycle": 1,
+      "run_id": "ed26a98f3c",
+      "warm": {
+        "request_id": "p0-soak-ed26a98f3c-warm",
+        "http": 200,
+        "start": 9930.784862833,
+        "first": 9958.992923416,
+        "end": 9958.993176208,
+        "ttft": 28.208060583001497,
+        "itl": [],
+        "completion_tokens": 1,
+        "prompt_tokens": 30107,
+        "usage_seen": true,
+        "finish_reason": "length"
+      },
+      "outputs": [
+        {
+          "request_id": "p0-soak-ed26a98f3c-lane0",
+          "http": 200,
+          "start": 9959.027764791,
+          "first": 9959.379663166,
+          "end": 10012.66140075,
+          "ttft": 0.35189837500001886,
+          "itl": [
+            0.10853012499865144,
+            0.12200687500080676,
+            0.1274131669997587,
+            0.11472991700065904,
+            0.1213675829985732,
+            0.1139471250007773,
+            0.11800220800068928,
+            0.11513566699977673,
+            0.12201004199960153,
+            0.12508120799975586,
+            0.1239575830004469,
+            0.12256962500032387,
+            0.11715741700027138,
+            0.8212825419996079,
+            0.5330810409996047,
+            0.6945193339997786,
+            0.6140354580002167,
+            0.7168464170008519,
+            0.6146532909988309,
+            0.6131999170011113,
+            0.6156702079988463,
+            0.6146988340005919,
+            0.5861527500001102,
+            0.6293793330005428,
+            0.6273723329995846,
+            0.7168181670003833,
+            0.6154940829983389,
+            0.7147242920000281,
+            0.6150090000010096,
+            0.9665374169999268,
+            1.0818907079992641,
+            0.997388542000408,
+            1.0219614159996127,
+            1.1595592920002673,
+            0.9110747499998979,
+            1.065037125001254,
+            1.0914332079992164,
+            0.9997660000008182,
+            1.1511728749992471,
+            1.6388673750007001,
+            1.6375436250000348,
+            2.357375999999931,
+            1.6350229999989097,
+            1.6404896670010203,
+            1.7400443749993428,
+            1.637965374999112,
+            1.7407048330005637,
+            1.6387026669999614,
+            1.7430352499995934,
+            1.6372278750004625,
+            1.6387204170005134,
+            1.73955662499975,
+            1.6459154580006725,
+            1.3252060419999907,
+            0.3063763749996724,
+            0.30619449999903736,
+            0.11015533300087554,
+            0.17486595799891802,
+            0.1674351250003383,
+            0.16473912500077859,
+            0.1660329169990291,
+            0.1604694580000796,
+            0.1609489170004963,
+            0.1608738329996413,
+            0.16765912499977276,
+            0.16124437500002387,
+            0.1623130839998339,
+            0.17150212500018824,
+            0.16518775000076857,
+            0.16333141599898227,
+            0.17003433400168433,
+            0.17042199999923469,
+            0.17278145800082712,
+            0.17076558299959288,
+            0.17132691699953284,
+            0.16437416699955065,
+            0.1683166250004433,
+            0.16966929100090056,
+            0.17362649999995483,
+            0.1676722089996474,
+            0.1854052500002581,
+            0.1510597910000797,
+            0.1605602089985041,
+            0.15672308300054283,
+            0.15437820800070767,
+            0.16794641699925705
+          ],
+          "completion_tokens": 192,
+          "prompt_tokens": 30112,
+          "usage_seen": true,
+          "finish_reason": "length"
+        },
+        {
+          "request_id": "p0-soak-ed26a98f3c-lane1",
+          "http": 200,
+          "start": 9959.029140166,
+          "first": 10007.729527291,
+          "end": 10018.276150916,
+          "ttft": 48.70038712499991,
+          "itl": [
+            0.11005649999970046,
+            0.17456283400133543,
+            0.1677339159996336,
+            0.16476800000054936,
+            0.16596212499825924,
+            0.16047087500010093,
+            0.16098329200031003,
+            0.16083858300044085,
+            0.1695958750005957,
+            0.15931929199905426,
+            0.16239429199958977,
+            0.17147225000007893,
+            0.1651640830004908,
+            0.16500458300106402,
+            0.16835324999919976,
+            0.17037641699971573,
+            0.17285625000113214,
+            0.1707708329995512,
+            0.17128908399899956,
+            0.1645770410013938,
+            0.16814004199841293,
+            0.1696131670014438,
+            0.17341983299957064,
+            0.16932154200003424,
+            0.183969874999093,
+            0.151026625000668,
+            0.1607012910008052,
+            0.156627499998649,
+            0.15435583399994357,
+            0.16913175000081537,
+            0.11824150000029476,
+            0.12092766599926108,
+            0.1256233340009203,
+            0.11372566599857237,
+            0.12157029199988756,
+            0.12241354200159549,
+            0.11659470799895644,
+            0.11855445800028974,
+            0.12114762499913923,
+            0.11686804200144252,
+            0.13027150000016263,
+            0.10793466699942655,
+            0.11369191599987971,
+            0.11535620900031063,
+            0.11900299999979325,
+            0.11646808300065459,
+            0.11738758299907204,
+            0.11856437499955064,
+            0.12184375000106229,
+            0.12688462499863817,
+            0.12118466700121644,
+            0.12234870799875353,
+            0.11982420900130819,
+            0.12267770799917344,
+            0.11516795799980173,
+            0.12214179200054787,
+            0.12098300000070594,
+            0.12130491700008861,
+            0.12141687499934051,
+            0.12051962499936053,
+            0.12440458300079626,
+            0.11496179200003098,
+            0.1146193749991653,
+            0.12197287500021048,
+            0.12598516599973664,
+            0.123959417000151,
+            0.11718791699968278,
+            0.11733541600005992,
+            0.11491654200108314,
+            0.11520658299923525,
+            0.11979258400060644,
+            0.12202295799943386,
+            0.12205991700102459,
+            0.1146821659986017,
+            0.11549683400153299,
+            0.11375349999980244,
+            0.12453820799964888
+          ],
+          "completion_tokens": 192,
+          "prompt_tokens": 75070,
+          "usage_seen": true,
+          "finish_reason": "length"
+        }
+      ],
+      "metric_delta": {
+        "prefix_cache_queries_total": 105182.0,
+        "prefix_cache_hits_total": 60160.0,
+        "num_preemptions_total": 0.0,
+        "num_requests_running": 0.0,
+        "num_requests_waiting": 0.0
+      },
+      "hit_ratio": 0.571960981917058
+    },
+    {
+      "file": "p0-soak-unequal-c2-20260905.json",
+      "cycle": 2,
+      "run_id": "e967e541cc",
+      "warm": {
+        "request_id": "p0-soak-e967e541cc-warm",
+        "http": 200,
+        "start": 10420.763766833,
+        "first": 10448.909564875,
+        "end": 10448.909676833,
+        "ttft": 28.145798042000024,
+        "itl": [],
+        "completion_tokens": 1,
+        "prompt_tokens": 30107,
+        "usage_seen": true,
+        "finish_reason": "length"
+      },
+      "outputs": [
+        {
+          "request_id": "p0-soak-e967e541cc-lane0",
+          "http": 200,
+          "start": 10448.9455625,
+          "first": 10449.346850458,
+          "end": 10501.562431041,
+          "ttft": 0.40128795800046646,
+          "itl": [
+            0.10004358300102467,
+            0.12420045899852994,
+            0.1174877910016221,
+            0.11984212499919522,
+            0.1231975840000814,
+            0.12379695799972978,
+            0.1257763329995214,
+            0.1261062920002587,
+            0.1322277920007764,
+            0.11252116600007867,
+            0.13289774999975634,
+            0.10896954199961328,
+            0.11420458300017344,
+            0.7316962090008019,
+            0.7182754999994359,
+            0.6135935830006929,
+            0.6176377499996306,
+            0.7144279579988506,
+            0.544136125001387,
+            0.6832468339998741,
+            0.6210499159988103,
+            0.6084392499997193,
+            0.6147386669999833,
+            0.7158857500016893,
+            0.592288332998578,
+            0.6373583750009857,
+            0.6135870839989366,
+            0.7173344580005505,
+            0.6139232080004149,
+            1.2527282089995424,
+            1.4097892499994487,
+            1.1276347500006523,
+            0.9222102500007168,
+            1.125334832999215,
+            1.0231160000003001,
+            1.0248851670003205,
+            0.9996187910001026,
+            1.0314508339997701,
+            1.7567951660003018,
+            1.6387837919992307,
+            1.6255879170003027,
+            1.6525498749997496,
+            1.73964899999919,
+            1.7407720830015023,
+            1.6390735829991172,
+            1.7404087089998939,
+            1.6391177080004127,
+            1.7398710420002317,
+            1.6380819999994856,
+            1.6396460409996507,
+            1.6376104589999159,
+            1.7411143750014162,
+            2.2530046659994696,
+            0.7165134169990779,
+            0.30611079200025415,
+            0.30948808300126984,
+            0.08199441699980525,
+            0.16811083299944585,
+            0.1661115000006248,
+            0.16671229199891968,
+            0.15922595800111594,
+            0.16417366699897684,
+            0.16163654100091662,
+            0.17542620899985195,
+            0.1563677079993795,
+            0.1636663330009469,
+            0.1684888339987083,
+            0.1702379580001434,
+            0.16997554199951992,
+            0.16764366600000358,
+            0.1603178340010345,
+            0.17712529100026586,
+            0.14511154199863086,
+            0.1696667920004984,
+            0.16838766600085364,
+            0.16510904200004006
+          ],
+          "completion_tokens": 192,
+          "prompt_tokens": 30112,
+          "usage_seen": true,
+          "finish_reason": "length"
+        },
+        {
+          "request_id": "p0-soak-e967e541cc-lane1",
+          "http": 200,
+          "start": 10448.946787666,
+          "first": 10498.336906083,
+          "end": 10508.006064125,
+          "ttft": 49.39011841699903,
+          "itl": [
+            0.08188383300148416,
+            0.16817812499903084,
+            0.16635079200023029,
+            0.16649675000007846,
+            0.159142750000683,
+            0.164212541998495,
+            0.16136400000141293,
+            0.17537554099908448,
+            0.15669858399996883,
+            0.16365000000041618,
+            0.16845420800018474,
+            0.17038412500005506,
+            0.1698783749998256,
+            0.16755974999978207,
+            0.16036783299932722,
+            0.1771352920004574,
+            0.14506891699966218,
+            0.16942575000030047,
+            0.16875208300007216,
+            0.16508170800079824,
+            0.11619824999979755,
+            0.11896270899887895,
+            0.1202268750002986,
+            0.11568166600045515,
+            0.11868700000013632,
+            0.12494295900069119,
+            0.1186856659987825,
+            0.11341750000065076,
+            0.12485324999943259,
+            0.12203720900106418,
+            0.1188929999989341,
+            0.11962754100022721,
+            0.12177800000063144,
+            0.11712883399923157,
+            0.11886354099988239,
+            0.13422895900112053,
+            0.10943695799869602,
+            0.11535266700047941,
+            0.11465629099984653,
+            0.11925920900102938,
+            0.11672087499937334,
+            0.11980608299927553,
+            0.11705658299979405,
+            0.12195754200001829,
+            0.11663108300126623,
+            0.11828029199932644,
+            0.11857395799961523,
+            0.11972787500053528,
+            0.12131112499992014,
+            0.11728862500058312,
+            0.11872425000001385,
+            0.11931970899968292,
+            0.12070954099908704,
+            0.11481083400030911,
+            0.1202764580011717,
+            0.11807687500004249,
+            0.12283587499950954,
+            0.126018541999656,
+            0.12714316600067832,
+            0.12278858399986348,
+            0.12920466600007785,
+            0.11295166699892434,
+            0.12134241700005077,
+            0.11819699999978184,
+            0.11783433300115576,
+            0.11678495799969824,
+            0.1131933750002645,
+            0.11636499999985972,
+            0.12486066699966614,
+            0.12205008300043119,
+            0.12138183400020353,
+            0.11583512499964854,
+            0.1118640000004234,
+            0.12064237499907904
+          ],
+          "completion_tokens": 192,
+          "prompt_tokens": 75070,
+          "usage_seen": true,
+          "finish_reason": "length"
+        }
+      ],
+      "metric_delta": {
+        "prefix_cache_queries_total": 105182.0,
+        "prefix_cache_hits_total": 60160.0,
+        "num_preemptions_total": 0.0,
+        "num_requests_running": 0.0,
+        "num_requests_waiting": 0.0
+      },
+      "hit_ratio": 0.571960981917058
+    },
+    {
+      "file": "p0-soak-unequal-c3-20260905.json",
+      "cycle": 3,
+      "run_id": "6564feb7ca",
+      "warm": {
+        "request_id": "p0-soak-6564feb7ca-warm",
+        "http": 200,
+        "start": 10901.770599583,
+        "first": 10929.97537675,
+        "end": 10929.975582458,
+        "ttft": 28.20477716700043,
+        "itl": [],
+        "completion_tokens": 1,
+        "prompt_tokens": 30107,
+        "usage_seen": true,
+        "finish_reason": "length"
+      },
+      "outputs": [
+        {
+          "request_id": "p0-soak-6564feb7ca-lane0",
+          "http": 200,
+          "start": 10930.016384166,
+          "first": 10930.346337541,
+          "end": 10988.499836666,
+          "ttft": 0.3299533749996044,
+          "itl": [
+            0.14986379200126976,
+            0.0738914579997072,
+            0.12220254199928604,
+            0.1200770420000481,
+            0.20855550000123912,
+            0.03435074999833887,
+            0.12357583300035913,
+            0.12923920800130873,
+            0.12551079199874948,
+            0.1258010830006242,
+            0.10924020899983589,
+            0.11702783299915609,
+            0.12083504200018069,
+            0.8150536250013829,
+            0.6152223749995755,
+            0.613862500000323,
+            0.5997661249984958,
+            0.7311600830016687,
+            0.6148937079997268,
+            0.6145269999997254,
+            1.0234118339994893,
+            0.9222019160006312,
+            0.4552177089990437,
+            0.6228171660004591,
+            0.6638785420000204,
+            0.6129718749998574,
+            0.7182237500001065,
+            0.5241010000008828,
+            6.131258249999519,
+            1.02501220799968,
+            0.9195489590001671,
+            1.045917040999484,
+            1.10952429200006,
+            1.6337985000009212,
+            1.6392426669990527,
+            1.7394392500009417,
+            1.6389802909998252,
+            1.639692249998916,
+            1.5824285840008088,
+            1.6600957499995275,
+            1.874992500001099,
+            1.5377602909993584,
+            1.6281541669995931,
+            2.0581637499999488,
+            2.0477598329998727,
+            1.7412654170002497,
+            1.6375948330005485,
+            1.6400390420003532,
+            1.638900250000006,
+            1.739215042000069,
+            1.435352458000125,
+            0.26987924999957613,
+            0.445658958000422,
+            0.018929458999991766,
+            0.16892620799990254,
+            0.16966974999922968,
+            0.17122708299939404,
+            0.16752266700132168,
+            0.16157516699968255,
+            0.1581694159995095,
+            0.1618855420001637,
+            0.1635827080008312,
+            0.1696665839990601,
+            0.16975729099976888,
+            0.164910499999678,
+            0.16608350000024075,
+            0.16998979200070607,
+            0.16794812499938416,
+            0.17219929200109618,
+            0.16917808299876924,
+            0.16843058300037228,
+            0.15663708399915777,
+            0.1584180000008928,
+            0.15504162499928498,
+            0.1652120830003696,
+            0.16123049999987416,
+            0.1592005420006899,
+            0.1703088750000461,
+            0.1660929159988882,
+            0.16178116700029932,
+            0.16491250000035507,
+            0.1709675830006745,
+            0.16597004199866205,
+            0.17058950000136974
+          ],
+          "completion_tokens": 180,
+          "prompt_tokens": 30112,
+          "usage_seen": true,
+          "finish_reason": "stop"
+        },
+        {
+          "request_id": "p0-soak-6564feb7ca-lane1",
+          "http": 200,
+          "start": 10930.018166791,
+          "first": 10983.513791166,
+          "end": 10994.559480166,
+          "ttft": 53.49562437500026,
+          "itl": [
+            0.018806916999892564,
+            0.1689270419992681,
+            0.1696453750009823,
+            0.17128145799870254,
+            0.16755333299988706,
+            0.16126658400025917,
+            0.1583905830011645,
+            0.161632457999076,
+            0.16382625000005646,
+            0.16970933400079957,
+            0.16975604099934571,
+            0.16490154200073448,
+            0.16573037499983911,
+            0.1703384169995843,
+            0.1678862080007093,
+            0.1722302079997462,
+            0.1692528339990531,
+            0.16845454100075585,
+            0.15644491700004437,
+            0.15855008300059126,
+            0.1550186249987746,
+            0.1651920420008537,
+            0.16141529199921933,
+            0.15907024999978603,
+            0.17040033299963397,
+            0.16621633300019312,
+            0.16130950000115263,
+            0.16521879199899558,
+            0.17083008300141955,
+            0.16655795899896475,
+            0.17207795800095482,
+            0.11632724999981292,
+            0.11744854199969268,
+            0.1172864580003079,
+            0.1398917079986859,
+            0.09046933399986301,
+            0.12196862500059069,
+            0.11606412500077568,
+            0.12255070799983514,
+            0.1289180829990073,
+            0.11625854200065078,
+            0.11859999999978754,
+            0.11188895799932652,
+            0.13139908400080458,
+            0.11274575000061304,
+            0.1259911249999277,
+            0.1180093749990192,
+            0.1227818750012375,
+            0.11926795799990941,
+            0.12886504199923365,
+            0.1066961659998924,
+            0.1160725839999941,
+            0.12007400000038615,
+            0.1167627499999071,
+            0.11312125000040396,
+            0.1251647499993851,
+            0.10907633299939334,
+            0.11961508300009882,
+            0.12786429200059501,
+            0.11585037499935424,
+            0.12096125000061875,
+            0.12043762500070443,
+            0.12062224999863247,
+            0.11849179199998616,
+            0.114740625000195,
+            0.12267579100080184,
+            0.11894412499896134,
+            0.11965066700031457,
+            0.11367083300137892,
+            0.12379424999926414,
+            0.12161504200048512,
+            0.16945029199996497,
+            0.06054658299945004,
+            0.14748633300041547,
+            0.082401083998775,
+            0.12499587500133202,
+            0.12712179099980858,
+            0.10390870899936999,
+            0.11967899999945075,
+            0.12536912500036124,
+            0.13683812500130443,
+            0.09718895799960592
+          ],
+          "completion_tokens": 188,
+          "prompt_tokens": 75070,
+          "usage_seen": true,
+          "finish_reason": "stop"
+        }
+      ],
+      "metric_delta": {
+        "prefix_cache_queries_total": 105182.0,
+        "prefix_cache_hits_total": 60160.0,
+        "num_preemptions_total": 0.0,
+        "num_requests_running": 0.0,
+        "num_requests_waiting": 0.0
+      },
+      "hit_ratio": 0.571960981917058
+    },
+    {
+      "file": "p0-soak-unequal-c4-20260905.json",
+      "cycle": 4,
+      "run_id": "e816be9556",
+      "warm": {
+        "request_id": "p0-soak-e816be9556-warm",
+        "http": 200,
+        "start": 11406.430453291,
+        "first": 11434.795172125,
+        "end": 11434.795289583,
+        "ttft": 28.364718834000087,
+        "itl": [],
+        "completion_tokens": 1,
+        "prompt_tokens": 30107,
+        "usage_seen": true,
+        "finish_reason": "length"
+      },
+      "outputs": [
+        {
+          "request_id": "p0-soak-e816be9556-lane0",
+          "http": 200,
+          "start": 11434.939936916,
+          "first": 11435.283073625,
+          "end": 11487.911089125,
+          "ttft": 0.3431367089997366,
+          "itl": [
+            0.09317095799997333,
+            0.12586795800052641,
+            0.24859370900048816,
+            0.0035731659991142806,
+            0.10588279200055695,
+            0.12078470800042851,
+            0.29253520899874275,
+            0.005516500001249369,
+            0.06450149999909627,
+            0.12753362500006915,
+            0.12251716600076179,
+            0.2041334999994433,
+            0.035376042000279995,
+            0.7119199169992498,
+            0.8258880829998816,
+            0.5226999580008851,
+            0.6142089999993914,
+            0.6078477499995643,
+            0.6360449170006177,
+            0.7651747500003694,
+            0.5229667499988864,
+            0.5789215830009198,
+            0.630171374999918,
+            0.6342722919998778,
+            0.8110212499996123,
+            0.6630760000007285,
+            1.139654167000117,
+            0.5185830829996121,
+            1.3181798330006131,
+            1.3105809169992426,
+            1.0250544579994312,
+            0.5288682500013238,
+            1.6216539170000033,
+            1.0505111669990583,
+            1.3050255830003152,
+            0.1737087919991609,
+            1.0710094580008445,
+            1.4180042919997504,
+            1.50325679100024,
+            1.5712060000005295,
+            1.6080311249988881,
+            1.6809507090001716,
+            2.032143250000445,
+            1.535867665999831,
+            1.5362447089992202,
+            1.740162041000076,
+            2.0484213750005438,
+            1.2029786670009344,
+            2.0737134579994745,
+            1.3189428339992446,
+            2.164766125000824,
+            1.8404107080004906,
+            1.7615634579997277,
+            0.09013062499980151,
+            0.26553016700017906,
+            0.7509312080001109,
+            0.003322541999295936,
+            7.124999683583155e-06,
+            0.06857170799958112,
+            0.17498566700123774,
+            0.21900183300022036,
+            0.10640383399913844,
+            0.16560191600001417,
+            0.2551716250000027,
+            0.07381079200058593,
+            0.18185266699947533,
+            0.26635220800017123,
+            0.0721808329999476,
+            0.17184370900031354,
+            0.2801352499991481,
+            0.025621333001254243,
+            0.1566810419990361,
+            0.15898600000036822,
+            0.1821931249996851,
+            0.14156283299962524,
+            0.38337420800053224,
+            0.003441834000113886,
+            0.09425383300003887,
+            0.16215887500038662
+          ],
+          "completion_tokens": 192,
+          "prompt_tokens": 30112,
+          "usage_seen": true,
+          "finish_reason": "length"
+        },
+        {
+          "request_id": "p0-soak-e816be9556-lane1",
+          "http": 200,
+          "start": 11434.941878291,
+          "first": 11484.563299958,
+          "end": 11493.417341916,
+          "ttft": 49.621421666999595,
+          "itl": [
+            0.0033308330002910225,
+            1.5334000636357814e-05,
+            0.06842883299941604,
+            0.17503150000084133,
+            0.2190925419999985,
+            0.10631766599908588,
+            0.16554995899969072,
+            0.25499287500133505,
+            0.07408366599884175,
+            0.18192199999975855,
+            0.26600266700006614,
+            0.07238599999982398,
+            0.17189829200106033,
+            0.28713266600061615,
+            0.018655083998964983,
+            0.15664729099989927,
+            0.15895545900093566,
+            0.18225974999950267,
+            0.14149675000044226,
+            0.38311433299895725,
+            0.0037360000005719485,
+            0.09423600000081933,
+            0.1621850829997129,
+            0.26349574999949255,
+            0.002997208999659051,
+            0.10187712500010093,
+            0.11799370799963071,
+            0.3019189170008758,
+            0.003376082999238861,
+            0.04767320800056041,
+            0.1308658750003815,
+            0.10909483399882447,
+            0.23280337500000314,
+            0.004914750001262291,
+            0.12000974999864411,
+            0.12077404100091371,
+            0.2799483750004583,
+            0.0032804589991428657,
+            0.06812654100031068,
+            0.12220600000000559,
+            0.12022741699911421,
+            0.20885062500019558,
+            0.04343133300062618,
+            0.11648658400008571,
+            0.11382545800006483,
+            0.25099583299925143,
+            0.00321191700095369,
+            0.09091145799902733,
+            0.14172716699977173,
+            0.10375495800144563,
+            0.18827133400009188,
+            0.05945208299999649,
+            0.11882341699856624,
+            0.34389804100101173,
+            0.0035370419991522795,
+            0.012595333000717801,
+            0.1248705420002807,
+            0.1250971669996943,
+            0.2567467080007191,
+            0.003027582999493461,
+            0.09132395899905532,
+            0.11468966600114072,
+            0.3144962089991168,
+            0.031847415999436635,
+            0.007779709001624724,
+            0.12162487499881536,
+            0.12820383300095273,
+            0.23526633300025424
+          ],
+          "completion_tokens": 183,
+          "prompt_tokens": 75070,
+          "usage_seen": true,
+          "finish_reason": "stop"
+        }
+      ],
+      "metric_delta": {
+        "prefix_cache_queries_total": 105182.0,
+        "prefix_cache_hits_total": 60160.0,
+        "num_preemptions_total": 0.0,
+        "num_requests_running": 0.0,
+        "num_requests_waiting": 0.0
+      },
+      "hit_ratio": 0.571960981917058
+    },
+    {
+      "file": "p0-soak-unequal-c5-20260905.json",
+      "cycle": 5,
+      "run_id": "29e355348b",
+      "warm": {
+        "request_id": "p0-soak-29e355348b-warm",
+        "http": 200,
+        "start": 11899.696135416,
+        "first": 11927.962112833,
+        "end": 11927.962304666,
+        "ttft": 28.265977417000613,
+        "itl": [],
+        "completion_tokens": 1,
+        "prompt_tokens": 30107,
+        "usage_seen": true,
+        "finish_reason": "length"
+      },
+      "outputs": [
+        {
+          "request_id": "p0-soak-29e355348b-lane0",
+          "http": 200,
+          "start": 11928.000903791,
+          "first": 11928.333157291,
+          "end": 11979.959610791,
+          "ttft": 0.332253499998842,
+          "itl": [
+            0.11094212500029244,
+            0.12235725000027742,
+            0.12569724999957543,
+            0.11548041700007161,
+            0.1179420830012532,
+            0.1109679999990476,
+            0.11295795899968653,
+            0.1235638750004,
+            0.1240230410003278,
+            0.12660829199921864,
+            0.12344750000011118,
+            0.12262866700075392,
+            0.12236829100038449,
+            0.7323817090000375,
+            0.715960665998864,
+            0.6153043340000295,
+            0.614852124999743,
+            0.6131667080007901,
+            0.6149472920005792,
+            0.7185567910000827,
+            0.6192992919986864,
+            0.5232324170010543,
+            0.6994237500002782,
+            0.6133087079997495,
+            0.615724291999868,
+            0.613956249999319,
+            0.54400429099951,
+            0.6858377500011557,
+            0.6126779169990186,
+            1.1263337500004127,
+            0.9225200830005633,
+            1.126286958999117,
+            1.028596791000382,
+            0.940298375000566,
+            1.1031616250002116,
+            1.0235556249990623,
+            1.0247611249997135,
+            1.0229893750001793,
+            1.1297717090001242,
+            1.6352347909996752,
+            2.0476902090013027,
+            1.948753915999987,
+            1.7396515000000363,
+            1.5551618339995912,
+            1.7211130409996258,
+            1.7420083340002748,
+            1.6355362909998803,
+            1.6397548339991772,
+            1.7400715000003402,
+            1.5971820409995416,
+            1.68026383400138,
+            1.6373689579995698,
+            1.6463541249995615,
+            1.3037923330011836,
+            0.3274916669997765,
+            0.3082085419991927,
+            0.1011240000007092,
+            0.17219729099997494,
+            0.1641099589996884,
+            0.17455979099941032,
+            0.16833920899989607,
+            0.17169395800010534,
+            0.1775984169998992,
+            0.1715362909999385,
+            0.17360575000020617,
+            0.16131533400039189,
+            0.15837212500082387,
+            0.15847337499872083,
+            0.15729908300090756,
+            0.1553871670002991,
+            0.16291708299831953,
+            0.17254625000168744,
+            0.1436346249993221,
+            0.15991137499986507,
+            0.15565145800064784,
+            0.16481254199970863,
+            0.16509374999986903,
+            0.17052562500066415
+          ],
+          "completion_tokens": 190,
+          "prompt_tokens": 30112,
+          "usage_seen": true,
+          "finish_reason": "stop"
+        },
+        {
+          "request_id": "p0-soak-29e355348b-lane1",
+          "http": 200,
+          "start": 11928.002369791,
+          "first": 11976.397893083,
+          "end": 11987.068953083,
+          "ttft": 48.39552329199978,
+          "itl": [
+            0.1017742919993907,
+            0.17218375000084052,
+            0.1639971250006056,
+            0.17467479100014316,
+            0.16833470899837266,
+            0.17166066600111662,
+            0.17761283399886452,
+            0.1716110410015972,
+            0.1736168749994249,
+            0.16125449999890407,
+            0.15842562500074564,
+            0.1584202499998355,
+            0.15728195900010178,
+            0.15543583299950114,
+            0.16289662500093982,
+            0.17253474999961327,
+            0.14363891699940723,
+            0.15993179100041743,
+            0.15557383400118852,
+            0.16490295799849264,
+            0.16506229200058442,
+            0.17052441600026214,
+            0.11819379199914692,
+            0.12217941700146184,
+            0.1193455829998129,
+            0.12471891699897242,
+            0.12555454100038332,
+            0.0996130000003177,
+            0.11539758399885613,
+            0.12538245800169534,
+            0.12079787499897066,
+            0.11876245799976459,
+            0.1194316670007538,
+            0.11713987499933864,
+            0.11689387499973236,
+            0.12194141700092587,
+            0.11877233300037915,
+            0.12125933300012548,
+            0.11854237499937881,
+            0.12203216699890618,
+            0.12037650000092981,
+            0.12388458299938065,
+            0.12275433400100155,
+            0.12264066599891521,
+            0.11944141700041655,
+            0.12031295800079533,
+            0.11550133399941842,
+            0.12186174999987998,
+            0.10580762499921548,
+            0.11824645800152211,
+            0.1126987919997191,
+            0.11215749999973923,
+            0.12578550000034738,
+            0.1251909999991767,
+            0.12070266600130708,
+            0.1197479589991417,
+            0.12137641600020288,
+            0.13799308399939036,
+            0.15546879100111255,
+            0.13214824999886332,
+            0.11453550000078394,
+            0.10932783399948676,
+            0.11645400000088557,
+            0.12157770799967693,
+            0.12227283299944247,
+            0.13077170900032797,
+            0.11803729100029159,
+            0.11748875000012049,
+            0.11907016700024542,
+            0.11553354199895693,
+            0.11799512499965203,
+            0.1175909160010633,
+            0.11714033399948676,
+            0.1256796249999752,
+            0.12372624999989057,
+            0.11989604100017459,
+            0.12153670900079305,
+            0.11731083299855527,
+            0.12335812499986787,
+            0.12126404199989338,
+            0.11890475000109291
+          ],
+          "completion_tokens": 187,
+          "prompt_tokens": 75070,
+          "usage_seen": true,
+          "finish_reason": "stop"
+        }
+      ],
+      "metric_delta": {
+        "prefix_cache_queries_total": 105182.0,
+        "prefix_cache_hits_total": 60160.0,
+        "num_preemptions_total": 0.0,
+        "num_requests_running": 0.0,
+        "num_requests_waiting": 0.0
+      },
+      "hit_ratio": 0.571960981917058
+    },
+    {
+      "file": "p0-soak-unequal-c6-20260905.json",
+      "cycle": 6,
+      "run_id": "a3bb77ae47",
+      "warm": {
+        "request_id": "p0-soak-a3bb77ae47-warm",
+        "http": 200,
+        "start": 12399.369948083,
+        "first": 12426.862560666,
+        "end": 12426.86312525,
+        "ttft": 27.492612583000664,
+        "itl": [],
+        "completion_tokens": 1,
+        "prompt_tokens": 30107,
+        "usage_seen": true,
+        "finish_reason": "length"
+      },
+      "outputs": [
+        {
+          "request_id": "p0-soak-a3bb77ae47-lane0",
+          "http": 200,
+          "start": 12426.9003325,
+          "first": 12427.229268958,
+          "end": 12480.475085208,
+          "ttft": 0.328936458001408,
+          "itl": [
+            0.11070812499929161,
+            0.1231035000000702,
+            0.11808166700029687,
+            0.11599195799863082,
+            0.12135766700157546,
+            0.11936499999865191,
+            0.11566720800146868,
+            0.1179163749984582,
+            0.1168260829999781,
+            0.1242322090001835,
+            0.16064279100100975,
+            0.17913808400044218,
+            1.1813643329987826,
+            0.71640408300118,
+            0.7169623339996178,
+            0.6138267909991555,
+            0.6147909999999683,
+            0.6178849999996601,
+            0.6111111670015816,
+            0.5890422079992277,
+            0.6121175839998614,
+            0.6444310829992901,
+            0.6136514580011863,
+            0.6126917090005009,
+            0.7170228329996462,
+            0.6151301249992684,
+            0.5482002080007078,
+            1.091381749998618,
+            1.0235592920016643,
+            1.0223630000000412,
+            1.1290849999986676,
+            1.0213962079997145,
+            1.0257761250013573,
+            0.9795201249999081,
+            1.068321583999932,
+            1.0253432499994233,
+            1.0288107079995825,
+            1.7336296670000593,
+            1.6418322080007783,
+            1.636182917000042,
+            1.6377190000002884,
+            1.740312082998571,
+            1.6402372920001653,
+            1.741949958000987,
+            1.6353539579995413,
+            2.3569991669992305,
+            1.6377675420008018,
+            1.6392472909992648,
+            1.6227750000016385,
+            1.6518614169999637,
+            1.6830957919992215,
+            1.6986538330002077,
+            0.30527970799994364,
+            0.21207899999899382,
+            0.4016090000004624,
+            0.07641416700062109,
+            0.17335683300007076,
+            0.17190558400034206,
+            0.16748558299877914,
+            0.16394454200053588,
+            0.17082462500002293,
+            0.1685481250005978,
+            0.17014295799890533,
+            0.16103020800073864,
+            0.16989587500029302,
+            0.1614628339993942,
+            0.15910333300053026,
+            0.16758283299895993,
+            0.15775475000009465,
+            0.15832445900014136,
+            0.16415383300045505,
+            0.15581324999948265,
+            0.16492674999972223,
+            0.1651757079998788,
+            0.16224704200067208,
+            0.17002829200100678,
+            0.16061345799971605,
+            0.15956854199976078,
+            0.1586090000000695,
+            0.1590405409988307,
+            0.16135600000052364,
+            0.16310750000047847,
+            0.1723182089990587,
+            0.1510779159998492
+          ],
+          "completion_tokens": 192,
+          "prompt_tokens": 30112,
+          "usage_seen": true,
+          "finish_reason": "length"
+        },
+        {
+          "request_id": "p0-soak-a3bb77ae47-lane1",
+          "http": 200,
+          "start": 12426.901500833,
+          "first": 12475.808970125,
+          "end": 12485.626709416,
+          "ttft": 48.907469291998495,
+          "itl": [
+            0.07644533300117473,
+            0.17325466699912795,
+            0.17189079099989613,
+            0.16736616700109153,
+            0.16416066700003284,
+            0.17082537500027684,
+            0.16800058299850207,
+            0.170692333000261,
+            0.16098108400001365,
+            0.16956541600120545,
+            0.16177316699941002,
+            0.15919120800026576,
+            0.16744924999875366,
+            0.15781245900143404,
+            0.15838208300010592,
+            0.16412279199903423,
+            0.15585270799965656,
+            0.1652726669999538,
+            0.16475945800084446,
+            0.16232770799979335,
+            0.17001191700001073,
+            0.1605819579999661,
+            0.1594788750007865,
+            0.1586915419993602,
+            0.15896137500021723,
+            0.16141787500055216,
+            0.1631035829996108,
+            0.17237233400010155,
+            0.15094295800008695,
+            0.1166436249986873,
+            0.1229839580009866,
+            0.12059891699936998,
+            0.11376474999997299,
+            0.11294229200029804,
+            0.11482350000005681,
+            0.11739362499974959,
+            0.12000962499951129,
+            0.11847629100157064,
+            0.11648187499849882,
+            0.12173000000075263,
+            0.11666541699923982,
+            0.12098241700005019,
+            0.11749229100132652,
+            0.11595587499868998,
+            0.12418462500136229,
+            0.11880441699941002,
+            0.12103949999982433,
+            0.12311233299988089,
+            0.12632429199948092,
+            0.124678166999729,
+            0.11803104099999473,
+            0.11777104200155009,
+            0.11766783299935923,
+            0.112430791999941,
+            0.12102387500090117,
+            0.12310654199973214,
+            0.12380008299987821,
+            0.12255308299972967,
+            0.12713212500057125,
+            0.11415758399925835,
+            0.11503308300052595,
+            0.12088291699910769,
+            0.11511600000085309,
+            0.12014304100011941,
+            0.12031970899988664,
+            0.1179865409994818,
+            0.12182500000017171,
+            0.11140595899996697,
+            0.12305616599951463,
+            0.12564791700060596,
+            0.12143995800033736,
+            0.1362615839989303
+          ],
+          "completion_tokens": 165,
+          "prompt_tokens": 75070,
+          "usage_seen": true,
+          "finish_reason": "stop"
+        }
+      ],
+      "metric_delta": {
+        "prefix_cache_queries_total": 105182.0,
+        "prefix_cache_hits_total": 60160.0,
+        "num_preemptions_total": 0.0,
+        "num_requests_running": 0.0,
+        "num_requests_waiting": 0.0
+      },
+      "hit_ratio": 0.571960981917058
+    },
+    {
+      "file": "p0-soak-unequal-c7-20260905.json",
+      "cycle": 7,
+      "run_id": "d0ac0e076e",
+      "warm": {
+        "request_id": "p0-soak-d0ac0e076e-warm",
+        "http": 200,
+        "start": 12893.34341975,
+        "first": 12921.564142666,
+        "end": 12921.564376916,
+        "ttft": 28.22072291600125,
+        "itl": [],
+        "completion_tokens": 1,
+        "prompt_tokens": 30107,
+        "usage_seen": true,
+        "finish_reason": "length"
+      },
+      "outputs": [
+        {
+          "request_id": "p0-soak-d0ac0e076e-lane0",
+          "http": 200,
+          "start": 12921.596601083,
+          "first": 12921.943614208,
+          "end": 12975.606583583,
+          "ttft": 0.3470131249996484,
+          "itl": [
+            0.10044600000037462,
+            0.12212883299980604,
+            0.12753062500087253,
+            0.11671612499958428,
+            0.12222099999962666,
+            0.12142370900073729,
+            0.11539820799953304,
+            0.12366545800068707,
+            0.11572654199881072,
+            0.12255562500104134,
+            0.12910158299928298,
+            0.1152713749997929,
+            0.12287070900129038,
+            0.7275787079997826,
+            0.7168555829994148,
+            0.6159124170007999,
+            0.6127155829999538,
+            0.6144110419991193,
+            0.7182508330006385,
+            0.6125955839997914,
+            0.6153553749991261,
+            0.6222939580002276,
+            0.6056244999999763,
+            0.6157937080006377,
+            0.6153605420004169,
+            0.6127937919991382,
+            0.6145497079996858,
+            0.716840625000259,
+            0.5699197920002916,
+            1.0683259580000595,
+            1.026214916999379,
+            1.4306940830010717,
+            1.331929082998613,
+            1.0231056669999816,
+            1.0256574170016393,
+            1.0226533749992086,
+            1.0229989580002439,
+            1.0247996250000142,
+            1.743088125000213,
+            1.6376234580002347,
+            1.6031745419986692,
+            1.6813827080004558,
+            1.7322059170001012,
+            1.6387603330003913,
+            1.6379270420002285,
+            1.69149112499872,
+            1.664241625001523,
+            1.7647319999996398,
+            1.640028292000352,
+            1.6154624999999214,
+            1.6603091659999336,
+            1.7398993749993679,
+            1.742103041999144,
+            0.6130408330009232,
+            0.3076554590006708,
+            0.30677108300005784,
+            0.1383100419989205,
+            0.3761318750002829,
+            0.15956175000064832,
+            0.34925683299843513,
+            0.17441554200013343,
+            0.3412412500001665,
+            0.14379266600008123,
+            0.19587370900080714,
+            0.18513125000026776,
+            0.17771354099932068,
+            0.17165874999955122,
+            0.16663475000132166,
+            0.16309008399912273,
+            0.16655887500019162,
+            0.16379575000064506,
+            0.16122654099854117,
+            0.15773587500007125,
+            0.15944833400135394,
+            0.15980062499875203,
+            0.15567079100037517,
+            0.1589070840000204,
+            0.16200766600013594,
+            0.16470208399914554,
+            0.1618949160001648,
+            0.16131537500041304,
+            0.15946616700057348,
+            0.15479320799931884,
+            0.17330904200025543,
+            0.16974833300082537,
+            0.17141337499924703
+          ],
+          "completion_tokens": 192,
+          "prompt_tokens": 30112,
+          "usage_seen": true,
+          "finish_reason": "stop"
+        },
+        {
+          "request_id": "p0-soak-d0ac0e076e-lane1",
+          "http": 200,
+          "start": 12921.597601541,
+          "first": 12970.101632541,
+          "end": 12981.079093541,
+          "ttft": 48.504031000000396,
+          "itl": [
+            0.13838349999969068,
+            0.37607616700006474,
+            0.15244670799984306,
+            0.3563984590000473,
+            0.17440800000076706,
+            0.34125849999873026,
+            0.14380725000046368,
+            0.19581074999950943,
+            0.18491483300022082,
+            0.17790737500035902,
+            0.17168920800031628,
+            0.16668216700054472,
+            0.1631055829984689,
+            0.16651187500065134,
+            0.16381650000039372,
+            0.16115187499963213,
+            0.15778141699956905,
+            0.15944391700031701,
+            0.1597099579994392,
+            0.15577075000146579,
+            0.15891683299923898,
+            0.16201620900028502,
+            0.16463808300068195,
+            0.16195466699900862,
+            0.16135591599959298,
+            0.15940804199999548,
+            0.15485362500112387,
+            0.17333024999970803,
+            0.1697192499996163,
+            0.17115766700044333,
+            0.11624312499952794,
+            0.11918633300047077,
+            0.12305324999942968,
+            0.11470924999957788,
+            0.11476191700057825,
+            0.12398512499930803,
+            0.1225985410001158,
+            0.12369470900011947,
+            0.12061808300131815,
+            0.11800920799942105,
+            0.11957341699962853,
+            0.1208259579998412,
+            0.11309329200048523,
+            0.12136233300043386,
+            0.12184741700002633,
+            0.11944270799904189,
+            0.12589520900110074,
+            0.12468099999932747,
+            0.1222994159998052,
+            0.12031829199986532,
+            0.11677279200011981,
+            0.1129627080008504,
+            0.11826687499888067,
+            0.11222420800004329,
+            0.12040262499976961,
+            0.12037625000084518,
+            0.1175474169995141,
+            0.15294933299992408,
+            0.0898740419997921,
+            0.11496216700106743,
+            0.11718754100002116,
+            0.11305308400005742,
+            0.11186683300002187,
+            0.11379570799908834,
+            0.1200625420005963,
+            0.118583542000124,
+            0.11864079099905211,
+            0.11473645899968687,
+            0.12224087499998859,
+            0.10784354099996563,
+            0.12231204200179491,
+            0.12249879199953284,
+            0.1235253750000993,
+            0.11932891600008588,
+            0.12009033399954205,
+            0.12432370799979253
+          ],
+          "completion_tokens": 175,
+          "prompt_tokens": 75070,
+          "usage_seen": true,
+          "finish_reason": "stop"
+        }
+      ],
+      "metric_delta": {
+        "prefix_cache_queries_total": 105182.0,
+        "prefix_cache_hits_total": 60160.0,
+        "num_preemptions_total": 0.0,
+        "num_requests_running": 0.0,
+        "num_requests_waiting": 0.0
+      },
+      "hit_ratio": 0.571960981917058
+    },
+    {
+      "file": "p0-soak-unequal-c8-20260905.json",
+      "cycle": 8,
+      "run_id": "2ca3afbe33",
+      "warm": {
+        "request_id": "p0-soak-2ca3afbe33-warm",
+        "http": 200,
+        "start": 13381.633683333,
+        "first": 13409.302675625,
+        "end": 13409.302901791,
+        "ttft": 27.66899229199953,
+        "itl": [],
+        "completion_tokens": 1,
+        "prompt_tokens": 30107,
+        "usage_seen": true,
+        "finish_reason": "length"
+      },
+      "outputs": [
+        {
+          "request_id": "p0-soak-2ca3afbe33-lane0",
+          "http": 200,
+          "start": 13409.337362208,
+          "first": 13409.664054333,
+          "end": 13462.159338791,
+          "ttft": 0.32669212499968125,
+          "itl": [
+            0.10648633300115762,
+            0.1262309590001678,
+            0.12098249999871769,
+            0.12088383300033456,
+            0.12270424999951501,
+            0.1282160830014618,
+            0.11791383399940969,
+            0.11922937499912223,
+            0.11585945800106856,
+            0.11261654199915938,
+            0.11284474999956728,
+            0.11622875000102795,
+            0.12055666599917458,
+            0.7702471669999795,
+            0.7066810000014812,
+            1.0353676669983543,
+            0.8073712500008696,
+            0.6161318750000646,
+            0.6121255409998412,
+            0.7178416250008013,
+            0.6134766249997483,
+            0.6141823749985633,
+            0.6147620000010647,
+            0.6141719999995985,
+            0.6149931250001828,
+            0.5884090840008867,
+            0.6391524999999092,
+            0.660516790998372,
+            1.0813485420003417,
+            1.0233962920010526,
+            1.0371156250002969,
+            1.060075165998569,
+            1.0769742090014915,
+            1.0240956659999938,
+            1.0318915839998226,
+            1.0327732079986163,
+            1.1108796670014272,
+            1.0232951660000253,
+            1.7421584999992774,
+            1.5686861249996582,
+            1.7069209170003887,
+            1.6393344169991906,
+            1.6639017910001712,
+            1.7139272920012445,
+            1.6664627919999475,
+            1.6841467499998544,
+            2.2813080830001127,
+            1.723888624999745,
+            1.663565708000533,
+            1.6555023749988322,
+            1.7171282500003144,
+            1.6373931670004822,
+            1.6980771669987007,
+            0.3496524580004916,
+            0.18972062499960884,
+            0.40325600000142003,
+            0.07599524999932328,
+            0.17291791699972237,
+            0.1692125000008673,
+            0.16800037499888276,
+            0.17044441600046412,
+            0.16883283400056825,
+            0.16962629099907645,
+            0.1726010000002134,
+            0.16994595899996057,
+            0.16842266599996947,
+            0.17621245900045324,
+            0.14919416600059776,
+            0.1615036669991241,
+            0.15395812499991735,
+            0.15944395800033817,
+            0.15647004200036463,
+            0.15861920799943618,
+            0.162630333999914,
+            0.159805833000064,
+            0.16103620799913188,
+            0.161072625000088,
+            0.1561139590012317
+          ],
+          "completion_tokens": 192,
+          "prompt_tokens": 30112,
+          "usage_seen": true,
+          "finish_reason": "length"
+        },
+        {
+          "request_id": "p0-soak-2ca3afbe33-lane1",
+          "http": 200,
+          "start": 13409.338367916,
+          "first": 13458.636126375,
+          "end": 13469.093597708,
+          "ttft": 49.29775845900076,
+          "itl": [
+            0.07685387499986973,
+            0.17291962499984947,
+            0.1692331659996853,
+            0.16795224999987113,
+            0.1704902920009772,
+            0.16876416699960828,
+            0.16968325000016193,
+            0.17260629100019287,
+            0.1698903340002289,
+            0.16847129099915037,
+            0.17612050000025192,
+            0.14898441699915566,
+            0.16116191699984483,
+            0.1546054999998887,
+            0.15943041600075958,
+            0.15647433400044974,
+            0.15859049999926356,
+            0.16264150000097288,
+            0.15913358299985703,
+            0.16173916699881374,
+            0.1610486250010581,
+            0.15615216600053827,
+            0.11811316699822783,
+            0.11680804200113926,
+            0.12430029099959938,
+            0.11719162500048697,
+            0.11809741700017184,
+            0.11953520799943362,
+            0.11137404200053425,
+            0.11512779199983925,
+            0.12023454100017261,
+            0.1284905840002466,
+            0.11136899999837624,
+            0.11918158300068171,
+            0.12258870799996657,
+            0.12299445899952843,
+            0.11994712500018068,
+            0.11553270800141036,
+            0.11871762499868055,
+            0.11690141700091772,
+            0.11935649999941234,
+            0.11090145799971651,
+            0.11745029200028512,
+            0.11904725000022154,
+            0.12608274999911373,
+            0.12237337500118883,
+            0.1229659159998846,
+            0.12111287500010803,
+            0.1169282499995461,
+            0.11970587500036345,
+            0.1169819999995525,
+            0.11927699999978358,
+            0.12042195899994113,
+            0.12215720800122654,
+            0.11978237499897659,
+            0.1212439999999333,
+            0.1261116250007035,
+            0.11141137499907927,
+            0.11833045800085529,
+            0.11718399999881512,
+            0.11542262500006473,
+            0.1229160420007247,
+            0.12211449999995239,
+            0.1271317499995348,
+            0.1208621250007127,
+            0.12138829200011969,
+            0.11693545799971616,
+            0.11512612499973329,
+            0.11988629200095602,
+            0.11673854099899472,
+            0.11296050000055402,
+            0.11967316699883668,
+            0.12064645800091967,
+            0.12189491699973587,
+            0.11814266700093867,
+            0.11940412500007369,
+            0.11869991599996865,
+            0.12180462499964051,
+            0.14704358400013007,
+            0.11016766600005212
+          ],
+          "completion_tokens": 187,
+          "prompt_tokens": 75070,
+          "usage_seen": true,
+          "finish_reason": "stop"
+        }
+      ],
+      "metric_delta": {
+        "prefix_cache_queries_total": 105182.0,
+        "prefix_cache_hits_total": 60160.0,
+        "num_preemptions_total": 0.0,
+        "num_requests_running": 0.0,
+        "num_requests_waiting": 0.0
+      },
+      "hit_ratio": 0.571960981917058
+    }
+  ],
+  "runtime_cycles": [
+    {
+      "file": "p0-soak-runtime-c1-20260905.json",
+      "run_id": "fa13684a4a",
+      "runs": [
+        {
+          "request_id": "glm53-p0-fa13684a4a-essay-1",
+          "http": 200,
+          "sse_chunks": 415,
+          "done": true,
+          "ttfb_s": 0.368,
+          "wall_s": 50.236,
+          "finish_reason": "length",
+          "usage": {
+            "prompt_tokens": 58,
+            "total_tokens": 1108,
+            "completion_tokens": 1050
+          },
+          "content_sha256": "4139285ad139c76fac318e99efef12d2582e6874f681901078e1c95d2675b7e1",
+          "content_head": "# How Ocean Tides Work: A Comprehensive Explanation\n\n## Introduction\n\nTides are among the most familiar yet most misunderstood phenomena in nature. Nearly everyone who has spent time near the ocean has witnessed the rhythmic rise and fall o",
+          "content_tail": " by the Coriolis effect. On a Kelvin wave, the Coriolis force balances the pressure gradient across the wave, so amplitude decays exponentially offshore (over the Rossby radius of deformation, typically ~100\u2013300 km... let me be careful here",
+          "diagnostics": {
+            "replacement_or_mojibake": [],
+            "max_16gram_repeats": 1,
+            "content_chars": 4788,
+            "reasoning_chars": 0
+          },
+          "name": "essay-1",
+          "thinking": false
+        },
+        {
+          "request_id": "glm53-p0-fa13684a4a-essay-2",
+          "http": 200,
+          "sse_chunks": 417,
+          "done": true,
+          "ttfb_s": 0.305,
+          "wall_s": 51.404,
+          "finish_reason": "length",
+          "usage": {
+            "prompt_tokens": 54,
+            "total_tokens": 1104,
+            "completion_tokens": 1050
+          },
+          "content_sha256": "f96e18bcb51773dd83e5e5b4dd45029efe811d02b335d22f834c904166342aaf",
+          "content_head": "# Virtual Memory in Modern Operating Systems\n\n## Introduction\n\nVirtual memory is one of the most consequential abstractions in computer systems. It gives every process the illusion of a large, private, contiguous address space while allowin",
+          "content_tail": "ation Mitigations\n\nSpectre-class vulnerabilities forced kernel designers to reduce the amount of kernel memory mapped in user address spaces. Linux's **KPTI** (Kernel Page Table Isolation) maintains separate user/kernel page-table roots and",
+          "diagnostics": {
+            "replacement_or_mojibake": [],
+            "max_16gram_repeats": 1,
+            "content_chars": 4684,
+            "reasoning_chars": 0
+          },
+          "name": "essay-2",
+          "thinking": false
+        },
+        {
+          "request_id": "glm53-p0-fa13684a4a-essay-3",
+          "http": 200,
+          "sse_chunks": 423,
+          "done": true,
+          "ttfb_s": 0.304,
+          "wall_s": 51.39,
+          "finish_reason": "length",
+          "usage": {
+            "prompt_tokens": 51,
+            "total_tokens": 1101,
+            "completion_tokens": 1050
+          },
+          "content_sha256": "19860c0a1bed19bc344ec3e5d97ae3e80f4416eceabbb3b9686b4abf9efc2926",
+          "content_head": "# The Scientific Method in Practice\n\n## Introduction\n\nThe scientific method is often presented in textbooks as a neat, linear sequence: observe, hypothesize, predict, test, revise. In practice, science rarely follows such a tidy path. Real ",
+          "content_tail": "actice involves reporting uncertainty explicitly: a length might be recorded as 24.6 \u00b1 0.2 mm, and a derived quantity's uncertainty is propagated through calculations using established rules. Statistical tools\u2014confidence intervals, p-values",
+          "diagnostics": {
+            "replacement_or_mojibake": [],
+            "max_16gram_repeats": 1,
+            "content_chars": 5784,
+            "reasoning_chars": 0
+          },
+          "name": "essay-3",
+          "thinking": false
+        },
+        {
+          "request_id": "glm53-p0-fa13684a4a-thinking-sse",
+          "http": 200,
+          "sse_chunks": 38,
+          "done": true,
+          "ttfb_s": 0.229,
+          "wall_s": 4.966,
+          "finish_reason": "stop",
+          "usage": {
+            "prompt_tokens": 24,
+            "total_tokens": 153,
+            "completion_tokens": 129
+          },
+          "content_sha256": "550115119cb73967fbde945339c84051cc742e78b0ddcff2cb12a005a9049ecf",
+          "content_head": "THINKING_STREAM_OK",
+          "content_tail": "THINKING_STREAM_OK",
+          "diagnostics": {
+            "replacement_or_mojibake": [],
+            "max_16gram_repeats": 0,
+            "content_chars": 18,
+            "reasoning_chars": 598
+          },
+          "name": "thinking-sse",
+          "thinking": true
+        }
+      ],
+      "metric_delta": {
+        "num_requests_running": 0.0,
+        "num_requests_waiting": 0.0,
+        "num_preemptions_total": 0.0,
+        "prefix_cache_queries_total": 187.0,
+        "prefix_cache_hits_total": 0.0
+      },
+      "passed": true,
+      "failures": []
+    },
+    {
+      "file": "p0-soak-runtime-c2-20260905.json",
+      "run_id": "e53d3994a4",
+      "runs": [
+        {
+          "request_id": "glm53-p0-e53d3994a4-essay-1",
+          "http": 200,
+          "sse_chunks": 384,
+          "done": true,
+          "ttfb_s": 0.337,
+          "wall_s": 47.255,
+          "finish_reason": "length",
+          "usage": {
+            "prompt_tokens": 58,
+            "total_tokens": 1108,
+            "completion_tokens": 1050
+          },
+          "content_sha256": "6a07e30be8ed5b1dfd1e587a238304ae5ec71e8ae858f0dcf98e07b16dacb9a4",
+          "content_head": "# How Ocean Tides Work: A Comprehensive Explanation\n\n## Introduction\n\nTides are among the most familiar yet most misunderstood phenomena in nature. Most people know that the ocean rises and falls twice a day in many places, and that the Moo",
+          "content_tail": "erigean spring tides.** The Moon's orbit is elliptical (perigee ~356,500 km, apogee ~405,500 km), and because tidal force scales with 1/d\u00b3, tides are noticeably stronger when spring tides coincide with perigee. These \"king tides\" can add 15",
+          "diagnostics": {
+            "replacement_or_mojibake": [],
+            "max_16gram_repeats": 1,
+            "content_chars": 4614,
+            "reasoning_chars": 0
+          },
+          "name": "essay-1",
+          "thinking": false
+        },
+        {
+          "request_id": "glm53-p0-e53d3994a4-essay-2",
+          "http": 200,
+          "sse_chunks": 379,
+          "done": true,
+          "ttfb_s": 0.396,
+          "wall_s": 46.135,
+          "finish_reason": "length",
+          "usage": {
+            "prompt_tokens": 54,
+            "total_tokens": 1104,
+            "completion_tokens": 1050
+          },
+          "content_sha256": "7b9c44d30b8f7bb8b80a32646489e175f72d382712baf9773df6578399b840e9",
+          "content_head": "# Virtual Memory in Modern Operating Systems\n\n## Introduction\n\nVirtual memory is one of the most consequential abstractions in computer science. It gives every process the illusion of a private, contiguous address space, isolates processes ",
+          "content_tail": "struction and data TLBs (small, fully associative, ~64\u2013128 entries)\n- **A unified L2 TLB** (thousands of entries, higher associativity)\n- Separate structures for different page sizes\n\nOn a TLB hit, translation is essentially free. On a miss",
+          "diagnostics": {
+            "replacement_or_mojibake": [],
+            "max_16gram_repeats": 1,
+            "content_chars": 4483,
+            "reasoning_chars": 0
+          },
+          "name": "essay-2",
+          "thinking": false
+        },
+        {
+          "request_id": "glm53-p0-e53d3994a4-essay-3",
+          "http": 200,
+          "sse_chunks": 422,
+          "done": true,
+          "ttfb_s": 0.331,
+          "wall_s": 52.083,
+          "finish_reason": "length",
+          "usage": {
+            "prompt_tokens": 51,
+            "total_tokens": 1101,
+            "completion_tokens": 1050
+          },
+          "content_sha256": "d3d78ad8e33af096a823d4b513448887159d687ecb983c378092e914e10fe045",
+          "content_head": "# The Scientific Method in Practice\n\n## Introduction\n\nThe scientific method is often presented in textbooks as a neat, linear sequence: observe, hypothesize, experiment, conclude. In actual practice, however, science rarely proceeds so tidi",
+          "content_tail": "\nBeyond instrument limitations, uncertainty also enters through sampling: no study can measure every frog in a wetland or every star in a galaxy, so scientists must infer properties of whole populations from samples. Statistics provides the",
+          "diagnostics": {
+            "replacement_or_mojibake": [],
+            "max_16gram_repeats": 1,
+            "content_chars": 6042,
+            "reasoning_chars": 0
+          },
+          "name": "essay-3",
+          "thinking": false
+        },
+        {
+          "request_id": "glm53-p0-e53d3994a4-thinking-sse",
+          "http": 200,
+          "sse_chunks": 50,
+          "done": true,
+          "ttfb_s": 0.235,
+          "wall_s": 5.867,
+          "finish_reason": "stop",
+          "usage": {
+            "prompt_tokens": 24,
+            "total_tokens": 173,
+            "completion_tokens": 149
+          },
+          "content_sha256": "550115119cb73967fbde945339c84051cc742e78b0ddcff2cb12a005a9049ecf",
+          "content_head": "THINKING_STREAM_OK",
+          "content_tail": "THINKING_STREAM_OK",
+          "diagnostics": {
+            "replacement_or_mojibake": [],
+            "max_16gram_repeats": 0,
+            "content_chars": 18,
+            "reasoning_chars": 676
+          },
+          "name": "thinking-sse",
+          "thinking": true
+        }
+      ],
+      "metric_delta": {
+        "num_requests_running": 0.0,
+        "num_requests_waiting": 0.0,
+        "num_preemptions_total": 0.0,
+        "prefix_cache_queries_total": 187.0,
+        "prefix_cache_hits_total": 0.0
+      },
+      "passed": true,
+      "failures": []
+    },
+    {
+      "file": "p0-soak-runtime-c3-20260905.json",
+      "run_id": "e2aea9c7f1",
+      "runs": [
+        {
+          "request_id": "glm53-p0-e2aea9c7f1-essay-1",
+          "http": 200,
+          "sse_chunks": 408,
+          "done": true,
+          "ttfb_s": 0.386,
+          "wall_s": 49.251,
+          "finish_reason": "length",
+          "usage": {
+            "prompt_tokens": 58,
+            "total_tokens": 1108,
+            "completion_tokens": 1050
+          },
+          "content_sha256": "3220bc1df6e86a07e3449a179747e32b3c77ee79044d231f8f1ae2d4a50d6b52",
+          "content_head": "# How Ocean Tides Work\n\n## Introduction\n\nOcean tides are among the most familiar yet most misunderstood phenomena in nature. Billions of people live near coastlines, and many check tide tables before fishing, boating, or walking the beach\u2014y",
+          "content_tail": "s roughly 45% as large as the Moon's, the interference is substantial: spring ranges can be roughly 1.5\u20132 times neap ranges at a typical mid-latitude site. Two refinements matter:\n\n1. **Perigee and apogee.** The Moon's orbit is elliptical (",
+          "diagnostics": {
+            "replacement_or_mojibake": [],
+            "max_16gram_repeats": 1,
+            "content_chars": 4658,
+            "reasoning_chars": 0
+          },
+          "name": "essay-1",
+          "thinking": false
+        },
+        {
+          "request_id": "glm53-p0-e2aea9c7f1-essay-2",
+          "http": 200,
+          "sse_chunks": 442,
+          "done": true,
+          "ttfb_s": 0.449,
+          "wall_s": 54.458,
+          "finish_reason": "length",
+          "usage": {
+            "prompt_tokens": 54,
+            "total_tokens": 1104,
+            "completion_tokens": 1050
+          },
+          "content_sha256": "a30fa79638a3b3f259617e7106ed9cbf0e86825eaaeff5157e25171385e86b2a",
+          "content_head": "# Virtual Memory in Modern Operating Systems\n\n## Introduction\n\nVirtual memory is one of the most consequential abstractions in computing. It gives every process the illusion of a large, private, contiguous address space, decoupled from phys",
+          "content_tail": " a zero page or COW break) or **major** (requiring I/O). The performance of the entire system depends heavily on the fault path being fast, since even trivial programs take thousands of faults at startup (mapping the binary, libraries, heap",
+          "diagnostics": {
+            "replacement_or_mojibake": [],
+            "max_16gram_repeats": 1,
+            "content_chars": 4908,
+            "reasoning_chars": 0
+          },
+          "name": "essay-2",
+          "thinking": false
+        },
+        {
+          "request_id": "glm53-p0-e2aea9c7f1-essay-3",
+          "http": 200,
+          "sse_chunks": 428,
+          "done": true,
+          "ttfb_s": 0.317,
+          "wall_s": 62.102,
+          "finish_reason": "length",
+          "usage": {
+            "prompt_tokens": 51,
+            "total_tokens": 1101,
+            "completion_tokens": 1050
+          },
+          "content_sha256": "9e1eceed7386fb890c2da41c2373d33afcdf4f0fd7a51c30017102ce4f7b193f",
+          "content_head": "# The Scientific Method in Practice\n\n## Introduction\n\nThe scientific method is often taught as a tidy flowchart: observe, hypothesize, experiment, conclude. Real science rarely follows this sequence so neatly. In practice, it is a recursive",
+          "content_tail": "n\u2014a miscalibrated scale that reads everything as two grams heavy. Averaging does not help; only recalibration, better instruments, or redesigned methods can remove it.\n3. **Sampling error** arises because we study samples rather than entire",
+          "diagnostics": {
+            "replacement_or_mojibake": [],
+            "max_16gram_repeats": 1,
+            "content_chars": 5595,
+            "reasoning_chars": 0
+          },
+          "name": "essay-3",
+          "thinking": false
+        },
+        {
+          "request_id": "glm53-p0-e2aea9c7f1-thinking-sse",
+          "http": 200,
+          "sse_chunks": 37,
+          "done": true,
+          "ttfb_s": 0.225,
+          "wall_s": 4.29,
+          "finish_reason": "stop",
+          "usage": {
+            "prompt_tokens": 24,
+            "total_tokens": 135,
+            "completion_tokens": 111
+          },
+          "content_sha256": "550115119cb73967fbde945339c84051cc742e78b0ddcff2cb12a005a9049ecf",
+          "content_head": "THINKING_STREAM_OK",
+          "content_tail": "THINKING_STREAM_OK",
+          "diagnostics": {
+            "replacement_or_mojibake": [],
+            "max_16gram_repeats": 0,
+            "content_chars": 18,
+            "reasoning_chars": 514
+          },
+          "name": "thinking-sse",
+          "thinking": true
+        }
+      ],
+      "metric_delta": {
+        "num_requests_running": 0.0,
+        "num_requests_waiting": 0.0,
+        "num_preemptions_total": 0.0,
+        "prefix_cache_queries_total": 187.0,
+        "prefix_cache_hits_total": 0.0
+      },
+      "passed": true,
+      "failures": []
+    },
+    {
+      "file": "p0-soak-runtime-c4-20260905.json",
+      "run_id": "0f48fc6526",
+      "runs": [
+        {
+          "request_id": "glm53-p0-0f48fc6526-essay-1",
+          "http": 200,
+          "sse_chunks": 405,
+          "done": true,
+          "ttfb_s": 0.389,
+          "wall_s": 49.606,
+          "finish_reason": "length",
+          "usage": {
+            "prompt_tokens": 58,
+            "total_tokens": 1108,
+            "completion_tokens": 1050
+          },
+          "content_sha256": "4b4cb09427a0b4a8d35ff10550791a8ba4f2797bbb8ad14a38f8d90d3ecba0fa",
+          "content_head": "# How Ocean Tides Work\n\n## Introduction\n\nTides are among the most familiar yet most misunderstood ocean phenomena. Most coastal residents know that tides rise and fall roughly twice a day, but the underlying physics is surprisingly subtle. ",
+          "content_tail": "on dissipates energy. The modern **dynamic theory of tides** treats the tidal response as forced oscillations of the ocean.\n\n### Natural Periods and Resonance\n\nEvery ocean basin has natural (seiche) periods depending on its length and depth",
+          "diagnostics": {
+            "replacement_or_mojibake": [],
+            "max_16gram_repeats": 1,
+            "content_chars": 4832,
+            "reasoning_chars": 0
+          },
+          "name": "essay-1",
+          "thinking": false
+        },
+        {
+          "request_id": "glm53-p0-0f48fc6526-essay-2",
+          "http": 200,
+          "sse_chunks": 437,
+          "done": true,
+          "ttfb_s": 0.306,
+          "wall_s": 53.059,
+          "finish_reason": "length",
+          "usage": {
+            "prompt_tokens": 54,
+            "total_tokens": 1104,
+            "completion_tokens": 1050
+          },
+          "content_sha256": "0e0a7f0533bec7890b18ec1fd42efa152328a85e5b4c726eec63878635ebdb7c",
+          "content_head": "# Virtual Memory in Modern Operating Systems\n\n## Introduction\n\nVirtual memory is among the most consequential abstractions in computing. By decoupling the addresses programs use from the locations in physical memory where their data actuall",
+          "content_tail": "flexibility for TLB efficiency.\n\n### Kernel Map and Direct Map\n\nMost kernels also maintain a **direct map** (physmap)\u2014a large region of every address space that linearly maps all physical memory at a fixed virtual offset, letting the kernel",
+          "diagnostics": {
+            "replacement_or_mojibake": [],
+            "max_16gram_repeats": 1,
+            "content_chars": 5028,
+            "reasoning_chars": 0
+          },
+          "name": "essay-2",
+          "thinking": false
+        },
+        {
+          "request_id": "glm53-p0-0f48fc6526-essay-3",
+          "http": 200,
+          "sse_chunks": 438,
+          "done": true,
+          "ttfb_s": 0.414,
+          "wall_s": 53.887,
+          "finish_reason": "length",
+          "usage": {
+            "prompt_tokens": 51,
+            "total_tokens": 1101,
+            "completion_tokens": 1050
+          },
+          "content_sha256": "55219913dd90ee174faebb6933b2577fa0e9d707e042475ae201cb17c6e8800b",
+          "content_head": "# The Scientific Method in Practice\n\n## Introduction\n\nThe scientific method is often taught as a tidy flowchart: observe, hypothesize, experiment, conclude. Real science rarely follows this sequence so neatly. In practice, the scientific me",
+          "content_tail": "me team and, crucially, by independent teams\u2014serves several functions:\n\n1. **Detecting error or fraud.** Independent replication is the ultimate safeguard against mistakes, flawed methods, and deliberate fabrication.\n2. **Establishing gener",
+          "diagnostics": {
+            "replacement_or_mojibake": [],
+            "max_16gram_repeats": 1,
+            "content_chars": 5937,
+            "reasoning_chars": 0
+          },
+          "name": "essay-3",
+          "thinking": false
+        },
+        {
+          "request_id": "glm53-p0-0f48fc6526-thinking-sse",
+          "http": 200,
+          "sse_chunks": 49,
+          "done": true,
+          "ttfb_s": 0.25,
+          "wall_s": 5.762,
+          "finish_reason": "stop",
+          "usage": {
+            "prompt_tokens": 24,
+            "total_tokens": 178,
+            "completion_tokens": 154
+          },
+          "content_sha256": "550115119cb73967fbde945339c84051cc742e78b0ddcff2cb12a005a9049ecf",
+          "content_head": "THINKING_STREAM_OK",
+          "content_tail": "THINKING_STREAM_OK",
+          "diagnostics": {
+            "replacement_or_mojibake": [],
+            "max_16gram_repeats": 0,
+            "content_chars": 18,
+            "reasoning_chars": 683
+          },
+          "name": "thinking-sse",
+          "thinking": true
+        }
+      ],
+      "metric_delta": {
+        "num_requests_running": 0.0,
+        "num_requests_waiting": 0.0,
+        "num_preemptions_total": 0.0,
+        "prefix_cache_queries_total": 187.0,
+        "prefix_cache_hits_total": 0.0
+      },
+      "passed": true,
+      "failures": []
+    },
+    {
+      "file": "p0-soak-runtime-c5-20260905.json",
+      "run_id": "91343ab8de",
+      "runs": [
+        {
+          "request_id": "glm53-p0-91343ab8de-essay-1",
+          "http": 200,
+          "sse_chunks": 408,
+          "done": true,
+          "ttfb_s": 0.399,
+          "wall_s": 49.413,
+          "finish_reason": "length",
+          "usage": {
+            "prompt_tokens": 58,
+            "total_tokens": 1108,
+            "completion_tokens": 1050
+          },
+          "content_sha256": "b7f7d5e5299caabcfaed2893195e01a41b25b8fb894640ba5971bfddea119c83",
+          "content_head": "# How Ocean Tides Work: The Physics, Geography, and Folklore of the Sea's Rhythm\n\n## Introduction\n\nTwice a day, in most places on Earth, the ocean rises and falls with remarkable regularity. In some locations, the water climbs more than twe",
+          "content_tail": "hort of it (parts of the Mediterranean, Polynesia, and Gulf of Mexico see ranges under 30 cm). The reason is that the real ocean cannot keep up with the Moon. The lunar day is 24 hours 50 minutes, but natural waves traveling at ocean depths",
+          "diagnostics": {
+            "replacement_or_mojibake": [],
+            "max_16gram_repeats": 1,
+            "content_chars": 4689,
+            "reasoning_chars": 0
+          },
+          "name": "essay-1",
+          "thinking": false
+        },
+        {
+          "request_id": "glm53-p0-91343ab8de-essay-2",
+          "http": 200,
+          "sse_chunks": 430,
+          "done": true,
+          "ttfb_s": 0.338,
+          "wall_s": 62.725,
+          "finish_reason": "length",
+          "usage": {
+            "prompt_tokens": 54,
+            "total_tokens": 1104,
+            "completion_tokens": 1050
+          },
+          "content_sha256": "5fca012054a5c409f90c62f59dd992635b16083ac68804cb529f48ea24b22aec",
+          "content_head": "# Virtual Memory in Modern Operating Systems\n\n## Introduction\n\nVirtual memory is one of the most consequential abstractions in computer science. It gives every process the illusion of a large, private, contiguous address space, isolates pro",
+          "content_tail": " an **interprocessor interrupt (IPI)-driven TLB shootdown**. Shootdowns are expensive (hundreds of cycles to microseconds, plus IPI overhead), which is why:\n\n- The kernel batches TLB flushes (deferred until returning to user space, `flush_t",
+          "diagnostics": {
+            "replacement_or_mojibake": [],
+            "max_16gram_repeats": 1,
+            "content_chars": 4612,
+            "reasoning_chars": 0
+          },
+          "name": "essay-2",
+          "thinking": false
+        },
+        {
+          "request_id": "glm53-p0-91343ab8de-essay-3",
+          "http": 200,
+          "sse_chunks": 431,
+          "done": true,
+          "ttfb_s": 0.381,
+          "wall_s": 57.412,
+          "finish_reason": "length",
+          "usage": {
+            "prompt_tokens": 51,
+            "total_tokens": 1101,
+            "completion_tokens": 1050
+          },
+          "content_sha256": "1d495f574caa6e690b44172d93e9b0e340c3c495d777342bee01e693d100de1f",
+          "content_head": "# The Scientific Method in Practice\n\n## Introduction\n\nThe scientific method is often taught as a tidy linear sequence: observe, hypothesize, predict, test, conclude. In practice, it is messier, more iterative, and far more interesting. Real",
+          "content_tail": "sis, now standard in many fields, formalizes this planning.\n\n## Measurement Uncertainty: Quantifying What We Don't Know\n\nNo measurement is exact. Every reading carries **uncertainty** from instrument limitations, environmental fluctuations,",
+          "diagnostics": {
+            "replacement_or_mojibake": [],
+            "max_16gram_repeats": 1,
+            "content_chars": 5666,
+            "reasoning_chars": 0
+          },
+          "name": "essay-3",
+          "thinking": false
+        },
+        {
+          "request_id": "glm53-p0-91343ab8de-thinking-sse",
+          "http": 200,
+          "sse_chunks": 50,
+          "done": true,
+          "ttfb_s": 0.311,
+          "wall_s": 5.794,
+          "finish_reason": "stop",
+          "usage": {
+            "prompt_tokens": 24,
+            "total_tokens": 197,
+            "completion_tokens": 173
+          },
+          "content_sha256": "550115119cb73967fbde945339c84051cc742e78b0ddcff2cb12a005a9049ecf",
+          "content_head": "THINKING_STREAM_OK",
+          "content_tail": "THINKING_STREAM_OK",
+          "diagnostics": {
+            "replacement_or_mojibake": [],
+            "max_16gram_repeats": 0,
+            "content_chars": 18,
+            "reasoning_chars": 814
+          },
+          "name": "thinking-sse",
+          "thinking": true
+        }
+      ],
+      "metric_delta": {
+        "num_requests_running": 0.0,
+        "num_requests_waiting": 0.0,
+        "num_preemptions_total": 0.0,
+        "prefix_cache_queries_total": 187.0,
+        "prefix_cache_hits_total": 0.0
+      },
+      "passed": true,
+      "failures": []
+    },
+    {
+      "file": "p0-soak-runtime-c6-20260905.json",
+      "run_id": "a2ce3fe149",
+      "runs": [
+        {
+          "request_id": "glm53-p0-a2ce3fe149-essay-1",
+          "http": 200,
+          "sse_chunks": 373,
+          "done": true,
+          "ttfb_s": 0.303,
+          "wall_s": 45.035,
+          "finish_reason": "length",
+          "usage": {
+            "prompt_tokens": 58,
+            "total_tokens": 1108,
+            "completion_tokens": 1050
+          },
+          "content_sha256": "9a9fcc9c9575b683664ce63561c7c4e5732175702cc584a1890bb2256a1a9065",
+          "content_head": "# How Ocean Tides Work: A Comprehensive Explanation\n\n## Introduction\n\nOcean tides are among the most familiar yet most misunderstood phenomena in nature. Billions of people live near coastlines and observe the sea's rhythmic rise and fall d",
+          "content_tail": "\"king tide.\"** Similarly, when the Moon is near apogee at quadrature, unusually weak tides (\"apogean neap\" tides) occur.\n\nThe Moon's orbital plane is tilted about 5.1\u00b0 to the ecliptic, and the lunar declination cycles between roughly \u00b128.5\u00b0",
+          "diagnostics": {
+            "replacement_or_mojibake": [],
+            "max_16gram_repeats": 1,
+            "content_chars": 4680,
+            "reasoning_chars": 0
+          },
+          "name": "essay-1",
+          "thinking": false
+        },
+        {
+          "request_id": "glm53-p0-a2ce3fe149-essay-2",
+          "http": 200,
+          "sse_chunks": 462,
+          "done": true,
+          "ttfb_s": 0.32,
+          "wall_s": 56.374,
+          "finish_reason": "length",
+          "usage": {
+            "prompt_tokens": 54,
+            "total_tokens": 1104,
+            "completion_tokens": 1050
+          },
+          "content_sha256": "4d08f65e3da39637b27269e487b0b64671ff940e49a9e3fe9dfa552debd4c91e",
+          "content_head": "# Virtual Memory in Modern Operating Systems\n\n## Introduction\n\nVirtual memory is one of the most consequential abstractions in computer science. It gives every process the illusion of a large, private, contiguous address space while allowin",
+          "content_tail": "e\u2014given a physical frame, which processes map it, and where? Linux maintains per-physical-page metadata (the `struct page` array) and, for reclaim and NUMA migration, reverse-mapping via per-VMA interval structures (VMA interval trees) that",
+          "diagnostics": {
+            "replacement_or_mojibake": [],
+            "max_16gram_repeats": 1,
+            "content_chars": 4826,
+            "reasoning_chars": 0
+          },
+          "name": "essay-2",
+          "thinking": false
+        },
+        {
+          "request_id": "glm53-p0-a2ce3fe149-essay-3",
+          "http": 200,
+          "sse_chunks": 445,
+          "done": true,
+          "ttfb_s": 0.365,
+          "wall_s": 54.135,
+          "finish_reason": "length",
+          "usage": {
+            "prompt_tokens": 51,
+            "total_tokens": 1101,
+            "completion_tokens": 1050
+          },
+          "content_sha256": "5b1a705ae3f84dd1faf440e5850599fa3774f0fea18b421f76f3cca3aaf95ced",
+          "content_head": "# The Scientific Method in Practice\n\n## Introduction\n\nThe scientific method is often presented in textbooks as a neat, linear sequence: observe, hypothesize, predict, test, revise. In practice, however, science rarely proceeds so tidily. Re",
+          "content_tail": "orked as intended (the result was flagged as anomalous and independently checked), but the episode shows how systematic errors can hide in plain sight.\n\nStatistical treatment of uncertainty involves confidence intervals, standard deviations",
+          "diagnostics": {
+            "replacement_or_mojibake": [],
+            "max_16gram_repeats": 1,
+            "content_chars": 5901,
+            "reasoning_chars": 0
+          },
+          "name": "essay-3",
+          "thinking": false
+        },
+        {
+          "request_id": "glm53-p0-a2ce3fe149-thinking-sse",
+          "http": 200,
+          "sse_chunks": 45,
+          "done": true,
+          "ttfb_s": 0.295,
+          "wall_s": 5.232,
+          "finish_reason": "stop",
+          "usage": {
+            "prompt_tokens": 24,
+            "total_tokens": 173,
+            "completion_tokens": 149
+          },
+          "content_sha256": "550115119cb73967fbde945339c84051cc742e78b0ddcff2cb12a005a9049ecf",
+          "content_head": "THINKING_STREAM_OK",
+          "content_tail": "THINKING_STREAM_OK",
+          "diagnostics": {
+            "replacement_or_mojibake": [],
+            "max_16gram_repeats": 0,
+            "content_chars": 18,
+            "reasoning_chars": 678
+          },
+          "name": "thinking-sse",
+          "thinking": true
+        }
+      ],
+      "metric_delta": {
+        "num_requests_running": 0.0,
+        "num_requests_waiting": 0.0,
+        "num_preemptions_total": 0.0,
+        "prefix_cache_queries_total": 187.0,
+        "prefix_cache_hits_total": 0.0
+      },
+      "passed": true,
+      "failures": []
+    },
+    {
+      "file": "p0-soak-runtime-c7-20260905.json",
+      "run_id": "369614cec7",
+      "runs": [
+        {
+          "request_id": "glm53-p0-369614cec7-essay-1",
+          "http": 200,
+          "sse_chunks": 385,
+          "done": true,
+          "ttfb_s": 0.319,
+          "wall_s": 47.425,
+          "finish_reason": "length",
+          "usage": {
+            "prompt_tokens": 58,
+            "total_tokens": 1108,
+            "completion_tokens": 1050
+          },
+          "content_sha256": "c34ef389a6fd40059bf38f6b58dae1f49bfdc186aecd085c1f508f673a1cfad6",
+          "content_head": "# How Ocean Tides Work\n\n## Introduction\n\nTides are among the most familiar phenomena of the sea, yet their underlying mechanics are subtle and often misunderstood. The essential cause is gravitational attraction: the Moon and Sun pull on Ea",
+          "content_tail": "ghly 1.46 times the M2 amplitude alone (M2 + S2 add fully: 1 + 0.46), and neap ranges about 0.54 times (1 \u2212 0.0.46... let me restate: 1 \u2212 0.46 = 0.54). At full springs, the combined semidiurnal forcing is about 3.7 times the neap forcing.\n\n",
+          "diagnostics": {
+            "replacement_or_mojibake": [],
+            "max_16gram_repeats": 1,
+            "content_chars": 4458,
+            "reasoning_chars": 0
+          },
+          "name": "essay-1",
+          "thinking": false
+        },
+        {
+          "request_id": "glm53-p0-369614cec7-essay-2",
+          "http": 200,
+          "sse_chunks": 429,
+          "done": true,
+          "ttfb_s": 0.285,
+          "wall_s": 52.281,
+          "finish_reason": "length",
+          "usage": {
+            "prompt_tokens": 54,
+            "total_tokens": 1104,
+            "completion_tokens": 1050
+          },
+          "content_sha256": "005201a5458608d8e355515dd670eb83380550a10e20c4bc8bd7f68ec889a7b2",
+          "content_head": "# Virtual Memory Management in Modern Operating Systems\n\n## Introduction\n\nVirtual memory is one of the most consequential abstractions in computer science. By decoupling the *logical* addresses a program uses from the *physical* locations w",
+          "content_tail": "rent cache domain). When one CPU modifies a PTE that another CPU may have cached, the OS must send **TLB shootdown IPIs** (inter-processor interrupts) to force remote invalidations. Shootdowns are a well-known source of scalability problems",
+          "diagnostics": {
+            "replacement_or_mojibake": [],
+            "max_16gram_repeats": 1,
+            "content_chars": 4857,
+            "reasoning_chars": 0
+          },
+          "name": "essay-2",
+          "thinking": false
+        },
+        {
+          "request_id": "glm53-p0-369614cec7-essay-3",
+          "http": 200,
+          "sse_chunks": 436,
+          "done": true,
+          "ttfb_s": 0.346,
+          "wall_s": 53.686,
+          "finish_reason": "length",
+          "usage": {
+            "prompt_tokens": 51,
+            "total_tokens": 1101,
+            "completion_tokens": 1050
+          },
+          "content_sha256": "ce4651934a4aea61a3cb15479f482dd8089ddcc124dc2bac06392dc4ca19f66f",
+          "content_head": "# The Scientific Method in Practice\n\n## Introduction\n\nThe scientific method is often presented in textbooks as a neat, linear recipe: observe, hypothesize, predict, test, conclude. In practice, science is messier, more iterative, and more c",
+          "content_tail": "s respondents. Averaging does not cure systematic error; only identifying and correcting its source does. A dataset can be very precise (low scatter) yet inaccurate (biased)\u2014like a rifle that consistently hits two inches left of the bullsey",
+          "diagnostics": {
+            "replacement_or_mojibake": [],
+            "max_16gram_repeats": 1,
+            "content_chars": 5664,
+            "reasoning_chars": 0
+          },
+          "name": "essay-3",
+          "thinking": false
+        },
+        {
+          "request_id": "glm53-p0-369614cec7-thinking-sse",
+          "http": 200,
+          "sse_chunks": 46,
+          "done": true,
+          "ttfb_s": 0.315,
+          "wall_s": 5.357,
+          "finish_reason": "stop",
+          "usage": {
+            "prompt_tokens": 24,
+            "total_tokens": 169,
+            "completion_tokens": 145
+          },
+          "content_sha256": "550115119cb73967fbde945339c84051cc742e78b0ddcff2cb12a005a9049ecf",
+          "content_head": "THINKING_STREAM_OK",
+          "content_tail": "THINKING_STREAM_OK",
+          "diagnostics": {
+            "replacement_or_mojibake": [],
+            "max_16gram_repeats": 0,
+            "content_chars": 18,
+            "reasoning_chars": 652
+          },
+          "name": "thinking-sse",
+          "thinking": true
+        }
+      ],
+      "metric_delta": {
+        "num_requests_running": 0.0,
+        "num_requests_waiting": 0.0,
+        "num_preemptions_total": 0.0,
+        "prefix_cache_queries_total": 187.0,
+        "prefix_cache_hits_total": 0.0
+      },
+      "passed": true,
+      "failures": []
+    },
+    {
+      "file": "p0-soak-runtime-c8-20260905.json",
+      "run_id": "ce522246b0",
+      "runs": [
+        {
+          "request_id": "glm53-p0-ce522246b0-essay-1",
+          "http": 200,
+          "sse_chunks": 377,
+          "done": true,
+          "ttfb_s": 0.396,
+          "wall_s": 45.757,
+          "finish_reason": "length",
+          "usage": {
+            "prompt_tokens": 58,
+            "total_tokens": 1108,
+            "completion_tokens": 1050
+          },
+          "content_sha256": "e2582769ba41433615df77d15721c3ac93fe6c249898368ccd2c3c2044091786",
+          "content_head": "# How Ocean Tides Work: A Comprehensive Explanation\n\n## Introduction\n\nOcean tides are among the most familiar yet most misunderstood phenomena in nature. Most people know the sea rises and falls twice a day at many coastlines, but few under",
+          "content_tail": "oon, because the oceans take time to respond to the forcing\u2014real oceans have friction, inertia, and finite wave speeds.\n2. **Distance effects:** The Moon's orbit is elliptical. When perigee (closest approach) coincides with new or full moon",
+          "diagnostics": {
+            "replacement_or_mojibake": [],
+            "max_16gram_repeats": 1,
+            "content_chars": 4837,
+            "reasoning_chars": 0
+          },
+          "name": "essay-1",
+          "thinking": false
+        },
+        {
+          "request_id": "glm53-p0-ce522246b0-essay-2",
+          "http": 200,
+          "sse_chunks": 423,
+          "done": true,
+          "ttfb_s": 0.304,
+          "wall_s": 52.211,
+          "finish_reason": "length",
+          "usage": {
+            "prompt_tokens": 54,
+            "total_tokens": 1104,
+            "completion_tokens": 1050
+          },
+          "content_sha256": "d86ef781bce3abdc1bf41569b527629befb8f71014baf855de2920dfb7cc7d98",
+          "content_head": "# Virtual Memory in Modern Operating Systems\n\n## Introduction\n\nVirtual memory is one of the most consequential abstractions in computer science. By decoupling the addresses a program uses from the physical locations where its data actually ",
+          "content_tail": "now their working sets.\n\nWindows offers \"large pages\" (2 MiB) via `VirtualAlloc` with a special flag, requiring `SeLockMemoryPrivilege`; it does not have a transparent mechanism, so THP-style opportunism is a distinctive Linux feature.\n\n## ",
+          "diagnostics": {
+            "replacement_or_mojibake": [],
+            "max_16gram_repeats": 1,
+            "content_chars": 4518,
+            "reasoning_chars": 0
+          },
+          "name": "essay-2",
+          "thinking": false
+        },
+        {
+          "request_id": "glm53-p0-ce522246b0-essay-3",
+          "http": 200,
+          "sse_chunks": 460,
+          "done": true,
+          "ttfb_s": 0.422,
+          "wall_s": 56.38,
+          "finish_reason": "length",
+          "usage": {
+            "prompt_tokens": 51,
+            "total_tokens": 1101,
+            "completion_tokens": 1050
+          },
+          "content_sha256": "95cc9308cde0e8ed12bc026c04340baddc08b43c57c07f0d08d172c659de8942",
+          "content_head": "# The Scientific Method in Practice\n\n## Introduction\n\nThe scientific method is often taught as a tidy flowchart: observe, hypothesize, experiment, conclude. Real science rarely follows such a linear path, but the underlying logic\u2014forming te",
+          "content_tail": "tive to the noise. Statistical tests estimate the probability that results at least as extreme as those observed would arise by chance alone if there were no real effect. A p-value, often misunderstood, is exactly this\u2014a measure of surprise",
+          "diagnostics": {
+            "replacement_or_mojibake": [],
+            "max_16gram_repeats": 1,
+            "content_chars": 5939,
+            "reasoning_chars": 0
+          },
+          "name": "essay-3",
+          "thinking": false
+        },
+        {
+          "request_id": "glm53-p0-ce522246b0-thinking-sse",
+          "http": 200,
+          "sse_chunks": 44,
+          "done": true,
+          "ttfb_s": 0.235,
+          "wall_s": 5.138,
+          "finish_reason": "stop",
+          "usage": {
+            "prompt_tokens": 24,
+            "total_tokens": 164,
+            "completion_tokens": 140
+          },
+          "content_sha256": "550115119cb73967fbde945339c84051cc742e78b0ddcff2cb12a005a9049ecf",
+          "content_head": "THINKING_STREAM_OK",
+          "content_tail": "THINKING_STREAM_OK",
+          "diagnostics": {
+            "replacement_or_mojibake": [],
+            "max_16gram_repeats": 0,
+            "content_chars": 18,
+            "reasoning_chars": 621
+          },
+          "name": "thinking-sse",
+          "thinking": true
+        }
+      ],
+      "metric_delta": {
+        "num_requests_running": 0.0,
+        "num_requests_waiting": 0.0,
+        "num_preemptions_total": 0.0,
+        "prefix_cache_queries_total": 187.0,
+        "prefix_cache_hits_total": 0.0
+      },
+      "passed": true,
+      "failures": []
+    }
+  ]
+}

--- a/overlay/patch_mamba_null_gap_retirement.py
+++ b/overlay/patch_mamba_null_gap_retirement.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Retire obsolete align-mode Mamba states across null block gaps.
+
+The pinned fork's generic ``_remove_blocks_in_range`` stops at the first null
+block. Align-mode prefill can intentionally leave null gaps between recurrent
+state blocks, so older states before a gap remain referenced indefinitely.
+
+This installer adds a MambaManager override that skips null gaps, tracks the
+already-retired prefix per request, and clears that tracking when the request is
+freed. It is adapted from vLLM PR #55450 to the exact production fork, whose
+MambaManager does not have mainline's ``_num_checkpoint_blocks`` member.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+import sys
+from pathlib import Path
+
+
+TARGET = Path(
+    os.environ.get(
+        "GLM53_SINGLE_TYPE_KV_MANAGER_PY",
+        "/usr/local/lib/python3.12/dist-packages/vllm/v1/core/"
+        "single_type_kv_cache_manager.py",
+    )
+)
+MARK = "# [glm53-mamba-null-gap]"
+
+INIT_OLD = """\
+            self.last_state_block_idx: dict[str, int] = {}
+            # The set of the requests that have been allocated blocks
+"""
+INIT_NEW = """\
+            self.last_state_block_idx: dict[str, int] = {}
+            # Highest align-mode block prefix already scanned for retirement.
+            self._num_retired_blocks: dict[str, int] = {}  # [glm53-mamba-null-gap]
+            # The set of the requests that have been allocated blocks
+"""
+
+REMOVE_ANCHOR = """\
+    def remove_skipped_blocks(
+        self,
+        request_id: str,
+"""
+REMOVE_OVERRIDE = """\
+    def _remove_blocks_in_range(
+        self, request_id: str, first_block: int, last_block: int
+    ) -> None:
+        if self.mamba_cache_mode != "align":
+            return super()._remove_blocks_in_range(
+                request_id, first_block, last_block
+            )
+        blocks = self.req_to_blocks.get(request_id, [])
+        first_block = max(
+            first_block, self._num_retired_blocks.get(request_id, 0)
+        )
+        last_block = min(last_block, len(blocks))
+        if first_block >= last_block:
+            return
+        freed: list[KVCacheBlock] = []
+        # Align-mode prefill can leave null gaps between state checkpoints.
+        for i in range(last_block - 1, first_block - 1, -1):
+            if blocks[i].is_null:
+                continue
+            freed.append(blocks[i])
+            blocks[i] = self._null_block
+        if freed:
+            self.block_pool.free_blocks(freed)
+        self._num_retired_blocks[request_id] = last_block
+
+"""
+
+FREE_OLD = """\
+            self.last_state_block_idx.pop(request_id, None)
+            self._producer_partial_tail_reqs.pop(request_id, None)
+"""
+FREE_NEW = """\
+            self.last_state_block_idx.pop(request_id, None)
+            self._num_retired_blocks.pop(request_id, None)  # [glm53-mamba-null-gap]
+            self._producer_partial_tail_reqs.pop(request_id, None)
+"""
+
+
+def replace_once(text: str, old: str, new: str, label: str) -> str:
+    count = text.count(old)
+    if count != 1:
+        raise SystemExit(f"{TARGET}: expected one {label} anchor, found {count}")
+    return text.replace(old, new, 1)
+
+
+def validate(text: str) -> None:
+    ast.parse(text, filename=str(TARGET))
+    expected = (
+        ("Mamba retirement init", INIT_NEW),
+        ("Mamba retirement override", REMOVE_OVERRIDE),
+        ("Mamba retirement cleanup", FREE_NEW),
+    )
+    for label, snippet in expected:
+        count = text.count(snippet)
+        if count != 1:
+            raise SystemExit(f"{TARGET}: expected exact {label}, found {count}")
+
+    class_pos = text.find("class MambaManager(")
+    next_class = text.find("\nclass ", class_pos + 1)
+    class_text = text[class_pos : next_class if next_class >= 0 else len(text)]
+    for label, snippet in expected:
+        if snippet not in class_text:
+            raise SystemExit(f"{TARGET}: {label} is outside MambaManager")
+    if text.count(MARK) != 2:
+        raise SystemExit(f"{TARGET}: null-gap markers missing or duplicated")
+
+
+def main() -> int:
+    if not TARGET.is_file():
+        raise SystemExit(f"missing target: {TARGET}")
+    text = TARGET.read_text()
+    if MARK in text:
+        validate(text)
+        print("glm53: Mamba null-gap retirement already installed", file=sys.stderr)
+        return 0
+
+    text = replace_once(text, INIT_OLD, INIT_NEW, "MambaManager init")
+    class_pos = text.find("class MambaManager(")
+    remove_pos = text.find(REMOVE_ANCHOR, class_pos)
+    if class_pos < 0 or remove_pos < 0:
+        raise SystemExit(f"{TARGET}: MambaManager remove_skipped_blocks anchor missing")
+    text = text[:remove_pos] + REMOVE_OVERRIDE + text[remove_pos:]
+    text = replace_once(text, FREE_OLD, FREE_NEW, "MambaManager cleanup")
+    validate(text)
+    TARGET.write_text(text)
+    print("glm53: installed Mamba null-gap retirement", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/start.sh
+++ b/start.sh
@@ -242,6 +242,7 @@ APC_NO_STORE_PATCH_HOST="${APC_NO_STORE_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_ap
 # LOCAL: W28 GLM-only indexer-workspace reclaim + bundled correctness backports
 INDEXER_WORKSPACE_PATCH_HOST="${INDEXER_WORKSPACE_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_indexer_workspace.py}"
 W28_CORRECTNESS_PATCH_HOST="${W28_CORRECTNESS_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_w28_correctness.py}"
+MAMBA_NULL_GAP_PATCH_HOST="${MAMBA_NULL_GAP_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_mamba_null_gap_retirement.py}"
 KV_CACHE_DTYPE="${KV_CACHE_DTYPE:-fp8}"
 QUANTIZATION="${QUANTIZATION:-exl3}"
 LANGUAGE_MODEL_ONLY="${LANGUAGE_MODEL_ONLY:-0}"
@@ -1108,55 +1109,58 @@ fi
 
 [ -f "${MODEL_DIR}/config.json" ] || { say "FATAL: ${MODEL_DIR}/config.json missing"; ls -la "${MODEL_DIR}" | head; exit 1; }
 if [ -f /opt/glm53/patch_glm_video_placeholders.py ]; then
-    python3 /opt/glm53/patch_glm_video_placeholders.py
+    python3 -S /opt/glm53/patch_glm_video_placeholders.py
 fi
 if [ -f /opt/glm53/patch_suppress_stops_in_reasoning.py ]; then
-    python3 /opt/glm53/patch_suppress_stops_in_reasoning.py
+    python3 -S /opt/glm53/patch_suppress_stops_in_reasoning.py
 fi
 if [ -f /opt/glm53/patch_scheduler_decode_floor.py ]; then
-    python3 /opt/glm53/patch_scheduler_decode_floor.py
+    python3 -S /opt/glm53/patch_scheduler_decode_floor.py
 fi
 if [ -f /opt/glm53/patch_glm5_drafter_group.py ]; then
-    python3 /opt/glm53/patch_glm5_drafter_group.py
+    python3 -S /opt/glm53/patch_glm5_drafter_group.py
 fi
 if [ -f /opt/glm53/patch_hybrid_prefix_hit.py ]; then
-    python3 /opt/glm53/patch_hybrid_prefix_hit.py
+    python3 -S /opt/glm53/patch_hybrid_prefix_hit.py
 fi
 if [ -f /opt/glm53/patch_apc_per_group_retention.py ]; then  # LOCAL: W25
-    python3 /opt/glm53/patch_apc_per_group_retention.py
+    python3 -S /opt/glm53/patch_apc_per_group_retention.py
 fi
 if [ -f /opt/glm53/patch_xgrammar_termination.py ]; then
-    python3 /opt/glm53/patch_xgrammar_termination.py
+    python3 -S /opt/glm53/patch_xgrammar_termination.py
 fi
 if [ -f /opt/glm53/patch_cache_reset.py ]; then
-    python3 /opt/glm53/patch_cache_reset.py
+    python3 -S /opt/glm53/patch_cache_reset.py
 fi
 if [ -f /opt/glm53/patch_router_gemm_gb10.py ]; then
-    python3 /opt/glm53/patch_router_gemm_gb10.py
+    python3 -S /opt/glm53/patch_router_gemm_gb10.py
 fi
 if [ -f /opt/glm53/patch_kpool_tail_slotmap.py ]; then
-    python3 /opt/glm53/patch_kpool_tail_slotmap.py
+    python3 -S /opt/glm53/patch_kpool_tail_slotmap.py
 fi
 if [ -f /opt/glm53/patch_spinwait_gb10.py ]; then
-    python3 /opt/glm53/patch_spinwait_gb10.py
+    python3 -S /opt/glm53/patch_spinwait_gb10.py
 fi
 if [ -f /opt/glm53/patch_fine_grained_apc.py ]; then
-    python3 /opt/glm53/patch_fine_grained_apc.py
+    python3 -S /opt/glm53/patch_fine_grained_apc.py
 fi
 if [ -f /opt/glm53/patch_align_floor.py ]; then
-    python3 /opt/glm53/patch_align_floor.py
+    python3 -S /opt/glm53/patch_align_floor.py
 fi
 if [ -f /opt/glm53/patch_kv_capacity_log.py ]; then  # LOCAL: W41 (after patch_hybrid_prefix_hit.py)
-    python3 /opt/glm53/patch_kv_capacity_log.py
+    python3 -S /opt/glm53/patch_kv_capacity_log.py
 fi
 if [ -f /opt/glm53/patch_apc_no_store.py ]; then  # LOCAL: W42
-    python3 /opt/glm53/patch_apc_no_store.py
+    python3 -S /opt/glm53/patch_apc_no_store.py
 fi
 if [ -f /opt/glm53/patch_w28_correctness.py ]; then  # LOCAL: W28 correctness first
-    python3 /opt/glm53/patch_w28_correctness.py
+    python3 -S /opt/glm53/patch_w28_correctness.py
 fi
 if [ -f /opt/glm53/patch_indexer_workspace.py ]; then  # LOCAL: W28 decision variable
-    python3 /opt/glm53/patch_indexer_workspace.py
+    python3 -S /opt/glm53/patch_indexer_workspace.py
+fi
+if [ -f /opt/glm53/patch_mamba_null_gap_retirement.py ]; then
+    python3 -S /opt/glm53/patch_mamba_null_gap_retirement.py
 fi
 say "launching: vllm serve ${MODEL_DIR} ${ARGS[*]}"
 exec vllm serve "${MODEL_DIR}" "${ARGS[@]}"
@@ -1238,55 +1242,58 @@ fi
 
 [ -f "${MODEL_DIR}/config.json" ] || { say "FATAL: ${MODEL_DIR}/config.json missing"; ls -la "${MODEL_DIR}" | head; exit 1; }
 if [ -f /opt/glm53/patch_glm_video_placeholders.py ]; then
-    python3 /opt/glm53/patch_glm_video_placeholders.py
+    python3 -S /opt/glm53/patch_glm_video_placeholders.py
 fi
 if [ -f /opt/glm53/patch_suppress_stops_in_reasoning.py ]; then
-    python3 /opt/glm53/patch_suppress_stops_in_reasoning.py
+    python3 -S /opt/glm53/patch_suppress_stops_in_reasoning.py
 fi
 if [ -f /opt/glm53/patch_scheduler_decode_floor.py ]; then
-    python3 /opt/glm53/patch_scheduler_decode_floor.py
+    python3 -S /opt/glm53/patch_scheduler_decode_floor.py
 fi
 if [ -f /opt/glm53/patch_glm5_drafter_group.py ]; then
-    python3 /opt/glm53/patch_glm5_drafter_group.py
+    python3 -S /opt/glm53/patch_glm5_drafter_group.py
 fi
 if [ -f /opt/glm53/patch_hybrid_prefix_hit.py ]; then
-    python3 /opt/glm53/patch_hybrid_prefix_hit.py
+    python3 -S /opt/glm53/patch_hybrid_prefix_hit.py
 fi
 if [ -f /opt/glm53/patch_apc_per_group_retention.py ]; then  # LOCAL: W25
-    python3 /opt/glm53/patch_apc_per_group_retention.py
+    python3 -S /opt/glm53/patch_apc_per_group_retention.py
 fi
 if [ -f /opt/glm53/patch_xgrammar_termination.py ]; then
-    python3 /opt/glm53/patch_xgrammar_termination.py
+    python3 -S /opt/glm53/patch_xgrammar_termination.py
 fi
 if [ -f /opt/glm53/patch_cache_reset.py ]; then
-    python3 /opt/glm53/patch_cache_reset.py
+    python3 -S /opt/glm53/patch_cache_reset.py
 fi
 if [ -f /opt/glm53/patch_router_gemm_gb10.py ]; then
-    python3 /opt/glm53/patch_router_gemm_gb10.py
+    python3 -S /opt/glm53/patch_router_gemm_gb10.py
 fi
 if [ -f /opt/glm53/patch_kpool_tail_slotmap.py ]; then
-    python3 /opt/glm53/patch_kpool_tail_slotmap.py
+    python3 -S /opt/glm53/patch_kpool_tail_slotmap.py
 fi
 if [ -f /opt/glm53/patch_spinwait_gb10.py ]; then
-    python3 /opt/glm53/patch_spinwait_gb10.py
+    python3 -S /opt/glm53/patch_spinwait_gb10.py
 fi
 if [ -f /opt/glm53/patch_fine_grained_apc.py ]; then
-    python3 /opt/glm53/patch_fine_grained_apc.py
+    python3 -S /opt/glm53/patch_fine_grained_apc.py
 fi
 if [ -f /opt/glm53/patch_align_floor.py ]; then
-    python3 /opt/glm53/patch_align_floor.py
+    python3 -S /opt/glm53/patch_align_floor.py
 fi
 if [ -f /opt/glm53/patch_kv_capacity_log.py ]; then  # LOCAL: W41 (after patch_hybrid_prefix_hit.py)
-    python3 /opt/glm53/patch_kv_capacity_log.py
+    python3 -S /opt/glm53/patch_kv_capacity_log.py
 fi
 if [ -f /opt/glm53/patch_apc_no_store.py ]; then  # LOCAL: W42
-    python3 /opt/glm53/patch_apc_no_store.py
+    python3 -S /opt/glm53/patch_apc_no_store.py
 fi
 if [ -f /opt/glm53/patch_w28_correctness.py ]; then  # LOCAL: W28 correctness first
-    python3 /opt/glm53/patch_w28_correctness.py
+    python3 -S /opt/glm53/patch_w28_correctness.py
 fi
 if [ -f /opt/glm53/patch_indexer_workspace.py ]; then  # LOCAL: W28 decision variable
-    python3 /opt/glm53/patch_indexer_workspace.py
+    python3 -S /opt/glm53/patch_indexer_workspace.py
+fi
+if [ -f /opt/glm53/patch_mamba_null_gap_retirement.py ]; then
+    python3 -S /opt/glm53/patch_mamba_null_gap_retirement.py
 fi
 say "joining TP2 at ${HEAD_IP}:${MASTER_PORT} as rank 1"
 exec vllm serve "${MODEL_DIR}" "${ARGS[@]}"
@@ -1338,6 +1345,8 @@ launch_cluster() {
     scp -q -o BatchMode=yes "$W28_CORRECTNESS_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_w28_correctness.py"
     [ -f "$INDEXER_WORKSPACE_PATCH_HOST" ] || die "missing $INDEXER_WORKSPACE_PATCH_HOST"  # LOCAL: W28
     scp -q -o BatchMode=yes "$INDEXER_WORKSPACE_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_indexer_workspace.py"
+    [ -f "$MAMBA_NULL_GAP_PATCH_HOST" ] || die "missing $MAMBA_NULL_GAP_PATCH_HOST"
+    scp -q -o BatchMode=yes "$MAMBA_NULL_GAP_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_mamba_null_gap_retirement.py"
 
 
     local -a nccl_common=(
@@ -1446,12 +1455,8 @@ launch_cluster() {
              LIMIT_MM CHAT_TEMPLATE ENFORCE_EAGER EXL3_FUSED_MOE EXL3_MOE_ROW_TILE EXL3_TEMP_ROWS_FUSED EXL3_FAT_SORTED EXL3_FAT_BATCHED EXL3_FAT_KERNEL MODEL_DIR EXTRA_ARGS; do
         serve_env+=" -e $v='${!v:-}'"
     done
-    # VLLM_API_KEY is read by the head (rank 0) API server for bearer auth; the
-    # worker runs --headless so it only needs the var for argv-parity, and
-    # start.sh below passes it explicitly on the head. Keep it out of the
-    # generic loop so the key never shows in process listings of either node
-    # beyond the container env (same as the DeepSeek deployment).
-    serve_env+=" -e VLLM_API_KEY='${VLLM_API_KEY:-}'"
+    # VLLM_API_KEY belongs only on rank 0, which owns the API server. Never send
+    # the bearer credential to the headless worker.
 
     log "starting worker on ${WORKER_SSH} (NCCL if=${WORKER_CX7_IF} hca=${WORKER_CX7_IB}) ..."
     worker_ssh "docker run -d --name '$CONTAINER_WORKER' \
@@ -1481,6 +1486,7 @@ launch_cluster() {
         -v '/tmp/patch_apc_no_store.py:/opt/glm53/patch_apc_no_store.py:ro' \
         -v '/tmp/patch_w28_correctness.py:/opt/glm53/patch_w28_correctness.py:ro' \
         -v '/tmp/patch_indexer_workspace.py:/opt/glm53/patch_indexer_workspace.py:ro' \
+        -v '/tmp/patch_mamba_null_gap_retirement.py:/opt/glm53/patch_mamba_null_gap_retirement.py:ro' \
         ${worker_preload} \
         ${worker_nccl} \
         -e NCCL_SOCKET_IFNAME='$WORKER_CX7_IF' \
@@ -1519,6 +1525,7 @@ launch_cluster() {
         -v "$APC_NO_STORE_PATCH_HOST:/opt/glm53/patch_apc_no_store.py:ro" \
         -v "$W28_CORRECTNESS_PATCH_HOST:/opt/glm53/patch_w28_correctness.py:ro" \
         -v "$INDEXER_WORKSPACE_PATCH_HOST:/opt/glm53/patch_indexer_workspace.py:ro" \
+        -v "$MAMBA_NULL_GAP_PATCH_HOST:/opt/glm53/patch_mamba_null_gap_retirement.py:ro" \
         "${head_preload[@]}" \
         "${nccl_common[@]}" \
         -e NCCL_SOCKET_IFNAME="$HEAD_CX7_IF" \

--- a/tests/test_apc_no_store.py
+++ b/tests/test_apc_no_store.py
@@ -954,13 +954,13 @@ def _launcher_wiring(prefix: str, host_var: str, overlay: str, knob: str, tag: s
     check(f'[ -f "${host_var}" ] || die "missing ${host_var}"' in src and f'scp -q -o BatchMode=yes "${host_var}" "${{WORKER_SSH}}:/tmp/{overlay}"' in src, f"{prefix}2 preflight existence check + scp to the worker")
     check(f"-v '/tmp/{overlay}:/opt/glm53/{overlay}:ro'" in src and f'-v "${host_var}:/opt/glm53/{overlay}:ro"' in src, f"{prefix}2 read-only mount on both ranks")
     check(f'-e "{knob}=${knob}"' in src, f"{prefix}2 the knob is forwarded in nccl_common (both ranks)")
-    runs = src.count(f"python3 /opt/glm53/{overlay}")
+    runs = src.count(f"python3 -S /opt/glm53/{overlay}")
     check(runs == 2, f"{prefix}3 both rank scripts run the overlay exactly once ({runs})")
     # order: after every overlay that edits the same files / the hybrid+drafter pair, before ablit
     for earlier in ("patch_glm5_drafter_group.py", "patch_hybrid_prefix_hit.py", "patch_apc_per_group_retention.py", "patch_fine_grained_apc.py", "patch_align_floor.py"):
-        check(src.index(f"python3 /opt/glm53/{earlier}") < src.index(f"python3 /opt/glm53/{overlay}"), f"{prefix}3 pinned order: {earlier} -> {overlay}")
-    if "python3 /opt/glm53/patch_ablit.py" in src:  # kit only; the public repo ships no ablit
-        check(src.index(f"python3 /opt/glm53/{overlay}") < src.index("python3 /opt/glm53/patch_ablit.py"), f"{prefix}3 pinned order: {overlay} -> patch_ablit.py (last)")
+        check(src.index(f"python3 -S /opt/glm53/{earlier}") < src.index(f"python3 -S /opt/glm53/{overlay}"), f"{prefix}3 pinned order: {earlier} -> {overlay}")
+    if "python3 -S /opt/glm53/patch_ablit.py" in src:  # kit only; the public repo ships no ablit
+        check(src.index(f"python3 -S /opt/glm53/{overlay}") < src.index("python3 -S /opt/glm53/patch_ablit.py"), f"{prefix}3 pinned order: {overlay} -> patch_ablit.py (last)")
     defaults = defaults_source()
     check(f'{knob}="${{{knob}-1}}"' in defaults, f"{prefix}1 default 1 applies only when UNSET ('' is a value)")
     for value, out in ((None, "1"), ("0", "0"), ("1", "1")):

--- a/tests/test_cache_reset_endpoint.py
+++ b/tests/test_cache_reset_endpoint.py
@@ -211,7 +211,7 @@ def test_recipe_wiring_if_present() -> None:
     assert 'GLM53_EXPOSE_CACHE_RESET="${GLM53_EXPOSE_CACHE_RESET:-1}"' in launcher
     # forwarded through the shared container env block (head + worker)
     assert '-e "GLM53_EXPOSE_CACHE_RESET=$GLM53_EXPOSE_CACHE_RESET"' in launcher
-    assert launcher.count("python3 /opt/glm53/patch_cache_reset.py") == 2
+    assert launcher.count("python3 -S /opt/glm53/patch_cache_reset.py") == 2
     assert (
         "-v '/tmp/patch_cache_reset.py:"
         "/opt/glm53/patch_cache_reset.py:ro'" in launcher

--- a/tests/test_indexer_workspace.py
+++ b/tests/test_indexer_workspace.py
@@ -489,7 +489,7 @@ def test_recipe_wiring() -> None:
     assert '_glm53_cli_indexer_workspace_set="${GLM53_INDEXER_WORKSPACE+a}"' in start
     assert 'GLM53_INDEXER_WORKSPACE="${GLM53_INDEXER_WORKSPACE-stock}"' in start
     assert "GLM53_INDEXER_WORKSPACE must be exactly one of: stock rightsize" in start
-    assert start.count("python3 /opt/glm53/patch_indexer_workspace.py") == 2
+    assert start.count("python3 -S /opt/glm53/patch_indexer_workspace.py") == 2
     assert start.count(
         "-v \"$INDEXER_WORKSPACE_PATCH_HOST:"
         "/opt/glm53/patch_indexer_workspace.py:ro\""

--- a/tests/test_kpool_tail_slotmap.py
+++ b/tests/test_kpool_tail_slotmap.py
@@ -182,7 +182,7 @@ def test_recipe_wiring_if_present() -> None:
     launcher = start.read_text()
     image = dockerfile.read_text()
     assert 'KPOOL_TAIL_PATCH_HOST="${KPOOL_TAIL_PATCH_HOST:-' in launcher
-    assert launcher.count("python3 /opt/glm53/patch_kpool_tail_slotmap.py") == 2
+    assert launcher.count("python3 -S /opt/glm53/patch_kpool_tail_slotmap.py") == 2
     assert (
         "-v '/tmp/patch_kpool_tail_slotmap.py:"
         "/opt/glm53/patch_kpool_tail_slotmap.py:ro'" in launcher

--- a/tests/test_kv_capacity_log.py
+++ b/tests/test_kv_capacity_log.py
@@ -801,13 +801,13 @@ def _launcher_wiring(prefix: str, host_var: str, overlay: str, knob: str, tag: s
     check(f'[ -f "${host_var}" ] || die "missing ${host_var}"' in src and f'scp -q -o BatchMode=yes "${host_var}" "${{WORKER_SSH}}:/tmp/{overlay}"' in src, f"{prefix}2 preflight existence check + scp to the worker")
     check(f"-v '/tmp/{overlay}:/opt/glm53/{overlay}:ro'" in src and f'-v "${host_var}:/opt/glm53/{overlay}:ro"' in src, f"{prefix}2 read-only mount on both ranks")
     check(f'-e "{knob}=${knob}"' in src, f"{prefix}2 the knob is forwarded in nccl_common (both ranks)")
-    runs = src.count(f"python3 /opt/glm53/{overlay}")
+    runs = src.count(f"python3 -S /opt/glm53/{overlay}")
     check(runs == 2, f"{prefix}3 both rank scripts run the overlay exactly once ({runs})")
     # order: after every overlay that edits the same files / the hybrid+drafter pair, before ablit
     for earlier in ("patch_glm5_drafter_group.py", "patch_hybrid_prefix_hit.py", "patch_apc_per_group_retention.py", "patch_fine_grained_apc.py", "patch_align_floor.py"):
-        check(src.index(f"python3 /opt/glm53/{earlier}") < src.index(f"python3 /opt/glm53/{overlay}"), f"{prefix}3 pinned order: {earlier} -> {overlay}")
-    if "python3 /opt/glm53/patch_ablit.py" in src:  # kit only; the public repo ships no ablit
-        check(src.index(f"python3 /opt/glm53/{overlay}") < src.index("python3 /opt/glm53/patch_ablit.py"), f"{prefix}3 pinned order: {overlay} -> patch_ablit.py (last)")
+        check(src.index(f"python3 -S /opt/glm53/{earlier}") < src.index(f"python3 -S /opt/glm53/{overlay}"), f"{prefix}3 pinned order: {earlier} -> {overlay}")
+    if "python3 -S /opt/glm53/patch_ablit.py" in src:  # kit only; the public repo ships no ablit
+        check(src.index(f"python3 -S /opt/glm53/{overlay}") < src.index("python3 -S /opt/glm53/patch_ablit.py"), f"{prefix}3 pinned order: {overlay} -> patch_ablit.py (last)")
     defaults = defaults_source()
     check(f'{knob}="${{{knob}-1}}"' in defaults, f"{prefix}1 default 1 applies only when UNSET ('' is a value)")
     for value, out in ((None, "1"), ("0", "0"), ("1", "1")):

--- a/tests/test_mamba_null_gap_retirement.py
+++ b/tests/test_mamba_null_gap_retirement.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Host regression tests for the null-gap Mamba retirement overlay."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PATCH = ROOT / "overlay" / "patch_mamba_null_gap_retirement.py"
+
+FIXTURE = """\
+class KVCacheBlock:
+    pass
+
+
+class SingleTypeKVCacheManager:
+    def _remove_blocks_in_range(
+        self,
+        request_id: str,
+        first_block: int,
+        last_block: int,
+    ) -> None:
+        blocks = self.req_to_blocks[request_id]
+        freed: list[KVCacheBlock] = []
+        for i in range(last_block - 1, first_block - 1, -1):
+            if blocks[i] == self._null_block:
+                break
+            freed.append(blocks[i])
+            blocks[i] = self._null_block
+        if freed:
+            self.block_pool.free_blocks(freed)
+
+
+class MambaManager(SingleTypeKVCacheManager):
+    def __init__(self):
+        if self.mamba_cache_mode == "align":
+            # Mapping from request ID to the index of the block
+            # allocated in the previous step
+            self.last_state_block_idx: dict[str, int] = {}
+            # The set of the requests that have been allocated blocks
+            self._allocated_block_reqs: set[str] = set()
+            self._producer_partial_tail_reqs: dict[str, int] = {}
+
+    def remove_skipped_blocks(
+        self,
+        request_id: str,
+        processed_computed_tokens: int,
+        num_prompt_tokens: int | None = None,
+    ) -> None:
+        pass
+
+    def pop_blocks_for_free(self, request_id: str) -> list[KVCacheBlock]:
+        if self.mamba_cache_mode == "align":
+            self._allocated_block_reqs.discard(request_id)
+            self.last_state_block_idx.pop(request_id, None)
+            self._producer_partial_tail_reqs.pop(request_id, None)
+        return []
+"""
+
+
+class Block:
+    def __init__(self, block_id: int, *, is_null: bool = False) -> None:
+        self.block_id = block_id
+        self.is_null = is_null
+        self.ref_cnt = 0 if is_null else 1
+
+
+class Pool:
+    def __init__(self) -> None:
+        self.freed: list[Block] = []
+
+    def free_blocks(self, blocks: list[Block]) -> None:
+        self.freed.extend(blocks)
+        for block in blocks:
+            block.ref_cnt -= 1
+
+
+def apply_patch(tmp_path: Path) -> Path:
+    target = tmp_path / "single_type_kv_cache_manager.py"
+    target.write_text(FIXTURE)
+    env = os.environ.copy()
+    env["GLM53_SINGLE_TYPE_KV_MANAGER_PY"] = str(target)
+    subprocess.run([sys.executable, "-S", str(PATCH)], check=True, env=env)
+    subprocess.run([sys.executable, "-S", str(PATCH)], check=True, env=env)
+    return target
+
+
+def load_module(path: Path):
+    spec = importlib.util.spec_from_file_location("patched_mamba_manager", path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_overlay_retires_states_across_null_gap(tmp_path: Path) -> None:
+    module = load_module(apply_patch(tmp_path))
+    manager = module.MambaManager.__new__(module.MambaManager)
+    manager.mamba_cache_mode = "align"
+    manager._null_block = Block(-1, is_null=True)
+    manager._num_retired_blocks = {}
+    manager.block_pool = Pool()
+
+    old = Block(0)
+    committed = Block(1)
+    in_flight = Block(2)
+    manager.req_to_blocks = {
+        "r": [old, manager._null_block, committed, in_flight]
+    }
+
+    manager._remove_blocks_in_range("r", 0, 2)
+    assert manager.req_to_blocks["r"] == [
+        manager._null_block,
+        manager._null_block,
+        committed,
+        in_flight,
+    ]
+    assert old.ref_cnt == 0
+    assert committed.ref_cnt == in_flight.ref_cnt == 1
+    assert manager._num_retired_blocks["r"] == 2
+
+    manager._remove_blocks_in_range("r", 0, 2)
+    assert manager.block_pool.freed == [old]
+
+
+def test_overlay_clears_request_retirement_state(tmp_path: Path) -> None:
+    module = load_module(apply_patch(tmp_path))
+    manager = module.MambaManager.__new__(module.MambaManager)
+    manager.mamba_cache_mode = "align"
+    manager._allocated_block_reqs = {"r"}
+    manager.last_state_block_idx = {"r": 1}
+    manager._num_retired_blocks = {"r": 2}
+    manager._producer_partial_tail_reqs = {"r": 3}
+    manager.pop_blocks_for_free("r")
+    assert "r" not in manager._num_retired_blocks
+
+
+def test_overlay_rejects_drifted_installed_body_without_writing(tmp_path: Path) -> None:
+    target = apply_patch(tmp_path)
+    drifted = target.read_text().replace(
+        "if blocks[i].is_null:\n                continue",
+        "if blocks[i].is_null:\n                break",
+        1,
+    )
+    assert drifted != target.read_text()
+    target.write_text(drifted)
+    before = target.read_bytes()
+    env = os.environ.copy()
+    env["GLM53_SINGLE_TYPE_KV_MANAGER_PY"] = str(target)
+    result = subprocess.run(
+        [sys.executable, "-S", str(PATCH)],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert result.returncode != 0
+    assert "expected exact Mamba retirement override" in result.stderr
+    assert target.read_bytes() == before

--- a/tests/test_p0_runtime_probe.py
+++ b/tests/test_p0_runtime_probe.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Regression tests for the P0 streaming diagnostic."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PROBE = ROOT / "local" / "p0-runtime-probe.py"
+
+
+def module():
+    spec = importlib.util.spec_from_file_location("p0_runtime_probe", PROBE)
+    assert spec and spec.loader
+    loaded = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(loaded)
+    return loaded
+
+
+def base_run(**overrides):
+    run = {
+        "http": 200,
+        "done": True,
+        "sse_chunks": 3,
+        "finish_reason": "stop",
+        "usage": {"completion_tokens": 1200},
+        "content_head": "THINKING_STREAM_OK",
+        "content_tail": "",
+        "diagnostics": {
+            "replacement_or_mojibake": [],
+            "max_16gram_repeats": 1,
+            "content_chars": 18,
+            "reasoning_chars": 20,
+        },
+    }
+    run.update(overrides)
+    return run
+
+
+def test_thinking_stream_requires_final_answer() -> None:
+    probe = module()
+    run = base_run(
+        finish_reason="length",
+        content_head="",
+        diagnostics={
+            "replacement_or_mojibake": [],
+            "max_16gram_repeats": 1,
+            "content_chars": 0,
+            "reasoning_chars": 400,
+        },
+    )
+    failures = probe.validate_run("thinking-sse", run, 1000)
+    assert "thinking-sse: finish_reason='length'" in failures
+    assert "thinking-sse: missing final answer marker" in failures
+
+
+def test_thinking_stream_accepts_reasoning_then_answer() -> None:
+    probe = module()
+    assert probe.validate_run("thinking-sse", base_run(), 1000) == []
+
+
+class Response:
+    status = 200
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def __iter__(self):
+        events = (
+            {"choices": [{"delta": {"content": "prefix\u0000suffix"}}]},
+            {
+                "choices": [{"delta": {}, "finish_reason": "stop"}],
+                "usage": {"completion_tokens": 2},
+            },
+        )
+        for event in events:
+            yield f"data: {json.dumps(event)}\n".encode()
+        yield b"data: [DONE]\n"
+
+
+def test_json_escaped_nul_is_detected(monkeypatch) -> None:
+    probe = module()
+    monkeypatch.setattr(probe, "open_url", lambda *_args, **_kwargs: Response())
+    run = probe.stream_request(
+        "http://example.invalid",
+        "prompt",
+        thinking=False,
+        temperature=0.0,
+        max_tokens=4,
+        timeout=1,
+        request_id="test",
+    )
+    assert "\x00" in run["diagnostics"]["replacement_or_mojibake"]

--- a/tests/test_runtime_hardening.py
+++ b/tests/test_runtime_hardening.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Static launcher regressions for P0 runtime hardening."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCE = (ROOT / "start.sh").read_text()
+README = (ROOT / "README.md").read_text()
+
+
+def test_patch_installers_skip_site_initialization() -> None:
+    invocations = re.findall(
+        r"^\s*(python3(?: -S)? /opt/glm53/patch_[^\s]+\.py)\s*$",
+        SOURCE,
+        re.MULTILINE,
+    )
+    assert invocations
+    assert all(command.startswith("python3 -S ") for command in invocations)
+    assert sum("patch_mamba_null_gap_retirement.py" in command for command in invocations) == 2
+
+
+def test_api_key_is_head_only() -> None:
+    worker_start = SOURCE.index('worker_ssh "docker run -d')
+    head_start = SOURCE.index('docker run -d --name "$CONTAINER_HEAD"', worker_start)
+    worker_command = SOURCE[worker_start:head_start]
+    head_command = SOURCE[head_start:SOURCE.index('log "containers up', head_start)]
+    assert "VLLM_API_KEY" not in worker_command
+    assert head_command.count('-e VLLM_API_KEY="$VLLM_API_KEY"') == 1
+
+
+def test_shared_head_guidance_uses_effective_launcher_names() -> None:
+    assert "`GPU_MEM_UTIL=0.78`" in README
+    assert "`CG_ESTIMATE=0`" in README
+    assert "GPU_MEMORY_UTILIZATION=0.78" not in README
+    assert "VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=0" not in README
+    assert '--gpu-memory-utilization "${GPU_MEM_UTIL}"' in SOURCE
+    assert '-e "VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=$CG_ESTIMATE"' in SOURCE

--- a/tests/test_w16_w18_wiring.py
+++ b/tests/test_w16_w18_wiring.py
@@ -27,7 +27,7 @@ def test_overlays_wired_six_ways() -> None:
         assert f'scp -q -o BatchMode=yes "${host_var}" "${{WORKER_SSH}}:/tmp/{fname}"' in START
         assert f"-v '/tmp/{fname}:/opt/glm53/{fname}:ro'" in START  # worker
         assert f'-v "${host_var}:/opt/glm53/{fname}:ro"' in START  # head
-        assert _count(f"python3 /opt/glm53/{fname}") == 2  # both ranks
+        assert _count(f"python3 -S /opt/glm53/{fname}") == 2  # both ranks
 
 
 def test_env_defaults_off_and_reach_both_ranks() -> None:

--- a/tests/test_w28_correctness.py
+++ b/tests/test_w28_correctness.py
@@ -182,7 +182,7 @@ def test_pinned_container_sources_apply() -> None:
 
 def test_recipe_wiring() -> None:
     start = (ROOT / "start.sh").read_text()
-    assert start.count("python3 /opt/glm53/patch_w28_correctness.py") == 2
+    assert start.count("python3 -S /opt/glm53/patch_w28_correctness.py") == 2
     assert start.count(
         "-v \"$W28_CORRECTNESS_PATCH_HOST:"
         "/opt/glm53/patch_w28_correctness.py:ro\""

--- a/tests/test_xgrammar_termination.py
+++ b/tests/test_xgrammar_termination.py
@@ -385,7 +385,7 @@ def test_recipe_wiring_if_present() -> None:
     launcher = start.read_text()
     image = dockerfile.read_text()
     assert 'XGRAMMAR_PATCH_HOST="${XGRAMMAR_PATCH_HOST:-' in launcher
-    assert launcher.count("python3 /opt/glm53/patch_xgrammar_termination.py") == 2
+    assert launcher.count("python3 -S /opt/glm53/patch_xgrammar_termination.py") == 2
     assert (
         "-v '/tmp/patch_xgrammar_termination.py:"
         "/opt/glm53/patch_xgrammar_termination.py:ro'" in launcher


### PR DESCRIPTION
## Summary

- fix align-mode Mamba state retirement across null block gaps on the pinned fork
- run runtime patch installers with site initialization disabled to prevent `.pth` hook re-entry
- keep `VLLM_API_KEY` on rank 0 only, never the headless worker
- add long-form corruption and thinking-on SSE diagnostics
- document GB10 UVM livelock handling and a conservative shared-head starting profile
- include the exact production control/candidate, decode, cache-burst, and mixed-soak receipts

## Why

The exact production fork reproduced the vLLM #55450 class: a null gap stopped generic retirement, leaving an obsolete recurrent-state block referenced and the free pool one block short. The existing runtime installer sequence also allowed the persisted video `.pth` hook to import during every later helper process, and the launcher passed the API bearer variable to the worker despite the worker being headless.

## Implementation

- `overlay/patch_mamba_null_gap_retirement.py`
  - installs a Mamba-only range-removal override
  - skips null gaps while preserving committed and in-flight states
  - tracks the already-retired prefix and clears it on request free
  - validates the exact installed body, class scope, AST, cleanup, idempotence, and drift without writes
- `start.sh`
  - mounts and runs the new overlay on both ranks
  - invokes every runtime patch installer through `python3 -S`
  - removes `VLLM_API_KEY` from the worker environment while retaining it on rank 0
- `local/p0-runtime-probe.py`
  - runs three >1k-token temp-0.7 essay streams and one thinking-on SSE request
  - rejects incomplete streams, missing final answers, invalid UTF-8/NUL/mojibake, repeated loops, preemptions, and leftover requests
- tests update all launcher wiring expectations and cover overlay drift, reasoning-only truncation, successful reasoning-to-answer transitions, actual JSON-escaped NUL, API-key scope, and effective README knob names

## Local validation

- shellcheck: clean
- bash syntax: clean
- Python compileall: clean
- pytest: **107 passed, 1 skipped**
- diff check and secret scan: clean
- independent final review: approved after four required findings were fixed

## Cluster validation

Exact deployed runtime candidate: commit `39d3ee5`

- `start.sh`: `d8fe5a644ebd2a6d6e79f38b89c10f206a2596db01df6513d8a9dbcad51a5fe1`
- null-gap overlay: `181b2d5ad93b1ae3a7eb8a878bba33e3a5934c1bf21893de9863c66119ba3dd8`
- before repair: old state refcount 1, free blocks 4
- after repair on both nodes: `[null,null,committed,in-flight]`, refs `[0,1,1]`, free blocks 5, cleanup passed
- no `.env`, image, model, KV pin, or JIT-shape change
- shape stamp unchanged; pool **1,396,551 tokens / 1.40×**; model load 82.03 GiB/rank; loopback bind retained
- worker API-key environment entries: **0**
- acceptance **7/7**; serving **6/6**; tool calls **23/23**
- structured n=3 median **71.94 tok/s**, acceptance **1.0000 / 7.0**
- prose n=3 median **29.42 tok/s**, coherent and no NaN
- control and candidate long-form/thinking-SSE batteries passed with zero preemptions
- 4×60k×3 cache burst: **98.7%** counter hits on rounds 2–3

Mixed-state soak: **3,949 seconds / 8 cycles**

- 96 C1/C4, 24k/60k code/data/chat thinking-SSE cells
- 8 cached unequal-length shared-prefix forks
- 128 quick tool turns
- 32 long-form/thinking streams
- zero errors and zero preemptions
- concurrency hit ratio 0.98–1.00; unequal-fork hit ratio 0.572 every cycle
- MemFree floor 3,946,516 / 3,387,340 kB
- post-soak health 200, running/waiting/preemptions 0, zero CUDA/segfault/Xid matches

Production retained the candidate and the watchdog is re-armed.

## Rollback

On spark1:

- `start.sh.bak-pre-20260905-p0-39d3ee5`
- `.env.bak-pre-p0-39d3ee5-20260905`
- shape-stamp backup `.config-shape.bak-pre-p0-39d3ee5-20260905`

Restore the saved launcher, remove the null-gap mount/invocation, and restart through the guarded user unit.
