### PR TITLE
T1: adopt selective Flash chat template port

### DIFF
--- a/docs/06-improvement-plan.md
+++ b/docs/06-improvement-plan.md
@@ -158,6 +158,64 @@ kept the candidate and the watchdog was re-armed. Receipts:
 `local/p0-cache-burst-candidate-20260905.txt` and
 `local/p0-soak-summary-20260905.json`.
 
+### 2026-09-05: T1 selective Flash chat-template port adopted
+
+Task 24 ports only the three changes from
+`zai-org/GLM-5.3-Flash@690b705278a3a58e538fcb37c2ca8b5f9511213c`
+that apply to this vision-enabled deployment: stop validating a tool-result
+block as soon as sorting is impossible, suppress `None` message content, and
+coerce tool names with Jinja string concatenation. The local
+`thinking`/`enable_thinking` controls, unconditional W16 reasoning-effort
+prefix, clear-thinking behavior and image/video/audio placeholders are retained.
+This is a template-only candidate: no image, model, drafter, KV geometry,
+launcher argument or JIT-shape input changes.
+
+The committed golden suite covers valid shuffled results; missing, duplicate and
+unknown result IDs; duplicate call IDs; list outputs; tool references; null
+content; non-string tool names; media placeholders; reasoning toggles; and
+fallback blocks with 1/10/100/500 results. Offline control/candidate rendering
+is byte-identical in the benchmarked unchanged cases. On this Mac, seven
+alternating rounds of three renders measured the 500-result missing-ID fallback
+at 4.466 s → 0.0108 s (**99.76% faster**) and the list-output equivalent at
+2.665 s → 0.00734 s (**99.72% faster**); the ordinary valid 10-result path was
+5.2% faster, within the 5% non-regression gate. Receipt:
+`local/t1-template-offline-20260905.json`.
+
+Cluster decision contract: preserve the exact control template and production
+configuration, install the candidate atomically on both nodes, and use the
+guarded template-only restart without a JIT wipe. Adopt only if both ranks mount
+the exact candidate hash, pool/shape/bind remain unchanged, acceptance 7/7,
+serving 6/6, toolcall 23/23, vision, thinking-SSE and mixed APC correctness pass
+without CUDA/IMA/Xid/preemption regressions. Rollback is the saved control
+template restored atomically on both nodes followed by the same guarded restart.
+
+**Executed and ADOPTED.** The live control template was
+`a872eaf2948cdfec4d50e144fc65a1ce013c5e8dcf4e0c9d0234cf9e106cb767`;
+before the change it passed acceptance 7/7, serving 6/6 and the W16 thinking
+toggle at 99.9% cache hits in both directions. The reviewed candidate
+`9df580ab99a062ad48105c3337063c7dfcb9c630a33cddc681ec60fcd5a3c3d3`
+was staged, hash-checked and installed with an atomic rename. The guarded unit
+restart changed no `.env`, launcher, image, model, drafter, KV pin or shape
+input. The shape stamp stayed `91fbe73a55b2590a3009762603dff284`,
+no JIT wipe ran, both container mounts matched the candidate hash, the pool
+stayed **1,396,551 tokens / 1.40×**, `rightsize` remained active and the API
+remained on `127.0.0.1:8000`.
+
+Candidate gates passed: acceptance **7/7**, serving **6/6**, tool calls
+**23/23** with zero blank required arguments, W16 on/off toggles **99.9%** cache
+hits, and 4×60k×3 mixed APC retention **98.7%** on rounds 2–3 with zero errors.
+The long-form/SSE probe completed three 1,800-token essays without corruption
+or repeated 16-grams and returned a thinking stream with 661 reasoning
+characters plus the final marker. Final metrics showed running=0, waiting=0
+and preemptions=0; both ranks had zero selected CUDA/NCCL/Traceback/segfault
+matches and both kernels had zero Xids. MemFree was 4,758,228 / 3,575,192 kB.
+The saved control remains
+`files/chat_template.jinja.t1-control-20260905` on spark1; the watchdog is
+re-armed. Receipts: `local/t1-template-offline-20260905.json`,
+`local/t1-candidate-gates-20260905.txt`,
+`local/t1-runtime-candidate-20260905.json` and
+`local/t1-cluster-audit-20260905.txt`.
+
 ```bash
 GLM53_BASE=http://127.0.0.1:8000 uv run python tests/bench_concurrency.py \
   --levels 1,2,3,4 --modes code,data,chat --ctx 0,60000 --reps 3 \

--- a/files/chat_template.jinja
+++ b/files/chat_template.jinja
@@ -74,8 +74,8 @@ For each function call, output the function name and arguments within the follow
                 {{- emit_audio() -}}
             {%- endif -%}
         {%- endfor -%}
-    {%- else -%}
-        {{- content }}
+    {%- elif content is not none -%}
+        {{- content -}}
     {%- endif -%}
 {%- endmacro -%}
 {%- macro tool_response(text) -%}
@@ -165,7 +165,7 @@ For each function call, output the function name and arguments within the follow
 {%- if tc.function %}
     {%- set tc = tc.function %}
 {%- endif %}
-{{- '<tool_call>' + tc.name -}}
+{{- '<tool_call>' ~ tc.name -}}
 {% set _args = tc.arguments %}{% for k, v in _args.items() %}<arg_key>{{ k }}</arg_key><arg_value>{{ v | tojson(ensure_ascii=False) if v is not string else v }}</arg_value>{% endfor %}</tool_call>{% endfor %}
 {% endif %}
 {%- elif m.role == 'tool' -%}
@@ -189,9 +189,11 @@ For each function call, output the function name and arguments within the follow
         {%- set ns_chk.can_sort = false -%}
     {%- else -%}
         {%- for k in range(block_start, ns_blk.end + 1) -%}
+            {%- if not ns_chk.can_sort -%}{%- break -%}{%- endif -%}
             {%- set m = messages[k] -%}
             {%- if is_list_of_outputs(m) -%}
                 {%- for entry in m.content -%}
+                    {%- if not ns_chk.can_sort -%}{%- break -%}{%- endif -%}
                     {%- set eid = id_of(entry) -%}
                     {%- if not eid -%}
                         {%- set ns_chk.can_sort = false -%}
@@ -213,6 +215,7 @@ For each function call, output the function name and arguments within the follow
             {%- endif -%}
         {%- endfor -%}
         {%- for i in range(ns_a.tool_calls | length) -%}
+            {%- if not ns_chk.can_sort -%}{%- break -%}{%- endif -%}
             {%- set tc_id = id_of(ns_a.tool_calls[i]) -%}
             {%- if not tc_id -%}
                 {%- set ns_chk.can_sort = false -%}
@@ -220,6 +223,7 @@ For each function call, output the function name and arguments within the follow
             {%- for j in range(i + 1, ns_a.tool_calls | length) -%}
                 {%- if id_of(ns_a.tool_calls[j]) == tc_id -%}
                     {%- set ns_chk.can_sort = false -%}
+                    {%- break -%}
                 {%- endif -%}
             {%- endfor -%}
     {%- endfor -%}

--- a/local/t1-candidate-gates-20260905.txt
+++ b/local/t1-candidate-gates-20260905.txt
@@ -1,0 +1,95 @@
+T1 candidate gates 2026-09-05
+candidate_template_sha256=9df580ab99a062ad48105c3337063c7dfcb9c630a33cddc681ec60fcd5a3c3d3
+
+== serving ==
+
+== 1. tunnel reaches the API ==
+  PASS  tunnel -> GLM-5.3-Flash-EXL3
+
+== 2. non-streaming chat completion ==
+  PASS  non-streaming
+
+== 3. STREAMING (SSE) — the path most clients use ==
+    SSE chunks: 11 | [DONE]: 1 | text: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30
+  PASS  streaming works (11 chunks, terminated)
+
+== 4. concurrency — 4 simultaneous (MAX_NUM_SEQS=4) ==
+    4/4 completed with pairwise-distinct content in 3s
+  PASS  4-way concurrency, no cross-talk
+
+== 5. tool call through the tunnel ==
+    finish: tool_calls | calls: 1 | get_weather {"city": "Bergen"}
+  PASS  tool call over tunnel
+
+== 6. sustained: 5 sequential requests, all must succeed ==
+    5/5 succeeded
+  PASS  sustained sequential
+
+== RESULT ==
+  passed: 6   failed: 0
+  SERVING TEST PASSED
+
+== toolcall ==
+c=1 stream temp0 x3                          n= 3 bad_args=0 short=0 errors=0 wall=   4.4s
+c=1 non-stream temp0 x2                      n= 2 bad_args=0 short=0 errors=0 wall=   3.1s
+c=1 stream temp1 (prod sampling) x3          n= 3 bad_args=0 short=0 errors=0 wall=   4.3s
+c=4 homogeneous stream temp1 x8              n= 8 bad_args=0 short=0 errors=0 wall=   5.4s
+c=4 mixed: 2 cold ~60000 pads + 2 tool (wave 1) n= 2 bad_args=0 short=0 errors=0 wall=  98.3s
+c=4 mixed: 2 cold ~60000 pads + 2 tool (wave 2) n= 2 bad_args=0 short=0 errors=0 wall=  97.6s
+c=4 mixed: 1 cold pad + 3 tool               n= 3 bad_args=0 short=0 errors=0 wall=  54.0s
+
+TOTAL tool turns: 23, blank-required-arg turns: 0
+
+== W16 APC toggle ==
+1 thinking ON  cold          prompt= 50225 queries= 50225 hits=     0 hit%=   0.0 wall= 46.49s
+2 thinking ON  warm          prompt= 50225 queries= 50225 hits= 50176 hit%=  99.9 wall=  0.54s
+3 thinking OFF toggle        prompt= 50226 queries= 50226 hits= 50176 hit%=  99.9 wall=  0.37s
+4 thinking ON  toggle back   prompt= 50225 queries= 50225 hits= 50176 hit%=  99.9 wall=  0.37s
+5 thinking OFF effort=low    prompt= 50226 queries= 50226 hits=     0 hit%=   0.0 wall= 46.19s
+
+W16 toggle verdict: PASS (warm 99.9% / off-toggle 99.9% / on-toggle 99.9%); turn 5 (different effort) 0.0% — expected to miss on this fork
+
+== mixed APC burst ==
+sessions=4 ctx~60000 tok each (~240,000 total vs 1,396,551 pool) rounds=3 conc=4
+round 1: wall  232.9s  hit%   0.0 (usage: 0/271,653)  [counters   0.0]  prefill_tps    1166  lat p50/max 232.6/232.9s  errors 0
+round 2: wall   15.2s  hit%   0.0 (usage: 0/271,653)  [counters  98.7]  prefill_tps   17856  lat p50/max 10.0/15.2s  errors 0
+round 3: wall    5.8s  hit%   0.0 (usage: 0/271,653)  [counters  98.7]  prefill_tps   46556  lat p50/max 5.7/5.8s  errors 0
+
+== long-form and thinking SSE ==
+{"passed": true, "failures": [], "out": "local/t1-runtime-candidate-20260905.json"}
+
+== acceptance (recorded post-adoption) ==
+Pseudo-terminal will not be allocated because stdin is not a terminal.
+
+== 1. served model id ==
+  PASS  /v1/models advertises GLM-5.3-Flash-EXL3
+
+== 2. basic completion, thinking OFF, temp 0 ==
+  PASS  basic completion
+
+== 3. thinking ON (reasoning parser glm45) ==
+    reasoning field: NONE
+    reasoning chars: 0 | content chars: 542
+    finish_reason: stop
+  PASS  thinking returns reasoning + content
+
+== 4. tool call (parser glm47, auto tool choice) ==
+    finish_reason: tool_calls | tool_calls: 1
+    name: get_weather | args: {"city": "Oslo"}
+  PASS  tool call emitted and parsed
+
+== 5. production sampling: temp 1.0, thinking ON ==
+    finish_reason: stop | content chars: 354
+  PASS  temp 1.0 + thinking (the real production path)
+
+== 6. vision (LANGUAGE_MODEL_ONLY=0, limit-mm image:4) ==
+    content: Colorful
+  PASS  vision tower accepts an image
+
+== 7. long-context needle (~32k tokens) ==
+    prompt_tokens: 36040 | answer: CORMORANT-8815
+  PASS  needle retrieved at ~32k
+
+== RESULT ==
+  passed: 7   failed: 0
+  ACCEPTANCE PASSED

--- a/local/t1-cluster-audit-20260905.txt
+++ b/local/t1-cluster-audit-20260905.txt
@@ -1,0 +1,17 @@
+candidate_template_sha256=9df580ab99a062ad48105c3337063c7dfcb9c630a33cddc681ec60fcd5a3c3d3
+control_template_sha256=a872eaf2948cdfec4d50e144fc65a1ce013c5e8dcf4e0c9d0234cf9e106cb767
+env_sha256=6e7a206ec05be1cf624df167128470a313d12566b744e1f542808373aaf0983a
+start_sha256=d8fe5a644ebd2a6d6e79f38b89c10f206a2596db01df6513d8a9dbcad51a5fe1
+shape_stamp=91fbe73a55b2590a3009762603dff284
+unit=active watchdog=active
+head_mount=9df580ab99a062ad48105c3337063c7dfcb9c630a33cddc681ec60fcd5a3c3d3
+worker_mount=9df580ab99a062ad48105c3337063c7dfcb9c630a33cddc681ec60fcd5a3c3d3
+head_MemFree: 4758228 kB
+worker_MemFree: 3575192 kB
+vllm:num_requests_running{engine="0",model_name="GLM-5.3-Flash-EXL3"} 0.0
+vllm:num_requests_waiting{engine="0",model_name="GLM-5.3-Flash-EXL3"} 0.0
+vllm:num_preemptions_total{engine="0",model_name="GLM-5.3-Flash-EXL3"} 0.0
+head_error_matches=0
+worker_error_matches=0
+head_xid_matches=0
+worker_xid_matches=0

--- a/local/t1-runtime-candidate-20260905.json
+++ b/local/t1-runtime-candidate-20260905.json
@@ -1,0 +1,133 @@
+{
+  "schema_version": 1,
+  "run_id": "4845fd4598",
+  "started": 1788614632.7161589,
+  "base": "http://127.0.0.1:18000",
+  "model": "GLM-5.3-Flash-EXL3",
+  "before": {
+    "num_requests_running": 0.0,
+    "num_requests_waiting": 0.0,
+    "num_preemptions_total": 0.0,
+    "prefix_cache_queries_total": 1417974.0,
+    "prefix_cache_hits_total": 686784.0
+  },
+  "runs": [
+    {
+      "request_id": "glm53-p0-4845fd4598-essay-1",
+      "http": 200,
+      "sse_chunks": 608,
+      "done": true,
+      "ttfb_s": 0.449,
+      "wall_s": 73.666,
+      "finish_reason": "length",
+      "usage": {
+        "prompt_tokens": 58,
+        "total_tokens": 1858,
+        "completion_tokens": 1800
+      },
+      "content_sha256": "381fee070ee9684938a89120af257caa52fb80a18b20fda82991816cb38a6211",
+      "content_head": "# How Ocean Tides Work: A Complete Explanation\n\n## Introduction\n\nTides are among the most familiar yet most misunderstood phenomena in nature. Billions of people live near coastlines and witness the daily rise and fall of the sea, yet the u",
+      "content_tail": "ats the tide-generating force as a very long wave forced at the sea surface. A free tidal wave in the open ocean travels at the long-wave speed c = \u221a(gh), where g is gravity and h is depth. For a 4 km deep ocean, c \u2248 200 m/s (about 700 km/h",
+      "diagnostics": {
+        "replacement_or_mojibake": [],
+        "max_16gram_repeats": 1,
+        "content_chars": 6790,
+        "reasoning_chars": 0
+      },
+      "name": "essay-1",
+      "thinking": false
+    },
+    {
+      "request_id": "glm53-p0-4845fd4598-essay-2",
+      "http": 200,
+      "sse_chunks": 752,
+      "done": true,
+      "ttfb_s": 0.402,
+      "wall_s": 90.937,
+      "finish_reason": "length",
+      "usage": {
+        "prompt_tokens": 54,
+        "total_tokens": 1854,
+        "completion_tokens": 1800
+      },
+      "content_sha256": "027f01c5d854513c6eeffba221a6d77c763a16be3f373a6d25f0ce9ef3c64493",
+      "content_head": "# Virtual Memory in Modern Operating Systems\n\n## Introduction\n\nVirtual memory is one of the most consequential abstractions in computer science. It gives every process the illusion of a private, contiguous address space, decouples logical a",
+      "content_tail": "ome SIGSEGV.\n5. **Allocate a frame** if needed; may trigger reclaim under pressure.\n6. **Install the PTE** and flush/invalidate as needed, return, re-execute the faulting instruction.\n\nFaults are the *mechanism* by which demand paging works",
+      "diagnostics": {
+        "replacement_or_mojibake": [],
+        "max_16gram_repeats": 1,
+        "content_chars": 7580,
+        "reasoning_chars": 0
+      },
+      "name": "essay-2",
+      "thinking": false
+    },
+    {
+      "request_id": "glm53-p0-4845fd4598-essay-3",
+      "http": 200,
+      "sse_chunks": 755,
+      "done": true,
+      "ttfb_s": 0.394,
+      "wall_s": 90.511,
+      "finish_reason": "length",
+      "usage": {
+        "prompt_tokens": 51,
+        "total_tokens": 1851,
+        "completion_tokens": 1800
+      },
+      "content_sha256": "8b200afd6810d2db345243983c2e52b83e7c2fdf45f2f9f91af5e1e7b65a8cd7",
+      "content_head": "# The Scientific Method in Practice\n\n## Introduction\n\nThe scientific method is often taught as a tidy, linear sequence: observe, hypothesize, experiment, conclude. In practice, it is messier, more iterative, and far more interesting. Workin",
+      "content_tail": "ph. The choice of what to revise\u2014theory or auxiliary\u2014is a judgment, not a mechanical rule.\n\nSecond, **theories are protected by their success**. Newtonian mechanics survived anomalies (Mercury's perihelion, for instance) for decades because",
+      "diagnostics": {
+        "replacement_or_mojibake": [],
+        "max_16gram_repeats": 1,
+        "content_chars": 9545,
+        "reasoning_chars": 0
+      },
+      "name": "essay-3",
+      "thinking": false
+    },
+    {
+      "request_id": "glm53-p0-4845fd4598-thinking-sse",
+      "http": 200,
+      "sse_chunks": 39,
+      "done": true,
+      "ttfb_s": 0.301,
+      "wall_s": 4.537,
+      "finish_reason": "stop",
+      "usage": {
+        "prompt_tokens": 24,
+        "total_tokens": 165,
+        "completion_tokens": 141
+      },
+      "content_sha256": "550115119cb73967fbde945339c84051cc742e78b0ddcff2cb12a005a9049ecf",
+      "content_head": "THINKING_STREAM_OK",
+      "content_tail": "THINKING_STREAM_OK",
+      "diagnostics": {
+        "replacement_or_mojibake": [],
+        "max_16gram_repeats": 0,
+        "content_chars": 18,
+        "reasoning_chars": 661
+      },
+      "name": "thinking-sse",
+      "thinking": true
+    }
+  ],
+  "after": {
+    "num_requests_running": 0.0,
+    "num_requests_waiting": 0.0,
+    "num_preemptions_total": 0.0,
+    "prefix_cache_queries_total": 1418161.0,
+    "prefix_cache_hits_total": 686784.0
+  },
+  "metric_delta": {
+    "num_requests_running": 0.0,
+    "num_requests_waiting": 0.0,
+    "num_preemptions_total": 0.0,
+    "prefix_cache_queries_total": 187.0,
+    "prefix_cache_hits_total": 0.0
+  },
+  "failures": [],
+  "passed": true,
+  "finished": 1788614892.400297
+}

--- a/local/t1-template-offline-20260905.json
+++ b/local/t1-template-offline-20260905.json
@@ -1,0 +1,31 @@
+{
+  "candidate": "files/chat_template.jinja",
+  "control": "glm53-chat-template-control-5e96cd6.jinja",
+  "gates": {
+    "fallback_improvement_at_least_15_percent": true,
+    "ordinary_regression_at_most_5_percent": true
+  },
+  "iterations": 3,
+  "passed": true,
+  "results": {
+    "fallback_list_missing_id_500": {
+      "candidate_over_control": 0.0027532354648724558,
+      "candidate_seconds": 0.007336083999689436,
+      "control_seconds": 2.6645320000006905,
+      "improvement": 0.9972467645351275
+    },
+    "fallback_missing_id_500": {
+      "candidate_over_control": 0.0024119383426351236,
+      "candidate_seconds": 0.0107710419997602,
+      "control_seconds": 4.465720292000697,
+      "improvement": 0.9975880616573649
+    },
+    "ordinary_valid_10": {
+      "candidate_over_control": 0.9481800446449429,
+      "candidate_seconds": 0.003616041998611763,
+      "control_seconds": 0.003813666000496596,
+      "improvement": 0.051819955355057123
+    }
+  },
+  "rounds": 7
+}

--- a/tests/bench_chat_template.py
+++ b/tests/bench_chat_template.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Compare two GLM chat templates on ordinary and fallback render paths."""
+
+import argparse
+import json
+import statistics
+import time
+from pathlib import Path
+
+from jinja2 import Environment
+
+
+ROOT = Path(__file__).parents[1]
+
+
+def display_path(path: Path) -> str:
+    try:
+        return str(path.resolve().relative_to(ROOT.resolve()))
+    except ValueError:
+        return path.name
+
+
+def compile_template(path: Path):
+    return Environment(extensions=["jinja2.ext.loopcontrols"]).from_string(
+        path.read_text()
+    )
+
+
+def tool_call(index: int) -> dict[str, object]:
+    call_id = f"call-{index}"
+    return {
+        "id": call_id,
+        "type": "function",
+        "function": {"name": "lookup", "arguments": {"query": call_id}},
+    }
+
+
+def valid_messages(count: int) -> list[dict[str, object]]:
+    return [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [tool_call(index) for index in range(count)],
+        },
+        *[
+            {
+                "role": "tool",
+                "tool_call_id": f"call-{index}",
+                "content": f"result-{index}",
+            }
+            for index in reversed(range(count))
+        ],
+    ]
+
+
+def fallback_messages(count: int) -> list[dict[str, object]]:
+    return [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [tool_call(index) for index in range(count)],
+        },
+        {"role": "tool", "content": "missing-id"},
+        *[
+            {
+                "role": "tool",
+                "tool_call_id": f"call-{index}",
+                "content": f"result-{index}",
+            }
+            for index in range(1, count)
+        ],
+    ]
+
+
+def fallback_list_messages(count: int) -> list[dict[str, object]]:
+    return [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [tool_call(index) for index in range(count)],
+        },
+        {
+            "role": "tool",
+            "content": [
+                {"output": "missing-id"},
+                *[
+                    {
+                        "tool_call_id": f"call-{index}",
+                        "output": f"result-{index}",
+                    }
+                    for index in range(1, count)
+                ],
+            ],
+        },
+    ]
+
+
+def render(template, messages: list[dict[str, object]]) -> str:
+    return template.render(
+        messages=messages,
+        tools=None,
+        add_generation_prompt=False,
+    )
+
+
+def sample(template, messages: list[dict[str, object]], iterations: int) -> float:
+    started = time.perf_counter()
+    for _ in range(iterations):
+        render(template, messages)
+    return time.perf_counter() - started
+
+
+def benchmark(
+    control,
+    candidate,
+    messages: list[dict[str, object]],
+    *,
+    rounds: int,
+    iterations: int,
+) -> dict[str, float]:
+    control_output = render(control, messages)
+    candidate_output = render(candidate, messages)
+    if control_output != candidate_output:
+        raise RuntimeError("control and candidate outputs differ in benchmark case")
+
+    render(control, messages)
+    render(candidate, messages)
+    control_samples: list[float] = []
+    candidate_samples: list[float] = []
+    for round_index in range(rounds):
+        if round_index % 2:
+            candidate_samples.append(sample(candidate, messages, iterations))
+            control_samples.append(sample(control, messages, iterations))
+        else:
+            control_samples.append(sample(control, messages, iterations))
+            candidate_samples.append(sample(candidate, messages, iterations))
+
+    control_median = statistics.median(control_samples)
+    candidate_median = statistics.median(candidate_samples)
+    ratio = candidate_median / control_median
+    return {
+        "control_seconds": control_median,
+        "candidate_seconds": candidate_median,
+        "candidate_over_control": ratio,
+        "improvement": 1.0 - ratio,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--control", type=Path, required=True)
+    parser.add_argument(
+        "--candidate",
+        type=Path,
+        default=ROOT / "files" / "chat_template.jinja",
+    )
+    parser.add_argument("--rounds", type=int, default=7)
+    parser.add_argument("--iterations", type=int, default=3)
+    parser.add_argument("--json-out", type=Path)
+    args = parser.parse_args()
+
+    control = compile_template(args.control)
+    candidate = compile_template(args.candidate)
+    cases = {
+        "ordinary_valid_10": valid_messages(10),
+        "fallback_missing_id_500": fallback_messages(500),
+        "fallback_list_missing_id_500": fallback_list_messages(500),
+    }
+    results = {
+        name: benchmark(
+            control,
+            candidate,
+            messages,
+            rounds=args.rounds,
+            iterations=args.iterations,
+        )
+        for name, messages in cases.items()
+    }
+    ordinary_ok = results["ordinary_valid_10"]["candidate_over_control"] <= 1.05
+    fallback_ok = all(
+        result["improvement"] >= 0.15
+        for name, result in results.items()
+        if name.startswith("fallback_")
+    )
+    report = {
+        "control": display_path(args.control),
+        "candidate": display_path(args.candidate),
+        "rounds": args.rounds,
+        "iterations": args.iterations,
+        "results": results,
+        "gates": {
+            "ordinary_regression_at_most_5_percent": ordinary_ok,
+            "fallback_improvement_at_least_15_percent": fallback_ok,
+        },
+        "passed": ordinary_ok and fallback_ok,
+    }
+    print(json.dumps(report, indent=2, sort_keys=True))
+    if args.json_out:
+        args.json_out.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")
+    return 0 if report["passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_chat_template.py
+++ b/tests/test_chat_template.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
-"""Regression checks for GLM-5.3 chat-template reasoning controls."""
+"""Golden regression checks for the production GLM-5.3 chat template."""
 
+import json
 import unittest
 from pathlib import Path
 
@@ -10,16 +11,75 @@ from jinja2 import Environment
 TEMPLATE = Path(__file__).parents[1] / "files" / "chat_template.jinja"
 
 
-def render_generation_prompt(**kwargs: object) -> str:
-    template = Environment(extensions=["jinja2.ext.loopcontrols"]).from_string(
-        TEMPLATE.read_text()
+def compile_template(source: str | None = None):
+    environment = Environment(extensions=["jinja2.ext.loopcontrols"])
+    environment.filters["tojson"] = lambda value, ensure_ascii=False: json.dumps(
+        value, ensure_ascii=ensure_ascii
     )
+    return environment.from_string(source if source is not None else TEMPLATE.read_text())
+
+
+def render(
+    messages: list[dict[str, object]],
+    *,
+    tools: list[dict[str, object]] | None = None,
+    add_generation_prompt: bool = False,
+    template=None,
+    **kwargs: object,
+) -> str:
+    template = template or compile_template()
     return template.render(
-        messages=[{"role": "user", "content": "hello"}],
-        tools=None,
+        messages=messages,
+        tools=tools,
+        add_generation_prompt=add_generation_prompt,
+        **kwargs,
+    )
+
+
+def render_generation_prompt(**kwargs: object) -> str:
+    return render(
+        [{"role": "user", "content": "hello"}],
         add_generation_prompt=True,
         **kwargs,
     )
+
+
+def tool_call(call_id: str, name: object = "lookup") -> dict[str, object]:
+    return {
+        "id": call_id,
+        "type": "function",
+        "function": {"name": name, "arguments": {"query": call_id}},
+    }
+
+
+def tool_result(call_id: str | None, content: object) -> dict[str, object]:
+    result: dict[str, object] = {"role": "tool", "content": content}
+    if call_id is not None:
+        result["tool_call_id"] = call_id
+    return result
+
+
+def list_output(call_id: str | None, output: object) -> dict[str, object]:
+    result: dict[str, object] = {"output": output}
+    if call_id is not None:
+        result["tool_call_id"] = call_id
+    return result
+
+
+TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "lookup",
+            "description": "Look up a value.",
+            "parameters": {
+                "type": "object",
+                "properties": {"query": {"type": "string"}},
+                "required": ["query"],
+            },
+        },
+    }
+]
 
 
 class ChatTemplateTests(unittest.TestCase):
@@ -55,6 +115,206 @@ class ChatTemplateTests(unittest.TestCase):
         )
         self.assertIn("<|system|>Reasoning Effort: Low", rendered)
         self.assertTrue(rendered.endswith("<|assistant|><think>"), rendered)
+
+    def test_valid_shuffled_tool_results_are_sorted_by_call_order(self) -> None:
+        messages = [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [tool_call("call-0"), tool_call("call-1")],
+            },
+            tool_result("call-1", "second"),
+            tool_result("call-0", "first"),
+        ]
+        rendered = render(messages)
+        self.assertIn(
+            "<|observation|><tool_response>first</tool_response>"
+            "<tool_response>second</tool_response>",
+            rendered,
+        )
+
+    def test_missing_id_falls_back_to_input_order(self) -> None:
+        messages = [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [tool_call("call-0"), tool_call("call-1")],
+            },
+            tool_result(None, "missing"),
+            tool_result("call-0", "known"),
+        ]
+        rendered = render(messages)
+        self.assertIn(
+            "<|observation|><tool_response>missing</tool_response>"
+            "<tool_response>known</tool_response>",
+            rendered,
+        )
+
+    def test_duplicate_result_id_falls_back_to_input_order(self) -> None:
+        messages = [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [tool_call("call-0"), tool_call("call-1")],
+            },
+            tool_result("call-0", "first"),
+            tool_result("call-0", "duplicate"),
+        ]
+        rendered = render(messages)
+        self.assertIn(
+            "<|observation|><tool_response>first</tool_response>"
+            "<tool_response>duplicate</tool_response>",
+            rendered,
+        )
+
+    def test_unknown_result_id_falls_back_to_input_order(self) -> None:
+        messages = [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [tool_call("call-0")],
+            },
+            tool_result("unknown", "unknown-result"),
+            tool_result("call-0", "known-result"),
+        ]
+        rendered = render(messages)
+        self.assertIn(
+            "<|observation|><tool_response>unknown-result</tool_response>"
+            "<tool_response>known-result</tool_response>",
+            rendered,
+        )
+
+    def test_duplicate_tool_call_id_falls_back_to_input_order(self) -> None:
+        messages = [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [tool_call("call-0"), tool_call("call-0")],
+            },
+            tool_result("call-0", "result"),
+        ]
+        rendered = render(messages)
+        self.assertIn(
+            "<|observation|><tool_response>result</tool_response>",
+            rendered,
+        )
+
+    def test_list_outputs_are_sorted_by_call_order(self) -> None:
+        messages = [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [tool_call("call-0"), tool_call("call-1")],
+            },
+            {
+                "role": "tool",
+                "content": [
+                    list_output("call-1", "second"),
+                    list_output("call-0", "first"),
+                ],
+            },
+        ]
+        rendered = render(messages)
+        self.assertIn(
+            "<|observation|><tool_response>first</tool_response>"
+            "<tool_response>second</tool_response>",
+            rendered,
+        )
+
+    def test_tool_reference_outputs_preserve_tool_definition(self) -> None:
+        messages = [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [tool_call("call-0")],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call-0",
+                "content": [{"type": "tool_reference", "name": "lookup"}],
+            },
+        ]
+        rendered = render(messages, tools=TOOLS)
+        self.assertIn("<tool_response><tools>\n", rendered)
+        self.assertIn('"name": "lookup"', rendered)
+        self.assertIn("</tools></tool_response>", rendered)
+
+    def test_null_content_is_suppressed(self) -> None:
+        rendered = render(
+            [
+                {"role": "system", "content": None},
+                {"role": "user", "content": None},
+                {"role": "assistant", "content": None},
+            ]
+        )
+        self.assertNotIn("None", rendered)
+        self.assertEqual(
+            rendered,
+            "[gMASK]<sop><|system|>Reasoning Effort: Max"
+            "<|system|><|user|><|assistant|><think></think>",
+        )
+
+    def test_non_string_tool_name_is_coerced(self) -> None:
+        rendered = render(
+            [
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [tool_call("call-0", name=7)],
+                }
+            ]
+        )
+        self.assertIn("<tool_call>7<arg_key>query</arg_key>", rendered)
+
+    def test_multimedia_placeholders_are_preserved(self) -> None:
+        rendered = render(
+            [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "inspect:"},
+                        {"type": "image_url", "image_url": {"url": "image"}},
+                        {"type": "video_url", "video_url": {"url": "video"}},
+                        {"type": "input_audio", "input_audio": {"data": "audio"}},
+                    ],
+                }
+            ]
+        )
+        self.assertIn(
+            "inspect:<|begin_of_image|><|image|><|end_of_image|>"
+            "<|begin_of_video|><|video|><|end_of_video|>"
+            "<|begin_of_audio|><|end_of_audio|>",
+            rendered,
+        )
+
+    def test_fallback_handles_1_10_100_and_500_tool_results(self) -> None:
+        template = compile_template()
+        for count in (1, 10, 100, 500):
+            with self.subTest(count=count):
+                messages = [
+                    {
+                        "role": "assistant",
+                        "content": "",
+                        "tool_calls": [
+                            tool_call(f"call-{index}") for index in range(count)
+                        ],
+                    },
+                    tool_result(None, "missing-id"),
+                    *[
+                        tool_result(f"call-{index}", f"result-{index}")
+                        for index in range(1, count)
+                    ],
+                ]
+                rendered = render(messages, template=template)
+                self.assertIn(
+                    "<|observation|><tool_response>missing-id</tool_response>",
+                    rendered,
+                )
+                if count > 1:
+                    self.assertIn(
+                        f"<tool_response>result-{count - 1}</tool_response>",
+                        rendered,
+                    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Port the GLM-5.3-Flash sorting early exits, null-content suppression, and tool-name coercion from upstream revision `690b705278a3a58e538fcb37c2ca8b5f9511213c`.
- Preserve the local `thinking`/`enable_thinking` controls, unconditional reasoning-effort prefix, clear-thinking behavior, and image/video/audio placeholders.
- Add golden coverage for sorting and fallback edge cases plus a reusable control/candidate render benchmark.
- Record the guarded two-node cluster adoption and remove completed task 24 from the local operator TODO.

## Validation

- Local suite: 118 passed, 1 skipped, 4 subtests.
- Shellcheck, bash syntax, Python compileall, and `git diff --check` clean.
- Independent final review: approved before the cluster window and approved again against final receipts.
- Offline A/B: 500-result missing-ID fallback improved 99.76%; list-output fallback improved 99.72%; ordinary valid rendering had no regression.
- Cluster: control template `a872eaf...` passed acceptance 7/7, serving 6/6, and W16 APC toggle 99.9%.
- Exact candidate template `9df580ab...` is mounted on both ranks. Image, `.env`, launcher, model/drafter, KV pin, loopback bind, and shape stamp were unchanged; no JIT wipe ran.
- Candidate gates: acceptance 7/7, serving 6/6, tool calls 23/23, W16 APC toggle 99.9%, 4x60kx3 retention 98.7%, long-form/thinking-SSE clean, zero preemptions, zero selected runtime errors, and zero Xids.

## Decision and rollback

ADOPT. Production retains the candidate and the watchdog is active. The exact control template remains on spark1 as `files/chat_template.jinja.t1-control-20260905`; rollback is an atomic restore followed by the guarded production-unit restart.
