### PR TITLE
C1/C2: measure mixed-prefill policy and request capacity

### DIFF
--- a/docs/06-improvement-plan.md
+++ b/docs/06-improvement-plan.md
@@ -216,6 +216,102 @@ re-armed. Receipts: `local/t1-template-offline-20260905.json`,
 `local/t1-runtime-candidate-20260905.json` and
 `local/t1-cluster-audit-20260905.txt`.
 
+### 2026-09-05: C1/C2 policy and capacity window — both chunk arms rejected, C4 retained
+
+Tasks 2 and 3 were run together because the mixed-prefill decision and the
+admission decision share the same current W26/W28 geometry. Two committed
+harnesses close the measurement gaps:
+
+- `tests/bench_mixed_prefill.py` starts a fixed incumbent decode, launches a
+  cold newcomer two seconds later, samples the queue, and records newcomer TTFT,
+  token-ID-counted incumbent decode plus client token-arrival gaps during the
+  overlap, aggregate generation-counter throughput, preemptions and request
+  IDs. Streamed token IDs preserve multi-token speculative batches (observed
+  maximum: 8 tokens/event); the gap calculation keeps leading/trailing boundary
+  stalls and represents same-event tokens with zero client-arrival gap.
+- `tests/bench_kv_request_cost.py` samples live
+  `vllm:kv_cache_usage_perc` during one request at a time and converts the peak
+  through the boot-reported 1,396,551-token pool. It records the raw gauge
+  samples, prompt size, excess occupancy and a descriptive linear fit.
+
+The first cluster smoke caught and fixed a prompt-generator calibration error
+before the window: nominal 9.5k/2k prompts had rendered as 13.5k/2.7k. The
+final exact harness bytes produced 9,725 and 1,931 tokens in their smoke cells;
+SHA256 was
+`f7c14e7af3f2f4dd19184844355b7320e3c339802ecd7184c109e201a709239c`
+for C1 and
+`ac9e6f2c098d5ba6a69c2afedbfcafff6489a2bc42ef615a64086c8ce1766b60`
+for C2 on both the Mac and spark1.
+
+#### C1: `skip` stays
+
+Control `skip`, candidate `512`, then candidate `2048` ran as isolated guarded
+restarts. LPTT=1792, MNBT=3584, wait=1500 ms, warm tail=3584, late cap=512,
+aging=10000 ms/max=1792, image/model/pool and every other knob stayed fixed.
+Both ranks' container environments were verified after each restart and the
+shape stamp stayed `91fbe73a55b2590a3009762603dff284`; no JIT wipe occurred.
+The `2048` policy is therefore still bounded by LPTT=1792, as intended.
+
+The pre-registered 100-request tail expansion was not run after either
+candidate failed mandatory non-tail gates in the five-sample screen:
+
+| nominal newcomer | arm | newcomer p95 | vs control | incumbent token-rate ratio median | vs control | token-arrival gap p99 | aggregate median | preemptions |
+|---|---|---:|---:|---:|---:|---:|---:|---:|
+| 9.5k (9,725–9,727 actual) | `skip` | 13.664 s | — | 0.220 | — | 1.576 s | 8.847 tok/s | 0 |
+| | `512` | 12.412 s | −9.2% | 0.201 | **−8.6%** | 1.653 s (+4.9%) | **−19.4%** | 0 |
+| | `2048` | 10.051 s | **−26.4%** | 0.107 | **−51.4%** | **1.842 s (+16.9%)** | **−24.4%** | 0 |
+| 38k (36,077–39,976 actual) | `skip` | 43.477 s | — | 0.101 | — | 1.758 s | 4.211 tok/s | 0 |
+| | `512` | 55.397 s | **+27.4% worse** | 0.156 | +54.5% | 1.213 s | +22.0% | 0 |
+| | `2048` | 39.551 s | −9.0% | 0.077 | **−23.8%** | 1.752 s (−0.3%) | **−20.4%** | 0 |
+
+`512` misses the required 20% newcomer gain at 9.5k, makes 38k newcomer p95
+worse, and breaches the incumbent/aggregate floors at 9.5k. `2048` reaches the
+9.5k newcomer target but breaches incumbent, token-arrival-gap and aggregate
+floors by large margins; at 38k it misses the newcomer target and also breaches
+incumbent and aggregate gates. **Both candidates are rejected; W26 v3 `skip`
+remains production.** The C4/short-behind-240k expansion cannot rescue a
+candidate that already fails these mandatory primary cells, so it was stopped
+rather than manufacturing small-tail precision for a settled decision.
+
+#### C2: retain `MAX_NUM_SEQS=4`
+
+The single-request occupancy probe ran three times each at nominal
+2k/9k/30k/70k. Median measured prompt/peak-pool/excess values were:
+
+| nominal | actual prompt | estimated peak pool tokens | excess over prompt |
+|---|---:|---:|---:|
+| 2k | 1,931 | 167,784 | 165,853 |
+| 9k | 9,206 | 249,208 | 240,002 |
+| 30k | 30,296 | 261,545 | 231,250 |
+| 70k | 71,315 | 291,154 | 219,839 |
+
+The descriptive fit was intercept 204,209, slope 1.35 and R² 0.65; page
+quantization makes the line too weak to treat as a precise allocator model.
+The direct observations are nevertheless enough for the decision: this stack
+does **not** reproduce the imported 85k–90k fixed-cost premise that would have
+triggered a 4→3 arm.
+
+The required current-control capacity check then completed 4×60k×3 with zero
+errors and zero preemptions. After the cold 43.8 tok/s pass, warm/rerun
+aggregate throughput was 63.4–66.3 tok/s, cache-hit ratio 1.000 and TTFT p95
+0.915–0.956 s. A cache-reset 4×60k×3 retention run was 0% cold then **98.7%**
+counter hits on rounds 2 and 3, with zero errors. No `MAX_NUM_SEQS=3` restart
+was justified; **`MAX_NUM_SEQS=4` remains production.**
+
+The byte-exact control `.env`
+`6e7a206ec05be1cf624df167128470a313d12566b744e1f542808373aaf0983a`
+was restored through the guarded unit. Final gates passed: acceptance 7/7,
+serving 6/6, tool calls 23/23 with zero blank arguments, and the long-form /
+thinking-SSE runtime probe with zero failures. Final metrics were
+running=0, waiting=0, preemptions=0; selected head/worker runtime errors and
+kernel Xids were zero; MemFree was 4,522,944 / 3,596,744 kB. The watchdog was
+re-armed. Receipts:
+`local/c1-{skip-token-control,chunk512-token-screen,chunk2048-token-screen}-20260905.json`,
+`local/c2-fixed-kv-final-20260905.json`,
+`local/c2-c4-60k-control-20260905.json`,
+`local/c2-cache-burst-control-cold-20260905.txt` and
+`local/c1c2-token-restored-runtime-20260905.json`.
+
 ```bash
 GLM53_BASE=http://127.0.0.1:8000 uv run python tests/bench_concurrency.py \
   --levels 1,2,3,4 --modes code,data,chat --ctx 0,60000 --reps 3 \
@@ -223,9 +319,9 @@ GLM53_BASE=http://127.0.0.1:8000 uv run python tests/bench_concurrency.py \
 ```
 
 For a future C4 tail decision, `--levels 4 --reps 25` yields 100 measured
-requests per mode/context cell before any spread-triggered rerun. C1 still
-needs its dedicated incumbent/newcomer arrival harness; this ladder is the
-concurrency baseline and audit substrate, not a substitute for that workload.
+requests per mode/context cell before any spread-triggered rerun. C1 now has
+its dedicated incumbent/newcomer harness; this ladder remains the general
+concurrency baseline and audit substrate.
 
 **W44 CLOSED 2026-09-03:** the 2.71 lifetime spec-accept vs bench 6.88 is
 **traffic mix, not a broken drafter.** Same-boot no-store four-arm: structured

--- a/tests/bench_kv_request_cost.py
+++ b/tests/bench_kv_request_cost.py
@@ -1,0 +1,381 @@
+#!/usr/bin/env python3
+"""Estimate fixed and marginal KV occupancy for one live request.
+
+The gauge is sampled while one cold request prefills and decodes. The peak
+``vllm:kv_cache_usage_perc`` value is converted with the boot-reported pool
+token count, then a least-squares line estimates fixed request cost (intercept)
+and marginal allocated pool tokens per prompt token (slope).
+
+Canonical C2 probe:
+
+  GLM53_BASE=http://127.0.0.1:8000 uv run python tests/bench_kv_request_cost.py \
+    --contexts 2000,9000,30000,70000 --reps 3 --pool-tokens 1396551 \
+    --out local/c2-fixed-kv-control-20260905.json
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import statistics
+import sys
+import threading
+import time
+import urllib.request
+import uuid
+from pathlib import Path
+from typing import Any
+
+BASE = os.environ.get("GLM53_BASE", "http://127.0.0.1:8000").rstrip("/")
+MODEL = os.environ.get("GLM53_MODEL", "GLM-5.3-Flash-EXL3")
+API_KEY = os.environ.get("VLLM_API_KEY", "")
+FILLER = "Ledger row %d reconciled to the cent under audit rule seven. "
+METRICS = (
+    "kv_cache_usage_perc",
+    "num_preemptions_total",
+    "num_requests_running",
+    "num_requests_waiting",
+)
+
+
+def headers(request_id: str = "") -> dict[str, str]:
+    result = {"Content-Type": "application/json"}
+    if API_KEY:
+        result["Authorization"] = f"Bearer {API_KEY}"
+    if request_id:
+        result["X-Request-Id"] = request_id
+    return result
+
+
+def open_url(path: str, body: dict | None, timeout: float, request_id: str = ""):
+    request = urllib.request.Request(
+        BASE + path,
+        data=json.dumps(body).encode() if body is not None else None,
+        headers=headers(request_id),
+        method="POST" if body is not None else "GET",
+    )
+    return urllib.request.urlopen(request, timeout=timeout)
+
+
+def parse_metrics(text: str) -> dict[str, float]:
+    result: dict[str, float] = {}
+    for name in METRICS:
+        values = re.findall(
+            rf"^vllm:{re.escape(name)}(?:\{{[^}}]*\}})?\s+(\S+)$",
+            text,
+            re.MULTILINE,
+        )
+        if values:
+            result[name] = sum(float(value) for value in values)
+    return result
+
+
+def metrics() -> dict[str, float]:
+    with open_url("/metrics", None, 20) as response:
+        return parse_metrics(response.read().decode("utf-8", "replace"))
+
+
+def unique_text(approx_tokens: int, seed: int) -> str:
+    # Calibrated on the production tokenizer: the unique row ids make this
+    # approximately 19.5 tokens per sentence.
+    rows = max(1, int(approx_tokens / 19.5))
+    return f"[kv-salt {seed:x}] " + "".join(
+        FILLER % (seed * 1_000_000 + row) for row in range(rows)
+    )
+
+
+def stream_request(
+    context: int,
+    seed: int,
+    max_tokens: int,
+    timeout: float,
+    request_id: str,
+    out: dict[str, Any],
+) -> None:
+    body = {
+        "model": MODEL,
+        "messages": [
+            {
+                "role": "user",
+                "content": unique_text(context, seed)
+                + "\nWrite a detailed numbered analysis and continue until the limit.",
+            }
+        ],
+        "max_tokens": max_tokens,
+        "temperature": 0.0,
+        "stream": True,
+        "stream_options": {"include_usage": True},
+        "chat_template_kwargs": {"enable_thinking": False},
+        "vllm_xargs": {"skip_writing_prefix_cache": 1},
+    }
+    started = time.perf_counter()
+    first = None
+    usage: dict[str, Any] = {}
+    status = None
+    done = False
+    finish_reason = None
+    try:
+        with open_url(
+            "/v1/chat/completions", body, timeout, request_id=request_id
+        ) as response:
+            status = response.status
+            for raw in response:
+                line = raw.decode("utf-8", "strict").strip()
+                if not line.startswith("data:"):
+                    continue
+                payload = line[5:].strip()
+                if payload == "[DONE]":
+                    done = True
+                    continue
+                event = json.loads(payload)
+                if event.get("usage"):
+                    usage = event["usage"]
+                choices = event.get("choices") or []
+                if choices:
+                    choice = choices[0]
+                    delta = choice.get("delta") or {}
+                    finish_reason = choice.get("finish_reason") or finish_reason
+                    if first is None and (
+                        delta.get("content")
+                        or delta.get("reasoning")
+                        or delta.get("reasoning_content")
+                    ):
+                        first = time.perf_counter()
+    except Exception as exc:
+        out["error"] = f"{type(exc).__name__}: {exc}"[:300]
+    ended = time.perf_counter()
+    out.update(
+        {
+            "request_id": request_id,
+            "http": status,
+            "ttft_s": first - started if first else None,
+            "wall_s": ended - started,
+            "usage": usage,
+            "finish_reason": finish_reason,
+            "done": done,
+        }
+    )
+
+
+def request_failure(result: dict[str, Any]) -> str | None:
+    if result.get("error"):
+        return str(result["error"])
+    if result.get("http") != 200:
+        return f"HTTP {result.get('http')!r}"
+    if not result.get("done"):
+        return "missing SSE [DONE]"
+    if result.get("finish_reason") not in {"stop", "length"}:
+        return f"finish_reason={result.get('finish_reason')!r}"
+    usage = result.get("usage") or {}
+    if not usage.get("prompt_tokens") or not usage.get("completion_tokens"):
+        return "missing final usage"
+    return None
+
+
+def wait_idle(timeout: float) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        snapshot = metrics()
+        if (
+            snapshot.get("num_requests_running", 0) == 0
+            and snapshot.get("num_requests_waiting", 0) == 0
+            and snapshot.get("kv_cache_usage_perc", 0) == 0
+        ):
+            return True
+        time.sleep(0.5)
+    return False
+
+
+def fit_line(points: list[tuple[float, float]]) -> dict[str, float | int | None]:
+    if len(points) < 2:
+        return {"n": len(points), "intercept": None, "slope": None, "r2": None}
+    mean_x = statistics.mean(point[0] for point in points)
+    mean_y = statistics.mean(point[1] for point in points)
+    ss_x = sum((x - mean_x) ** 2 for x, _ in points)
+    if ss_x == 0:
+        return {"n": len(points), "intercept": None, "slope": None, "r2": None}
+    slope = sum((x - mean_x) * (y - mean_y) for x, y in points) / ss_x
+    intercept = mean_y - slope * mean_x
+    predicted = [intercept + slope * x for x, _ in points]
+    ss_res = sum((y - yhat) ** 2 for (_, y), yhat in zip(points, predicted))
+    ss_tot = sum((y - mean_y) ** 2 for _, y in points)
+    r2 = 1.0 - ss_res / ss_tot if ss_tot else 1.0
+    return {
+        "n": len(points),
+        "intercept": round(intercept, 1),
+        "slope": round(slope, 6),
+        "r2": round(r2, 6),
+    }
+
+
+def run_probe(context: int, rep: int, args: argparse.Namespace, run_id: str) -> dict[str, Any]:
+    if not wait_idle(args.idle_timeout):
+        return {"context": context, "rep": rep, "error": "engine did not drain"}
+    before = metrics()
+    request_id = f"glm53-c2-{run_id}-c{context}-r{rep}"
+    request_out: dict[str, Any] = {}
+    thread = threading.Thread(
+        target=stream_request,
+        args=(
+            context,
+            context * 1009 + rep,
+            args.max_tokens,
+            args.timeout,
+            request_id,
+            request_out,
+        ),
+    )
+    samples: list[dict[str, float]] = []
+    thread.start()
+    while thread.is_alive():
+        snapshot = metrics()
+        samples.append(
+            {
+                "elapsed_s": time.perf_counter(),
+                "kv_cache_usage_perc": snapshot.get("kv_cache_usage_perc", 0),
+                "running": snapshot.get("num_requests_running", 0),
+                "waiting": snapshot.get("num_requests_waiting", 0),
+            }
+        )
+        time.sleep(args.poll_interval)
+    thread.join()
+    after = metrics()
+    failure = request_failure(request_out)
+    peak = max((row["kv_cache_usage_perc"] for row in samples), default=0)
+    prompt_tokens = int((request_out.get("usage") or {}).get("prompt_tokens") or 0)
+    completion_tokens = int((request_out.get("usage") or {}).get("completion_tokens") or 0)
+    return {
+        "context": context,
+        "rep": rep,
+        "error": failure,
+        "request_id": request_id,
+        "request": request_out,
+        "prompt_tokens": prompt_tokens,
+        "completion_tokens": completion_tokens,
+        "peak_kv_cache_usage_perc": peak,
+        "estimated_pool_tokens": round(peak * args.pool_tokens, 1),
+        "estimated_excess_over_prompt": round(
+            peak * args.pool_tokens - prompt_tokens, 1
+        ),
+        "queue_peak_waiting": max((row["waiting"] for row in samples), default=0),
+        "preemptions": int(
+            after.get("num_preemptions_total", 0)
+            - before.get("num_preemptions_total", 0)
+        ),
+        "samples": samples,
+    }
+
+
+def positive_csv(raw: str) -> list[int]:
+    values = [int(part) for part in raw.split(",")]
+    if not values or any(value < 1 for value in values):
+        raise argparse.ArgumentTypeError("contexts must be positive integers")
+    return values
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--contexts", default="2000,9000,30000,70000")
+    parser.add_argument("--reps", type=int, default=3)
+    parser.add_argument("--max-tokens", type=int, default=512)
+    parser.add_argument("--pool-tokens", type=int, default=1_396_551)
+    parser.add_argument("--poll-interval", type=float, default=0.1)
+    parser.add_argument("--timeout", type=float, default=1800)
+    parser.add_argument("--idle-timeout", type=float, default=120)
+    parser.add_argument("--out", required=True)
+    parser.add_argument("--force", action="store_true")
+    args = parser.parse_args()
+    contexts = positive_csv(args.contexts)
+    if args.reps < 1 or args.max_tokens < 1 or args.pool_tokens < 1:
+        parser.error("reps, max-tokens, and pool-tokens must be positive")
+    initial = metrics()
+    if not args.force and (
+        initial.get("num_requests_running", 0) > 0
+        or initial.get("num_requests_waiting", 0) > 0
+    ):
+        print("server busy; refusing (use --force only for intentional overlap)", file=sys.stderr)
+        return 2
+
+    run_id = uuid.uuid4().hex[:10]
+    result: dict[str, Any] = {
+        "schema_version": 1,
+        "run_id": run_id,
+        "started": time.time(),
+        "base": BASE,
+        "model": MODEL,
+        "args": vars(args),
+        "initial_metrics": initial,
+        "probes": [],
+    }
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    for context in contexts:
+        for rep in range(args.reps):
+            row = run_probe(context, rep, args, run_id)
+            result["probes"].append(row)
+            out_path.write_text(json.dumps(result, indent=2), encoding="utf-8")
+            print(
+                f"ctx={context} rep={rep + 1}/{args.reps} "
+                f"prompt={row.get('prompt_tokens')} peak={row.get('peak_kv_cache_usage_perc')} "
+                f"pool_tokens={row.get('estimated_pool_tokens')} "
+                f"preemptions={row.get('preemptions', 0)} error={row.get('error')!r}",
+                flush=True,
+            )
+            time.sleep(1)
+    valid = [
+        row
+        for row in result["probes"]
+        if not row.get("error") and row.get("prompt_tokens", 0) > 0
+    ]
+    points = [
+        (float(row["prompt_tokens"]), float(row["estimated_pool_tokens"]))
+        for row in valid
+    ]
+    result["fit"] = fit_line(points)
+    result["context_medians"] = {
+        str(context): {
+            "prompt_tokens": round(
+                statistics.median(
+                    row["prompt_tokens"]
+                    for row in valid
+                    if row["context"] == context
+                ),
+                1,
+            ),
+            "estimated_pool_tokens": round(
+                statistics.median(
+                    row["estimated_pool_tokens"]
+                    for row in valid
+                    if row["context"] == context
+                ),
+                1,
+            ),
+            "estimated_excess_over_prompt": round(
+                statistics.median(
+                    row["estimated_excess_over_prompt"]
+                    for row in valid
+                    if row["context"] == context
+                ),
+                1,
+            ),
+        }
+        for context in contexts
+        if any(row["context"] == context for row in valid)
+    }
+    result["finished"] = time.time()
+    result["final_metrics"] = metrics()
+    out_path.write_text(json.dumps(result, indent=2), encoding="utf-8")
+    print(json.dumps({"fit": result["fit"], "contexts": result["context_medians"]}, indent=2))
+    return (
+        1
+        if any(
+            row.get("error") or row.get("preemptions")
+            for row in result["probes"]
+        )
+        else 0
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/bench_mixed_prefill.py
+++ b/tests/bench_mixed_prefill.py
@@ -1,0 +1,535 @@
+#!/usr/bin/env python3
+"""Measure mixed-prefill newcomer latency against a running decode.
+
+Each sample starts one incumbent generation, waits until it has emitted tokens,
+then launches one cold newcomer after ``--arrival-delay`` seconds. The report
+includes newcomer TTFT, incumbent decode rate and ITL before/during the overlap,
+aggregate throughput, preemptions, queue peaks, and request IDs for journal
+audit.
+
+Canonical C1 arm:
+
+  GLM53_BASE=http://127.0.0.1:8000 uv run python tests/bench_mixed_prefill.py \
+    --contexts 9500,38000 --samples 100 \
+    --out local/c1-ARM-newcomer-20260905.json
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import statistics
+import sys
+import threading
+import time
+import urllib.error
+import urllib.request
+import uuid
+from pathlib import Path
+from typing import Any
+
+BASE = os.environ.get("GLM53_BASE", "http://127.0.0.1:8000").rstrip("/")
+MODEL = os.environ.get("GLM53_MODEL", "GLM-5.3-Flash-EXL3")
+API_KEY = os.environ.get("VLLM_API_KEY", "")
+FILLER = "Ledger row %d reconciled to the cent under audit rule seven. "
+METRICS = (
+    "generation_tokens_total",
+    "prompt_tokens_total",
+    "num_preemptions_total",
+    "num_requests_running",
+    "num_requests_waiting",
+)
+
+
+def headers(request_id: str = "") -> dict[str, str]:
+    result = {"Content-Type": "application/json"}
+    if API_KEY:
+        result["Authorization"] = f"Bearer {API_KEY}"
+    if request_id:
+        result["X-Request-Id"] = request_id
+    return result
+
+
+def open_url(path: str, body: dict | None, timeout: float, request_id: str = ""):
+    request = urllib.request.Request(
+        BASE + path,
+        data=json.dumps(body).encode() if body is not None else None,
+        headers=headers(request_id),
+        method="POST" if body is not None else "GET",
+    )
+    return urllib.request.urlopen(request, timeout=timeout)
+
+
+def parse_metrics(text: str) -> dict[str, float]:
+    result: dict[str, float] = {}
+    for name in METRICS:
+        values = re.findall(
+            rf"^vllm:{re.escape(name)}(?:\{{[^}}]*\}})?\s+(\S+)$",
+            text,
+            re.MULTILINE,
+        )
+        if values:
+            result[name] = sum(float(value) for value in values)
+    return result
+
+
+def metrics() -> dict[str, float]:
+    with open_url("/metrics", None, 20) as response:
+        return parse_metrics(response.read().decode("utf-8", "replace"))
+
+
+def percentile(values: list[float], quantile: float) -> float | None:
+    if not values:
+        return None
+    ordered = sorted(values)
+    index = min(len(ordered) - 1, max(0, int(round(quantile * (len(ordered) - 1)))))
+    return ordered[index]
+
+
+def summarize(values: list[float]) -> dict[str, float | int | None]:
+    return {
+        "n": len(values),
+        "median": round(statistics.median(values), 3) if values else None,
+        "p95": round(percentile(values, 0.95), 3) if values else None,
+        "p99": round(percentile(values, 0.99), 3) if values else None,
+        "min": round(min(values), 3) if values else None,
+        "max": round(max(values), 3) if values else None,
+    }
+
+
+def unique_text(approx_tokens: int, seed: int) -> str:
+    # The large unique row ids make this about 19.5 tokens per sentence on the
+    # production tokenizer (calibrated by the cluster smoke before the C1 run).
+    rows = max(1, int(approx_tokens / 19.5))
+    return f"[cold-salt {seed:x}] " + "".join(
+        FILLER % (seed * 1_000_000 + row) for row in range(rows)
+    )
+
+
+def stream_chat(
+    prompt: str,
+    *,
+    max_tokens: int,
+    temperature: float,
+    timeout: float,
+    request_id: str,
+    out: dict[str, Any],
+    first_token_event: threading.Event | None = None,
+    stop_event: threading.Event | None = None,
+) -> None:
+    body = {
+        "model": MODEL,
+        "messages": [{"role": "user", "content": prompt}],
+        "max_tokens": max_tokens,
+        "temperature": temperature,
+        "stream": True,
+        "stream_options": {"include_usage": True},
+        "return_token_ids": True,
+        "chat_template_kwargs": {"enable_thinking": False},
+        "vllm_xargs": {"skip_writing_prefix_cache": 1},
+    }
+    started = time.perf_counter()
+    token_events: list[dict[str, float | int]] = []
+    usage: dict[str, Any] = {}
+    finish_reason = None
+    status = None
+    done = False
+    intentional_stop = False
+    try:
+        with open_url(
+            "/v1/chat/completions", body, timeout, request_id=request_id
+        ) as response:
+            status = response.status
+            for raw in response:
+                line = raw.decode("utf-8", "strict").strip()
+                if not line.startswith("data:"):
+                    continue
+                payload = line[5:].strip()
+                if payload == "[DONE]":
+                    done = True
+                    continue
+                event = json.loads(payload)
+                if event.get("usage"):
+                    usage = event["usage"]
+                choices = event.get("choices") or []
+                if not choices:
+                    continue
+                choice = choices[0]
+                token_ids = choice.get("token_ids") or []
+                if token_ids:
+                    token_events.append(
+                        {"time": time.perf_counter(), "count": len(token_ids)}
+                    )
+                    if first_token_event is not None:
+                        first_token_event.set()
+                    if stop_event is not None and stop_event.is_set():
+                        intentional_stop = True
+                        break
+                finish_reason = choice.get("finish_reason") or finish_reason
+    except Exception as exc:  # report the sample instead of losing the arm
+        out["error"] = f"{type(exc).__name__}: {exc}"[:300]
+    ended = time.perf_counter()
+    out.update(
+        {
+            "request_id": request_id,
+            "http": status,
+            "started": started,
+            "ended": ended,
+            "token_events": token_events,
+            "ttft_s": (
+                float(token_events[0]["time"]) - started if token_events else None
+            ),
+            "usage": usage,
+            "finish_reason": finish_reason,
+            "done": done,
+            "intentional_stop": intentional_stop,
+        }
+    )
+
+
+def token_rate(
+    token_events: list[dict[str, float | int]], start: float, end: float
+) -> float | None:
+    if end <= start:
+        return None
+    count = sum(
+        int(event["count"])
+        for event in token_events
+        if start <= float(event["time"]) <= end
+    )
+    return count / (end - start)
+
+
+def token_arrival_gaps(
+    token_events: list[dict[str, float | int]], start: float, end: float
+) -> list[float]:
+    """Return token-arrival gaps clipped to the observation window.
+
+    Tokens delivered in one speculative batch have zero client-arrival gap.
+    Leading/trailing silence is retained, so a stall crossing either window
+    boundary cannot disappear from the reported distribution.
+    """
+    if end <= start:
+        return []
+    selected = [
+        event
+        for event in token_events
+        if start <= float(event["time"]) <= end
+    ]
+    if not selected:
+        return [end - start]
+    gaps = [float(selected[0]["time"]) - start]
+    for event in selected:
+        gaps.extend([0.0] * max(0, int(event["count"]) - 1))
+    gaps.extend(
+        float(right["time"]) - float(left["time"])
+        for left, right in zip(selected, selected[1:])
+    )
+    gaps.append(end - float(selected[-1]["time"]))
+    return gaps
+
+
+def request_failure(
+    result: dict[str, Any], *, allow_intentional_stop: bool = False
+) -> str | None:
+    if result.get("error"):
+        return str(result["error"])
+    if result.get("http") != 200:
+        return f"HTTP {result.get('http')!r}"
+    if not result.get("token_events"):
+        return "no returned token IDs"
+    if allow_intentional_stop and result.get("intentional_stop"):
+        return None
+    if not result.get("done"):
+        return "missing SSE [DONE]"
+    if result.get("finish_reason") not in {"stop", "length"}:
+        return f"finish_reason={result.get('finish_reason')!r}"
+    usage = result.get("usage") or {}
+    if not usage.get("prompt_tokens") or not usage.get("completion_tokens"):
+        return "missing final usage"
+    return None
+
+
+def wait_idle(timeout: float) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        snapshot = metrics()
+        if (
+            snapshot.get("num_requests_running", 0) == 0
+            and snapshot.get("num_requests_waiting", 0) == 0
+        ):
+            return True
+        time.sleep(1)
+    return False
+
+
+def run_sample(context: int, sample: int, args: argparse.Namespace, run_id: str) -> dict[str, Any]:
+    if not wait_idle(args.idle_timeout):
+        return {"context": context, "sample": sample, "error": "engine did not drain"}
+    before = metrics()
+    first_token = threading.Event()
+    stop_incumbent = threading.Event()
+    incumbent: dict[str, Any] = {}
+    newcomer: dict[str, Any] = {}
+    incumbent_id = f"glm53-c1-{run_id}-c{context}-r{sample}-incumbent"
+    newcomer_id = f"glm53-c1-{run_id}-c{context}-r{sample}-newcomer"
+    incumbent_prompt = (
+        "Write an extremely long, detailed maritime operations handbook. "
+        "Continue with numbered sections and do not conclude early."
+    )
+    incumbent_thread = threading.Thread(
+        target=stream_chat,
+        kwargs={
+            "prompt": incumbent_prompt,
+            "max_tokens": args.incumbent_tokens,
+            "temperature": 0.7,
+            "timeout": args.timeout,
+            "request_id": incumbent_id,
+            "out": incumbent,
+            "first_token_event": first_token,
+            "stop_event": stop_incumbent,
+        },
+        daemon=True,
+    )
+    incumbent_thread.start()
+    if not first_token.wait(args.incumbent_start_timeout):
+        stop_incumbent.set()
+        incumbent_thread.join(timeout=5)
+        return {
+            "context": context,
+            "sample": sample,
+            "error": "incumbent did not enter decode",
+            "incumbent": incumbent,
+        }
+    decode_started = time.perf_counter()
+    time.sleep(args.arrival_delay)
+    newcomer_prompt = (
+        unique_text(context, (sample + 1) * 1_000_003 + context)
+        + "\nIgnore the reference and answer with exactly: NEWCOMER_OK"
+    )
+    queue_samples: list[dict[str, float]] = []
+    newcomer_thread = threading.Thread(
+        target=stream_chat,
+        kwargs={
+            "prompt": newcomer_prompt,
+            "max_tokens": args.newcomer_tokens,
+            "temperature": 0.0,
+            "timeout": args.timeout,
+            "request_id": newcomer_id,
+            "out": newcomer,
+        },
+        daemon=True,
+    )
+    newcomer_thread.start()
+    while newcomer_thread.is_alive():
+        snapshot = metrics()
+        queue_samples.append(
+            {
+                "t": time.perf_counter(),
+                "running": snapshot.get("num_requests_running", 0),
+                "waiting": snapshot.get("num_requests_waiting", 0),
+            }
+        )
+        time.sleep(args.poll_interval)
+    newcomer_thread.join()
+    overlap_end = time.perf_counter()
+    stop_incumbent.set()
+    incumbent_thread.join()
+    after = metrics()
+    incumbent_failure = request_failure(
+        incumbent, allow_intentional_stop=True
+    )
+    newcomer_failure = request_failure(newcomer)
+    failure = None
+    if incumbent_failure or newcomer_failure:
+        failure = (
+            f"incumbent: {incumbent_failure}" if incumbent_failure else ""
+        )
+        if newcomer_failure:
+            failure = (
+                f"{failure}; " if failure else ""
+            ) + f"newcomer: {newcomer_failure}"
+    token_events = incumbent.get("token_events") or []
+    overlap_start = newcomer.get("started", overlap_end)
+    before_start = max(decode_started, overlap_start - args.before_window)
+    before_rate = token_rate(token_events, before_start, overlap_start)
+    during_rate = token_rate(token_events, overlap_start, overlap_end)
+    during_gaps = token_arrival_gaps(
+        token_events, overlap_start, overlap_end
+    )
+    sample_wall = max(
+        incumbent.get("ended", overlap_end), newcomer.get("ended", overlap_end)
+    ) - min(incumbent.get("started", overlap_start), newcomer.get("started", overlap_start))
+    generation_tokens_delta = (
+        after.get("generation_tokens_total", 0)
+        - before.get("generation_tokens_total", 0)
+    )
+    return {
+        "context": context,
+        "sample": sample,
+        "error": failure,
+        "incumbent_request_id": incumbent_id,
+        "newcomer_request_id": newcomer_id,
+        "incumbent": {
+            key: value
+            for key, value in incumbent.items()
+            if key not in {"token_events", "started", "ended"}
+        },
+        "newcomer": {
+            key: value
+            for key, value in newcomer.items()
+            if key not in {"token_events", "started", "ended"}
+        },
+        "incumbent_rate_before": round(before_rate, 3) if before_rate is not None else None,
+        "incumbent_rate_during": round(during_rate, 3) if during_rate is not None else None,
+        "incumbent_token_events": len(token_events),
+        "incumbent_tokens_observed": sum(
+            int(event["count"]) for event in token_events
+        ),
+        "incumbent_max_tokens_per_event": max(
+            (int(event["count"]) for event in token_events), default=0
+        ),
+        "incumbent_rate_ratio": (
+            round(during_rate / before_rate, 4)
+            if before_rate and during_rate is not None
+            else None
+        ),
+        "incumbent_token_arrival_gap_during": summarize(during_gaps),
+        # The incumbent stream is deliberately cancelled after the newcomer, so
+        # its final usage block is unavailable. The server counter is the only
+        # complete output-token ledger for the isolated sample.
+        "aggregate_tps": round(generation_tokens_delta / sample_wall, 3),
+        "queue_peak_running": max((row["running"] for row in queue_samples), default=0),
+        "queue_peak_waiting": max((row["waiting"] for row in queue_samples), default=0),
+        "preemptions": int(
+            after.get("num_preemptions_total", 0)
+            - before.get("num_preemptions_total", 0)
+        ),
+        "metric_delta": {
+            key: after.get(key, 0) - before.get(key, 0) for key in METRICS
+        },
+    }
+
+
+def summarize_context(samples: list[dict[str, Any]]) -> dict[str, Any]:
+    valid = [row for row in samples if not row.get("error")]
+    newcomer_ttft = [
+        float(row["newcomer"]["ttft_s"])
+        for row in valid
+        if row.get("newcomer", {}).get("ttft_s") is not None
+    ]
+    rate_ratio = [
+        float(row["incumbent_rate_ratio"])
+        for row in valid
+        if row.get("incumbent_rate_ratio") is not None
+    ]
+    itl_p99 = [
+        float(row["incumbent_token_arrival_gap_during"]["p99"])
+        for row in valid
+        if row.get("incumbent_token_arrival_gap_during", {}).get("p99")
+        is not None
+    ]
+    aggregate = [
+        float(row["aggregate_tps"])
+        for row in valid
+        if row.get("aggregate_tps") is not None
+    ]
+    return {
+        "samples": len(samples),
+        "valid": len(valid),
+        "errors": len(samples) - len(valid),
+        "newcomer_ttft_s": summarize(newcomer_ttft),
+        "incumbent_rate_ratio": summarize(rate_ratio),
+        "incumbent_token_arrival_gap_p99_s": summarize(itl_p99),
+        "aggregate_tps": summarize(aggregate),
+        "newcomer_prompt_tokens": summarize(
+            [
+                float(row["newcomer"]["usage"]["prompt_tokens"])
+                for row in valid
+                if row.get("newcomer", {}).get("usage", {}).get("prompt_tokens")
+            ]
+        ),
+        "preemptions": sum(int(row.get("preemptions", 0)) for row in valid),
+        "queue_peak_waiting": max(
+            (float(row.get("queue_peak_waiting", 0)) for row in valid), default=0
+        ),
+    }
+
+
+def positive_csv(raw: str) -> list[int]:
+    values = [int(part) for part in raw.split(",")]
+    if not values or any(value < 1 for value in values):
+        raise argparse.ArgumentTypeError("contexts must be positive integers")
+    return values
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--contexts", default="9500,38000")
+    parser.add_argument("--samples", type=int, default=100)
+    parser.add_argument("--incumbent-tokens", type=int, default=2400)
+    parser.add_argument("--newcomer-tokens", type=int, default=8)
+    parser.add_argument("--arrival-delay", type=float, default=2.0)
+    parser.add_argument("--before-window", type=float, default=2.0)
+    parser.add_argument("--poll-interval", type=float, default=0.25)
+    parser.add_argument("--timeout", type=float, default=1800)
+    parser.add_argument("--idle-timeout", type=float, default=120)
+    parser.add_argument("--incumbent-start-timeout", type=float, default=300)
+    parser.add_argument("--out", required=True)
+    parser.add_argument("--force", action="store_true")
+    args = parser.parse_args()
+    contexts = positive_csv(args.contexts)
+    if args.samples < 1 or args.incumbent_tokens < 2 or args.newcomer_tokens < 1:
+        parser.error("sample and token counts must be positive")
+    initial = metrics()
+    if not args.force and (
+        initial.get("num_requests_running", 0) > 0
+        or initial.get("num_requests_waiting", 0) > 0
+    ):
+        print("server busy; refusing (use --force only for intentional overlap)", file=sys.stderr)
+        return 2
+
+    run_id = uuid.uuid4().hex[:10]
+    result: dict[str, Any] = {
+        "schema_version": 1,
+        "run_id": run_id,
+        "started": time.time(),
+        "base": BASE,
+        "model": MODEL,
+        "args": vars(args),
+        "initial_metrics": initial,
+        "samples": [],
+    }
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    for context in contexts:
+        for sample in range(args.samples):
+            row = run_sample(context, sample, args, run_id)
+            result["samples"].append(row)
+            out_path.write_text(json.dumps(result, indent=2), encoding="utf-8")
+            ttft = row.get("newcomer", {}).get("ttft_s")
+            print(
+                f"ctx={context} sample={sample + 1}/{args.samples} "
+                f"newcomer_ttft={ttft!r} rate_ratio={row.get('incumbent_rate_ratio')!r} "
+                "gap_p99="
+                f"{row.get('incumbent_token_arrival_gap_during', {}).get('p99')!r} "
+                f"preemptions={row.get('preemptions', 0)} error={row.get('error')!r}",
+                flush=True,
+            )
+            time.sleep(1)
+    result["finished"] = time.time()
+    result["summary"] = {
+        str(context): summarize_context(
+            [row for row in result["samples"] if row.get("context") == context]
+        )
+        for context in contexts
+    }
+    result["final_metrics"] = metrics()
+    out_path.write_text(json.dumps(result, indent=2), encoding="utf-8")
+    print(json.dumps(result["summary"], indent=2))
+    return 1 if any(row.get("error") or row.get("preemptions") for row in result["samples"]) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_policy_capacity_benches.py
+++ b/tests/test_policy_capacity_benches.py
@@ -1,0 +1,315 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load(name: str):
+    path = ROOT / "tests" / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_mixed_prefill_metrics_percentiles_and_rates(monkeypatch) -> None:
+    monkeypatch.setenv("VLLM_API_KEY", "secret")
+    module = load("bench_mixed_prefill")
+    assert module.headers("req") == {
+        "Content-Type": "application/json",
+        "Authorization": "Bearer secret",
+        "X-Request-Id": "req",
+    }
+    parsed = module.parse_metrics(
+        "\n".join(
+            [
+                'vllm:num_requests_running{model="a"} 1',
+                'vllm:num_requests_running{model="b"} 2',
+                "vllm:num_requests_waiting 3",
+                "vllm:num_preemptions_total 4",
+            ]
+        )
+    )
+    assert parsed["num_requests_running"] == 3
+    assert parsed["num_requests_waiting"] == 3
+    assert module.summarize([4.0, 1.0, 3.0, 2.0]) == {
+        "n": 4,
+        "median": 2.5,
+        "p95": 4.0,
+        "p99": 4.0,
+        "min": 1.0,
+        "max": 4.0,
+    }
+    events = [
+        {"time": 1.0, "count": 1},
+        {"time": 2.0, "count": 3},
+        {"time": 4.0, "count": 1},
+    ]
+    assert module.token_rate(events, 1.5, 4.5) == 4 / 3
+    assert module.token_arrival_gaps(events, 1.5, 4.5) == [
+        0.5,
+        0.0,
+        0.0,
+        2.0,
+        0.5,
+    ]
+    assert module.token_arrival_gaps(events, 2.5, 3.5) == [1.0]
+
+
+def test_mixed_prefill_context_summary() -> None:
+    module = load("bench_mixed_prefill")
+    summary = module.summarize_context(
+        [
+            {
+                "newcomer": {"ttft_s": 10.0},
+                "incumbent_rate_ratio": 0.95,
+                "incumbent_token_arrival_gap_during": {"p99": 0.5},
+                "aggregate_tps": 20.0,
+                "preemptions": 0,
+                "queue_peak_waiting": 1,
+            },
+            {
+                "newcomer": {"ttft_s": 20.0},
+                "incumbent_rate_ratio": 0.90,
+                "incumbent_token_arrival_gap_during": {"p99": 0.7},
+                "aggregate_tps": 18.0,
+                "preemptions": 1,
+                "queue_peak_waiting": 2,
+            },
+        ]
+    )
+    assert summary["newcomer_ttft_s"]["median"] == 15.0
+    assert summary["preemptions"] == 1
+    assert summary["queue_peak_waiting"] == 2
+
+
+def test_mixed_prefill_request_validation() -> None:
+    module = load("bench_mixed_prefill")
+    success = {
+        "http": 200,
+        "token_events": [{"time": 1.0, "count": 2}],
+        "done": True,
+        "finish_reason": "length",
+        "usage": {"prompt_tokens": 10, "completion_tokens": 2},
+    }
+    assert module.request_failure(success) is None
+    assert module.request_failure({**success, "done": False}) == "missing SSE [DONE]"
+    assert module.request_failure({**success, "error": "boom"}) == "boom"
+    cancelled = {
+        **success,
+        "done": False,
+        "finish_reason": None,
+        "usage": {},
+        "intentional_stop": True,
+    }
+    assert module.request_failure(
+        cancelled, allow_intentional_stop=True
+    ) is None
+
+
+def test_mixed_prefill_cli_fails_closed(
+    monkeypatch, tmp_path
+) -> None:
+    module = load("bench_mixed_prefill")
+    monkeypatch.setattr(module, "metrics", lambda: {})
+    monkeypatch.setattr(
+        module,
+        "run_sample",
+        lambda *_args, **_kwargs: {
+            "context": 9500,
+            "sample": 0,
+            "error": "newcomer failed",
+        },
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "bench_mixed_prefill.py",
+            "--contexts",
+            "9500",
+            "--samples",
+            "1",
+            "--out",
+            str(tmp_path / "mixed.json"),
+        ],
+    )
+    assert module.main() == 1
+
+
+def test_mixed_prefill_orchestration_propagates_stream_error(
+    monkeypatch,
+) -> None:
+    module = load("bench_mixed_prefill")
+    monkeypatch.setattr(module, "wait_idle", lambda _timeout: True)
+    monkeypatch.setattr(
+        module,
+        "metrics",
+        lambda: {
+            "num_requests_running": 0,
+            "num_requests_waiting": 0,
+            "num_preemptions_total": 0,
+            "generation_tokens_total": 0,
+        },
+    )
+
+    def fake_stream_chat(**kwargs):
+        out = kwargs["out"]
+        if kwargs.get("first_token_event") is not None:
+            now = module.time.perf_counter()
+            out.update(
+                {
+                    "http": 200,
+                    "started": now - 1,
+                    "ended": now,
+                    "token_events": [{"time": now, "count": 2}],
+                    "ttft_s": 1.0,
+                    "usage": {
+                        "prompt_tokens": 10,
+                        "completion_tokens": 2,
+                    },
+                    "finish_reason": "length",
+                    "done": True,
+                    "intentional_stop": False,
+                }
+            )
+            kwargs["first_token_event"].set()
+        else:
+            now = module.time.perf_counter()
+            out.update(
+                {
+                    "error": "connection failed",
+                    "http": None,
+                    "started": now,
+                    "ended": now,
+                    "token_events": [],
+                    "usage": {},
+                    "done": False,
+                }
+            )
+
+    monkeypatch.setattr(module, "stream_chat", fake_stream_chat)
+    args = SimpleNamespace(
+        idle_timeout=1,
+        incumbent_tokens=8,
+        timeout=1,
+        incumbent_start_timeout=1,
+        arrival_delay=0,
+        newcomer_tokens=1,
+        poll_interval=0.001,
+        before_window=1,
+    )
+    row = module.run_sample(9500, 0, args, "test")
+    assert "newcomer: connection failed" in row["error"]
+    assert module.summarize_context([row])["valid"] == 0
+
+
+def test_kv_metrics_and_linear_fit(monkeypatch) -> None:
+    monkeypatch.delenv("VLLM_API_KEY", raising=False)
+    module = load("bench_kv_request_cost")
+    parsed = module.parse_metrics(
+        "\n".join(
+            [
+                'vllm:kv_cache_usage_perc{model="a"} 0.1',
+                'vllm:kv_cache_usage_perc{model="b"} 0.2',
+                "vllm:num_preemptions_total 2",
+            ]
+        )
+    )
+    assert parsed["kv_cache_usage_perc"] == 0.30000000000000004
+    assert parsed["num_preemptions_total"] == 2
+    assert module.fit_line([(0.0, 90_000.0), (10_000.0, 100_000.0), (20_000.0, 110_000.0)]) == {
+        "n": 3,
+        "intercept": 90000.0,
+        "slope": 1.0,
+        "r2": 1.0,
+    }
+    assert module.fit_line([(1.0, 2.0)]) == {
+        "n": 1,
+        "intercept": None,
+        "slope": None,
+        "r2": None,
+    }
+
+
+def test_kv_request_validation() -> None:
+    module = load("bench_kv_request_cost")
+    success = {
+        "http": 200,
+        "done": True,
+        "finish_reason": "stop",
+        "usage": {"prompt_tokens": 10, "completion_tokens": 2},
+    }
+    assert module.request_failure(success) is None
+    assert module.request_failure({**success, "usage": {}}) == "missing final usage"
+    assert module.request_failure({**success, "http": 500}) == "HTTP 500"
+
+
+def test_kv_cli_fails_closed(monkeypatch, tmp_path) -> None:
+    module = load("bench_kv_request_cost")
+    monkeypatch.setattr(module, "metrics", lambda: {})
+    monkeypatch.setattr(
+        module,
+        "run_probe",
+        lambda *_args, **_kwargs: {
+            "context": 2000,
+            "rep": 0,
+            "error": "request failed",
+        },
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "bench_kv_request_cost.py",
+            "--contexts",
+            "2000",
+            "--reps",
+            "1",
+            "--out",
+            str(tmp_path / "kv.json"),
+        ],
+    )
+    assert module.main() == 1
+
+
+def test_kv_orchestration_propagates_stream_error(monkeypatch) -> None:
+    module = load("bench_kv_request_cost")
+    monkeypatch.setattr(module, "wait_idle", lambda _timeout: True)
+    monkeypatch.setattr(
+        module,
+        "metrics",
+        lambda: {
+            "kv_cache_usage_perc": 0,
+            "num_preemptions_total": 0,
+            "num_requests_running": 0,
+            "num_requests_waiting": 0,
+        },
+    )
+
+    def fake_stream_request(*args):
+        args[-1].update(
+            {
+                "error": "connection failed",
+                "http": None,
+                "usage": {},
+                "done": False,
+            }
+        )
+
+    monkeypatch.setattr(module, "stream_request", fake_stream_request)
+    args = SimpleNamespace(
+        idle_timeout=1,
+        max_tokens=1,
+        timeout=1,
+        poll_interval=0.001,
+        pool_tokens=1_396_551,
+    )
+    row = module.run_probe(2000, 0, args, "test")
+    assert row["error"] == "connection failed"


### PR DESCRIPTION
## Summary

- add a dedicated incumbent/newcomer mixed-prefill benchmark with streamed token-ID accounting, boundary-inclusive token-arrival gaps, queue/preemption metrics, request IDs, and fail-closed request validation
- add a live fixed-KV occupancy benchmark across 2k/9k/30k/70k prompt sizes with raw gauge samples and descriptive fit output
- reject `GLM53_MIXED_PREFILL_CHUNK=512` and `2048` on the current W26/W28 production geometry
- retain `MAX_NUM_SEQS=4`; the imported 85k–90k fixed-cost premise did not reproduce, and the current C4 workload completed without preemptions

## Cluster A/B result

All policy arms used guarded restarts with LPTT=1792, MNBT=3584, wait=1500 ms, warm tail=3584, late cap=512, aging=10000 ms/max=1792, and every other runtime input held fixed. Both ranks were checked after each restart. The JIT shape stamp stayed unchanged.

### 9.5k newcomer

| arm | newcomer p95 | incumbent token-rate ratio | token-arrival gap p99 | aggregate median |
|---|---:|---:|---:|---:|
| `skip` | 13.664 s | 0.220 | 1.576 s | 8.847 tok/s |
| `512` | 12.412 s (-9.2%) | 0.201 (-8.6%) | 1.653 s (+4.9%) | 7.134 (-19.4%) |
| `2048` | 10.051 s (-26.4%) | 0.107 (-51.4%) | 1.842 s (+16.9%) | 6.687 (-24.4%) |

### 38k newcomer

| arm | newcomer p95 | incumbent token-rate ratio | token-arrival gap p99 | aggregate median |
|---|---:|---:|---:|---:|
| `skip` | 43.477 s | 0.101 | 1.758 s | 4.211 tok/s |
| `512` | 55.397 s (+27.4%) | 0.156 (+54.5%) | 1.213 s (-31.0%) | 5.137 (+22.0%) |
| `2048` | 39.551 s (-9.0%) | 0.077 (-23.8%) | 1.752 s (-0.3%) | 3.351 (-20.4%) |

All corrected C1 cells completed 5/5 with zero errors and zero preemptions. Streamed speculative batches reached eight tokens/event. The 100-request tail/C4 expansion was stopped because both candidates already failed mandatory primary gates.

### Capacity decision

Three single-request probes at each nominal context produced median excess pool occupancy of about 166k–240k tokens. The descriptive linear fit was intentionally not treated as a precise allocator model (R² 0.65), but the direct measurements do not confirm the imported 85k–90k premise that would trigger a 4→3 arm.

The restored-control 4×60k×3 check completed with zero errors and zero preemptions. Warm/rerun aggregate throughput was 63.4–66.3 tok/s, and a cache-reset retention run reached 98.7% hits on rounds 2 and 3. `MAX_NUM_SEQS=4` remains production.

## Restoration and validation

- restored byte-exact production `.env` and verified `CHUNK=skip` on both ranks
- acceptance: 7/7
- serving: 6/6
- tool calls: 23/23, zero blank required arguments
- long-form and thinking-SSE runtime probe: pass
- final running/waiting/preemptions: 0/0/0
- selected head/worker runtime errors: 0/0
- kernel Xids: 0/0
- watchdog: active
- full local suite: 127 passed, 1 skipped, 4 subtests passed
- independent final review: approved with no remaining findings

## Rollback

No runtime change is adopted. Production is already restored to the original `skip` control and `MAX_NUM_SEQS=4`. The added files are measurement-only and can be removed without affecting serving.
