### PR TITLE
Q1: add live-weight attribution gates

### DIFF
--- a/docs/06-improvement-plan.md
+++ b/docs/06-improvement-plan.md
@@ -80,6 +80,51 @@ worker logs contained zero CUDA/IMA/Xid/Traceback matches, and MemFree was
 6,441,380 / 6,091,752 kB. These are correctness smokes, not performance
 samples. The full canonical baseline is prepared, not yet a performance claim:
 
+### 2026-09-05: task 1 live-weight attribution foundation adopted; quantization parked
+
+`scripts/audit_live_weight_bytes.py` turns the prior broad BF16 disk bucket
+into a header-only module and TP-geometry audit. It distinguishes target
+dense/shared/KDA/MLA/router/head/embedding/vision/MTP/routed-expert bytes,
+models the mixed replicated and sharded KDA/MLA paths, and reports rank
+residency plus routed-expert traffic envelopes. `docs/14-selective-quantization-gate.md`
+records the separate draft-only and target dense/head A/Bs, quality gates,
+aborts and rollback.
+
+The exact candidate script SHA256
+`1b69b17894b7c9e8b0b84f5f8116b565e38c6cf851acae6b7bd83f8d971702d1`
+ran against the selected incumbent snapshots on both target nodes. Their
+reports matched after path normalization, classified all tensors, and measured
+175,622,979,576 target payload bytes plus 2,342,160,896 drafter bytes. Estimated
+resident weight bytes were 88,614,683,128 on rank 0 and 86,272,522,232 on rank
+1; the difference is the rank-0-only BF16 drafter. The target's MTP layer
+accounts for 4,004,169,728 on-disk bytes but zero live DFlash-target residency;
+text-idle vision accounts for 1,127,254,016 on disk. These are loaded-byte
+attribution figures, not DRAM traffic counters.
+
+The same-day prose control recorded 2.607 accepted drafts per verification
+step. At that rate, the accounting model estimates 3.79/4.38/5.56/7.92 GB of
+rank-0 weight reads per emitted token for 8/16/32/64 unique routed experts per
+MoE layer. The 64-expert case reproduces the upstream report's approximately
+17 GB routed-expert read premise per verification step, while making the
+uncertainty explicit. Hardware-counter profiling remains open; these envelopes
+must not be presented as measured DRAM traffic.
+
+Permission gates stop the implementation before a weight build. The target
+pack reports `shapleymcg-1.0` and requires manual attribution/license review.
+The drafter reports `cc-by-nc-nd-4.0`, so a derived quantized draft remains
+blocked pending explicit derivative/commercial permission. Target dense/head
+quantization also remains blocked until the owner explicitly replaces the
+standing bit-exact gate with task 1's KL/top-1/task-quality contract. Therefore
+the audit/runbook is adopted, but both quantization arms stay parked and the
+original weights remain untouched.
+
+No production file, image, model, drafter, KV pin, service or watchdog state
+changed. Post-audit service/health were active/200, preemptions were zero, and
+MemFree was 6,906,112 / 4,040,188 kB. Local validation: 131 passed, 1 skipped,
+4 subtests passed before review; after fail-closed review fixes the full suite
+was **134 passed, 1 skipped, 4 subtests passed**. Ruff, Python compile, bash
+syntax and diff checks passed.
+
 ### 2026-09-05: P0 runtime diagnostics and null-gap repair adopted
 
 The next priority block combines tasks 18, 9 and the task-27 null-gap

--- a/docs/14-selective-quantization-gate.md
+++ b/docs/14-selective-quantization-gate.md
@@ -1,0 +1,85 @@
+# 14 — Selective quantization attribution and gate
+
+This document prepares task 1's offline attribution and A/B work. It does not
+approve, build, deploy, or distribute modified weights.
+
+## Current production finding
+
+Run `scripts/audit_live_weight_bytes.py` against the exact target and DFlash2
+snapshots on both nodes. The tool reads safetensors headers only and reports:
+
+- on-disk bytes by live module family;
+- estimated resident weight bytes per TP rank;
+- explicit replicated versus TP-sharded geometry, including KDA
+  `f_a`/`g_a`, MLA fused-a/indexer projections, routed EXL3 metadata, vision,
+  embeddings and the unused MTP layer;
+- rank-0 weight-streaming scenarios for 8/16/32/64 unique routed experts per
+  MoE layer;
+- model-card weight-license gates.
+
+The traffic scenarios are an accounting model, not DRAM counter receipts. They
+count each non-routed matrix once per verification step, the shared `lm_head`
+twice (draft candidate generation plus target verification), and each active
+routed expert once. Embedding row lookups and text-idle vision weights are
+excluded. Supply the measured `accepted_per_step` from `bench_decode.py` to
+derive bytes per emitted token.
+
+```bash
+uv run python scripts/audit_live_weight_bytes.py \
+  --target-snapshot "$TARGET_SNAPSHOT" \
+  --draft-snapshot "$DRAFT_SNAPSHOT" \
+  --tp-size 2 --draft-tp-size 1 \
+  --active-experts 8,16,32,64 \
+  --accepted-per-step "$ACCEPTED_PER_STEP" \
+  --out local/live-weight-bytes-$(hostname)-$(date +%F).json
+```
+
+Fail the audit if either node has unclassified tensors, the category totals
+differ, or the report does not identify the target pack as `shapleymcg-1.0`
+and the drafter as `cc-by-nc-nd-4.0`.
+
+## Permission and quality gates
+
+Draft-only quantization remains blocked unless the owner confirms explicit
+derivative and commercial permission from the drafter publisher. The
+CC BY-NC-ND card does not permit assuming that locally generated quantized
+weights are allowed merely because the serving code is open.
+
+Target dense/head quantization remains blocked until the owner explicitly
+waives the standing bit-exact rule for this change class. If approved, use the
+predeclared gate from task 1:
+
+- fixed-probe KL at most 0.005 versus the current artifact;
+- top-1 agreement at least 97%;
+- toolcall probe 23/23;
+- structured speculative acceptance with no position below 0.90;
+- no correctness or security defect in the task-quality set.
+
+Keep draft-only and target dense/head changes in separate windows.
+
+## Prepared A/B sequence
+
+Do not run the candidate arms until both gates above are satisfied.
+
+1. Save exact `.env`, image/model/drafter revisions, both-node hashes, live
+   PID-1 arguments, load-line bytes and rollback files. Stop and drain the
+   watchdog. Preserve the 15,414,698,763-byte KV pin.
+2. Control A: current target, BF16 drafter, current k=7/draft-TP1. Run the
+   quality panel, toolcall 23/23, structured and prose/agentic decode, 60k and
+   240k prefill, C4 tails, acceptance by position and a short profiler window.
+3. Candidate B1: draft-only quantization. Rebuild both nodes from identical
+   source bytes, verify content hashes, invalidate both-node shape caches,
+   warm finitely, then run A-B1-B1-A with at least nine prose observations.
+   Adopt only with target-output/distribution correctness and at least 5%
+   prose gain.
+4. Candidate B2, in a separate maintenance window: restore the BF16 drafter
+   and change only target dense/head weights. Run A-B2-B2-A with the approved
+   quality gate and the same performance cells. Re-baseline the 82.01 GiB/node
+   load line and verify TP geometry, pool bytes and max-context admission.
+5. Abort on CUDA/Xid/IMA, corruption, lost progress, worker failure,
+   preemption regression or either-node `MemFree < 2.5 GiB`. Restore the saved
+   model id through `local/prod-start.sh`, rerun production gates, then re-arm
+   the watchdog.
+
+The original artifacts stay on disk throughout both windows. A rejected or
+inconclusive arm returns to the current model id; no KV re-pin is allowed.

--- a/scripts/audit_live_weight_bytes.py
+++ b/scripts/audit_live_weight_bytes.py
@@ -1,0 +1,581 @@
+#!/usr/bin/env python3
+"""Audit GLM-5.3-Flash weight residency and decode-step traffic.
+
+The audit reads safetensors headers only. It does not load tensor payloads.
+Traffic figures are a weight-streaming model, not hardware-counter receipts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import struct
+from collections import defaultdict
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+DTYPE_BYTES = {
+    "BOOL": 1,
+    "U8": 1,
+    "I8": 1,
+    "F8_E4M3": 1,
+    "F8_E4M3FN": 1,
+    "F8_E5M2": 1,
+    "U16": 2,
+    "I16": 2,
+    "F16": 2,
+    "BF16": 2,
+    "U32": 4,
+    "I32": 4,
+    "F32": 4,
+    "U64": 8,
+    "I64": 8,
+    "F64": 8,
+}
+
+
+@dataclass(frozen=True)
+class TensorInfo:
+    name: str
+    dtype: str
+    disk_bytes: int
+    category: str
+    rank_fraction: float
+    geometry: str
+
+
+def read_header(path: Path) -> dict[str, Any]:
+    with path.open("rb") as handle:
+        raw = handle.read(8)
+        if len(raw) != 8:
+            raise ValueError(f"{path}: missing safetensors header length")
+        header_len = struct.unpack("<Q", raw)[0]
+        header = handle.read(header_len)
+        if len(header) != header_len:
+            raise ValueError(f"{path}: truncated safetensors header")
+    decoded = json.loads(header)
+    if not isinstance(decoded, dict):
+        raise ValueError(f"{path}: safetensors header is not an object")
+    payload_bytes = path.stat().st_size - 8 - header_len
+    ranges = []
+    for name, entry in decoded.items():
+        if name == "__metadata__":
+            if not isinstance(entry, dict):
+                raise ValueError(f"{path}: __metadata__ is not an object")
+            continue
+        validate_tensor_entry(path, name, entry, payload_bytes)
+        ranges.append((entry["data_offsets"][0], entry["data_offsets"][1], name))
+    ranges.sort()
+    previous_end = 0
+    for start, end, name in ranges:
+        if start != previous_end:
+            kind = "overlap" if start < previous_end else "gap"
+            raise ValueError(f"{path}: tensor {name!r} has payload {kind}")
+        previous_end = end
+    if previous_end != payload_bytes:
+        raise ValueError(
+            f"{path}: payload size {payload_bytes} != tensor extent {previous_end}"
+        )
+    return decoded
+
+
+def validate_tensor_entry(
+    path: Path, name: str, entry: Any, payload_bytes: int
+) -> None:
+    if not isinstance(entry, dict):
+        raise ValueError(f"{path}: tensor {name!r} record is not an object")
+    dtype = entry.get("dtype")
+    if dtype not in DTYPE_BYTES:
+        raise ValueError(f"{path}: tensor {name!r} has unsupported dtype {dtype!r}")
+    shape = entry.get("shape")
+    if not isinstance(shape, list) or not all(
+        isinstance(value, int) and not isinstance(value, bool) and value >= 0
+        for value in shape
+    ):
+        raise ValueError(f"{path}: tensor {name!r} has invalid shape {shape!r}")
+    elements = 1
+    for value in shape:
+        elements *= value
+    offsets = entry.get("data_offsets")
+    if (
+        not isinstance(offsets, list)
+        or len(offsets) != 2
+        or not all(
+            isinstance(value, int) and not isinstance(value, bool)
+            for value in offsets
+        )
+        or offsets[0] < 0
+        or offsets[1] < offsets[0]
+        or offsets[1] > payload_bytes
+    ):
+        raise ValueError(
+            f"{path}: tensor {name!r} has invalid data_offsets {offsets!r}"
+        )
+    expected = elements * DTYPE_BYTES[dtype]
+    actual = offsets[1] - offsets[0]
+    if actual != expected:
+        raise ValueError(
+            f"{path}: tensor {name!r} byte length {actual} != "
+            f"shape/dtype length {expected}"
+        )
+
+
+def read_indexed_tensors(snapshot: Path) -> list[tuple[str, dict[str, Any]]]:
+    index_path = snapshot / "model.safetensors.index.json"
+    index = json.loads(index_path.read_text(encoding="utf-8"))
+    weight_map = index.get("weight_map")
+    if not isinstance(weight_map, dict) or not weight_map:
+        raise ValueError(f"{index_path}: missing non-empty weight_map")
+    headers = {
+        filename: read_header(snapshot / filename)
+        for filename in sorted(set(weight_map.values()))
+    }
+    tensors = []
+    for name, filename in weight_map.items():
+        entry = headers[filename].get(name)
+        if not isinstance(entry, dict):
+            raise ValueError(f"{snapshot / filename}: indexed tensor {name!r} missing")
+        tensors.append((name, entry))
+    return tensors
+
+
+def read_single_tensors(path: Path) -> list[tuple[str, dict[str, Any]]]:
+    header = read_header(path)
+    return [
+        (name, entry)
+        for name, entry in header.items()
+        if name != "__metadata__"
+    ]
+
+
+def tensor_bytes(entry: dict[str, Any]) -> int:
+    offsets = entry.get("data_offsets")
+    if (
+        not isinstance(offsets, list)
+        or len(offsets) != 2
+        or not all(isinstance(value, int) for value in offsets)
+        or offsets[0] < 0
+        or offsets[1] < offsets[0]
+    ):
+        raise ValueError(f"invalid tensor data_offsets: {offsets!r}")
+    return offsets[1] - offsets[0]
+
+
+def layer_index(name: str) -> int | None:
+    match = re.search(r"\.layers\.(\d+)\.", name)
+    return int(match.group(1)) if match else None
+
+
+def target_category(name: str, config: dict[str, Any]) -> str:
+    text = config.get("text_config", config)
+    base_layers = int(text.get("num_hidden_layers", 0))
+    idx = layer_index(name)
+    if name.startswith("model.visual."):
+        return "target.vision"
+    if name == "model.language_model.embed_tokens.weight":
+        return "target.embedding"
+    if name == "lm_head.weight":
+        return "target.lm_head"
+    if idx is not None and idx >= base_layers:
+        return "target.mtp_unused_dflash"
+    if ".mlp.experts." in name:
+        return "target.routed_experts"
+    if ".mlp.shared_experts." in name:
+        return "target.shared_experts"
+    if idx is not None and idx < int(text.get("first_k_dense_replace", 0)):
+        if ".mlp." in name:
+            return "target.dense_mlp"
+    if ".mlp.gate." in name:
+        return "target.router"
+    if ".self_attn." in name and idx is not None:
+        layer_types = text.get("layer_types") or []
+        if idx < len(layer_types) and layer_types[idx] == "linear_attention":
+            return "target.kda"
+        return "target.mla"
+    if any(
+        token in name
+        for token in (
+            "layernorm",
+            ".norm.",
+            ".norm.weight",
+            ".hc_",
+            ".eh_proj",
+            ".hnorm",
+            ".enorm",
+        )
+    ):
+        return "target.norm_mhc_aux"
+    return "target.unknown"
+
+
+def routed_geometry(name: str, tp_size: int) -> tuple[float, str]:
+    projection = ""
+    for candidate in ("gate_proj", "up_proj", "down_proj"):
+        if f".{candidate}." in name:
+            projection = candidate
+            break
+    suffix = name.rsplit(".", 1)[-1]
+    if suffix == "mcg":
+        return 1.0, "replicated marker"
+    if projection in {"gate_proj", "up_proj"}:
+        if suffix in {"trellis", "svh"}:
+            return 1 / tp_size, "column-sharded packed expert"
+        return 1.0, "replicated packed expert metadata"
+    if projection == "down_proj":
+        if suffix in {"trellis", "suh"}:
+            return 1 / tp_size, "row-sharded packed expert"
+        return 1.0, "replicated packed expert metadata"
+    return 1.0, "unknown routed tensor geometry"
+
+
+def target_geometry(
+    name: str, category: str, tp_size: int
+) -> tuple[float, str]:
+    if category == "target.mtp_unused_dflash":
+        return 0.0, "not loaded by DFlash target path"
+    if category == "target.unknown":
+        return 1.0, "unknown target geometry"
+    if tp_size == 1:
+        return 1.0, "single rank"
+    if category == "target.routed_experts":
+        return routed_geometry(name, tp_size)
+    if category in {"target.embedding", "target.lm_head"}:
+        return 1 / tp_size, "vocabulary-parallel"
+    if category == "target.vision":
+        if any(
+            token in name
+            for token in (
+                ".attn.qkv.weight",
+                ".attn.proj.weight",
+                ".mlp.gate_proj.weight",
+                ".mlp.up_proj.weight",
+                ".mlp.down_proj.weight",
+                ".merger.proj.weight",
+                ".merger.gate_proj.weight",
+                ".merger.up_proj.weight",
+                ".merger.down_proj.weight",
+            )
+        ):
+            return 1 / tp_size, "vision tensor-parallel linear"
+        return 1.0, "vision replicated/nonlinear"
+    if any(token in name for token in (".f_a_proj.", ".g_a_proj.")):
+        return 1.0, "replicated KDA fused shard"
+    if category == "target.mla" and any(
+        token in name
+        for token in (
+            ".q_a_proj.",
+            ".kv_a_proj_with_mqa.",
+            ".indexer.",
+        )
+    ):
+        return 1.0, "replicated MLA/indexer projection"
+    if name.endswith((".gate_proj.weight", ".up_proj.weight")):
+        return 1 / tp_size, "column-sharded linear"
+    if name.endswith(".down_proj.weight"):
+        return 1 / tp_size, "row-sharded linear"
+    if category in {"target.kda", "target.mla"} and name.endswith(".weight"):
+        if any(
+            token in name
+            for token in (
+                ".q_proj.",
+                ".k_proj.",
+                ".v_proj.",
+                ".b_proj.",
+                ".f_b_proj.",
+                ".g_b_proj.",
+                ".q_b_proj.",
+                ".kv_b_proj.",
+                ".o_proj.",
+                "_conv1d.",
+            )
+        ):
+            return 1 / tp_size, "attention tensor-parallel"
+    return 1.0, "replicated"
+
+
+def draft_category(name: str) -> str:
+    if name.startswith("candidate_selector."):
+        return "draft.selector"
+    if name == "fc.weight" or any(
+        token in name for token in (".self_attn.", ".mlp.")
+    ):
+        return "draft.backbone_linears"
+    if any(
+        token in name
+        for token in (
+            "attention_conv.base_kernel",
+            "attention_conv.kernel_projection.weight",
+            "mlp_conv.base_kernel",
+            "mlp_conv.kernel_projection.weight",
+        )
+    ):
+        return "draft.conv"
+    if (
+        name in {"hidden_norm.weight", "norm.weight"}
+        or name.endswith(".input_layernorm.weight")
+        or name.endswith(".post_attention_layernorm.weight")
+    ):
+        return "draft.norm"
+    return "draft.unknown"
+
+
+def read_license(snapshot: Path) -> str | None:
+    card = snapshot / "README.md"
+    if not card.is_file():
+        return None
+    text = card.read_text(encoding="utf-8", errors="replace")
+    if not text.startswith("---\n"):
+        return None
+    end = text.find("\n---", 4)
+    if end < 0:
+        return None
+    frontmatter = text[4:end]
+    match = re.search(r"(?m)^license:\s*([^\n#]+)", frontmatter)
+    if not match:
+        return None
+    license_id = match.group(1).strip()
+    if license_id.lower() != "other":
+        return license_id
+    name = re.search(r"(?m)^license_name:\s*([^\n#]+)", frontmatter)
+    return name.group(1).strip() if name else license_id
+
+
+def collect_target(snapshot: Path, tp_size: int) -> list[TensorInfo]:
+    config = json.loads((snapshot / "config.json").read_text(encoding="utf-8"))
+    result = []
+    for name, entry in read_indexed_tensors(snapshot):
+        category = target_category(name, config)
+        fraction, geometry = target_geometry(name, category, tp_size)
+        result.append(
+            TensorInfo(
+                name=name,
+                dtype=str(entry.get("dtype", "unknown")),
+                disk_bytes=tensor_bytes(entry),
+                category=category,
+                rank_fraction=fraction,
+                geometry=geometry,
+            )
+        )
+    return result
+
+
+def collect_draft(snapshot: Path, draft_tp_size: int) -> list[TensorInfo]:
+    result = []
+    for name, entry in read_single_tensors(snapshot / "model.safetensors"):
+        category = draft_category(name)
+        result.append(
+            TensorInfo(
+                name=name,
+                dtype=str(entry.get("dtype", "unknown")),
+                disk_bytes=tensor_bytes(entry),
+                category=category,
+                rank_fraction=1 / draft_tp_size,
+                geometry=(
+                    "draft tensor-parallel"
+                    if draft_tp_size > 1
+                    else "draft rank 0 only"
+                ),
+            )
+        )
+    return result
+
+
+def aggregate(tensors: list[TensorInfo]) -> dict[str, dict[str, Any]]:
+    groups: dict[str, dict[str, Any]] = defaultdict(
+        lambda: {"disk_bytes": 0, "rank_bytes": 0.0, "tensor_count": 0}
+    )
+    for tensor in tensors:
+        group = groups[tensor.category]
+        group["disk_bytes"] += tensor.disk_bytes
+        group["rank_bytes"] += tensor.disk_bytes * tensor.rank_fraction
+        group["tensor_count"] += 1
+    return dict(sorted(groups.items()))
+
+
+def routed_bytes_by_layer(
+    tensors: list[TensorInfo],
+) -> dict[int, dict[int, float]]:
+    layers: dict[int, dict[int, float]] = defaultdict(lambda: defaultdict(float))
+    for tensor in tensors:
+        if tensor.category != "target.routed_experts":
+            continue
+        match = re.search(r"\.layers\.(\d+)\..*\.experts\.(\d+)\.", tensor.name)
+        if match:
+            layers[int(match.group(1))][int(match.group(2))] += (
+                tensor.disk_bytes * tensor.rank_fraction
+            )
+    return {layer: dict(experts) for layer, experts in layers.items()}
+
+
+def estimate_traffic(
+    target: list[TensorInfo],
+    draft: list[TensorInfo],
+    active_experts: list[int],
+    accepted_per_step: float | None,
+) -> dict[str, Any]:
+    target_groups = aggregate(target)
+    draft_groups = aggregate(draft)
+    always_target = (
+        "target.shared_experts",
+        "target.dense_mlp",
+        "target.kda",
+        "target.mla",
+        "target.router",
+        "target.norm_mhc_aux",
+    )
+    base = sum(target_groups.get(name, {}).get("rank_bytes", 0.0) for name in always_target)
+    base += 2 * target_groups.get("target.lm_head", {}).get("rank_bytes", 0.0)
+    base += sum(group["rank_bytes"] for group in draft_groups.values())
+
+    routed = routed_bytes_by_layer(target)
+    scenarios = []
+    for active in active_experts:
+        routed_bytes = 0.0
+        for experts in routed.values():
+            sizes = sorted(experts.values(), reverse=True)
+            routed_bytes += sum(sizes[:active])
+        total = base + routed_bytes
+        scenario = {
+            "active_experts_per_moe_layer": active,
+            "rank0_weight_bytes_per_verify_step": round(total),
+            "routed_weight_bytes_per_verify_step": round(routed_bytes),
+        }
+        if accepted_per_step is not None:
+            emitted = 1.0 + accepted_per_step
+            scenario["estimated_weight_bytes_per_emitted_token"] = round(
+                total / emitted
+            )
+            scenario["emitted_tokens_per_verify_step"] = emitted
+        scenarios.append(scenario)
+    return {
+        "model": (
+            "Each non-routed weight is counted once per verify step, the shared "
+            "lm_head twice (draft plus verify), and routed experts once when active. "
+            "Embeddings are sparse row lookups and excluded. This is not a DRAM "
+            "counter measurement."
+        ),
+        "rank0_non_routed_and_draft_bytes_per_verify_step": round(base),
+        "scenarios": scenarios,
+    }
+
+
+def permission_report(target_license: str | None, draft_license: str | None) -> dict[str, Any]:
+    draft_blocked = bool(
+        draft_license and "nc-nd" in draft_license.lower().replace("_", "-")
+    )
+    return {
+        "target_license": target_license,
+        "target_quantization": (
+            "manual review required; preserve all base-model and pack attribution"
+        ),
+        "draft_license": draft_license,
+        "draft_quantization": (
+            "BLOCKED pending explicit derivative/commercial permission"
+            if draft_blocked
+            else "manual review required"
+        ),
+        "quality_gate": (
+            "Target dense/head quantization remains blocked until the owner explicitly "
+            "replaces the standing bit-exact gate with the task-specific quality gate."
+        ),
+    }
+
+
+def build_report(args: argparse.Namespace) -> dict[str, Any]:
+    target_snapshot = args.target_snapshot.resolve()
+    draft_snapshot = args.draft_snapshot.resolve()
+    target = collect_target(target_snapshot, args.tp_size)
+    draft = collect_draft(draft_snapshot, args.draft_tp_size)
+    target_groups = aggregate(target)
+    draft_groups = aggregate(draft)
+    rank_bytes = []
+    for rank in range(args.tp_size):
+        target_bytes = sum(item.disk_bytes * item.rank_fraction for item in target)
+        draft_bytes = (
+            sum(item.disk_bytes * item.rank_fraction for item in draft)
+            if rank < args.draft_tp_size
+            else 0.0
+        )
+        rank_bytes.append(round(target_bytes + draft_bytes))
+    return {
+        "target_snapshot": str(target_snapshot),
+        "draft_snapshot": str(draft_snapshot),
+        "tp_size": args.tp_size,
+        "draft_tp_size": args.draft_tp_size,
+        "target": {
+            "disk_bytes": sum(item.disk_bytes for item in target),
+            "categories": target_groups,
+        },
+        "draft": {
+            "disk_bytes": sum(item.disk_bytes for item in draft),
+            "categories": draft_groups,
+        },
+        "estimated_resident_weight_bytes_by_rank": rank_bytes,
+        "traffic": estimate_traffic(
+            target,
+            draft,
+            args.active_experts,
+            args.accepted_per_step,
+        ),
+        "permissions": permission_report(
+            read_license(target_snapshot), read_license(draft_snapshot)
+        ),
+        "unclassified": [
+            asdict(item)
+            for item in [*target, *draft]
+            if item.category.endswith(".unknown")
+            or item.geometry.startswith("unknown")
+        ],
+    }
+
+
+def positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("must be >= 1")
+    return parsed
+
+
+def active_expert_list(value: str) -> list[int]:
+    result = sorted({positive_int(part.strip()) for part in value.split(",")})
+    if not result:
+        raise argparse.ArgumentTypeError("must contain at least one count")
+    return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--target-snapshot", type=Path, required=True)
+    parser.add_argument("--draft-snapshot", type=Path, required=True)
+    parser.add_argument("--tp-size", type=positive_int, default=2)
+    parser.add_argument("--draft-tp-size", type=positive_int, default=1)
+    parser.add_argument(
+        "--active-experts",
+        type=active_expert_list,
+        default=active_expert_list("8,16,32,64"),
+        help="comma-separated unique routed experts per MoE layer",
+    )
+    parser.add_argument(
+        "--accepted-per-step",
+        type=float,
+        help="accepted draft tokens per verify step; emitted tokens are 1 + this value",
+    )
+    parser.add_argument("--out", type=Path)
+    args = parser.parse_args()
+    if args.draft_tp_size > args.tp_size:
+        parser.error("--draft-tp-size cannot exceed --tp-size")
+    if args.accepted_per_step is not None and args.accepted_per_step < 0:
+        parser.error("--accepted-per-step must be >= 0")
+    report = build_report(args)
+    rendered = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if args.out:
+        args.out.write_text(rendered, encoding="utf-8")
+    else:
+        print(rendered, end="")
+    return 2 if report["unclassified"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_live_weight_bytes.py
+++ b/tests/test_live_weight_bytes.py
@@ -1,0 +1,295 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import struct
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "audit_live_weight_bytes.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("audit_live_weight_bytes", SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def write_safetensors(path: Path, tensors: dict[str, tuple[str, int]]) -> None:
+    dtype_bytes = load_module().DTYPE_BYTES
+    offset = 0
+    header = {}
+    payload = bytearray()
+    for name, (dtype, size) in tensors.items():
+        assert size % dtype_bytes[dtype] == 0
+        header[name] = {
+            "dtype": dtype,
+            "shape": [size // dtype_bytes[dtype]],
+            "data_offsets": [offset, offset + size],
+        }
+        payload.extend(b"x" * size)
+        offset += size
+    encoded = json.dumps(header).encode()
+    path.write_bytes(struct.pack("<Q", len(encoded)) + encoded + payload)
+
+
+def fixture_snapshots(tmp_path: Path) -> tuple[Path, Path]:
+    target = tmp_path / "target"
+    draft = tmp_path / "draft"
+    target.mkdir()
+    draft.mkdir()
+    target_tensors = {
+        "model.language_model.embed_tokens.weight": ("BF16", 100),
+        "lm_head.weight": ("BF16", 100),
+        "model.language_model.layers.0.mlp.gate_proj.weight": ("BF16", 80),
+        "model.language_model.layers.0.mlp.down_proj.weight": ("BF16", 80),
+        "model.language_model.layers.0.self_attn.f_a_proj.weight": ("BF16", 20),
+        "model.language_model.layers.0.self_attn.q_proj.weight": ("BF16", 80),
+        "model.language_model.layers.3.self_attn.q_a_proj.weight": ("BF16", 40),
+        "model.language_model.layers.3.self_attn.o_proj.weight": ("BF16", 80),
+        "model.language_model.layers.3.mlp.shared_experts.up_proj.weight": (
+            "BF16",
+            80,
+        ),
+        "model.language_model.layers.3.mlp.experts.0.gate_proj.trellis": (
+            "I16",
+            40,
+        ),
+        "model.language_model.layers.3.mlp.experts.0.gate_proj.suh": ("F16", 8),
+        "model.language_model.layers.3.mlp.experts.0.down_proj.trellis": (
+            "I16",
+            40,
+        ),
+        "model.language_model.layers.3.mlp.experts.0.down_proj.svh": ("F16", 8),
+        "model.language_model.layers.4.mlp.experts.0.gate_proj.trellis": (
+            "I16",
+            40,
+        ),
+        "model.language_model.layers.4.mlp.experts.0.down_proj.trellis": (
+            "I16",
+            40,
+        ),
+        "model.language_model.layers.45.mlp.gate_proj.weight": ("BF16", 80),
+        "model.visual.blocks.0.attn.qkv.weight": ("BF16", 80),
+        "model.visual.patch_embed.proj.weight": ("BF16", 20),
+    }
+    shard = target / "model-00001-of-00001.safetensors"
+    write_safetensors(shard, target_tensors)
+    (target / "model.safetensors.index.json").write_text(
+        json.dumps({"weight_map": {name: shard.name for name in target_tensors}})
+    )
+    (target / "config.json").write_text(
+        json.dumps(
+            {
+                "text_config": {
+                    "num_hidden_layers": 45,
+                    "first_k_dense_replace": 3,
+                    "layer_types": [
+                        "linear_attention",
+                        "linear_attention",
+                        "linear_attention",
+                        "deepseek_sparse_attention",
+                    ],
+                }
+            }
+        )
+    )
+    (target / "README.md").write_text("---\nlicense: shapleymcg-1.0\n---\n")
+    write_safetensors(
+        draft / "model.safetensors",
+        {
+            "layers.0.self_attn.q_proj.weight": ("BF16", 80),
+            "candidate_selector.hidden_projection.weight": ("BF16", 20),
+            "hidden_norm.weight": ("BF16", 4),
+        },
+    )
+    (draft / "README.md").write_text("---\nlicense: cc-by-nc-nd-4.0\n---\n")
+    return target, draft
+
+
+def test_mixed_tp_geometry_and_unused_tensors(tmp_path: Path) -> None:
+    module = load_module()
+    target, _ = fixture_snapshots(tmp_path)
+    tensors = module.collect_target(target, 2)
+    by_name = {tensor.name: tensor for tensor in tensors}
+    assert by_name[
+        "model.language_model.layers.0.self_attn.f_a_proj.weight"
+    ].rank_fraction == 1
+    assert by_name[
+        "model.language_model.layers.0.self_attn.q_proj.weight"
+    ].rank_fraction == 0.5
+    assert by_name[
+        "model.language_model.layers.3.self_attn.q_a_proj.weight"
+    ].rank_fraction == 1
+    assert by_name[
+        "model.language_model.layers.3.mlp.experts.0.gate_proj.trellis"
+    ].rank_fraction == 0.5
+    assert by_name[
+        "model.language_model.layers.3.mlp.experts.0.gate_proj.suh"
+    ].rank_fraction == 1
+    assert by_name[
+        "model.language_model.layers.45.mlp.gate_proj.weight"
+    ].rank_fraction == 0
+    assert by_name["model.visual.blocks.0.attn.qkv.weight"].rank_fraction == 0.5
+    assert by_name["model.visual.patch_embed.proj.weight"].rank_fraction == 1
+
+
+def test_report_separates_residency_traffic_and_permissions(tmp_path: Path) -> None:
+    module = load_module()
+    target, draft = fixture_snapshots(tmp_path)
+    args = type(
+        "Args",
+        (),
+        {
+            "target_snapshot": target,
+            "draft_snapshot": draft,
+            "tp_size": 2,
+            "draft_tp_size": 1,
+            "active_experts": [1],
+            "accepted_per_step": 3.0,
+        },
+    )()
+    report = module.build_report(args)
+    assert report["estimated_resident_weight_bytes_by_rank"][0] > report[
+        "estimated_resident_weight_bytes_by_rank"
+    ][1]
+    assert report["target"]["categories"]["target.vision"]["disk_bytes"] == 100
+    assert report["target"]["categories"]["target.mtp_unused_dflash"][
+        "rank_bytes"
+    ] == 0
+    scenario = report["traffic"]["scenarios"][0]
+    assert scenario["emitted_tokens_per_verify_step"] == 4
+    assert scenario["routed_weight_bytes_per_verify_step"] == 96
+    assert report["permissions"]["draft_quantization"].startswith("BLOCKED")
+    assert "explicitly replaces" in report["permissions"]["quality_gate"]
+
+
+def test_invalid_header_fails_closed(tmp_path: Path) -> None:
+    module = load_module()
+    broken = tmp_path / "broken.safetensors"
+    broken.write_bytes(b"\x10\x00\x00")
+    try:
+        module.read_header(broken)
+    except ValueError as exc:
+        assert "missing safetensors header length" in str(exc)
+    else:
+        raise AssertionError("truncated safetensors header was accepted")
+
+
+def test_malformed_tensor_records_and_payloads_fail_closed(tmp_path: Path) -> None:
+    module = load_module()
+    malformed = tmp_path / "malformed.safetensors"
+    header = json.dumps({"tensor": "not-an-object"}).encode()
+    malformed.write_bytes(struct.pack("<Q", len(header)) + header)
+    try:
+        module.read_header(malformed)
+    except ValueError as exc:
+        assert "record is not an object" in str(exc)
+    else:
+        raise AssertionError("malformed tensor record was accepted")
+
+    oversized = tmp_path / "oversized.safetensors"
+    header = json.dumps(
+        {
+            "tensor": {
+                "dtype": "BF16",
+                "shape": [1],
+                "data_offsets": [0, 1_000_000],
+            }
+        }
+    ).encode()
+    oversized.write_bytes(struct.pack("<Q", len(header)) + header)
+    try:
+        module.read_header(oversized)
+    except ValueError as exc:
+        assert "invalid data_offsets" in str(exc)
+    else:
+        raise AssertionError("out-of-bounds tensor payload was accepted")
+
+    wrong_size = tmp_path / "wrong-size.safetensors"
+    header = json.dumps(
+        {
+            "tensor": {
+                "dtype": "BF16",
+                "shape": [1],
+                "data_offsets": [0, 4],
+            }
+        }
+    ).encode()
+    wrong_size.write_bytes(struct.pack("<Q", len(header)) + header + b"xxxx")
+    try:
+        module.read_header(wrong_size)
+    except ValueError as exc:
+        assert "shape/dtype length" in str(exc)
+    else:
+        raise AssertionError("shape/dtype mismatch was accepted")
+
+
+def test_custom_license_name_is_reported(tmp_path: Path) -> None:
+    module = load_module()
+    snapshot = tmp_path / "snapshot"
+    snapshot.mkdir()
+    (snapshot / "README.md").write_text(
+        "---\nlicense: other\nlicense_name: shapleymcg-1.0\n---\n"
+    )
+    assert module.read_license(snapshot) == "shapleymcg-1.0"
+
+
+def test_unknown_target_and_draft_tensors_make_cli_fail(tmp_path: Path) -> None:
+    target, draft = fixture_snapshots(tmp_path)
+    target_shard = target / "model-00001-of-00001.safetensors"
+    write_safetensors(
+        target_shard,
+        {
+            "model.unrecognized.weight": ("BF16", 8),
+        },
+    )
+    (target / "model.safetensors.index.json").write_text(
+        json.dumps(
+            {
+                "weight_map": {
+                    "model.unrecognized.weight": target_shard.name,
+                }
+            }
+        )
+    )
+    write_safetensors(
+        draft / "model.safetensors",
+        {"mystery.weight": ("BF16", 8)},
+    )
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--target-snapshot",
+            str(target),
+            "--draft-snapshot",
+            str(draft),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 2
+    report = json.loads(result.stdout)
+    assert {item["name"] for item in report["unclassified"]} == {
+        "model.unrecognized.weight",
+        "mystery.weight",
+    }
+
+
+def test_unused_mtp_is_excluded_at_tp1(tmp_path: Path) -> None:
+    module = load_module()
+    target, _ = fixture_snapshots(tmp_path)
+    tensors = module.collect_target(target, 1)
+    mtp = next(
+        tensor
+        for tensor in tensors
+        if tensor.name == "model.language_model.layers.45.mlp.gate_proj.weight"
+    )
+    assert mtp.rank_fraction == 0


### PR DESCRIPTION
## Summary

- add a header-only safetensors audit that classifies target and DFlash2 weights by live module and TP residency
- model verification-step and emitted-token weight-read envelopes without presenting them as DRAM counter measurements
- fail closed on malformed payloads, unsupported or unknown tensor records, and incomplete attribution
- expose target and draft weight-license gates
- document separate draft-only and target dense/head A/B windows, quality gates, aborts, and rollback
- record the exact two-node attribution receipt in the improvement ledger

## Decision

Adopt the audit tool and A/B runbook. Keep both quantization arms parked. Draft quantization requires explicit derivative/commercial permission, and target dense/head quantization requires an explicit owner waiver replacing the standing bit-exact gate with the documented quality gate.

No model weights, image, launcher, runtime configuration, service, KV pin, or production file changed.

## Validation

- `uv run --with pytest --with jinja2 python -m pytest tests/ -q`: 134 passed, 1 skipped, 4 subtests passed
- `uvx ruff check scripts/audit_live_weight_bytes.py tests/test_live_weight_bytes.py`: passed
- Python compile, bash syntax, and `git diff --check`: passed
- independent final review: approved, no required findings
- exact script SHA256 `1b69b17894b7c9e8b0b84f5f8116b565e38c6cf851acae6b7bd83f8d971702d1` ran on both target nodes
- both-node reports matched after path normalization, classified every tensor, and identified the expected weight licenses
- post-run service and watchdog active, health 200, preemptions 0
