### PR TITLE
Q1: record rejected hardware profile

### DIFF
--- a/docs/06-improvement-plan.md
+++ b/docs/06-improvement-plan.md
@@ -125,6 +125,39 @@ MemFree was 6,906,112 / 4,040,188 kB. Local validation: 131 passed, 1 skipped,
 was **134 passed, 1 skipped, 4 subtests passed**. Ruff, Python compile, bash
 syntax and diff checks passed.
 
+### 2026-09-05: hardware-counter profile rejected; no quantized A/B
+
+The degraded prose baseline recovered after an unchanged clean restart. Five
+1,200-token prose controls reached 27.61 tok/s median, nine 2,600-token controls
+reached 27.73 tok/s median, and five structured controls reached 67.32 tok/s.
+This closed the suspected production regression without another configuration
+change.
+
+Nsight Systems 2025.3.2 exposed SM/tensor activity on GB10 but no usable
+external-memory byte counter. Nsight Compute 2025.3.1 validated that external
+LPDDR traffic appears as 32-byte L2 sysmem-aperture sectors on isolated
+workloads. A default-off, bounded two-rank profiler candidate passed local
+tests and independent review before each target attempt.
+
+The exact production TP2, DFlash2 k=7/draft-TP1, MNBT=3584 request did not
+produce a valid receipt. Per-kernel replay failed on
+`unrolled_elementwise_kernel` on both ranks. A separately reviewed whole-graph
+retry failed on `graph` on both ranks. Each lifecycle log contains
+`==ERROR==`; neither partial capture was parsed or used as evidence.
+
+The profiling launcher and helpers were reverted rather than published.
+Production returned to launcher SHA256
+`d8fe5a644ebd2a6d6e79f38b89c10f206a2596db01df6513d8a9dbcad51a5fe1`,
+with the service, watchdog and metrics timer active. Post-rollback controls:
+five 1,200-token prose runs at 27.35 tok/s median, coherent and NaN-free; five
+structured runs at 69.21 tok/s with acceptance 1.000/7.000; health 200 and zero
+preemptions.
+
+Decision: **NO A/B**. Header accounting remains a model, not a hardware
+measurement. Do not build or test quantized weights unless a different exact
+production counter path succeeds and the existing drafter-permission and
+target-quality-waiver gates are both cleared.
+
 ### 2026-09-05: P0 runtime diagnostics and null-gap repair adopted
 
 The next priority block combines tasks 18, 9 and the task-27 null-gap

--- a/docs/14-selective-quantization-gate.md
+++ b/docs/14-selective-quantization-gate.md
@@ -24,6 +24,39 @@ routed expert once. Embedding row lookups and text-idle vision weights are
 excluded. Supply the measured `accepted_per_step` from `bench_decode.py` to
 derive bytes per emitted token.
 
+## Hardware-counter attempt — rejected 2026-09-05
+
+The degraded prose observation recovered after an unchanged clean restart, so
+no production tuning change was needed. The stable controls were 27.73 tok/s
+median across nine 2,600-token prose runs and 67.32 tok/s across five
+structured runs.
+
+Nsight Systems 2025.3.2 did not expose a usable GB10 external-memory byte
+counter. Nsight Compute 2025.3.1 did validate the L2 sysmem-aperture method on
+isolated workloads (32 bytes per sector), but it could not collect the exact
+production TP2 request safely:
+
+- default per-kernel replay failed symmetrically on both ranks while profiling
+  `unrolled_elementwise_kernel`;
+- whole-graph profiling, filtered to `regex:^graph$`, failed symmetrically on
+  both ranks while profiling `graph`.
+
+Both failures terminated the profiled API process. Their partial lifecycle logs
+contain Nsight `==ERROR==` markers, so no report was parsed and no measured-byte
+claim is valid. The profiler launcher and helper files were reverted instead of
+being shipped.
+
+Normal production was restored with the original launcher SHA256
+`d8fe5a644ebd2a6d6e79f38b89c10f206a2596db01df6513d8a9dbcad51a5fe1`.
+Post-rollback controls were coherent at 27.35 tok/s median for five 1,200-token
+prose runs and 69.21 tok/s for five structured runs, with structured
+acceptance 1.000/7.000, health 200 and zero preemptions.
+
+Decision: do not run a quantized-weight A/B from the header accounting model
+alone. Reopen hardware attribution only when a different counter path is
+validated against the exact multi-process CUDA-graph workload. The permission
+and target-quality gates below remain independently blocking.
+
 ```bash
 uv run python scripts/audit_live_weight_bytes.py \
   --target-snapshot "$TARGET_SNAPSHOT" \


### PR DESCRIPTION
## Summary
- record that the degraded prose baseline recovered after an unchanged clean restart
- document both fail-closed exact-production Nsight Compute attempts
- record the complete runtime rollback and post-rollback production controls
- close the quantized A/B lane until a different exact-workload counter path succeeds

## Result
The exact TP2, DFlash2 k=7/draft-TP1, MNBT=3584 workload produced no valid hardware-counter receipt:

- per-kernel replay failed on `unrolled_elementwise_kernel` on both ranks
- whole-graph profiling failed on `graph` on both ranks
- both partial logs contain Nsight `==ERROR==` markers and were not parsed

No profiler runtime code is included in this PR. The deployed launcher was restored to SHA256 `d8fe5a644ebd2a6d6e79f38b89c10f206a2596db01df6513d8a9dbcad51a5fe1`, and task-created profiler helpers were removed.

## Production validation
- service, watchdog, and metrics timer active
- health HTTP 200
- preemptions 0
- post-rollback prose: 27.35 tok/s median across five 1,200-token runs, coherent and NaN-free
- post-rollback structured: 69.21 tok/s median, acceptance 1.000 / 7.000

## Decision
Do not run a quantized-weight A/B from header accounting alone. Reopen only after a different counter path succeeds on the exact multi-process CUDA-graph workload. DFlash2 derivative/commercial permission and the target-quality waiver remain independent blockers.

## Validation
- `git diff --check`
- independent final review approved the docs-only outcome
