### PR TITLE
D2: park unsupported verification-length arm

### DIFF
--- a/docs/06-improvement-plan.md
+++ b/docs/06-improvement-plan.md
@@ -36,6 +36,41 @@ Mainline GLM support (#53906) has merged, so model resolution is no longer the
 mainline blocker described in the historical section above; EXL3 integration
 and overlay compatibility still block a stock-image replacement.
 
+### 2026-09-05: task 4 verification-length study parked before restart
+
+The required implementation audit found no supported verification-only k=4/3
+arm in the production legacy DFlash2 path. The pinned checkpoint declares an
+eight-row block. The proposer derives its query/mask rows from
+`1 + num_speculative_tokens`; the DFlash2 overlay uses the same value for the
+grouped-convolution block, selector walk and draft-logit cache. The image does
+contain adaptive-verification machinery, but its configuration rejects every
+method except DSpark. Therefore changing `DFLASH_TOKENS` would change the
+trained draft contract, not only target verification work.
+
+`scripts/audit_dflash_verification_length.py` records this decision from exact
+checkpoint and image source files and fails closed on source drift. The
+launcher exposes a side-effect-free `validate` command, and the production
+wrapper invokes it before stopping either node or handling JIT caches. It
+refuses non-native DFlash2 values while leaving production untouched. No k=3/4
+arm, shape-cache invalidation or production restart was performed. Reopen only
+on a reviewed MRV2/adaptive-verification path that keeps the native eight-row
+draft intact.
+
+Exact candidate audit SHA256 `180f18e35deee722bcf27378ca88f15501726d649be92148ca41176ec70c3fd4`
+launcher SHA256 `e7a98c6db84cbb55dad404e09e07a8f88094f5aad9c91b3e95673ee90c72c3ad`
+and production-wrapper SHA256
+`3e6a1bd49ba5b246be13ee1e86a509c849271a14ec7c53770e6e63deb52575ca`
+were staged under `/tmp` and matched on both nodes. Both audits returned
+`decision=park`, native block 8 / k=7, and all six checkpoint/source-contract
+checks true. The exact launcher accepted the current production configuration
+and non-DFlash k=4, while the exact wrapper rejected DFlash k=4 on the head and
+k=3 on the worker with rc=2 before stop or cache handling. The head JIT stamp
+remained SHA256 `9ef05abc7f69f015838edda9b3ddac3b975f300a1450f4166db5ef033cf55c34`.
+The head stayed HTTP 200 with zero preemptions; head and worker containers
+remained running with unchanged start timestamps `23:17:30.503013329Z` /
+`23:17:29.752030646Z`. Local validation was 139 passed, 1 skipped and 4
+subtests; Ruff, shell syntax, shellcheck, Python compile and diff checks passed.
+
 ### 2026-09-05: R0 harness foundation implemented
 
 The first priority block from the September 5 survey is implemented without a

--- a/env.example
+++ b/env.example
@@ -183,8 +183,9 @@ DFLASH_MODEL=incoai/GLM-5.3-Flash-DFlash2
 # this repo was taken on 7d74cdd. A drafter swap is a JIT-shape change (hashed by
 # local/prod-start.sh). Empty = track main deliberately.
 DFLASH_REVISION=7d74cdd881ed7e32c31175984a67823127b66cfe
-DFLASH_TOKENS=7                     # k=7; verify batch = 8 tokens/seq — cudagraph capture
-                                    # sizes 1 2 4 8 16 24 32 are TOKEN batches for 1-4 seqs
+DFLASH_TOKENS=7                     # Fixed native eight-row DFlash2 block. This legacy
+                                    # path refuses non-7 values: changing k also changes
+                                    # masks/conv/selector/cache, not verification alone.
 
 # --- downloads / sync ---------------------------------------------------------
 # HF CLI override when `hf` lives outside PATH (venv installs). May contain

--- a/local/prod-start.sh
+++ b/local/prod-start.sh
@@ -42,6 +42,15 @@ SETTLE_INTERVAL="${SETTLE_INTERVAL:-10}"
 
 log() { echo "[prod-start] $*"; }
 
+log "validating configuration before stop or JIT-cache handling"
+if ./start.sh validate; then
+    :
+else
+    rc=$?
+    log "configuration invalid — production left untouched"
+    exit "$rc"
+fi
+
 log "stopping any running pair (idempotent)"
 ./start.sh stop || true
 

--- a/scripts/audit_dflash_verification_length.py
+++ b/scripts/audit_dflash_verification_length.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Classify whether a DFlash2 verification-only length arm is supported."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+def _contains_all(source: str, anchors: tuple[str, ...]) -> bool:
+    return all(anchor in source for anchor in anchors)
+
+
+def audit(
+    config: dict[str, Any],
+    base_speculator: str,
+    dflash2_speculator: str,
+    dflash2_model: str,
+    speculative_config: str,
+    candidates: list[int],
+) -> dict[str, Any]:
+    architectures = config.get("architectures") or []
+    draft_config = config.get("dflash_config") or {}
+    block_size = draft_config.get("block_size")
+    native_tokens = block_size - 1 if isinstance(block_size, int) else None
+
+    checks = {
+        "dflash2_checkpoint": "DFlash2DraftModel" in architectures,
+        "native_block_size_present": isinstance(block_size, int) and block_size > 1,
+        "query_rows_coupled_to_num_speculative_tokens": _contains_all(
+            base_speculator,
+            (
+                "self.num_query_per_req = 1 + self.num_speculative_steps",
+                "max_num_sampled_tokens = "
+                "self.max_num_reqs * self.num_speculative_steps",
+                "num_query_tokens = num_reqs * self.num_query_per_req",
+            ),
+        ),
+        "selector_and_cache_coupled_to_num_speculative_tokens": _contains_all(
+            dflash2_speculator,
+            (
+                "self.num_speculative_steps,",
+                "num_steps=self.num_speculative_steps",
+                "num_sample = num_reqs * self.num_speculative_steps",
+            ),
+        ),
+        "grouped_conv_block_coupled_to_num_speculative_tokens": (
+            "block_size=1 + speculative_config.num_speculative_tokens"
+            in dflash2_model
+        ),
+        "adaptive_verification_restricted_to_dspark": (
+            'if self.method != "dspark" and self.enable_adaptive_verification:'
+            in speculative_config
+            and 'raise ValueError("Adaptive verification only supported with DSpark")'
+            in speculative_config
+        ),
+    }
+
+    recognized_legacy_path = all(checks.values())
+    if recognized_legacy_path:
+        decision = "park"
+        reason = (
+            "The legacy DFlash2 path has no independent verification-length "
+            "control. Changing num_speculative_tokens also changes the native "
+            "query rows, grouped-convolution block, selector walk, and draft-logit "
+            "cache. Adaptive verification is restricted to DSpark."
+        )
+    else:
+        decision = "unknown"
+        reason = (
+            "The audited source or checkpoint contract drifted. Do not run a "
+            "verification-length arm until the new path is reviewed."
+        )
+
+    return {
+        "decision": decision,
+        "supported_verification_only_arm": False,
+        "requested_num_speculative_tokens": candidates,
+        "native_block_size": block_size,
+        "native_num_speculative_tokens": native_tokens,
+        "checks": checks,
+        "reason": reason,
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--config", type=Path, required=True)
+    parser.add_argument("--base-speculator", type=Path, required=True)
+    parser.add_argument("--dflash2-speculator", type=Path, required=True)
+    parser.add_argument("--dflash2-model", type=Path, required=True)
+    parser.add_argument("--speculative-config", type=Path, required=True)
+    parser.add_argument(
+        "--candidate",
+        action="append",
+        type=int,
+        default=[],
+        help="Proposed num_speculative_tokens value; repeat for multiple arms.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    candidates = args.candidate or [4, 3]
+    if any(candidate < 1 for candidate in candidates):
+        raise SystemExit("--candidate values must be positive")
+    report = audit(
+        json.loads(args.config.read_text()),
+        args.base_speculator.read_text(),
+        args.dflash2_speculator.read_text(),
+        args.dflash2_model.read_text(),
+        args.speculative_config.read_text(),
+        candidates,
+    )
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0 if report["decision"] == "park" else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/start.sh
+++ b/start.sh
@@ -36,6 +36,7 @@
 #                                 (no worker). Same as ./download.sh
 #   ./start.sh stop               stop both nodes
 #   ./start.sh restart            stop + start
+#   ./start.sh validate           validate start/restart configuration only
 #   ./start.sh status             containers + API health
 #   ./start.sh logs               follow head logs
 #   ./start.sh logs worker        follow worker container logs
@@ -47,7 +48,10 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 
-if [ ! -f "$SCRIPT_DIR/.env" ]; then
+if [ ! -f "$SCRIPT_DIR/.env" ] && [ "${1:-start}" = validate ]; then
+    echo "ERROR: missing .env; validation does not create configuration files" >&2
+    exit 1
+elif [ ! -f "$SCRIPT_DIR/.env" ]; then
     [ -f "$SCRIPT_DIR/env.example" ] || {
         echo "ERROR: missing env.example" >&2
         exit 1
@@ -199,6 +203,10 @@ if [ -n "${DFLASH_REVISION:-}" ] && ! [[ "$DFLASH_REVISION" =~ ^[0-9a-f]{40}$ ]]
     exit 1
 fi
 DFLASH_TOKENS="${DFLASH_TOKENS:-7}"
+# The pinned DFlash2 checkpoint has a native eight-row block. On this legacy
+# proposer num_speculative_tokens also controls query/mask rows, grouped
+# convolution, selector walking and draft-logit cache shape. It is not an
+# independent verification-length knob; task 4 parked k=3/4 for MRV2.
 # 2 = shard the ~2.3 GiB DFlash2 drafter across TP (C4 keep, 2026-08-30:
 # idle 8k 938 / 16k 972 / 100k 997; decode structured 65.1 / prose 27.1).
 # 1 = rank 0 only (no CX7 on every draft step). Empty = inherit target TP.
@@ -294,7 +302,7 @@ GLM53_SUPPRESS_STOPS_IN_REASONING="${GLM53_SUPPRESS_STOPS_IN_REASONING:-1}"
 # LOCAL (W27, kit PR #87): server-side default reasoning effort, injected as
 # --default-chat-template-kwargs '{"reasoning_effort":"<v>"}'. EMPTY (default)
 # sends no flag and the template renders Max for any client that omits it.
-# low | high | max (validated in validate_numeric_config — start/restart only,
+# low | high | max (validated before start/restart, or by `validate`,
 # so a bad value never blocks stop/status/logs). Per-request
 # chat_template_kwargs.reasoning_effort overrides the default.
 GLM53_DEFAULT_REASONING_EFFORT="${GLM53_DEFAULT_REASONING_EFFORT-}"
@@ -317,9 +325,9 @@ GLM53_FINE_GRAINED_APC="${GLM53_FINE_GRAINED_APC:-0}"
 # (scheduler livelock, dormant at LPTT=1792 — proven 0 mismatches over 608 combinations). Read once at import.
 GLM53_ALIGN_FLOOR="${GLM53_ALIGN_FLOOR:-1}"
 # LOCAL: W41/W42 knob defaults (begin) -- exactly 0 or 1; UNSET -> 1; "" is a
-# value and is rejected. Strict validation lives in validate_numeric_config
-# (start/restart only), so a bad value can never block stop/status/logs on a
-# running pair; the overlays re-validate in-process and fail closed at boot.
+# value and is rejected. Strict validation runs before start/restart and through
+# `validate`, so a bad value cannot block stop/status/logs on a running pair;
+# the overlays re-validate in-process and fail closed at boot.
 GLM53_KV_CAPACITY_LOG="${GLM53_KV_CAPACITY_LOG-1}"
 GLM53_APC_NO_STORE="${GLM53_APC_NO_STORE-1}"
 # W28: stock is the shipped allocation; rightsize enables the GLM-5.3-only
@@ -407,6 +415,13 @@ validate_numeric_config() {
     _glm53_canonical_positive_int MAX_MODEL_LEN "$MAX_MODEL_LEN" 1000000 || return
     _glm53_canonical_positive_int MAX_NUM_SEQS "$MAX_NUM_SEQS" 4096 || return
     _glm53_canonical_positive_int MAX_NUM_BATCHED_TOKENS "$MAX_NUM_BATCHED_TOKENS" 8388608 || return
+    if [ "$SPEC_METHOD" = dflash ]; then
+        _glm53_canonical_positive_int DFLASH_TOKENS "$DFLASH_TOKENS" 64 || return
+        if [ "$DFLASH_TOKENS" != 7 ]; then
+            echo "DFLASH_TOKENS must remain 7 for this fixed-block DFlash2 path; verification-only k=3/4 is unsupported (got: $DFLASH_TOKENS)" >&2
+            return 2
+        fi
+    fi
     # LOCAL: W27 — strict enum; it is also the safety boundary for the worker's
     # word-split `-e` transport (never widen it without adding quoting).
     case "${GLM53_DEFAULT_REASONING_EFFORT-}" in
@@ -414,9 +429,9 @@ validate_numeric_config() {
         *) echo "GLM53_DEFAULT_REASONING_EFFORT must be one of: low high max (got: ${GLM53_DEFAULT_REASONING_EFFORT})" >&2; return 2 ;;
     esac
     # LOCAL: W41/W42 strict-bool validation (begin) -- exactly 0 or 1; "" is a
-    # value and is rejected. Lives in validate_numeric_config (start/restart
-    # only): a bad value fails the boot, never stop/status/logs on a running
-    # pair; the overlays re-validate in-process and fail closed.
+    # value and is rejected. Runs before start/restart and through `validate`:
+    # a bad value fails before boot, never stop/status/logs on a running pair;
+    # the overlays re-validate in-process and fail closed.
     for _v in GLM53_KV_CAPACITY_LOG GLM53_APC_NO_STORE; do
         case "${!_v}" in 0|1) ;; *) echo "$_v must be exactly 0 or 1 (got: '${!_v}')" >&2; return 2 ;; esac
     done
@@ -1761,11 +1776,12 @@ logs() {
 main() {
     local cmd="${1:-start}"
     case "$cmd" in
-        start|restart) validate_numeric_config ;;
+        start|restart|validate) validate_numeric_config ;;
     esac
     case "$cmd" in
         stop)     banner stop.sh ;;
         download) banner download.sh ;;
+        validate) ;;
         *)        banner start.sh ;;
     esac
     case "$cmd" in
@@ -1773,6 +1789,7 @@ main() {
         download) download_only ;;
         stop)     stop ;;
         restart)  stop; start ;;
+        validate) log "configuration valid" ;;
         status)   status ;;
         logs)     shift || true; logs "$@" ;;
         -h|--help|help) usage ;;

--- a/tests/test_apc_no_store.py
+++ b/tests/test_apc_no_store.py
@@ -872,7 +872,7 @@ def part_c(root: Path | None) -> None:
 def defaults_source() -> str:
     """The fork's W41/W42 knob-defaults block in start.sh. Top level, but it
     only substitutes UNSET -> 1 and never exits: strict validation lives in
-    validate_numeric_config (start/restart only), so a bad value can never
+    validate_numeric_config (before start/restart or through validate), so a bad value can never
     block stop/status/logs on a running pair."""
     text = START.read_text()
     begin = text.index("# LOCAL: W41/W42 knob defaults (begin)")
@@ -971,8 +971,8 @@ def _launcher_wiring(prefix: str, host_var: str, overlay: str, knob: str, tag: s
         check(rc == 0 and o == f"{len(value)}|{value}", f"{prefix}4 top level passes {value!r} through byte-exact (rc=0) -- stop/status/logs unblockable")
     src2 = START.read_text()
     check(src2.count("# LOCAL: W41/W42 strict-bool validation (begin)") == 1, f"{prefix}5 strict-bool validator present exactly once")
-    check(src2.index("# LOCAL: W41/W42 strict-bool validation (begin)") > src2.index("validate_numeric_config() {"), f"{prefix}5 validator lives inside validate_numeric_config (start/restart only)")
-    check("start|restart) validate_numeric_config" in src2, f"{prefix}5 validator wired to start|restart only")
+    check(src2.index("# LOCAL: W41/W42 strict-bool validation (begin)") > src2.index("validate_numeric_config() {"), f"{prefix}5 validator lives inside validate_numeric_config")
+    check("start|restart|validate) validate_numeric_config" in src2, f"{prefix}5 validator wired before start/restart and through validate")
     check("bool knob guard (begin)" not in src2, f"{prefix}5 no top-level W41/W42 guard remains")
     for value in ("1", "0"):
         rc, o, e = _run_validator(knob, value)

--- a/tests/test_dflash_verification_length.py
+++ b/tests/test_dflash_verification_length.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""CPU tests for the DFlash2 verification-length compatibility audit."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/audit_dflash_verification_length.py"
+SPEC = importlib.util.spec_from_file_location("dflash_length_audit", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+CONFIG = {
+    "architectures": ["DFlash2DraftModel"],
+    "dflash_config": {"block_size": 8, "selector_top_k": 16},
+}
+BASE_SPECULATOR = """
+self.num_query_per_req = 1 + self.num_speculative_steps
+max_num_sampled_tokens = self.max_num_reqs * self.num_speculative_steps
+num_query_tokens = num_reqs * self.num_query_per_req
+"""
+DFLASH2_SPECULATOR = """
+self.num_speculative_steps,
+num_steps=self.num_speculative_steps
+num_sample = num_reqs * self.num_speculative_steps
+"""
+DFLASH2_MODEL = "block_size=1 + speculative_config.num_speculative_tokens"
+SPECULATIVE_CONFIG = """
+if self.method != "dspark" and self.enable_adaptive_verification:
+    raise ValueError("Adaptive verification only supported with DSpark")
+"""
+
+
+def run_audit(**overrides):
+    values = {
+        "config": CONFIG,
+        "base_speculator": BASE_SPECULATOR,
+        "dflash2_speculator": DFLASH2_SPECULATOR,
+        "dflash2_model": DFLASH2_MODEL,
+        "speculative_config": SPECULATIVE_CONFIG,
+        "candidates": [4, 3],
+    }
+    values.update(overrides)
+    return MODULE.audit(**values)
+
+
+def test_legacy_dflash2_path_parks_verification_only_arm() -> None:
+    report = run_audit()
+    assert report["decision"] == "park"
+    assert report["supported_verification_only_arm"] is False
+    assert report["native_block_size"] == 8
+    assert report["native_num_speculative_tokens"] == 7
+    assert all(report["checks"].values())
+
+
+def test_source_drift_fails_closed() -> None:
+    report = run_audit(dflash2_model="block_size=8")
+    assert report["decision"] == "unknown"
+    assert report["supported_verification_only_arm"] is False
+    assert not report["checks"][
+        "grouped_conv_block_coupled_to_num_speculative_tokens"
+    ]

--- a/tests/test_kv_capacity_log.py
+++ b/tests/test_kv_capacity_log.py
@@ -719,7 +719,7 @@ def stat_mode(path: Path) -> int:
 def defaults_source() -> str:
     """The fork's W41/W42 knob-defaults block in start.sh. Top level, but it
     only substitutes UNSET -> 1 and never exits: strict validation lives in
-    validate_numeric_config (start/restart only), so a bad value can never
+    validate_numeric_config (before start/restart or through validate), so a bad value can never
     block stop/status/logs on a running pair."""
     text = START.read_text()
     begin = text.index("# LOCAL: W41/W42 knob defaults (begin)")
@@ -818,8 +818,8 @@ def _launcher_wiring(prefix: str, host_var: str, overlay: str, knob: str, tag: s
         check(rc == 0 and o == f"{len(value)}|{value}", f"{prefix}4 top level passes {value!r} through byte-exact (rc=0) -- stop/status/logs unblockable")
     src2 = START.read_text()
     check(src2.count("# LOCAL: W41/W42 strict-bool validation (begin)") == 1, f"{prefix}5 strict-bool validator present exactly once")
-    check(src2.index("# LOCAL: W41/W42 strict-bool validation (begin)") > src2.index("validate_numeric_config() {"), f"{prefix}5 validator lives inside validate_numeric_config (start/restart only)")
-    check("start|restart) validate_numeric_config" in src2, f"{prefix}5 validator wired to start|restart only")
+    check(src2.index("# LOCAL: W41/W42 strict-bool validation (begin)") > src2.index("validate_numeric_config() {"), f"{prefix}5 validator lives inside validate_numeric_config")
+    check("start|restart|validate) validate_numeric_config" in src2, f"{prefix}5 validator wired before start/restart and through validate")
     check("bool knob guard (begin)" not in src2, f"{prefix}5 no top-level W41/W42 guard remains")
     for value in ("1", "0"):
         rc, o, e = _run_validator(knob, value)

--- a/tests/test_numeric_config.py
+++ b/tests/test_numeric_config.py
@@ -26,17 +26,35 @@ def guard_source() -> str:
     return source[d_begin:d_end] + "\n" + source[begin:end]
 
 
-def validate(util: str, model: str, seqs: str, batch: str) -> subprocess.CompletedProcess[str]:
+def validate(
+    util: str,
+    model: str,
+    seqs: str,
+    batch: str,
+    spec_method: str = "dflash",
+    dflash_tokens: str = "7",
+) -> subprocess.CompletedProcess[str]:
     script = (
         guard_source()
         + '\nGPU_MEM_UTIL="$1"; MAX_MODEL_LEN="$2"; MAX_NUM_SEQS="$3"; '
-        + 'MAX_NUM_BATCHED_TOKENS="$4"\n'
+        + 'MAX_NUM_BATCHED_TOKENS="$4"; SPEC_METHOD="$5"; DFLASH_TOKENS="$6"\n'
         + 'validate_numeric_config || exit $?\n'
-        + 'printf "%s|%s|%s|%s\\n" "$GPU_MEM_UTIL" "$MAX_MODEL_LEN" '
-        + '"$MAX_NUM_SEQS" "$MAX_NUM_BATCHED_TOKENS"\n'
+        + 'printf "%s|%s|%s|%s|%s\\n" "$GPU_MEM_UTIL" "$MAX_MODEL_LEN" '
+        + '"$MAX_NUM_SEQS" "$MAX_NUM_BATCHED_TOKENS" "$DFLASH_TOKENS"\n'
     )
     return subprocess.run(
-        ["bash", "-c", script, "test", util, model, seqs, batch],
+        [
+            "bash",
+            "-c",
+            script,
+            "test",
+            util,
+            model,
+            seqs,
+            batch,
+            spec_method,
+            dflash_tokens,
+        ],
         text=True,
         capture_output=True,
         check=False,
@@ -65,15 +83,25 @@ def test_matrix() -> None:
 
 
 def test_decimal_normalization() -> None:
-    result = validate(".87", "01000000", "0004", "01024")
+    result = validate(".87", "01000000", "0004", "01024", dflash_tokens="07")
     assert result.returncode == 0
-    assert result.stdout.strip() == ".87|1000000|4|1024"
+    assert result.stdout.strip() == ".87|1000000|4|1024|7"
+
+
+def test_dflash2_rejects_non_native_block_lengths() -> None:
+    for tokens in ("3", "4", "8", "nope"):
+        result = validate("0.87", "1000000", "4", "1024", dflash_tokens=tokens)
+        assert result.returncode == 2
+    result = validate(
+        "0.87", "1000000", "4", "1024", spec_method="none", dflash_tokens="4"
+    )
+    assert result.returncode == 0
 
 
 def test_restart_validates_before_stop() -> None:
     source = START.read_text()
     main = source.index("main() {")
-    validation = source.index("start|restart) validate_numeric_config", main)
+    validation = source.index("start|restart|validate) validate_numeric_config", main)
     restart = source.index("restart)  stop; start", main)
     assert validation < restart
 

--- a/tests/test_prod_start_guard.py
+++ b/tests/test_prod_start_guard.py
@@ -9,6 +9,7 @@ unchanged; the hash covers DFLASH_REVISION (from .env or the launcher default).
 from __future__ import annotations
 
 import os
+import shutil
 import stat
 import subprocess
 import tempfile
@@ -30,16 +31,71 @@ def make_shim(bindir: Path, name: str, body: str) -> None:
     p.chmod(p.stat().st_mode | stat.S_IEXEC)
 
 
-def run_guard(tmp: Path, env_text: str, docker_rc: int, ssh_rc: int, stamp: str | None = None,
-              start_sh_default: str = 'DFLASH_REVISION="${DFLASH_REVISION-abc}"\n') -> tuple[subprocess.CompletedProcess[str], Path, Path]:
-    work = tmp / "kit"; work.mkdir(exist_ok=True)
+def run_prod_start(
+    tmp: Path, env_text: str
+) -> tuple[subprocess.CompletedProcess[str], Path, Path]:
+    work = tmp / "kit"
+    local = work / "local"
+    local.mkdir(parents=True)
+    shutil.copy2(ROOT / "local" / "prod-start.sh", local / "prod-start.sh")
+    calls = tmp / "start-calls.log"
+    (work / ".env").write_text(env_text)
+    start = work / "start.sh"
+    start.write_text(
+        "#!/usr/bin/env bash\n"
+        f'echo "$1" >> {calls}\n'
+        'if [ "$1" = validate ]; then\n'
+        "  source .env\n"
+        '  if [ "${SPEC_METHOD:-dflash}" = dflash ] '
+        '&& [ "${DFLASH_TOKENS:-7}" != 7 ]; then exit 2; fi\n'
+        "fi\n"
+    )
+    start.chmod(start.stat().st_mode | stat.S_IEXEC)
+    home = tmp / "home"
+    home.mkdir()
+    bindir = tmp / "bin"
+    bindir.mkdir()
+    external = tmp / "external-calls.log"
+    make_shim(
+        bindir,
+        "ssh",
+        f'case "$*" in *MemFree*) echo 100 ;; *) echo "ssh $*" >> {external} ;; esac\n',
+    )
+    make_shim(bindir, "docker", f'echo "docker $*" >> {external}\n')
+    result = subprocess.run(
+        ["bash", str(local / "prod-start.sh")],
+        env={
+            "PATH": f"{bindir}:{os.environ['PATH']}",
+            "HOME": str(home),
+            "NEED_GIB": "0",
+            "SETTLE_TIMEOUT": "0",
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result, calls, external
+
+
+def run_guard(
+    tmp: Path,
+    env_text: str,
+    docker_rc: int,
+    ssh_rc: int,
+    stamp: str | None = None,
+    start_sh_default: str = 'DFLASH_REVISION="${DFLASH_REVISION-abc}"\n',
+) -> tuple[subprocess.CompletedProcess[str], Path, Path]:
+    work = tmp / "kit"
+    work.mkdir(exist_ok=True)
     (work / ".env").write_text(env_text)
     (work / "start.sh").write_text(start_sh_default)
-    home = tmp / "home"; (home / ".cache" / "vllm-glm53-flash").mkdir(parents=True, exist_ok=True)
+    home = tmp / "home"
+    (home / ".cache" / "vllm-glm53-flash").mkdir(parents=True, exist_ok=True)
     stamp_path = home / ".cache" / "vllm-glm53-flash" / ".config-shape"
     if stamp is not None:
         stamp_path.write_text(stamp)
-    bindir = tmp / "bin"; bindir.mkdir(exist_ok=True)
+    bindir = tmp / "bin"
+    bindir.mkdir(exist_ok=True)
     log = tmp / "calls.log"
     make_shim(bindir, "docker", f'echo "docker $*" >> {log}\nexit {docker_rc}\n')
     make_shim(bindir, "ssh", f'echo "ssh $*" >> {log}\nexit {ssh_rc}\n')
@@ -52,6 +108,29 @@ def run_guard(tmp: Path, env_text: str, docker_rc: int, ssh_rc: int, stamp: str 
 ENV = "IMAGE=glm53-selfbuild:b5ab8091-w15a\nDFLASH_TOKENS=7\nDFLASH_REVISION=abc\n"
 
 
+def test_invalid_dflash_length_exits_before_stop_or_cache_handling() -> None:
+    with tempfile.TemporaryDirectory() as t:
+        result, calls, external = run_prod_start(
+            Path(t),
+            "SPEC_METHOD=dflash\nDFLASH_TOKENS=4\n",
+        )
+        assert result.returncode == 2
+        assert calls.read_text().splitlines() == ["validate"]
+        assert not external.exists()
+        assert "production left untouched" in result.stdout
+
+
+def test_native_dflash_and_non_dflash_continue_after_validation() -> None:
+    for env_text in (
+        "SPEC_METHOD=dflash\nDFLASH_TOKENS=7\n",
+        "SPEC_METHOD=none\nDFLASH_TOKENS=4\n",
+    ):
+        with tempfile.TemporaryDirectory() as t:
+            result, calls, _ = run_prod_start(Path(t), env_text)
+            assert result.returncode == 0, result.stderr
+            assert calls.read_text().splitlines() == ["validate", "stop", "start"]
+
+
 def test_image_resolved_from_IMAGE_line_and_stamp_written_on_success() -> None:
     with tempfile.TemporaryDirectory() as t:
         r, stamp, log = run_guard(Path(t), ENV, 0, 0, stamp="stale")
@@ -59,8 +138,10 @@ def test_image_resolved_from_IMAGE_line_and_stamp_written_on_success() -> None:
         calls = log.read_text()
         lines = calls.splitlines()
         assert "glm53-selfbuild:b5ab8091-w15a" in calls
-        assert sum(l.startswith("docker ") for l in lines) == 1 and sum(l.startswith("ssh ") for l in lines) == 1
-        assert stamp.read_text().strip() != "stale" and len(stamp.read_text().strip()) == 32
+        assert sum(line.startswith("docker ") for line in lines) == 1
+        assert sum(line.startswith("ssh ") for line in lines) == 1
+        assert stamp.read_text().strip() != "stale"
+        assert len(stamp.read_text().strip()) == 32
 
 
 def test_head_wipe_failure_leaves_stamp() -> None:
@@ -87,15 +168,28 @@ def test_hash_tracks_revision_and_launcher_default() -> None:
         _, s1, _ = run_guard(Path(t), ENV, 0, 0)
         h1 = s1.read_text()
     with tempfile.TemporaryDirectory() as t:
-        _, s2, _ = run_guard(Path(t), ENV.replace("DFLASH_REVISION=abc", "DFLASH_REVISION=def"), 0, 0)
+        _, s2, _ = run_guard(
+            Path(t),
+            ENV.replace("DFLASH_REVISION=abc", "DFLASH_REVISION=def"),
+            0,
+            0,
+        )
         h2 = s2.read_text()
     with tempfile.TemporaryDirectory() as t:
-        _, s3, _ = run_guard(Path(t), ENV, 0, 0, start_sh_default='DFLASH_REVISION="${DFLASH_REVISION-zzz}"\n')
+        _, s3, _ = run_guard(
+            Path(t),
+            ENV,
+            0,
+            0,
+            start_sh_default='DFLASH_REVISION="${DFLASH_REVISION-zzz}"\n',
+        )
         h3 = s3.read_text()
     assert h1 != h2 and h1 != h3
 
 
 if __name__ == "__main__":
+    test_invalid_dflash_length_exits_before_stop_or_cache_handling()
+    test_native_dflash_and_non_dflash_continue_after_validation()
     test_image_resolved_from_IMAGE_line_and_stamp_written_on_success()
     test_head_wipe_failure_leaves_stamp()
     test_worker_wipe_failure_leaves_stamp()


### PR DESCRIPTION
## Summary

- add a fail-closed audit for the production DFlash2 verification-length contract
- confirm the legacy proposer cannot vary target verification length independently of its native eight-row draft block
- refuse non-native `DFLASH_TOKENS` values for this DFlash2 path
- add a side-effect-free `start.sh validate` command and run it in `local/prod-start.sh` before stop or JIT-cache handling
- record task 4 as parked for an MRV2/adaptive-verification path, without claiming a performance rejection

## Decision

The k=4/3 A/B was not run. The exact live path couples `num_speculative_tokens` to query/mask rows, grouped convolution, selector walking, and draft-logit cache shape. The image's adaptive-verification implementation explicitly supports DSpark only. Changing `DFLASH_TOKENS` would therefore alter the trained draft contract instead of verification work alone.

## Safety and rollback

The production wrapper now validates configuration before stopping either node, waiting for memory, calculating the shape hash, wiping caches, or updating the JIT stamp. Invalid DFlash k=3/4 configurations exit with rc=2 and leave production untouched. Reverting this commit restores the prior launcher behavior; no production configuration or image was changed by this task.

## Validation

Local:
- `139 passed, 1 skipped, 4 subtests passed`
- focused production-wrapper/audit/numeric tests: `13 passed`
- Ruff, Python compile, `bash -n`, shellcheck, and `git diff --check` passed
- independent final review approved after the production-wrapper ordering fix

Exact DGX Spark candidate:
- `start.sh`: `e7a98c6db84cbb55dad404e09e07a8f88094f5aad9c91b3e95673ee90c72c3ad`
- `local/prod-start.sh`: `3e6a1bd49ba5b246be13ee1e86a509c849271a14ec7c53770e6e63deb52575ca`
- audit: `180f18e35deee722bcf27378ca88f15501726d649be92148ca41176ec70c3fd4`

Both nodes returned `decision=park`, native block 8 / k=7, with all six checkpoint/source checks true. The exact wrapper rejected k=4 on the head and k=3 on the worker before disruption. Head and worker container start timestamps were unchanged, the head JIT stamp was unchanged, health stayed HTTP 200, and preemptions remained zero.
