### PR TITLE
A3: close guarded align-floor window

### DIFF
--- a/docs/06-improvement-plan.md
+++ b/docs/06-improvement-plan.md
@@ -36,6 +36,52 @@ Mainline GLM support (#53906) has merged, so model resolution is no longer the
 mainline blocker described in the historical section above; EXL3 integration
 and overlay compatibility still block a stock-image replacement.
 
+### 2026-09-05: A3 align-floor window completed; LPTT 3584 remains rejected
+
+Task 12 ran the previously blocked 60k mixed-prefill window at
+`LONG_PREFILL_TOKEN_THRESHOLD=3584`. `scripts/run_a3_align_floor_window.py`
+validates the effective container environment, pins traffic to the local
+service, samples both nodes before the first request and throughout the run,
+terminates on the 3 GiB MemFree floor, correlates `decode-floor-v3` logs to the
+benchmark's transformed scheduler request ID, requires a sub-page cap and
+records preemption deltas. The first control smoke exposed that post-startup
+scheduler output lives in `docker logs`, not the systemd journal; the reviewed
+runner was corrected to collect both container output streams before the
+decision runs.
+
+The exact 57,049-token newcomer and incumbent prompt were held fixed. Both
+arms used MNBT 3584, W26 `skip`, wait 1500 ms, warm tail 3584, cap
+512→1024→1792, C4 admission, the same image/model/pool and zero preemptions.
+Both correlated receipts logged late admission at 512, escalation to 1024 and
+1792, then completion of the capped crawl while the incumbent remained active.
+Neither node approached the tripwire.
+
+| arm | newcomer TTFT | incumbent rate retention | aggregate | MemFree floor head / worker |
+|---|---:|---:|---:|---:|
+| align-floor `0` control | 58.293 s | 0.1678 | 4.991 tok/s | 5,128,692 / 4,316,624 KiB |
+| align-floor `1` candidate | 58.650 s | 0.1265 | 3.623 tok/s | 4,517,340 / 4,407,384 KiB |
+
+The candidate did not improve newcomer TTFT (+0.6% worse), and its
+single-sample incumbent retention and aggregate throughput were lower. This
+correctness smoke is not a powered performance comparison, but it provides no
+reason to reopen W34a's already decisive head-of-line rejection or to keep
+LPTT 3584. The exact pre-window `.env` was restored, returning production to
+LPTT 1792 where the align-floor overlay remains dormant. Restored `.env`
+SHA256 was `6e7a206ec05be1cf624df167128470a313d12566b744e1f542808373aaf0983a`,
+byte-identical to the saved rollback. Post-rollback gates passed acceptance
+7/7, serving 6/6 and tool calls 23/23 with zero blank required arguments.
+Health finished 200 with running/waiting/preemptions all zero, selected runtime
+errors and kernel Xids zero, MemFree 4,474,264 / 4,648,192 KiB, and the
+watchdog re-armed. Task 12 is closed; a future adaptive-threshold proposal
+needs a new mechanism and its own guarded window rather than reusing this arm.
+
+Runner SHA256:
+`9ad310e535426aee07d8897be6dbb34962f06c5e72f94eb2cb09479edc85e009`.
+Local validation passed 158 tests, 1 skipped and 4 subtests; exact cluster
+focused tests passed 19/19. Receipts:
+`local/a3-control-align-floor-off-v2-20260905.json` and
+`local/a3-candidate-align-floor-on-20260905.json`.
+
 ### 2026-09-05: task 4 verification-length study parked before restart
 
 The required implementation audit found no supported verification-only k=4/3

--- a/scripts/run_a3_align_floor_window.py
+++ b/scripts/run_a3_align_floor_window.py
@@ -1,0 +1,447 @@
+#!/usr/bin/env python3
+"""Run one guarded A3 mixed-prefill align-floor arm on the cluster head.
+
+The service restart and environment flip stay operator-controlled. This runner
+validates the effective container environment, starts both-node MemFree
+monitoring before the first request, runs the fixed 60k newcomer probe, and
+requires a decode-floor-v3 log showing a sub-page cap.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import os
+import re
+import signal
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+BENCH = ROOT / "tests" / "bench_mixed_prefill.py"
+BLOCK_SIZE = 3584
+BASE = "http://127.0.0.1:8000"
+MIN_TRIPWIRE_KIB = 3 * 1024 * 1024
+SELECTED_ENV = (
+    "LONG_PREFILL_TOKEN_THRESHOLD",
+    "MAX_NUM_BATCHED_TOKENS",
+    "MAX_NUM_SEQS",
+    "GLM53_ALIGN_FLOOR",
+    "GLM53_MIXED_PREFILL_CHUNK",
+    "GLM53_MIXED_PREFILL_MAX_WAIT_MS",
+    "GLM53_MIXED_PREFILL_WARM_TOKENS",
+    "GLM53_MIXED_PREFILL_LATE_CAP",
+    "GLM53_MIXED_PREFILL_ESCALATE_MS",
+    "GLM53_MIXED_PREFILL_LATE_CAP_MAX",
+)
+
+
+def run_text(argv: list[str], timeout: float = 30) -> str:
+    completed = subprocess.run(
+        argv,
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    return completed.stdout
+
+
+def parse_env(text: str) -> dict[str, str]:
+    result: dict[str, str] = {}
+    for line in text.splitlines():
+        if "=" not in line:
+            continue
+        name, value = line.split("=", 1)
+        if name in SELECTED_ENV:
+            result[name] = value
+    return result
+
+
+def validate_arm(env: dict[str, str], expected_align_floor: str) -> list[str]:
+    errors: list[str] = []
+    required = set(SELECTED_ENV)
+    missing = sorted(required - env.keys())
+    if missing:
+        errors.append("missing effective environment: " + ", ".join(missing))
+        return errors
+
+    try:
+        lptt = int(env["LONG_PREFILL_TOKEN_THRESHOLD"])
+        mnbt = int(env["MAX_NUM_BATCHED_TOKENS"])
+        late_cap = int(env["GLM53_MIXED_PREFILL_LATE_CAP"])
+    except ValueError as exc:
+        errors.append(f"non-integer effective environment: {exc}")
+        return errors
+
+    if lptt < BLOCK_SIZE:
+        errors.append(f"LPTT must be >= {BLOCK_SIZE}, got {lptt}")
+    if mnbt < BLOCK_SIZE:
+        errors.append(f"MNBT must be >= {BLOCK_SIZE}, got {mnbt}")
+    if late_cap >= BLOCK_SIZE:
+        errors.append(f"late cap must be sub-page, got {late_cap}")
+    if env["GLM53_ALIGN_FLOOR"] != expected_align_floor:
+        errors.append(
+            "align-floor arm mismatch: expected "
+            f"{expected_align_floor}, got {env['GLM53_ALIGN_FLOOR']}"
+        )
+    if env["GLM53_MIXED_PREFILL_CHUNK"] != "skip":
+        errors.append(
+            "mixed-prefill policy must remain skip, got "
+            f"{env['GLM53_MIXED_PREFILL_CHUNK']!r}"
+        )
+    return errors
+
+
+def read_memfree_kib(path: Path = Path("/proc/meminfo")) -> int:
+    for line in path.read_text().splitlines():
+        if line.startswith("MemFree:"):
+            return int(line.split()[1])
+    raise RuntimeError(f"MemFree missing from {path}")
+
+
+def read_worker_memfree_kib(worker: str) -> int:
+    text = run_text(
+        [
+            "ssh",
+            "-o",
+            "BatchMode=yes",
+            "-o",
+            "ConnectTimeout=10",
+            worker,
+            "grep '^MemFree:' /proc/meminfo",
+        ],
+        timeout=15,
+    )
+    return int(text.split()[1])
+
+
+def matches_scheduler_request_id(log_id: str, request_ids: set[str]) -> bool:
+    for request_id in request_ids:
+        external_id = f"chatcmpl-{request_id}"
+        if log_id == external_id or re.fullmatch(
+            rf"{re.escape(external_id)}-[0-9a-f]{{8}}", log_id
+        ):
+            return True
+    return False
+
+
+def extract_subblock_caps(log_text: str, request_ids: set[str]) -> list[int]:
+    caps: list[int] = []
+    for line in log_text.splitlines():
+        request_match = re.search(r"\breq=(\S+)", line)
+        if not request_match or not matches_scheduler_request_id(
+            request_match.group(1), request_ids
+        ):
+            continue
+        if "[glm53-decode-floor-v3] late-admit" in line:
+            match = re.search(r"\bcap=(\d+)\b", line)
+        elif "[glm53-decode-floor-v3] late-escalate" in line:
+            match = re.search(r"->(\d+)\b", line)
+        else:
+            continue
+        if match and int(match.group(1)) < BLOCK_SIZE:
+            caps.append(int(match.group(1)))
+    return caps
+
+
+def benchmark_request_ids(path: Path) -> set[str]:
+    report = json.loads(path.read_text(encoding="utf-8"))
+    samples = report.get("samples")
+    if not isinstance(samples, list) or not samples:
+        raise ValueError("benchmark receipt has no samples")
+    ids = {
+        row.get("newcomer_request_id")
+        for row in samples
+        if isinstance(row, dict) and row.get("newcomer_request_id")
+    }
+    if len(ids) != len(samples):
+        raise ValueError("benchmark receipt is missing newcomer request IDs")
+    return ids
+
+
+def read_runtime_logs(container: str, since_epoch: int) -> str:
+    completed = subprocess.run(
+        ["docker", "logs", "--since", str(since_epoch), container],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    return completed.stdout + completed.stderr
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+class MemoryMonitor:
+    def __init__(self, worker: str, tripwire_kib: int, interval: float) -> None:
+        self.worker = worker
+        self.tripwire_kib = tripwire_kib
+        self.interval = interval
+        self.samples: list[dict[str, Any]] = []
+        self.error: str | None = None
+        self.breached = threading.Event()
+        self.ready = threading.Event()
+        self._stop = threading.Event()
+        self._thread = threading.Thread(target=self._run, daemon=True)
+
+    def start(self, timeout: float = 20) -> None:
+        self._thread.start()
+        if not self.ready.wait(timeout):
+            self.error = "initial both-node sample timed out"
+            self.breached.set()
+
+    def stop(self) -> None:
+        self._stop.set()
+        self._thread.join()
+
+    def _run(self) -> None:
+        while not self._stop.is_set():
+            try:
+                head = read_memfree_kib()
+                worker = read_worker_memfree_kib(self.worker)
+                self.samples.append(
+                    {"time": time.time(), "head_kib": head, "worker_kib": worker}
+                )
+                if min(head, worker) < self.tripwire_kib:
+                    self.breached.set()
+                self.ready.set()
+                if self.breached.is_set():
+                    return
+            except Exception as exc:
+                self.error = f"{type(exc).__name__}: {exc}"
+                self.breached.set()
+                self.ready.set()
+                return
+            self._stop.wait(self.interval)
+
+
+def tripwire_kib(raw: str) -> int:
+    value = int(raw)
+    if value < MIN_TRIPWIRE_KIB:
+        raise argparse.ArgumentTypeError(
+            f"tripwire must be at least {MIN_TRIPWIRE_KIB} KiB (3 GiB)"
+        )
+    return value
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--label", required=True)
+    parser.add_argument("--expected-align-floor", choices=("0", "1"), required=True)
+    parser.add_argument("--out", required=True)
+    parser.add_argument("--worker", default="nvidia@192.168.177.11")
+    parser.add_argument("--container", default="glm53-exl3-head")
+    parser.add_argument(
+        "--tripwire-kib", type=tripwire_kib, default=MIN_TRIPWIRE_KIB
+    )
+    parser.add_argument("--monitor-interval", type=float, default=1.0)
+    parser.add_argument("--samples", type=int, default=1)
+    parser.add_argument("--incumbent-tokens", type=int, default=2400)
+    parser.add_argument("--timeout", type=float, default=1800)
+    return parser.parse_args()
+
+
+def install_signal_handlers(interrupted: threading.Event) -> None:
+    def handle_signal(_signum: int, _frame: object) -> None:
+        interrupted.set()
+
+    signal.signal(signal.SIGINT, handle_signal)
+    signal.signal(signal.SIGTERM, handle_signal)
+
+
+def terminate_process(process: subprocess.Popen[Any]) -> None:
+    if process.poll() is not None:
+        return
+    process.terminate()
+    try:
+        process.wait(timeout=10)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.wait(timeout=10)
+
+
+def run_benchmark(
+    args: argparse.Namespace,
+    bench_out: Path,
+    monitor: MemoryMonitor,
+    interrupted: threading.Event,
+) -> int:
+    bench_cmd = [
+        sys.executable,
+        str(BENCH),
+        "--contexts",
+        "60000",
+        "--samples",
+        str(args.samples),
+        "--incumbent-tokens",
+        str(args.incumbent_tokens),
+        "--timeout",
+        str(args.timeout),
+        "--out",
+        str(bench_out),
+    ]
+    child_env = os.environ.copy()
+    child_env["GLM53_BASE"] = BASE
+    process = subprocess.Popen(bench_cmd, env=child_env)
+    try:
+        while process.poll() is None:
+            if monitor.breached.wait(0.25) or interrupted.is_set():
+                terminate_process(process)
+                break
+        return process.wait()
+    finally:
+        terminate_process(process)
+
+
+def main() -> int:
+    args = parse_args()
+    if args.tripwire_kib < MIN_TRIPWIRE_KIB:
+        raise SystemExit(
+            f"tripwire must be at least {MIN_TRIPWIRE_KIB} KiB (3 GiB)"
+        )
+    out_path = Path(args.out)
+    bench_out = out_path.with_suffix(".bench.json")
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    started_epoch = int(time.time())
+    interrupted = threading.Event()
+    install_signal_handlers(interrupted)
+    receipt: dict[str, Any] = {
+        "schema_version": 1,
+        "label": args.label,
+        "started": time.time(),
+        "expected_align_floor": args.expected_align_floor,
+        "tripwire_kib": args.tripwire_kib,
+        "base": BASE,
+        "bench_path": str(bench_out),
+        "runner_sha256": sha256(Path(__file__)),
+        "bench_sha256": sha256(BENCH),
+        "errors": [],
+    }
+
+    try:
+        env_text = run_text(
+            [
+                "docker",
+                "inspect",
+                args.container,
+                "--format",
+                "{{range .Config.Env}}{{println .}}{{end}}",
+            ]
+        )
+        effective_env = parse_env(env_text)
+        receipt["effective_env"] = effective_env
+        receipt["errors"].extend(
+            validate_arm(effective_env, args.expected_align_floor)
+        )
+        if receipt["errors"]:
+            return finish(receipt, out_path)
+
+        initial_metrics = run_text(["curl", "-fsS", f"{BASE}/metrics"])
+        preemptions_before = metric_total(
+            initial_metrics, "num_preemptions_total"
+        )
+        if preemptions_before is None:
+            raise ValueError("initial preemption counter missing or invalid")
+        receipt["preemptions_before"] = preemptions_before
+
+        monitor = MemoryMonitor(
+            args.worker, args.tripwire_kib, args.monitor_interval
+        )
+        bench_rc = 1
+        try:
+            monitor.start()
+            if not monitor.breached.is_set() and not interrupted.is_set():
+                bench_rc = run_benchmark(
+                    args, bench_out, monitor, interrupted
+                )
+        finally:
+            monitor.stop()
+        receipt["bench_returncode"] = bench_rc
+        receipt["memory_samples"] = monitor.samples
+        receipt["memory_monitor_error"] = monitor.error
+        if monitor.samples:
+            receipt["min_memfree_kib"] = {
+                "head": min(row["head_kib"] for row in monitor.samples),
+                "worker": min(row["worker_kib"] for row in monitor.samples),
+            }
+        if monitor.error:
+            receipt["errors"].append(
+                "memory monitor failed closed: " + monitor.error
+            )
+        if monitor.breached.is_set() and not monitor.error:
+            receipt["errors"].append(
+                f"MemFree crossed {args.tripwire_kib} KiB tripwire"
+            )
+        if interrupted.is_set():
+            receipt["errors"].append("runner interrupted")
+        if bench_rc != 0:
+            receipt["errors"].append(f"mixed-prefill bench exited {bench_rc}")
+
+        logs = read_runtime_logs(args.container, started_epoch)
+        request_ids = benchmark_request_ids(bench_out)
+        receipt["newcomer_request_ids"] = sorted(request_ids)
+        caps = extract_subblock_caps(logs, request_ids)
+        receipt["subblock_caps"] = caps
+        receipt["decode_floor_log_lines"] = [
+            line
+            for line in logs.splitlines()
+            if "[glm53-decode-floor-v3]" in line
+        ]
+        if not caps:
+            receipt["errors"].append(
+                "no decode-floor-v3 sub-page late cap was logged"
+            )
+
+        final_metrics = run_text(["curl", "-fsS", f"{BASE}/metrics"])
+        preemptions_after = metric_total(final_metrics, "num_preemptions_total")
+        if preemptions_after is None:
+            raise ValueError("final preemption counter missing or invalid")
+        receipt["preemptions_after"] = preemptions_after
+        receipt["preemptions_delta"] = preemptions_after - preemptions_before
+        if receipt["preemptions_delta"]:
+            receipt["errors"].append(
+                f"preemptions increased by {receipt['preemptions_delta']}"
+            )
+    except Exception as exc:
+        receipt["errors"].append(f"{type(exc).__name__}: {exc}")
+    if interrupted.is_set() and "runner interrupted" not in receipt["errors"]:
+        receipt["errors"].append("runner interrupted")
+    return finish(receipt, out_path)
+
+
+def metric_total(text: str, name: str) -> float | None:
+    values = re.findall(
+        rf"^vllm:{re.escape(name)}(?:\{{[^}}]*\}})?\s+(\S+)$",
+        text,
+        re.MULTILINE,
+    )
+    if not values:
+        return None
+    parsed = [float(value) for value in values]
+    if not all(math.isfinite(value) for value in parsed):
+        return None
+    return sum(parsed)
+
+
+def finish(receipt: dict[str, Any], out_path: Path) -> int:
+    receipt["finished"] = time.time()
+    receipt["decision"] = "pass" if not receipt["errors"] else "abort"
+    out_path.write_text(json.dumps(receipt, indent=2), encoding="utf-8")
+    print(json.dumps(receipt, indent=2))
+    return 0 if receipt["decision"] == "pass" else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_a3_align_floor_window.py
+++ b/tests/test_a3_align_floor_window.py
@@ -1,0 +1,287 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import signal
+import sys
+import threading
+from pathlib import Path
+from types import SimpleNamespace
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "run_a3_align_floor_window.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("run_a3_align_floor_window", SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def valid_env() -> dict[str, str]:
+    return {
+        "LONG_PREFILL_TOKEN_THRESHOLD": "3584",
+        "MAX_NUM_BATCHED_TOKENS": "3584",
+        "MAX_NUM_SEQS": "4",
+        "GLM53_ALIGN_FLOOR": "1",
+        "GLM53_MIXED_PREFILL_CHUNK": "skip",
+        "GLM53_MIXED_PREFILL_MAX_WAIT_MS": "1500",
+        "GLM53_MIXED_PREFILL_WARM_TOKENS": "3584",
+        "GLM53_MIXED_PREFILL_LATE_CAP": "512",
+        "GLM53_MIXED_PREFILL_ESCALATE_MS": "10000",
+        "GLM53_MIXED_PREFILL_LATE_CAP_MAX": "1792",
+    }
+
+
+def test_parse_and_validate_effective_arm() -> None:
+    module = load_module()
+    text = "\n".join(f"{key}={value}" for key, value in valid_env().items())
+    parsed = module.parse_env(text)
+    assert parsed == valid_env()
+    assert module.validate_arm(parsed, "1") == []
+
+
+def test_validation_rejects_wrong_or_unsafe_arm() -> None:
+    module = load_module()
+    env = valid_env()
+    env["LONG_PREFILL_TOKEN_THRESHOLD"] = "1792"
+    env["GLM53_ALIGN_FLOOR"] = "0"
+    env["GLM53_MIXED_PREFILL_LATE_CAP"] = "3584"
+    env["GLM53_MIXED_PREFILL_CHUNK"] = "512"
+    errors = module.validate_arm(env, "1")
+    assert any("LPTT" in error for error in errors)
+    assert any("late cap" in error for error in errors)
+    assert any("arm mismatch" in error for error in errors)
+    assert any("must remain skip" in error for error in errors)
+
+
+def test_extracts_only_sub_page_decode_floor_caps() -> None:
+    module = load_module()
+    logs = """
+[glm53-decode-floor-v3] late-admit req=chatcmpl-a waited_ms=1501 remaining=60000 cap=512
+[glm53-decode-floor-v3] late-escalate req=chatcmpl-a-1a2b3c4d cap=512->1024
+[glm53-decode-floor-v3] late-admit req=chatcmpl-unrelated-a-1a2b3c4d waited_ms=1501 remaining=60000 cap=1792
+[glm53-decode-floor-v3] late-escalate req=chatcmpl-a-1234567g cap=1024->1792
+[glm53-decode-floor-v3] late-escalate req=chatcmpl-a-lookalike cap=1024->1792
+[glm53-decode-floor-v3] late-escalate req=chatcmpl-a-abcdef12-extra cap=1024->1792
+[glm53-decode-floor-v3] late-escalate req=chatcmpl-a-abcdef12 cap=1792->3584
+"""
+    assert module.extract_subblock_caps(logs, {"a"}) == [512, 1024]
+    assert module.extract_subblock_caps(logs, {"missing"}) == []
+
+
+def test_scheduler_request_id_matching_is_anchored() -> None:
+    module = load_module()
+    request_ids = {"glm53-c1-run-c60000-r0-newcomer"}
+    raw = "glm53-c1-run-c60000-r0-newcomer"
+    assert module.matches_scheduler_request_id(f"chatcmpl-{raw}", request_ids)
+    assert module.matches_scheduler_request_id(
+        f"chatcmpl-{raw}-1a2b3c4d", request_ids
+    )
+    for lookalike in (
+        raw,
+        f"xchatcmpl-{raw}",
+        f"chatcmpl-{raw}x",
+        f"chatcmpl-{raw}-1a2b3c4",
+        f"chatcmpl-{raw}-1a2b3c4g",
+        f"chatcmpl-{raw}-1a2b3c4d-extra",
+    ):
+        assert not module.matches_scheduler_request_id(lookalike, request_ids)
+
+
+def test_metric_total_sums_labeled_series() -> None:
+    module = load_module()
+    text = """
+vllm:num_preemptions_total{engine="0"} 2
+vllm:num_preemptions_total{engine="1"} 3
+vllm:num_requests_running{engine="0"} 1
+"""
+    assert module.metric_total(text, "num_preemptions_total") == 5
+    assert module.metric_total(text, "missing") is None
+    assert module.metric_total("vllm:x NaN", "x") is None
+
+
+def test_memory_monitor_samples_before_ready(monkeypatch) -> None:
+    module = load_module()
+    monkeypatch.setattr(module, "read_memfree_kib", lambda: 4 * 1024 * 1024)
+    monkeypatch.setattr(
+        module, "read_worker_memfree_kib", lambda _worker: 4 * 1024 * 1024
+    )
+    monitor = module.MemoryMonitor(
+        "worker", tripwire_kib=3 * 1024 * 1024, interval=60
+    )
+    monitor.start(timeout=1)
+    monitor.stop()
+    assert monitor.ready.is_set()
+    assert len(monitor.samples) == 1
+    assert not monitor.breached.is_set()
+
+
+def test_memory_monitor_publishes_initial_breach_before_ready(monkeypatch) -> None:
+    module = load_module()
+    monkeypatch.setattr(module, "read_memfree_kib", lambda: 2 * 1024 * 1024)
+    monkeypatch.setattr(
+        module, "read_worker_memfree_kib", lambda _worker: 4 * 1024 * 1024
+    )
+    monitor = module.MemoryMonitor(
+        "worker", tripwire_kib=3 * 1024 * 1024, interval=60
+    )
+    monitor.start(timeout=1)
+    monitor.stop()
+    assert monitor.ready.is_set()
+    assert monitor.breached.is_set()
+
+
+def test_memory_monitor_publishes_initial_error_before_ready(monkeypatch) -> None:
+    module = load_module()
+    monkeypatch.setattr(
+        module,
+        "read_memfree_kib",
+        lambda: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+    monitor = module.MemoryMonitor(
+        "worker", tripwire_kib=3 * 1024 * 1024, interval=60
+    )
+    monitor.start(timeout=1)
+    monitor.stop()
+    assert monitor.ready.is_set()
+    assert monitor.breached.is_set()
+    assert monitor.error == "RuntimeError: boom"
+
+
+def test_memory_monitor_stop_waits_for_outstanding_sample(monkeypatch) -> None:
+    module = load_module()
+    release = threading.Event()
+    monkeypatch.setattr(module, "read_memfree_kib", lambda: 4 * 1024 * 1024)
+
+    def delayed_worker(_worker):
+        release.wait(1)
+        return 2 * 1024 * 1024
+
+    monkeypatch.setattr(module, "read_worker_memfree_kib", delayed_worker)
+    monitor = module.MemoryMonitor(
+        "worker", tripwire_kib=3 * 1024 * 1024, interval=60
+    )
+    monitor._thread.start()
+    stopper = threading.Thread(target=monitor.stop)
+    stopper.start()
+    assert stopper.is_alive()
+    release.set()
+    stopper.join(1)
+    assert not stopper.is_alive()
+    assert monitor.breached.is_set()
+
+
+def test_tripwire_cannot_be_lowered() -> None:
+    module = load_module()
+    assert module.tripwire_kib(str(3 * 1024 * 1024)) == 3 * 1024 * 1024
+    for value in ("0", "-1", str(3 * 1024 * 1024 - 1)):
+        try:
+            module.tripwire_kib(value)
+        except Exception as exc:
+            assert "at least" in str(exc)
+        else:
+            raise AssertionError(f"accepted unsafe tripwire {value}")
+
+
+def test_benchmark_receipt_requires_all_newcomer_ids(tmp_path: Path) -> None:
+    module = load_module()
+    path = tmp_path / "bench.json"
+    path.write_text(
+        json.dumps(
+            {
+                "samples": [
+                    {"newcomer_request_id": "a"},
+                    {"newcomer_request_id": "b"},
+                ]
+            }
+        )
+    )
+    assert module.benchmark_request_ids(path) == {"a", "b"}
+    path.write_text(json.dumps({"samples": [{"newcomer_request_id": "a"}, {}]}))
+    try:
+        module.benchmark_request_ids(path)
+    except ValueError as exc:
+        assert "request IDs" in str(exc)
+    else:
+        raise AssertionError("accepted missing request ID")
+
+
+def test_runtime_logs_come_from_the_live_container(monkeypatch) -> None:
+    module = load_module()
+    calls = []
+    result = SimpleNamespace(stdout="out", stderr="err")
+
+    def fake_run(argv, **kwargs):
+        calls.append((argv, kwargs))
+        return result
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+    assert module.read_runtime_logs("head", 1234) == "outerr"
+    assert calls == [
+        (
+            ["docker", "logs", "--since", "1234", "head"],
+            {
+                "check": True,
+                "capture_output": True,
+                "text": True,
+                "timeout": 60,
+            },
+        )
+    ]
+
+
+def test_signal_handlers_mark_interrupt(monkeypatch) -> None:
+    module = load_module()
+    installed = {}
+    monkeypatch.setattr(
+        module.signal,
+        "signal",
+        lambda signum, handler: installed.setdefault(signum, handler),
+    )
+    interrupted = threading.Event()
+    module.install_signal_handlers(interrupted)
+    for signum in (signal.SIGINT, signal.SIGTERM):
+        interrupted.clear()
+        installed[signum](signum, None)
+        assert interrupted.is_set()
+
+
+def test_run_benchmark_pins_endpoint_and_terminates_on_interrupt(
+    monkeypatch, tmp_path: Path
+) -> None:
+    module = load_module()
+    interrupted = threading.Event()
+    interrupted.set()
+    calls = {}
+
+    class FakeProcess:
+        def __init__(self, argv, env):
+            calls["argv"] = argv
+            calls["env"] = env
+            self.terminated = False
+
+        def poll(self):
+            return None if not self.terminated else -15
+
+        def terminate(self):
+            self.terminated = True
+
+        def wait(self, timeout=None):
+            return -15
+
+        def kill(self):
+            self.terminated = True
+
+    monkeypatch.setenv("GLM53_BASE", "http://wrong.example:9999")
+    monkeypatch.setattr(module.subprocess, "Popen", FakeProcess)
+    args = SimpleNamespace(samples=1, incumbent_tokens=8, timeout=10)
+    monitor = SimpleNamespace(breached=threading.Event())
+    rc = module.run_benchmark(
+        args, tmp_path / "bench.json", monitor, interrupted
+    )
+    assert rc == -15
+    assert calls["env"]["GLM53_BASE"] == module.BASE


### PR DESCRIPTION
## Summary

- add a fail-closed A3 runner for the 60k mixed-prefill align-floor window
- monitor both Sparks before and during each sample with a mandatory 3 GiB MemFree floor
- validate the effective arm, pin traffic to loopback, correlate transformed scheduler request IDs, and require sub-page decode-floor logs
- record the completed control/candidate window and retain production LPTT 1792

## A/B result

| Arm | Newcomer TTFT | Incumbent retention | Aggregate | Preemptions |
|---|---:|---:|---:|---:|
| align-floor off | 58.293 s | 0.1678 | 4.991 tok/s | 0 |
| align-floor on | 58.650 s | 0.1265 | 3.623 tok/s | 0 |

The candidate did not improve newcomer TTFT and reduced the single-sample incumbent and aggregate measurements. The exact saved `.env` was restored, so production remains at LPTT 1792 with align-floor dormant.

## Validation

- `uv run --with pytest --with jinja2 pytest -q tests`: 158 passed, 1 skipped, 4 subtests passed
- `uv run python -m compileall -q scripts tests overlay local`
- exact cluster focused tests: 19 passed
- independent final review: approved
- post-rollback acceptance: 7/7
- post-rollback serving: 6/6
- post-rollback tool calls: 23/23, zero blank required arguments
- final health 200, running/waiting/preemptions 0, selected runtime errors 0, Xids 0
- watchdog re-armed

## Rollback and receipts

The pre-window `.env` was saved and restored byte-for-byte (`6e7a206e...`). Cluster receipts remain local on spark1:

- `local/a3-control-align-floor-off-v2-20260905.json`
- `local/a3-candidate-align-floor-on-20260905.json`
