### PR TITLE
Launcher: fix caller precedence and crawl accounting

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,13 @@ local/prod-start.sh         # NOT start.sh directly — see docs/03-bringup.md
 local/acceptance.sh         # 7 checks: tools, thinking, vision, long-context needle
 ```
 
+For direct launcher operations, a non-empty caller export wins over any
+matching key assigned by `.env`, for example
+`MAX_MODEL_LEN=200000 ./start.sh validate`. The scanner accepts lexical
+`[export ]NAME[+]=VALUE` assignments. Empty exports normally leave `.env` in
+control; the three strict runtime-overlay knobs documented in `env.example`
+preserve empty so validation can reject it.
+
 Then install the units in `local/` (`systemctl --user enable ...`) so the pair
 survives reboots and heals itself. Full drill: `docs/03-bringup.md`.
 

--- a/docs/02-parameters.md
+++ b/docs/02-parameters.md
@@ -4,6 +4,20 @@ Every value in `env.example`, and why. The short version: **four knobs form a lo
 system — `MAX_MODEL_LEN=1000000`, `MAX_NUM_BATCHED_TOKENS=3584`, the KV pin, and
 `--no-async-scheduling`. Change one and you must re-derive the others.**
 
+## Caller exports and `.env`
+
+For every key assigned by `.env`, a non-empty caller export wins for that
+invocation. This makes guarded commands such as
+`MAX_MODEL_LEN=200000 ./start.sh validate` reflect the requested arm instead of
+silently retaining the file value. The launcher captures only exported,
+non-readonly names and never evaluates generated shell text.
+
+An empty caller export normally keeps the `.env` value, matching the historical
+launcher behavior. `GLM53_KV_CAPACITY_LOG`, `GLM53_APC_NO_STORE`, and
+`GLM53_INDEXER_WORKSPACE` are deliberate exceptions: empty is invalid for those
+strict knobs, so it survives to `validate_numeric_config` and fails before any
+restart side effect.
+
 ## MAX_MODEL_LEN=1000000
 
 This deployment started at 262k because the pinned pool then counted 318,640 tokens

--- a/docs/06-improvement-plan.md
+++ b/docs/06-improvement-plan.md
@@ -36,6 +36,67 @@ Mainline GLM support (#53906) has merged, so model resolution is no longer the
 mainline blocker described in the historical section above; EXL3 integration
 and overlay compatibility still block a stock-image replacement.
 
+### 2026-09-06: task 14 adopts caller precedence and gate v3.1 accounting
+
+The launcher now implements its general precedence contract instead of a
+per-knob allowlist. Before sourcing `.env`, it captures every non-empty,
+exported, non-readonly caller value for keys lexically assigned by the file,
+then replays those values without `eval`. The three strict runtime-overlay
+knobs (`GLM53_KV_CAPACITY_LOG`, `GLM53_APC_NO_STORE`, and
+`GLM53_INDEXER_WORKSPACE`) retain their setness-aware exception so an explicit
+empty caller value reaches validation and fails before a restart.
+
+The decode-floor overlay advances from v3 to v3.1 without changing scheduling
+decisions. `late-done` now reports `crawl_wall_ms` and `crawl_capped_ms`
+separately; intervals where no decoding peer exists close the capped interval
+while the overall late episode continues. The installer upgrades pristine,
+v1, v2, and exact deployed-v3 sources, validates the complete helper, policy,
+both scheduler gate bodies, a real top-level `import os`, and syntax before
+every write or idempotent success. Damaged predecessor and v3.1 fixtures fail
+without changing target bytes.
+
+Local validation passed 169 tests, 1 skipped and 4 subtests, plus Bash syntax,
+Python compilation, ShellCheck and diff checks. Independent final review
+approved exact candidate diff
+`24a8c8c1fc17bcf9c84cf61488f474c99b3ccb79817fbd53c0793e832ef5931a`
+after the fail-closed installer checks were strengthened.
+
+The guarded cluster control proved the defect without touching production:
+`MAX_MODEL_LEN=bogus ./start.sh validate` returned rc=0 because `.env` silently
+won. Candidate launcher SHA256
+`1f004b5bc1c5d3ffa225107a9a65c3eb4153c886260e1d8eeafd79e569983114`
+returned rc=2 with the named positive-integer error before stop. Candidate
+overlay SHA256
+`055283cbdce1cbd5ce4cbb35eb7cfc2868bf29ce251c4d481801019db6d20d74`
+was staged atomically; both live schedulers then matched SHA256
+`45e73c4aef98a6e91c541fac237706853252cbc0009eb5a4c4fe470f72bef2c4`
+with the v3.1 marker. `.env` stayed byte-identical at
+`6e7a206ec05be1cf624df167128470a313d12566b744e1f542808373aaf0983a`;
+the shape stamp stayed `91fbe73a55b2590a3009762603dff284`, so no JIT-cache
+wipe occurred. The pool remained 1,396,551 tokens / 566 usable block IDs.
+
+The fixed 9.7k newcomer smoke was 13.517 s control, 18.207 s on the first
+post-restart candidate sample, and 13.578 s after warmup, all with zero
+preemptions. This is a correctness smoke, not a powered performance claim.
+The scheduling-equivalence fixtures cover admission, aging, peer gaps,
+preemption and tail bypass. Live mixed tool traffic demonstrated the accounting
+split directly: representative completed crawls logged 87,556 / 1,045 ms and
+90,394 / 1,045 ms wall / capped time, where v3 had reported only the inflated
+wall figure.
+
+**Decision: ADOPT.** Acceptance passed 7/7, serving passed 6/6, tool calls
+passed 23/23 with zero blank required arguments, and the long-form/thinking-SSE
+battery passed. Structured decode was 69.87 tok/s median at 1.000 / 7.000;
+prose was 28.20 tok/s median with coherence passing. One prose run tripped the
+broad standalone-`NaN` text diagnostic, while a deterministic repeat, the
+coherence battery and the dedicated runtime probe had no corruption marker.
+Final health was 200 with running/waiting/preemptions zero, selected errors and
+kernel Xids zero, and MemFree 4,563 / 4,218 MiB. The watchdog was re-armed.
+Rollback files are `start.sh.bak-20260906-task14` and
+`overlay/patch_scheduler_decode_floor.py.bak-20260906-task14` on spark1,
+followed by the guarded unit restart. Task 14's caller-precedence and
+crawl-accounting subitems are closed; W31 remains closed separately by task 6.
+
 ### 2026-09-06: task 6 adopts PR #125 participation-scoped fine-grained APC
 
 The W18 fine-grained APC overlay no longer exempts a cache manager by the
@@ -1117,11 +1178,11 @@ probe finish at 512 and 1,024 respectively — exactly the intended split. The e
 "a 512 crawl already runs at ~840 tok/s (84% of solo)" measurement is why the
 throughput gain is real but bounded: the cap costs per-step overhead, not bandwidth.
 
-⚠ `crawl_ms` semantics: the line measures **wall time from late-admit to bypass**, not
-capped-step time. If the peer decoder stops mid-crawl the request finishes at full
-chunks while the timer keeps running — the 240k HoL probe logged `crawl_ms=206898`
-with `final_cap=512` for exactly this reason. Read it as "time spent late", not "time
-spent capped". A v3.1 could split the two.
+v3.1 now reports both meanings explicitly. `crawl_wall_ms` is wall time from
+late admission to bypass; `crawl_capped_ms` accumulates only intervals while
+the late cap is active. Mixed tool traffic measured 87,556 / 1,045 ms and
+90,394 / 1,045 ms wall / capped, confirming that the old single timer could
+overstate capped time by almost the whole request.
 
 Production setting: `GLM53_MIXED_PREFILL_ESCALATE_MS=10000`,
 `GLM53_MIXED_PREFILL_LATE_CAP=512` (default), `GLM53_MIXED_PREFILL_LATE_CAP_MAX=1792`
@@ -1150,8 +1211,8 @@ proposal that must pass our own review and gates.
 | W29 | Extend the F0 ladder past 195k (measurement only) | vLLM #54691/#52258/#48944, kit #73, **our F0** | **Not a speculation gate.** F0 (2026-08-31) already found no long-context decay here — structured flat 56–65 tok/s @ 0.93–0.98 to ~195k, both ladder orders; #73's 70%→16% was on ABLIT=1 / MNBT 2048 / draft TP=2. But F0 stopped at 195k, droid compacts at 300k and the window is 1M, so 195k–400k is unmeasured and is where #54691's profiled mechanism (drafter re-scans the full accumulated drafter KV each cycle) would first bite. | none |
 | W30 | `/reset_prefix_cache` endpoint | kit PR #37 | Every cache A/B so far (W3, W18, W25, W25b) needed a full restart for a cold cache — 8–12 min, and restart churn contaminates the first probe pass with swap fault-in. An endpoint removes that confound from the protocol. | restart once to install |
 | W31 | Fine-grained APC #59 → #84 | kit PR #84 | #84 excludes every non-participating manager (not just `KpoolTailManager`), enforces `hash_block_size % index_kpool == 0` at init, composes with `patch_hybrid_prefix_hit` both orders, and no-ops on a future image where upstream scopes the veto. Author: re-turn hit 96.4–99.4% → 99.9–100%, TTFT 0.9–4.0 s → 0.3–0.5 s. We already have the 64 grid from W18, so this needs a same-day A/B against our own numbers. | restart |
-| W32 | Caller-export precedence | kit PR #92 / issue #91 | Caller exports beat `.env` for only 17 allowlisted knobs while the README promises the general rule; `GLM53_MIXED_PREFILL_CHUNK`, `CG_ESTIMATE`, `MAX_MODEL_LEN` silently lose. Our protocol edits `.env` and is accidentally safe — the trap is one export away and fails as a silent null result. | restart |
-| W33 | Gate v3.1 — split crawl accounting | ours (W26) | `crawl_ms` is wall time since late-admit, not time spent capped. Bundle with the next restart. | none |
+| W32 | Caller-export precedence | kit PR #92 / issue #91 | **ADOPTED 2026-09-06.** Every non-empty exported key assigned by `.env` now follows the documented caller-wins rule; strict empty-value guards are preserved. | restart |
+| W33 | Gate v3.1 — split crawl accounting | ours (W26) | **ADOPTED 2026-09-06.** `late-done` now separates total late wall time from intervals actually spent under the cap. | none |
 
 ### Codex review of PR #86 — DO NOT RUN AS WRITTEN
 

--- a/env.example
+++ b/env.example
@@ -3,6 +3,12 @@
 #
 #   cp env.example .env
 #
+# Every key assigned in .env can be overridden for one invocation with a
+# non-empty caller export: KEY=value ./start.sh validate|start|restart.
+# The strict GLM53_KV_CAPACITY_LOG, GLM53_APC_NO_STORE and
+# GLM53_INDEXER_WORKSPACE knobs also preserve an explicitly empty caller value
+# so validation reports the operator error instead of silently using .env.
+#
 # Every non-default value below is a deliberate, measured choice — docs/02-parameters.md
 # explains each one. Values marked PROD are what this cluster actually runs.
 
@@ -124,7 +130,9 @@ GLM53_INDEXER_WORKSPACE=stock
 # long-prefill chunk ceiling, LONG_PREFILL_TOKEN_THRESHOLD): on this MoE the per-step
 # cost is mostly expert-weight streaming, so a flat 512 cap multiplies expensive steps
 # and taxes running decodes for longer. The late path logs late-admit / late-escalate /
-# late-done lines (grep "decode-floor-v3"). Not in the JIT shape hash.
+# late-done lines (grep "decode-floor-v3"). v3.1 reports both
+# crawl_wall_ms and the time actually capped as crawl_capped_ms. Not in the
+# JIT shape hash.
 # Measured (W26, 2x DGX Spark, 60k cold read against a running decoder): aging on vs
 # off = read 78.3 -> 63.1 s, decode tokens per 240 s 677 -> 863 (+27%), short TTFT
 # behind a 240k read 6.93 -> 6.65 s, gap p99 1.39 -> 1.78 s. A flat LATE_CAP=1024

--- a/overlay/patch_scheduler_decode_floor.py
+++ b/overlay/patch_scheduler_decode_floor.py
@@ -31,8 +31,11 @@ TTFT/completion bound (the request then crawls like cap:N). Both gate sites call
 v3 (aging + instrumentation): once late, the cap doubles every GLM53_MIXED_PREFILL_ESCALATE_MS
 (default 0 = flat v2 crawl) up to GLM53_MIXED_PREFILL_LATE_CAP_MAX (default 1792 = the
 long-prefill chunk ceiling), and the late path logs one line per admission / escalation /
-crawl end. Installer states: pristine -> v3, v1-baked -> v3, v2 (applied or baked) -> v3,
-v3 -> no-op. The v2 helper text is kept verbatim as the byte-exact upgrade anchor.
+crawl end. v3.1 splits crawl wall time from time actually spent under the late
+cap, so intervals where no peer is decoding no longer inflate the operational
+receipt. Installer states: pristine -> v3.1, v1-baked -> v3.1, v2 (applied or
+baked) -> v3.1, v3 -> v3.1, v3.1 -> no-op. The v2 and v3 helper texts are kept
+verbatim as byte-exact upgrade anchors.
 """
 from __future__ import annotations
 
@@ -288,6 +291,122 @@ def _glm53_mixed_prefill_gate(running, current, num_computed_tokens):
 
 '''
 
+
+def _build_v31_helper() -> str:
+    """Derive v3.1 from the exact v3 block retained as the upgrade anchor."""
+    text = HELPER_V3_ONLY.replace(
+        "[glm53-decode-floor-v3]", "[glm53-decode-floor-v3.1]"
+    )
+
+    old = """def _glm53_gate_state(current, create=False):
+    \"\"\"Per-request gate state (first_seen / late_at / cap / done / last_computed) kept on the Request so it
+    survives chunking, preemption and requeue; bounded id-keyed fallback (request_id-checked) if the Request
+    class rejects attributes -- no weakrefs, so slotted or unhashable Request types cannot raise here.  [glm53-decode-floor-v3.1]\"\"\"
+    st = getattr(current, "_glm53_gate_state", None)
+    if st is None:
+        st = _glm53_fallback_get(current)
+    if st is None and create:
+        st = {}
+        try:
+            current._glm53_gate_state = st
+        except AttributeError:
+            _glm53_fallback_put(current, st)
+    return st
+"""
+    new = old + """
+
+def _glm53_set_capped(st, now, active):
+    \"\"\"Accumulate only intervals where the late-admitted request is capped.\"\"\"
+    if st is None or st.get("late_at") is None:
+        return
+    capped_at = st.get("capped_at")
+    if active:
+        if capped_at is None:
+            st["capped_at"] = now
+    elif capped_at is not None:
+        st["capped_s"] = st.get("capped_s", 0.0) + max(now - capped_at, 0.0)
+        st["capped_at"] = None
+"""
+    if text.count(old) != 1:
+        raise RuntimeError("v3.1 state-helper anchor drift")
+    text = text.replace(old, new, 1)
+
+    old = """    import time as _t
+    cfg = _glm53_gate_config()
+    remaining = current.num_tokens - num_computed_tokens
+"""
+    new = """    import time as _t
+    cfg = _glm53_gate_config()
+    now = _t.monotonic()
+    remaining = current.num_tokens - num_computed_tokens
+"""
+    if text.count(old) != 1:
+        raise RuntimeError("v3.1 monotonic anchor drift")
+    text = text.replace(old, new, 1)
+
+    old = """            st.pop("late_at", None); st.pop("cap", None); st.pop("done", None)
+"""
+    new = """            st.pop("late_at", None); st.pop("cap", None); st.pop("done", None)
+            st.pop("capped_at", None); st.pop("capped_s", None)
+"""
+    if text.count(old) != 1:
+        raise RuntimeError("v3.1 preemption anchor drift")
+    text = text.replace(old, new, 1)
+
+    old = """        if st is not None and st.get("late_at") is not None and not st.get("done"):
+            st["done"] = True
+            print(f"[glm53-decode-floor-v3.1] late-done req={getattr(current, 'request_id', '?')} "
+                  f"crawl_ms={int((_t.monotonic() - st['late_at']) * 1000)} final_cap={st.get('cap')}", flush=True)
+"""
+    new = """        if st is not None and st.get("late_at") is not None and not st.get("done"):
+            _glm53_set_capped(st, now, False)
+            st["done"] = True
+            print(f"[glm53-decode-floor-v3.1] late-done req={getattr(current, 'request_id', '?')} "
+                  f"crawl_wall_ms={round((now - st['late_at']) * 1000)} "
+                  f"crawl_capped_ms={round(st.get('capped_s', 0.0) * 1000)} "
+                  f"final_cap={st.get('cap')}", flush=True)
+"""
+    if text.count(old) != 1:
+        raise RuntimeError("v3.1 completion anchor drift")
+    text = text.replace(old, new, 1)
+
+    old = """    cap = _glm53_mixed_prefill_policy(running, current)
+    if cap is None or cap > 0:
+        return cap
+"""
+    new = """    cap = _glm53_mixed_prefill_policy(running, current)
+    if cap is None or cap > 0:
+        _glm53_set_capped(st, now, False)
+        return cap
+"""
+    if text.count(old) != 1:
+        raise RuntimeError("v3.1 uncapped-policy anchor drift")
+    text = text.replace(old, new, 1)
+
+    old = """    now = _t.monotonic()
+    if st.get("first_seen") is None:
+"""
+    new = """    if st.get("first_seen") is None:
+"""
+    if text.count(old) != 1:
+        raise RuntimeError("v3.1 late-clock anchor drift")
+    text = text.replace(old, new, 1)
+
+    old = """        st["cap"] = late_cap
+    return max(min(late_cap, remaining), 1)
+"""
+    new = """        st["cap"] = late_cap
+    _glm53_set_capped(st, now, True)
+    return max(min(late_cap, remaining), 1)
+"""
+    if text.count(old) != 1:
+        raise RuntimeError("v3.1 capped-return anchor drift")
+    return text.replace(old, new, 1)
+
+
+HELPER_V31_ONLY = _build_v31_helper()
+
+
 HELPER_POLICY = '''def _glm53_mixed_prefill_policy(running, current):
     """Mixed-step prefill policy when a peer in `running` is decoding.
 
@@ -316,9 +435,9 @@ HELPER_POLICY = '''def _glm53_mixed_prefill_policy(running, current):
 
 '''
 
-# pristine insert = v3 helper + the v1 policy; the v2 text is kept verbatim as the byte-exact
-# anchor that the v2-baked (image build) -> v3 upgrade replaces.
-HELPER = HELPER_V3_ONLY + HELPER_POLICY
+# Pristine insert = v3.1 helper + the v1 policy. The older helpers remain
+# byte-exact anchors for already-built image and already-deployed overlay states.
+HELPER = HELPER_V31_ONLY + HELPER_POLICY
 
 RUNNING_OLD = """            if 0 < self.scheduler_config.long_prefill_token_threshold < num_new_tokens:
                 num_new_tokens = self.scheduler_config.long_prefill_token_threshold
@@ -384,6 +503,7 @@ V2_WAITING = """                    mixed_cap = _glm53_mixed_prefill_gate(self.r
                     if mixed_cap is not None:
 """
 MARK_V3 = "[glm53-decode-floor-v3]"
+MARK_V31 = "[glm53-decode-floor-v3.1]"
 
 
 def upgrade_v1_to_v2(text: str) -> str:
@@ -397,11 +517,19 @@ def upgrade_v1_to_v2(text: str) -> str:
     return text
 
 
-def upgrade_v2_to_v3(text: str) -> str:
-    """v2 (applied or baked) -> v3: swap the byte-exact v2 helper block for the v3 one; call sites are unchanged."""
-    text = replace_once(text, HELPER_V2_ONLY, HELPER_V3_ONLY, "v2 helper block")
-    if MARK_V3 not in text or HELPER_V2_ONLY in text or text.count("def _glm53_mixed_prefill_gate(") != 1:
-        raise SystemExit(f"{P}: v2 -> v3 upgrade postcondition failed")
+def upgrade_v2_to_v31(text: str) -> str:
+    """v2 (applied or baked) -> v3.1; call sites are unchanged."""
+    text = replace_once(text, HELPER_V2_ONLY, HELPER_V31_ONLY, "v2 helper block")
+    if MARK_V31 not in text or HELPER_V2_ONLY in text or text.count("def _glm53_mixed_prefill_gate(") != 1:
+        raise SystemExit(f"{P}: v2 -> v3.1 upgrade postcondition failed")
+    return text
+
+
+def upgrade_v3_to_v31(text: str) -> str:
+    """Already-deployed v3 -> v3.1 using the exact retained v3 helper."""
+    text = replace_once(text, HELPER_V3_ONLY, HELPER_V31_ONLY, "v3 helper block")
+    if MARK_V31 not in text or HELPER_V3_ONLY in text or text.count("def _glm53_mixed_prefill_gate(") != 1:
+        raise SystemExit(f"{P}: v3 -> v3.1 upgrade postcondition failed")
     return text
 
 
@@ -412,28 +540,59 @@ def replace_once(text: str, old: str, new: str, label: str) -> str:
     return text.replace(old, new, 1)
 
 
+def validate_v31(text: str) -> None:
+    """Fail closed unless the complete installed v3.1 contract is intact."""
+    import ast as _ast
+
+    expected = (
+        ("v3.1 helper", HELPER_V31_ONLY),
+        ("mixed-prefill policy", HELPER_POLICY),
+        ("complete running gate", RUNNING_NEW),
+        ("complete waiting gate", WAITING_NEW),
+    )
+    for label, snippet in expected:
+        count = text.count(snippet)
+        if count != 1:
+            raise SystemExit(f"{P}: expected one {label}, found {count}")
+    if HELPER_V2_ONLY in text or HELPER_V3_ONLY in text:
+        raise SystemExit(f"{P}: predecessor helper remains after v3.1 install")
+    tree = _ast.parse(text, filename=str(P))
+    has_top_level_os = any(
+        isinstance(node, _ast.Import)
+        and any(alias.name == "os" and alias.asname is None for alias in node.names)
+        for node in tree.body
+    )
+    if not has_top_level_os:
+        raise SystemExit(f"{P}: required top-level unaliased import os is missing")
+
+
 def main() -> int:
     if not P.is_file():
         raise SystemExit(f"missing {P}")
     text = P.read_text()
+    if MARK_V31 in text:
+        validate_v31(text)
+        print(f"{P.name}: {MARK_V31} already present — skipping")
+        return 0
     if MARK_V3 in text:
-        print(f"{P.name}: {MARK_V3} already present — skipping")
+        text = upgrade_v3_to_v31(text)
+        validate_v31(text)
+        P.write_text(text)
+        print(f"{P.name}: upgraded v3 -> v3.1 (split crawl wall/capped accounting active)")
         return 0
     if MARK_V2 in text:
-        # v2 applied at start or baked into the image (the w24 production image): upgrade in place.
-        text = upgrade_v2_to_v3(text)
-        import ast as _ast
-        _ast.parse(text, filename=str(P))
+        # v2 applied at start or baked into an older image: upgrade in place.
+        text = upgrade_v2_to_v31(text)
+        validate_v31(text)
         P.write_text(text)
-        print(f"{P.name}: upgraded v2 -> v3 (mixed-prefill gate v3 active: aging + late-path log)")
+        print(f"{P.name}: upgraded v2 -> v3.1 (aging + split crawl accounting active)")
         return 0
     if MARK in text:
-        # v1 baked into the image (self-built production path): upgrade in place, v1 -> v2 -> v3.
-        text = upgrade_v2_to_v3(upgrade_v1_to_v2(text))
-        import ast as _ast
-        _ast.parse(text, filename=str(P))
+        # v1 baked into an older image: upgrade in place, v1 -> v2 -> v3.1.
+        text = upgrade_v2_to_v31(upgrade_v1_to_v2(text))
+        validate_v31(text)
         P.write_text(text)
-        print(f"{P.name}: upgraded v1 -> v3 (mixed-prefill gate v3 active: aging + late-path log)")
+        print(f"{P.name}: upgraded v1 -> v3.1 (aging + split crawl accounting active)")
         return 0
     if "import os\n" not in text.split("import time\n", 1)[0]:
         text = replace_once(text, IMPORT_OLD, IMPORT_NEW, "import os")
@@ -444,6 +603,7 @@ def main() -> int:
         text = text.replace(needle, HELPER + needle, 1)
     text = replace_once(text, RUNNING_OLD, RUNNING_NEW, "running-prefill")
     text = replace_once(text, WAITING_OLD, WAITING_NEW, "waiting-prefill")
+    validate_v31(text)
     P.write_text(text)
     cap = os.environ.get("GLM53_MIXED_PREFILL_CHUNK", "skip")
     print(f"patched {P.name} (mixed prefill policy={cap})")

--- a/scripts/run_a3_align_floor_window.py
+++ b/scripts/run_a3_align_floor_window.py
@@ -4,7 +4,7 @@
 The service restart and environment flip stay operator-controlled. This runner
 validates the effective container environment, starts both-node MemFree
 monitoring before the first request, runs the fixed 60k newcomer probe, and
-requires a decode-floor-v3 log showing a sub-page cap.
+requires a decode-floor-v3/v3.1 log showing a sub-page cap.
 """
 from __future__ import annotations
 
@@ -139,9 +139,15 @@ def extract_subblock_caps(log_text: str, request_ids: set[str]) -> list[int]:
             request_match.group(1), request_ids
         ):
             continue
-        if "[glm53-decode-floor-v3] late-admit" in line:
+        if (
+            "[glm53-decode-floor-v3] late-admit" in line
+            or "[glm53-decode-floor-v3.1] late-admit" in line
+        ):
             match = re.search(r"\bcap=(\d+)\b", line)
-        elif "[glm53-decode-floor-v3] late-escalate" in line:
+        elif (
+            "[glm53-decode-floor-v3] late-escalate" in line
+            or "[glm53-decode-floor-v3.1] late-escalate" in line
+        ):
             match = re.search(r"->(\d+)\b", line)
         else:
             continue
@@ -397,11 +403,14 @@ def main() -> int:
         receipt["decode_floor_log_lines"] = [
             line
             for line in logs.splitlines()
-            if "[glm53-decode-floor-v3]" in line
+            if (
+                "[glm53-decode-floor-v3]" in line
+                or "[glm53-decode-floor-v3.1]" in line
+            )
         ]
         if not caps:
             receipt["errors"].append(
-                "no decode-floor-v3 sub-page late cap was logged"
+                "no decode-floor-v3/v3.1 sub-page late cap was logged"
             )
 
         final_metrics = run_text(["curl", "-fsS", f"{BASE}/metrics"])

--- a/start.sh
+++ b/start.sh
@@ -59,27 +59,25 @@ elif [ ! -f "$SCRIPT_DIR/.env" ]; then
     cp "$SCRIPT_DIR/env.example" "$SCRIPT_DIR/.env"
     printf '\033[1;36m[glm53-exl3]\033[0m wrote .env from env.example — edit HEAD_IP / WORKER_IP if needed\n'
 fi
-# Caller exports (MTP_TOKENS=2 ./start.sh restart) must win over .env.
-_cli_mtp="${MTP_TOKENS-}"
-_cli_spec="${SPEC_METHOD-}"
-_cli_eager="${ENFORCE_EAGER-}"
-_cli_fused="${EXL3_FUSED_MOE-}"
-_cli_row_tile="${EXL3_MOE_ROW_TILE-}"
-_cli_temp_rows="${EXL3_TEMP_ROWS_FUSED-}"
-_cli_fat_sorted="${EXL3_FAT_SORTED-}"
-_cli_fat_batched="${EXL3_FAT_BATCHED-}"
-_cli_fat_kernel="${EXL3_FAT_KERNEL-}"
-_cli_mnbt="${MAX_NUM_BATCHED_TOKENS-}"
-_cli_image="${IMAGE-}"
-_cli_util="${GPU_MEM_UTIL-}"
-_cli_lm="${LANGUAGE_MODEL_ONLY-}"
-_cli_max_num_seqs="${MAX_NUM_SEQS-}"
-_cli_chunk="${GLM53_MIXED_PREFILL_CHUNK-}"
-_cli_warm="${GLM53_MIXED_PREFILL_WARM_TOKENS-}"
-_cli_wait="${GLM53_MIXED_PREFILL_MAX_WAIT_MS-}"
-_cli_late="${GLM53_MIXED_PREFILL_LATE_CAP-}"
-_cli_esc="${GLM53_MIXED_PREFILL_ESCALATE_MS-}"  # LOCAL: W26
-_cli_latemax="${GLM53_MIXED_PREFILL_LATE_CAP_MAX-}"  # LOCAL: W26
+# Caller exports must win over .env for every key .env defines: remember each
+# caller's non-empty exported value, source .env, then re-apply it. The scanner
+# is lexical and accepts `[export ]NAME[+]=VALUE`. Empty caller values retain
+# the historical generic behavior (the .env value wins); strict knobs that
+# treat empty as an operator error keep the setness-aware exceptions below.
+# Only exported, non-readonly names are captured, so shell internals are never
+# replayed and nothing is eval'd. This works under bash 3.2 and 5.x.
+_env_keys="$(sed -nE 's/^[[:space:]]*(export[[:space:]]+)?([A-Za-z_][A-Za-z0-9_]*)\+?=.*/\2/p' "$SCRIPT_DIR/.env")"
+_caller_overrides=()
+while IFS= read -r _k; do
+    [ -n "$_k" ] || continue
+    _flags="$(declare -p "$_k" 2>/dev/null || true)"
+    _flags="${_flags#declare -}"
+    _flags="${_flags%% *}"
+    case "$_flags" in *r*) continue ;; *x*) ;; *) continue ;; esac
+    if [ -n "${!_k:+x}" ]; then
+        _caller_overrides+=("$_k=${!_k}")
+    fi
+done <<< "$_env_keys"
 # LOCAL: W41/W42 caller-wins capture (begin) -- setness-aware: a caller-provided
 # value (even explicitly EMPTY, which is a value the validator must see) wins
 # over .env. ${VAR+a} is non-empty iff the variable was set at entry.
@@ -94,26 +92,12 @@ set -a
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/.env"
 set +a
-[ -n "${_cli_mtp}" ] && MTP_TOKENS="$_cli_mtp"
-[ -n "${_cli_chunk}" ] && GLM53_MIXED_PREFILL_CHUNK="$_cli_chunk"
-[ -n "${_cli_warm}" ] && GLM53_MIXED_PREFILL_WARM_TOKENS="$_cli_warm"
-[ -n "${_cli_wait}" ] && GLM53_MIXED_PREFILL_MAX_WAIT_MS="$_cli_wait"
-[ -n "${_cli_late}" ] && GLM53_MIXED_PREFILL_LATE_CAP="$_cli_late"
-[ -n "${_cli_esc}" ] && GLM53_MIXED_PREFILL_ESCALATE_MS="$_cli_esc"
-[ -n "${_cli_latemax}" ] && GLM53_MIXED_PREFILL_LATE_CAP_MAX="$_cli_latemax"
-[ -n "${_cli_spec}" ] && SPEC_METHOD="$_cli_spec"
-[ -n "${_cli_eager}" ] && ENFORCE_EAGER="$_cli_eager"
-[ -n "${_cli_fused}" ] && EXL3_FUSED_MOE="$_cli_fused"
-[ -n "${_cli_row_tile}" ] && EXL3_MOE_ROW_TILE="$_cli_row_tile"
-[ -n "${_cli_temp_rows}" ] && EXL3_TEMP_ROWS_FUSED="$_cli_temp_rows"
-[ -n "${_cli_fat_sorted}" ] && EXL3_FAT_SORTED="$_cli_fat_sorted"
-[ -n "${_cli_fat_batched}" ] && EXL3_FAT_BATCHED="$_cli_fat_batched"
-[ -n "${_cli_fat_kernel}" ] && EXL3_FAT_KERNEL="$_cli_fat_kernel"
-[ -n "${_cli_mnbt}" ] && MAX_NUM_BATCHED_TOKENS="$_cli_mnbt"
-[ -n "${_cli_image}" ] && IMAGE="$_cli_image"
-[ -n "${_cli_util}" ] && GPU_MEM_UTIL="$_cli_util"
-[ -n "${_cli_lm}" ] && LANGUAGE_MODEL_ONLY="$_cli_lm"
-[ -n "${_cli_max_num_seqs}" ] && MAX_NUM_SEQS="$_cli_max_num_seqs"
+# Each entry is NAME=value (SC2163 misreads the indirection).
+# shellcheck disable=SC2163
+for _kv in ${_caller_overrides[@]+"${_caller_overrides[@]}"}; do
+    export "$_kv"
+done
+unset _k _kv _flags _env_keys _caller_overrides
 # LOCAL: W41/W42 caller-wins restore (begin)
 [ -n "${_glm53_cli_kvlog_set}" ] && GLM53_KV_CAPACITY_LOG="$_glm53_cli_kvlog_val"
 [ -n "${_glm53_cli_apcns_set}" ] && GLM53_APC_NO_STORE="$_glm53_cli_apcns_val"

--- a/tests/test_a3_align_floor_window.py
+++ b/tests/test_a3_align_floor_window.py
@@ -61,8 +61,8 @@ def test_validation_rejects_wrong_or_unsafe_arm() -> None:
 def test_extracts_only_sub_page_decode_floor_caps() -> None:
     module = load_module()
     logs = """
-[glm53-decode-floor-v3] late-admit req=chatcmpl-a waited_ms=1501 remaining=60000 cap=512
-[glm53-decode-floor-v3] late-escalate req=chatcmpl-a-1a2b3c4d cap=512->1024
+[glm53-decode-floor-v3.1] late-admit req=chatcmpl-a waited_ms=1501 remaining=60000 cap=512
+[glm53-decode-floor-v3.1] late-escalate req=chatcmpl-a-1a2b3c4d cap=512->1024
 [glm53-decode-floor-v3] late-admit req=chatcmpl-unrelated-a-1a2b3c4d waited_ms=1501 remaining=60000 cap=1792
 [glm53-decode-floor-v3] late-escalate req=chatcmpl-a-1234567g cap=1024->1792
 [glm53-decode-floor-v3] late-escalate req=chatcmpl-a-lookalike cap=1024->1792

--- a/tests/test_gate_v2_upgrade.py
+++ b/tests/test_gate_v2_upgrade.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
-"""The gate-v2 patcher must handle a scheduler.py that already carries the BAKED v1
-overlay (the self-built production image applies overlays at image build): pristine ->
-full v3, v1-baked -> v3, v2 (applied or baked) -> v3, v3 -> no-op. Discovered live 2026-08-31: the original
+"""The gate patcher must handle every deployed predecessor state: pristine ->
+v3.1, v1-baked -> v3.1, v2 (applied or baked) -> v3.1, v3 -> v3.1,
+v3.1 -> no-op. Discovered live 2026-08-31: the original
 PR #80 installer saw the v1 marker and skipped, leaving production on the v1 gate."""
 from __future__ import annotations
 
@@ -85,19 +85,19 @@ def build_v1_file(mod) -> str:
     return v1
 
 
-def test_pristine_v2_then_noop() -> None:
+def test_pristine_v31_then_noop() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         t = Path(tmp) / "scheduler.py"
         mod = load_overlay(t)
         assert mod.RUNNING_OLD in PRISTINE and mod.WAITING_OLD in PRISTINE, "fixture drifted"
         t.write_text(PRISTINE)
         r = run_patcher(t); assert r.returncode == 0, r.stderr
-        v2 = t.read_text()
-        assert v2.count("[glm53-decode-floor-v2]") >= 3
-        assert v2.count("_glm53_mixed_prefill_gate(") >= 3
-        compile(v2, "v2.py", "exec")
+        v31 = t.read_text()
+        assert mod.MARK_V31 in v31
+        assert v31.count("_glm53_mixed_prefill_gate(") >= 3
+        compile(v31, "v31.py", "exec")
         r = run_patcher(t); assert r.returncode == 0 and "already present" in r.stdout, r.stdout
-        assert t.read_text() == v2
+        assert t.read_text() == v31
 
 
 def test_v1_baked_upgrades_then_noop() -> None:
@@ -110,7 +110,7 @@ def test_v1_baked_upgrades_then_noop() -> None:
         compile(v1, "v1.py", "exec")
         t.write_text(v1)
         r = run_patcher(t); assert r.returncode == 0, r.stderr
-        assert "upgraded v1 -> v3" in r.stdout, r.stdout
+        assert "upgraded v1 -> v3.1" in r.stdout, r.stdout
         up = t.read_text()
         assert mod.V1_RUNNING not in up and mod.V1_WAITING not in up
         assert up.count("_glm53_mixed_prefill_gate(") >= 3
@@ -140,9 +140,9 @@ def test_v2_baked_upgrades_to_v3_then_noop() -> None:
         compile(v2, "v2.py", "exec")
         t.write_text(v2)
         r = run_patcher(t); assert r.returncode == 0, r.stderr
-        assert "upgraded v2 -> v3" in r.stdout, r.stdout
+        assert "upgraded v2 -> v3.1" in r.stdout, r.stdout
         up = t.read_text()
-        assert mod.HELPER_V2_ONLY not in up and mod.HELPER_V3_ONLY in up
+        assert mod.HELPER_V2_ONLY not in up and mod.HELPER_V31_ONLY in up
         assert up.count("def _glm53_mixed_prefill_gate(") == 1
         assert up.count("def _glm53_gate_state(") == 1
         assert up.count("_glm53_mixed_prefill_gate(") >= 3   # call sites untouched
@@ -151,8 +151,121 @@ def test_v2_baked_upgrades_to_v3_then_noop() -> None:
         assert t.read_text() == up
 
 
+def test_v3_baked_upgrades_to_v31_then_noop() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        t = Path(tmp) / "scheduler.py"
+        mod = load_overlay(t)
+        v3 = PRISTINE.replace(mod.IMPORT_OLD, mod.IMPORT_NEW, 1)
+        v3 = v3.replace(
+            "from vllm.compilation.cuda_graph import CUDAGraphStat\n",
+            mod.HELPER_V3_ONLY
+            + mod.HELPER_POLICY
+            + "from vllm.compilation.cuda_graph import CUDAGraphStat\n",
+            1,
+        )
+        v3 = v3.replace(mod.RUNNING_OLD, mod.RUNNING_NEW, 1).replace(
+            mod.WAITING_OLD, mod.WAITING_NEW, 1
+        )
+        assert mod.MARK_V3 in v3 and mod.MARK_V31 not in v3
+        compile(v3, "v3.py", "exec")
+        t.write_text(v3)
+        r = run_patcher(t)
+        assert r.returncode == 0 and "upgraded v3 -> v3.1" in r.stdout, r.stdout
+        up = t.read_text()
+        assert mod.HELPER_V3_ONLY not in up and mod.HELPER_V31_ONLY in up
+        compile(up, "v31.py", "exec")
+        r = run_patcher(t)
+        assert r.returncode == 0 and "already present" in r.stdout, r.stdout
+        assert t.read_text() == up
+
+
+def test_damaged_v3_predecessor_fails_without_writing() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        t = Path(tmp) / "scheduler.py"
+        mod = load_overlay(t)
+        v3 = PRISTINE.replace(mod.IMPORT_OLD, mod.IMPORT_NEW, 1)
+        v3 = v3.replace(
+            "from vllm.compilation.cuda_graph import CUDAGraphStat\n",
+            mod.HELPER_V3_ONLY
+            + mod.HELPER_POLICY
+            + "from vllm.compilation.cuda_graph import CUDAGraphStat\n",
+            1,
+        )
+        v3 = v3.replace(mod.RUNNING_OLD, mod.RUNNING_NEW, 1).replace(
+            mod.WAITING_OLD, mod.WAITING_NEW, 1
+        )
+        damaged = v3.replace(mod.V2_RUNNING, "            mixed_cap = None\n", 1)
+        t.write_text(damaged)
+        before = t.read_bytes()
+        r = run_patcher(t)
+        assert r.returncode != 0
+        assert "complete running gate" in r.stderr
+        assert t.read_bytes() == before
+
+
+def test_damaged_v31_noop_fails_without_writing() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        t = Path(tmp) / "scheduler.py"
+        mod = load_overlay(t)
+        t.write_text(PRISTINE)
+        r = run_patcher(t)
+        assert r.returncode == 0, r.stderr
+        damaged = t.read_text().replace(
+            "_glm53_set_capped(st, now, True)",
+            "_glm53_set_capped(st, now, False)",
+            1,
+        )
+        t.write_text(damaged)
+        before = t.read_bytes()
+        r = run_patcher(t)
+        assert r.returncode != 0
+        assert "v3.1 helper" in r.stderr
+        assert t.read_bytes() == before
+
+
+def test_damaged_waiting_body_fails_without_writing() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        t = Path(tmp) / "scheduler.py"
+        load_overlay(t)
+        t.write_text(PRISTINE)
+        r = run_patcher(t)
+        assert r.returncode == 0, r.stderr
+        damaged = t.read_text().replace(
+            "                        num_new_tokens = min(num_new_tokens, mixed_cap)\n",
+            "                        pass\n",
+            1,
+        )
+        t.write_text(damaged)
+        before = t.read_bytes()
+        r = run_patcher(t)
+        assert r.returncode != 0
+        assert "complete waiting gate" in r.stderr
+        assert t.read_bytes() == before
+
+
+def test_commented_import_fails_without_writing() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        t = Path(tmp) / "scheduler.py"
+        load_overlay(t)
+        t.write_text(PRISTINE)
+        r = run_patcher(t)
+        assert r.returncode == 0, r.stderr
+        damaged = t.read_text().replace("import os\n", "# import os\n", 1)
+        t.write_text(damaged)
+        before = t.read_bytes()
+        r = run_patcher(t)
+        assert r.returncode != 0
+        assert "top-level unaliased import os" in r.stderr
+        assert t.read_bytes() == before
+
+
 if __name__ == "__main__":
-    test_pristine_v2_then_noop()
+    test_pristine_v31_then_noop()
     test_v1_baked_upgrades_then_noop()
     test_v2_baked_upgrades_to_v3_then_noop()
+    test_v3_baked_upgrades_to_v31_then_noop()
+    test_damaged_v3_predecessor_fails_without_writing()
+    test_damaged_v31_noop_fails_without_writing()
+    test_damaged_waiting_body_fails_without_writing()
+    test_commented_import_fails_without_writing()
     print("gate v2 upgrade paths OK")

--- a/tests/test_gate_v3.py
+++ b/tests/test_gate_v3.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
-"""Gate v3 behavior: bypass, hold, deadline, aging escalation and the late-path log lines,
-driven with a fake monotonic clock against the overlay's own helper text."""
+"""Gate v3.1 behavior: deadline, aging, and split crawl accounting."""
 from __future__ import annotations
 
 import importlib.util
@@ -74,6 +73,8 @@ def test_bypass_hold_deadline_and_aging() -> None:
         assert log.count("late-admit req=cold") == 1, log
         assert "cap=512->1024" in log and "cap=1024->1792" in log, log
         assert log.count("late-done req=cold") == 1 and "final_cap=1792" in log, log
+        assert "crawl_wall_ms=70000" in log, log
+        assert "crawl_capped_ms=70000" in log, log
         # no peer decoding -> no policy
         assert gate([], Req("solo", 100_000), 0) is None
     finally:
@@ -95,6 +96,37 @@ def test_flat_v2_crawl_when_escalation_off() -> None:
             clock[0] += 120.0
             assert gate(running, cold, 30_000) == 512   # never escalates
         assert "late-escalate" not in out.getvalue()
+    finally:
+        time.monotonic = real
+
+
+def test_capped_time_excludes_uncapped_wall_intervals() -> None:
+    clock = [100.0]
+    ns, real = _helper_ns(
+        {
+            "GLM53_MIXED_PREFILL_MAX_WAIT_MS": "1",
+            "GLM53_MIXED_PREFILL_ESCALATE_MS": "10000",
+        },
+        clock,
+    )
+    try:
+        gate = ns["_glm53_mixed_prefill_gate"]
+        cold = Req("split", 60_000)
+        peer = _decoding_peer()
+        out = io.StringIO()
+        with redirect_stdout(out):
+            assert gate([peer], cold, 0) == 0
+            clock[0] += 0.01
+            assert gate([peer], cold, 0) == 512
+            clock[0] += 5.0
+            assert gate([], cold, 512) is None
+            clock[0] += 20.0
+            assert gate([peer], cold, 512) == 1792
+            clock[0] += 5.0
+            assert gate([peer], cold, 60_000 - 3_000) is None
+        log = out.getvalue()
+        assert "crawl_wall_ms=30000" in log, log
+        assert "crawl_capped_ms=10000" in log, log
     finally:
         time.monotonic = real
 
@@ -163,6 +195,7 @@ def test_fallback_when_request_rejects_attributes() -> None:
 if __name__ == "__main__":
     test_bypass_hold_deadline_and_aging()
     test_flat_v2_crawl_when_escalation_off()
+    test_capped_time_excludes_uncapped_wall_intervals()
     test_wait_forever_when_max_wait_zero()
     test_preemption_rollback_starts_a_new_crawl_episode()
     test_fallback_when_request_rejects_attributes()

--- a/tests/test_start_overrides.py
+++ b/tests/test_start_overrides.py
@@ -1,21 +1,219 @@
 #!/usr/bin/env python3
-"""Regression test for caller overrides that must win over ``.env``."""
+"""Regression tests for caller overrides that must win over ``.env`` (#28, #44, #91).
+
+The README rule is "prefix env wins over .env". start.sh implements it in the
+prologue (before the configuration section): remember the caller's non-empty
+value of every key .env assigns, source .env, re-apply them. These tests drive
+that prologue two ways:
+
+  1. The spliced preamble (everything before the configuration marker) with a
+     one-key .env -- the original #28 regression, unchanged.
+  2. The real start.sh, with its trailing ``main "$@"`` swapped for ``"$@"`` so
+     the full prologue + configuration section runs and a printf can then read
+     the resolved values, from an allow-listed environment with docker / ssh /
+     scp / rsync / curl / ip / nvidia-smi stubbed first on PATH (nothing
+     touches a host; the stubs record every call and the tests assert none).
+     Every key env.example defines is exported by
+     the caller and must survive; a child process must inherit the override
+     (the ``set -a`` contract); with no caller export .env must still beat the
+     script defaults; an explicitly empty export must NOT override (the
+     ``[ -n ]`` semantics the per-knob allowlist had); a readonly exported
+     shell variable (SHELLOPTS) must not break the prologue, even when a
+     heredoc line in .env looks like `SHELLOPTS=...`; a .env naming a
+     launcher-internal variable (SCRIPT_DIR) must not replay it; a .env with
+     comments, blank lines, indentation, ``export KEY=``, ``KEY+=``, a CRLF
+     line (sourced with the carriage return kept, as before) and a quoted
+     JSON value must parse. The matrix runs under every bash found on
+     the host (``bash`` on PATH, /bin/bash -- 3.2 on macOS -- and Homebrew's
+     5.x when present).
+
+Run:  python3 tests/test_start_overrides.py   (or pytest)
+"""
 
 from __future__ import annotations
 
 import os
+import re
+import shutil
+import stat
 import subprocess
 import tempfile
 from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
+START = ROOT / "start.sh"
+ENV_EXAMPLE = ROOT / "env.example"
+CONFIG_MARKER = "# ----------------------------- configuration -------------------------------"
+
+# Same shape as the sed in start.sh: an assignment at line start, optional
+# `export`, optional leading whitespace. Comments (`# KEY=`) do not count.
+KEY_RE = re.compile(r"^[ \t]*(?:export[ \t]+)?([A-Za-z_][A-Za-z0-9_]*)\+?=", re.M)
+HOST_TOOLS = ("docker", "ssh", "scp", "rsync", "curl", "ip", "nvidia-smi")
+SEP = "\x1f"
+
+STUB = """#!/usr/bin/env bash
+# Records every invocation; never touches a host.
+{ printf '%s\\x1f' "$(basename "$0")" "$@"; printf '\\n'; } >> "$GLM53_STUB_LOG"
+exit 0
+"""
+
+
+def env_keys(text: str) -> list[str]:
+    seen: list[str] = []
+    for key in KEY_RE.findall(text):
+        if key not in seen:
+            seen.append(key)
+    return seen
+
+
+def bashes() -> list[str]:
+    """Every distinct bash on this host: PATH's, /bin/bash (macOS 3.2), Homebrew 5.x."""
+    found: list[str] = []
+    seen: set[str] = set()
+    for cand in (shutil.which("bash"), "/bin/bash", "/opt/homebrew/bin/bash", "/usr/local/bin/bash"):
+        if not cand or not Path(cand).is_file() or not os.access(cand, os.X_OK):
+            continue
+        real = os.path.realpath(cand)
+        if real in seen:
+            continue
+        seen.add(real)
+        found.append(cand)
+    assert found, "no bash found"
+    return found
+
+
+def bash_version(bash: str) -> str:
+    out = subprocess.run([bash, "-c", 'printf "%s" "$BASH_VERSION"'], capture_output=True, text=True, check=True)
+    return out.stdout.strip()
+
+
+class Harness:
+    """Throwaway copy of the launcher plus a stub PATH (no real docker / ssh)."""
+
+    def __init__(self, tmp: Path) -> None:
+        self.tmp = tmp
+        self.repo = tmp / "repo"
+        self.repo.mkdir()
+        shutil.copy2(START, self.repo / "start.sh")
+        shutil.copy2(ENV_EXAMPLE, self.repo / "env.example")
+        text = (self.repo / "start.sh").read_text()
+        assert text.rstrip().endswith('\nmain "$@"'), 'start.sh must end with main "$@"'
+        (self.repo / "start.fn.sh").write_text(text.rstrip()[: -len('main "$@"')] + '"$@"\n')
+        self.home = tmp / "home"
+        self.home.mkdir()
+        self.bin = tmp / "bin"
+        self.bin.mkdir()
+        for tool in HOST_TOOLS:
+            p = self.bin / tool
+            p.write_text(STUB)
+            p.chmod(p.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+        self.log = tmp / "calls.log"
+
+    def env(self, extra: dict[str, str]) -> dict[str, str]:
+        # Allow-listed: nothing from the developer shell leaks in (no BASH_ENV,
+        # HF_*, GLM53_*, SKIP_* ...); PATH is the stubs plus the system dirs only.
+        env = {
+            "PATH": f"{self.bin}{os.pathsep}/usr/bin:/bin",
+            "HOME": str(self.home),
+            "USER": "glm53-overrides",
+            "LC_ALL": "C",
+            "TERM": "dumb",
+            "GLM53_STUB_LOG": str(self.log),
+        }
+        env.update(extra)
+        return env
+
+    def host_calls(self) -> list[str]:
+        if not self.log.exists():
+            return []
+        return [line.split(SEP)[0] for line in self.log.read_text().splitlines() if line]
+
+    def resolve(self, bash: str, dotenv: str, keys: list[str], caller: dict[str, str]) -> tuple[dict[str, str], dict[str, str]]:
+        """Run the full prologue + configuration under `bash`; return the
+        resolved value of every key in the launcher and in a child process."""
+        (self.repo / ".env").write_text(dotenv)
+        if self.log.exists():
+            self.log.unlink()
+        names = " ".join(keys)
+        # `eval` runs in the launcher's own context after the whole prologue.
+        body = (
+            f'for _n in {names}; do printf "P\\x1f%s\\x1f%s\\n" "$_n" "${{!_n-<unset>}}"; done; '
+            f'"$BASH" -c \'for _n in {names}; do printf "C\\x1f%s\\x1f%s\\n" "$_n" "${{!_n-<unset>}}"; done\''
+        )
+        # bytes, not text=True: universal newlines would turn a CRLF value's
+        # carriage return into a newline before we can see it.
+        r = subprocess.run(
+            [bash, "./start.fn.sh", "eval", body],
+            cwd=self.repo,
+            capture_output=True,
+            check=False,
+            env=self.env(caller),
+        )
+        assert r.returncode == 0, (bash, r.returncode, r.stderr[-800:].decode(errors="replace"))
+        parent: dict[str, str] = {}
+        child: dict[str, str] = {}
+        for line in r.stdout.decode(errors="replace").split("\n"):
+            if SEP not in line:
+                continue
+            scope, name, value = line.split(SEP, 2)
+            (parent if scope == "P" else child)[name] = value
+        assert not self.host_calls(), f"prologue must not touch a host: {self.host_calls()}"
+        return parent, child
+
+
+def caller_value(key: str) -> str:
+    constrained = {
+        "MODEL_REVISION": "a" * 40,
+        "DFLASH_REVISION": "b" * 40,
+        "SPEC_METHOD": "mtp",
+        "GLM53_DEFAULT_REASONING_EFFORT": "max",
+        "GLM53_INDEXER_WORKSPACE": "stock",
+        "GLM53_KV_CAPACITY_LOG": "0",
+        "GLM53_APC_NO_STORE": "0",
+        "KV_CACHE_DTYPE": "auto",
+    }
+    if key in constrained:
+        return constrained[key]
+    if key == "LIMIT_MM":
+        return '{"image":9,"video":2}'
+    if key == "SERVED_MODEL_NAME":
+        return 'caller "quoted" value with spaces = and equals'
+    return f"caller-{key}"
+
+
+def test_no_per_knob_allowlist_remains() -> None:
+    src = START.read_text()
+    # The generic [ -n ] replay cannot express "an explicitly EMPTY caller
+    # export must reach validate_numeric_config", so exactly the three strict
+    # runtime-overlay knobs keep documented setness-aware captures.
+    import re as _re
+    cli_tokens = set(_re.findall(r"_glm53_cli_[A-Za-z0-9_]*", src))
+    allowed = {
+        "_glm53_cli_kvlog_set",
+        "_glm53_cli_kvlog_val",
+        "_glm53_cli_apcns_set",
+        "_glm53_cli_apcns_val",
+        "_glm53_cli_indexer_workspace_set",
+        "_glm53_cli_indexer_workspace_val",
+    }
+    assert cli_tokens <= allowed, (
+        f"the per-knob _cli_* allowlist must be gone (generic rule, #91); "
+        f"unexpected: {sorted(cli_tokens - allowed)}"
+    )
+    code = "\n".join(l for l in src.splitlines() if not l.lstrip().startswith("#"))
+    assert "export -p" not in code, "never replay every export (readonly declare -rx fails under set -e)"
+    prologue = src.partition(CONFIG_MARKER)[0]
+    assert 'source "$SCRIPT_DIR/.env"' in prologue
+    assert "_caller_overrides" in prologue and "${!_k:+x}" in prologue
+    assert 'declare -p "$_k"' in prologue, "only exported names are captured"
+    assert "*r*) continue" in prologue, "readonly (declare -rx) names are never replayed"
 
 
 def test_max_num_seqs_inline_override_wins() -> None:
-    source = (ROOT / "start.sh").read_text()
-    marker = "# ----------------------------- configuration -------------------------------"
-    preamble, separator, _rest = source.partition(marker)
+    """The original #28 regression: spliced preamble, one-key .env."""
+    source = START.read_text()
+    preamble, separator, _rest = source.partition(CONFIG_MARKER)
     assert separator, "start.sh configuration marker is missing"
 
     with tempfile.TemporaryDirectory() as raw_tmp:
@@ -28,8 +226,8 @@ def test_max_num_seqs_inline_override_wins() -> None:
         script.chmod(0o755)
         (tmp / ".env").write_text("MAX_NUM_SEQS=2\n")
 
-        env = os.environ.copy()
-        env["MAX_NUM_SEQS"] = "4"
+        # isolated: no BASH_ENV / PATH surprises from the developer shell
+        env = {"PATH": "/usr/bin:/bin", "HOME": str(tmp), "USER": "glm53", "MAX_NUM_SEQS": "4"}
         result = subprocess.run(
             ["bash", str(script)],
             check=True,
@@ -41,7 +239,126 @@ def test_max_num_seqs_inline_override_wins() -> None:
     assert result.stdout.strip() == "MAX_NUM_SEQS=4"
 
 
-def test_mixed_prefill_chunk_inline_override_wins() -> None:
+def test_every_env_example_key_survives_a_caller_export() -> None:
+    example = ENV_EXAMPLE.read_text()
+    keys = env_keys(example)
+    assert len(keys) >= 40, keys
+    for key in ("MAX_NUM_SEQS", "MAX_MODEL_LEN", "SPEC_METHOD", "DFLASH_TOKENS",
+                "EXL3_FAT_KERNEL", "GLM53_INDEXER_WORKSPACE",
+                "GLM53_KV_CAPACITY_LOG", "GLM53_APC_NO_STORE"):
+        assert key in keys, key
+    caller = {k: caller_value(k) for k in keys}
+    with tempfile.TemporaryDirectory() as raw_tmp:
+        h = Harness(Path(raw_tmp))
+        for bash in bashes():
+            ver = bash_version(bash)
+            parent, child = h.resolve(bash, example, keys, caller)
+            lost = {
+                k: parent.get(k)
+                for k in keys
+                if parent.get(k) != caller[k] and k != "EXTRA_ARGS"
+            }
+            if not parent.get("EXTRA_ARGS", "").startswith(caller["EXTRA_ARGS"]):
+                lost["EXTRA_ARGS"] = parent.get("EXTRA_ARGS")
+            assert not lost, f"{bash} ({ver}): .env clobbered caller exports: {lost}"
+            not_inherited = {
+                k: child.get(k)
+                for k in keys
+                if child.get(k) != parent.get(k)
+            }
+            assert not not_inherited, f"{bash} ({ver}): child did not inherit: {not_inherited}"
+            print(f"  ok   {len(keys)} env.example keys survive a caller export under {bash} ({ver})")
+
+
+def test_env_still_beats_script_defaults_without_caller_exports() -> None:
+    """No caller export: the .env value wins over the start.sh default and is
+    exported to children (unchanged behaviour)."""
+    keys = ["MAX_NUM_SEQS", "MAX_MODEL_LEN", "GLM53_MIXED_PREFILL_CHUNK", "CG_ESTIMATE", "DFLASH_TOKENS", "SPEC_METHOD", "LIMIT_MM"]
+    dotenv = (
+        "MAX_NUM_SEQS=2\nMAX_MODEL_LEN=200000\nGLM53_MIXED_PREFILL_CHUNK=512\n"
+        "CG_ESTIMATE=0\nDFLASH_TOKENS=5\nSPEC_METHOD=mtp\nLIMIT_MM='{\"image\":1,\"video\":0}'\n"
+    )
+    expect = {
+        "MAX_NUM_SEQS": "2", "MAX_MODEL_LEN": "200000", "GLM53_MIXED_PREFILL_CHUNK": "512",
+        "CG_ESTIMATE": "0", "DFLASH_TOKENS": "5", "SPEC_METHOD": "mtp", "LIMIT_MM": '{"image":1,"video":0}',
+    }
+    with tempfile.TemporaryDirectory() as raw_tmp:
+        h = Harness(Path(raw_tmp))
+        for bash in bashes():
+            parent, child = h.resolve(bash, dotenv, keys, {})
+            assert parent == expect, (bash, parent)
+            assert child == expect, (bash, child)
+            print(f"  ok   .env beats script defaults with no caller export under {bash}")
+
+
+def test_empty_caller_export_does_not_override() -> None:
+    """`MAX_NUM_SEQS= ./start.sh` keeps the .env value: same [ -n ] rule as the
+    allowlist this replaces (DFLASH_DRAFT_TP treats empty as meaningful, and
+    an empty export is the usual accident of `VAR= cmd` typos)."""
+    keys = ["MAX_NUM_SEQS", "DFLASH_DRAFT_TP", "CG_ESTIMATE"]
+    dotenv = "MAX_NUM_SEQS=2\nDFLASH_DRAFT_TP=2\nCG_ESTIMATE=0\n"
+    with tempfile.TemporaryDirectory() as raw_tmp:
+        h = Harness(Path(raw_tmp))
+        for bash in bashes():
+            parent, _child = h.resolve(bash, dotenv, keys, {"MAX_NUM_SEQS": "", "DFLASH_DRAFT_TP": "", "CG_ESTIMATE": "1"})
+            assert parent == {"MAX_NUM_SEQS": "2", "DFLASH_DRAFT_TP": "2", "CG_ESTIMATE": "1"}, (bash, parent)
+            print(f"  ok   empty caller export does not override .env under {bash}")
+
+
+def test_readonly_exports_and_odd_env_lines() -> None:
+    """SHELLOPTS in the environment is imported readonly+exported by bash
+    (`declare -rx`); an `eval "$(export -p)"` replay dies on it under set -e.
+    The .env-key rule never replays it. The .env itself carries every line
+    shape the parser must accept."""
+    dotenv = (
+        "# GLM-5.3-Flash EXL3 -- comment lines are not keys\n"
+        "\n"
+        "   \n"
+        "# MAX_NUM_SEQS=99\n"
+        "MAX_NUM_SEQS=2\n"
+        "export SPEC_METHOD=mtp\n"
+        "  CG_ESTIMATE=0\n"
+        "DFLASH_TOKENS=5\r\n"
+        "GLM53_MIXED_PREFILL_CHUNK=512 # trailing comment\n"
+        "LIMIT_MM='{\"image\":4,\"video\":1}'\n"
+        "MAX_MODEL_LEN=\n"
+        "MODEL_REVISION+=-suffix\n"
+        "SCRIPT_DIR=/nowhere\n"
+        # assignment-looking text inside a heredoc: the lexical scanner picks
+        # SHELLOPTS up, and the readonly filter must then refuse to replay it
+        # (export "SHELLOPTS=..." would abort the launcher under set -e).
+        "cat >/dev/null <<'NOTES'\n"
+        "SHELLOPTS=ignored\n"
+        "NOTES\n"
+    )
+    keys = ["MAX_NUM_SEQS", "SPEC_METHOD", "CG_ESTIMATE", "DFLASH_TOKENS", "GLM53_MIXED_PREFILL_CHUNK", "LIMIT_MM", "MAX_MODEL_LEN", "MODEL_REVISION", "SCRIPT_DIR"]
+    caller = {
+        "MAX_NUM_SEQS": "4", "SPEC_METHOD": "dflash", "CG_ESTIMATE": "1", "DFLASH_TOKENS": "7",
+        "GLM53_MIXED_PREFILL_CHUNK": "skip", "LIMIT_MM": '{"image":9,"video":2}', "MAX_MODEL_LEN": "300000",
+        "MODEL_REVISION": "abc123",
+        "SHELLOPTS": "braceexpand:hashall:interactive-comments",
+    }
+    with tempfile.TemporaryDirectory() as raw_tmp:
+        h = Harness(Path(raw_tmp))
+        for bash in bashes():
+            parent, child = h.resolve(bash, dotenv, keys, caller)
+            want = {k: caller[k] for k in keys if k != "SCRIPT_DIR"}
+            # SCRIPT_DIR is a launcher-internal (non-exported) variable: a .env
+            # that assigns it is sourced as before, but the launcher's own
+            # pre-source value must never be captured and replayed over it.
+            want["SCRIPT_DIR"] = "/nowhere"
+            assert parent == want, (bash, parent)
+            assert {k: child[k] for k in want if k != "SCRIPT_DIR"} == {k: want[k] for k in want if k != "SCRIPT_DIR"}, (bash, child)
+            # and with no caller export the odd lines source as bash sources them
+            parent, _ = h.resolve(bash, dotenv, keys, {"SHELLOPTS": "braceexpand:hashall"})
+            assert parent["MAX_NUM_SEQS"] == "2" and parent["SPEC_METHOD"] == "mtp" and parent["CG_ESTIMATE"] == "0"
+            assert parent["DFLASH_TOKENS"] == "5\r", "CRLF line: carriage return stays in the value (unchanged; no normalisation)"
+            assert parent["LIMIT_MM"] == '{"image":4,"video":1}'
+            assert parent["MAX_MODEL_LEN"] == "1000000", "empty .env value falls through to the launcher default"
+            assert parent["MODEL_REVISION"].endswith("-suffix"), "KEY+= line is sourced as an append"
+            assert parent["SCRIPT_DIR"] == "/nowhere"
+            print(f"  ok   readonly SHELLOPTS export, internal SCRIPT_DIR not replayed, comment/blank/indented/export/+=/CRLF/JSON .env lines under {bash}")
+def _run_preamble(env_file: str, caller: dict[str, str], probe: str) -> str:
     source = (ROOT / "start.sh").read_text()
     marker = "# ----------------------------- configuration -------------------------------"
     preamble, separator, _rest = source.partition(marker)
@@ -50,27 +367,51 @@ def test_mixed_prefill_chunk_inline_override_wins() -> None:
     with tempfile.TemporaryDirectory() as raw_tmp:
         tmp = Path(raw_tmp)
         script = tmp / "start.sh"
-        script.write_text(
-            preamble
-            + '\nprintf "GLM53_MIXED_PREFILL_CHUNK=%s\\n" "${GLM53_MIXED_PREFILL_CHUNK:-unset}"\n'
-        )
+        script.write_text(preamble + probe)
         script.chmod(0o755)
-        (tmp / ".env").write_text("GLM53_MIXED_PREFILL_CHUNK=2\n")
+        (tmp / ".env").write_text(env_file)
 
-        env = os.environ.copy()
-        env["GLM53_MIXED_PREFILL_CHUNK"] = "skip"
+        env = {
+            k: v
+            for k, v in os.environ.items()
+            if k not in (
+                "GLM53_INDEXER_WORKSPACE",
+                "GLM53_KV_CAPACITY_LOG",
+                "GLM53_APC_NO_STORE",
+            )
+        }
+        env.update(caller)
         result = subprocess.run(
-            ["bash", str(script)],
-            check=True,
-            capture_output=True,
-            text=True,
-            env=env,
+            ["bash", str(script)], check=True, capture_output=True, text=True, env=env
         )
+    return result.stdout.strip()
 
-    assert result.stdout.strip() == "GLM53_MIXED_PREFILL_CHUNK=skip"
+
+def test_strict_knob_caller_captures_are_setness_aware() -> None:
+    """An explicitly empty strict-knob value must reach validation."""
+    cases = (
+        ("GLM53_INDEXER_WORKSPACE", "rightsize", "stock"),
+        ("GLM53_KV_CAPACITY_LOG", "1", "0"),
+        ("GLM53_APC_NO_STORE", "1", "0"),
+    )
+    for knob, env_value, caller_value_ in cases:
+        probe = f'\nprintf "V=[%s]\\n" "${{{knob}-UNSET}}"\n'
+        env_file = f"{knob}={env_value}\n"
+        assert _run_preamble(env_file, {}, probe) == f"V=[{env_value}]"
+        assert _run_preamble(
+            env_file, {knob: caller_value_}, probe
+        ) == f"V=[{caller_value_}]"
+        assert _run_preamble(env_file, {knob: ""}, probe) == "V=[]"
+        assert _run_preamble("", {knob: ""}, probe) == "V=[]"
+        assert _run_preamble("", {}, probe) == "V=[UNSET]"
 
 
 if __name__ == "__main__":
+    test_no_per_knob_allowlist_remains()
     test_max_num_seqs_inline_override_wins()
-    test_mixed_prefill_chunk_inline_override_wins()
+    test_every_env_example_key_survives_a_caller_export()
+    test_env_still_beats_script_defaults_without_caller_exports()
+    test_empty_caller_export_does_not_override()
+    test_readonly_exports_and_odd_env_lines()
+    test_strict_knob_caller_captures_are_setness_aware()
     print("start.sh caller override regression OK")


### PR DESCRIPTION
## Summary

- replace the launcher's hand-maintained caller-override allowlist with a generic, Bash 3.2-compatible rule for every key assigned by `.env`
- preserve setness-aware empty-value validation for the three strict runtime-overlay knobs
- upgrade decode-floor v3 to v3.1 and report total late wall time separately from time actually spent under the cap
- validate the complete installed helper, policy, scheduler gate bodies, real `import os`, and syntax before writes or idempotent success
- keep the A3 evidence parser compatible with legacy v3 and current v3.1 logs

## Local validation

- `uv run --with-requirements requirements-dev.txt pytest tests/ -q`: 169 passed, 1 skipped, 4 subtests passed
- `bash -n start.sh`
- Python compilation for changed Python files
- `shellcheck -S warning start.sh`
- `git diff --check`
- independent final review approved the exact operational candidate

## Guarded cluster deployment

Control reproduced the launcher defect without stopping production: `MAX_MODEL_LEN=bogus ./start.sh validate` returned rc=0 because `.env` won. The candidate returned rc=2 with the named validation error before any restart side effect.

The candidate was staged to temporary names, hash-verified, installed atomically, and restarted through `vllm-glm53exl3.service` with the watchdog stopped. Both live schedulers matched SHA256 `45e73c4aef98a6e91c541fac237706853252cbc0009eb5a4c4fe470f72bef2c4` and reported the v3.1 marker. `.env`, image, model, drafter, template, KV pin, and shape stamp stayed unchanged. The pool remained 1,396,551 tokens / 566 usable block IDs.

Live mixed traffic demonstrated the new accounting split: completed crawls included 87,556 / 1,045 ms and 90,394 / 1,045 ms wall / capped time.

## Gates

- acceptance: 7/7
- serving: 6/6
- tool calls: 23/23, zero blank required arguments
- long-form/thinking-SSE runtime probe: pass
- structured decode: 69.87 tok/s median, acceptance 1.000 / 7.000
- prose decode: 28.20 tok/s median, coherence pass
- preemptions, running, waiting: 0 at final audit
- selected head/worker runtime errors and kernel Xids: 0
- MemFree: 4,563 / 4,218 MiB
- watchdog re-armed

One prose run triggered the broad standalone-`NaN` text diagnostic. A deterministic repeat, the coherence battery, and the dedicated runtime probe had no corruption marker. No output-policy or scheduling-decision change was observed.

## Rollback

Restore `start.sh.bak-20260906-task14` and `overlay/patch_scheduler_decode_floor.py.bak-20260906-task14` on the head, then restart through the guarded production unit.
