### PR TITLE
DFlash2: reject exact-fit page promotion

### DIFF
--- a/docs/06-improvement-plan.md
+++ b/docs/06-improvement-plan.md
@@ -36,6 +36,71 @@ Mainline GLM support (#53906) has merged, so model resolution is no longer the
 mainline blocker described in the historical section above; EXL3 integration
 and overlay compatibility still block a stock-image replacement.
 
+### 2026-09-06: task 7 rejects DFlash2 exact-fit page promotion
+
+The production mismatch is now accounted exactly at boot. A 2,351,104-byte
+MLA page holds 1,148 DFlash2 tokens at 2,048 bytes/token. Kernel block 64 can
+use 1,088 of those tokens, leaving 122,880 bytes (5.23%) of structural tail
+waste. The next exact 64-token multiple is 1,152 tokens / 2,359,296 bytes,
+an 8,192-byte (0.35%) page increase. The existing drafter overlay logs all of
+these computed values without changing allocation geometry.
+
+The guarded candidate gave the five DFlash2 layers standalone, unpadded
+2,359,296-byte pages with a 1,152-token manager block split into 18×64 kernel
+blocks. MLA and Mamba pages remained 2,351,104 bytes. This replaced an unsafe
+first design before cluster testing: pinned runner-source review established
+that `KVCacheTensor.block_stride` marks a packed allocation, not a per-layer
+physical stride, so Task 7 never used that field or `page_size_padded` for the
+standalone candidate.
+
+The A/B used reviewed exact-source overlays, effective-arm JIT invalidation,
+both-node memory aborts, exact geometry/admission checks, correctness-aware
+acceptance/tool/decode probes, preemption checks and fatal-log scans. Bounded
+control and two promoted-arm smokes passed acceptance 7/7 and quick tool calls
+16/16 with zero preemptions or fatal logs. Full mixed traffic correctly
+aborted at the deployment memory floor in both attempted control windows, so
+performance was measured separately at bounded concurrency.
+
+| measure | control | promoted exact-fit | delta |
+|---|---:|---:|---:|
+| total / usable block IDs | 567 / 566 | 395 / 394 | -30.3% usable |
+| reported 1M-token admission | 1.40× | 1.22× | -12.9% |
+| structured decode | 69.60 tok/s | 69.70 tok/s | +0.14% |
+| accepted fraction / drafts per step | 1.000 / 7.000 | 1.000 / 7.000 | unchanged |
+| prose decode | 27.01 tok/s | 28.86 tok/s | +6.84% |
+| 60k cold prefill | 1,115.3 tok/s | 1,060.4 tok/s | -4.92% |
+| 240k cold prefill | 1,057.0 tok/s | 1,025.4 tok/s | -2.99% |
+| 36,040-token APC replay | 36,032 hits, ~0.6 s | 32,256 hits, ~3.6 s | regressed |
+
+One of three long prose runs contained the broad standalone-`NaN` text marker
+in each arm, so it did not distinguish the candidate. The promoted prose gain
+does not offset the materially smaller pool, lower max-context admission,
+prefill regression and severe APC replay regression.
+
+**Decision: REJECT.** The exact pre-window production files were restored:
+`start.sh` SHA256 `1f004b5b...83114`, `local/prod-start.sh`
+`7a655020...b2cd`, and `.env` `6e7a206e...983a`. The experimental runtime
+overlay and runner were removed from production. The restored boot returned
+to 1,396,551 reported tokens / 566 usable block IDs, health 200, zero
+preemptions, and the watchdog was re-armed. Task 7 is closed with the
+boot-accounting fallback; any future page redesign needs a new allocation
+model that preserves shared-pool capacity and APC alignment.
+
+The fallback overlay SHA256 `d6634b8d...0e86` was then validated against
+temporary copies of both live scheduler sources and deployed without changing
+the launcher, `.env`, allocation geometry or JIT shape. Its first production
+boot logged the exact 122,880-byte / 5.23% waste and 2,359,296-byte candidate
+page values above. Post-deploy acceptance passed 7/7 and quick tool calls
+16/16 with zero blank required arguments. Final health was 200 with
+running/waiting/preemptions zero, selected runtime errors and Xids zero,
+MemFree 5,243,676 / 4,431,980 KiB, and the watchdog active. Rollback is
+`overlay/patch_glm5_drafter_group.py.bak-20260906-task7` on spark1 followed
+by the guarded unit restart.
+
+Cluster receipts remain on spark1 under
+`/home/nvidia/task7-ab-20260906/`; the exact pre-window backups remain under
+`/home/nvidia/.task7-backup-20260906/`.
+
 ### 2026-09-06: task 14 adopts caller precedence and gate v3.1 accounting
 
 The launcher now implements its general precedence contract instead of a

--- a/overlay/patch_glm5_drafter_group.py
+++ b/overlay/patch_glm5_drafter_group.py
@@ -207,14 +207,39 @@ EDIT_GROUPS_RETURN_NEW = """\
             # to mla_page is a safe strided view (boot 8 OOB was kernel 64
             # inside a 2304-token manager). Layer i co-owns MLA tensor i.
             compact_block = 64
+            kernel_page_bytes = compact_block * draft_bytes_per_token
+            draft_tokens_per_mla_page = mla_page // draft_bytes_per_token
+            usable_draft_tokens = (
+                draft_tokens_per_mla_page // compact_block * compact_block
+            )
+            structural_padding_waste_bytes = (
+                draft_tokens_per_mla_page - usable_draft_tokens
+            ) * draft_bytes_per_token
+            exact_fit_draft_tokens = (
+                (draft_tokens_per_mla_page + compact_block - 1)
+                // compact_block
+                * compact_block
+            )
+            exact_fit_page_bytes = exact_fit_draft_tokens * draft_bytes_per_token
             logger.info(
                 "DFlash2 drafter KV: padded slot-share block=%d "
                 "mla_page=%d (was block=%d); exact-fit page mismatch "
-                "draft_bytes/token=%d",
+                "draft_bytes/token=%d kernel_page=%d "
+                "draft_tokens/page=%d usable_draft_tokens=%d "
+                "structural_padding_waste_bytes=%d (%.2f%% of mla_page) "
+                "exact_fit_page=%d growth_bytes=%d (%.2f%%)",
                 compact_block,
                 mla_page,
                 any_draft.block_size,
                 draft_bytes_per_token,
+                kernel_page_bytes,
+                draft_tokens_per_mla_page,
+                usable_draft_tokens,
+                structural_padding_waste_bytes,
+                100.0 * structural_padding_waste_bytes / mla_page,
+                exact_fit_page_bytes,
+                exact_fit_page_bytes - mla_page,
+                100.0 * (exact_fit_page_bytes - mla_page) / mla_page,
             )
             new_draft_specs = {
                 name: replace(
@@ -654,38 +679,8 @@ def patch_file(path: str, dry_run: bool = False) -> int:
             "                return None\n"
         )
         v3_marker = "padded slot-share block=%d"
-        if v4_old in text:
-            text = text.replace(v4_old, v4_new, 1)
-            try:
-                ast.parse(text, filename=path)
-            except SyntaxError as e:
-                raise AssertionError(
-                    f"POST-EDIT ast.parse FAILED for {path}: {e}"
-                ) from e
-            if v3_marker in text:
-                if dry_run:
-                    print(f"[patch_glm5_drafter_group] DRY RUN -- {path} not written.")
-                else:
-                    with open(path, "w", encoding="utf-8") as f:
-                        f.write(text)
-                print(
-                    f"[patch_glm5_drafter_group] {path}: padded slot-share v4 "
-                    "(allow padded draft in glm5 layout) applied."
-                )
-                return 0
-            # v3 grouping not yet present; keep going with mutated text.
-        elif v3_marker in text:
-            print(
-                f"[patch_glm5_drafter_group] {path}: already patched "
-                f"({MARKER} + padded slot-share); no-op."
-            )
-            return 0
-
-        new_padded = (
-            "            # PADDED SLOT-SHARE: 656 vs 4096 cannot exact-fill on this MLA\n"
-            "            # block. Manager 64 matches the SWA kernel, so padding the page\n"
-            "            # to mla_page is a safe strided view (boot 8 OOB was kernel 64\n"
-            "            # inside a 2304-token manager). Layer i co-owns MLA tensor i.\n"
+        waste_marker = "structural_padding_waste_bytes=%d"
+        old_padded_log = (
             "            compact_block = 64\n"
             "            logger.info(\n"
             "                \"DFlash2 drafter KV: padded slot-share block=%d \"\n"
@@ -696,7 +691,89 @@ def patch_file(path: str, dry_run: bool = False) -> int:
             "                any_draft.block_size,\n"
             "                draft_bytes_per_token,\n"
             "            )\n"
-            "            new_draft_specs = {\n"
+        )
+        new_padded_log = (
+            "            compact_block = 64\n"
+            "            kernel_page_bytes = compact_block * draft_bytes_per_token\n"
+            "            draft_tokens_per_mla_page = mla_page // draft_bytes_per_token\n"
+            "            usable_draft_tokens = (\n"
+            "                draft_tokens_per_mla_page // compact_block * compact_block\n"
+            "            )\n"
+            "            structural_padding_waste_bytes = (\n"
+            "                draft_tokens_per_mla_page - usable_draft_tokens\n"
+            "            ) * draft_bytes_per_token\n"
+            "            exact_fit_draft_tokens = (\n"
+            "                (draft_tokens_per_mla_page + compact_block - 1)\n"
+            "                // compact_block\n"
+            "                * compact_block\n"
+            "            )\n"
+            "            exact_fit_page_bytes = exact_fit_draft_tokens * draft_bytes_per_token\n"
+            "            logger.info(\n"
+            "                \"DFlash2 drafter KV: padded slot-share block=%d \"\n"
+            "                \"mla_page=%d (was block=%d); exact-fit page mismatch \"\n"
+            "                \"draft_bytes/token=%d kernel_page=%d \"\n"
+            "                \"draft_tokens/page=%d usable_draft_tokens=%d \"\n"
+            "                \"structural_padding_waste_bytes=%d (%.2f%% of mla_page) \"\n"
+            "                \"exact_fit_page=%d growth_bytes=%d (%.2f%%)\",\n"
+            "                compact_block,\n"
+            "                mla_page,\n"
+            "                any_draft.block_size,\n"
+            "                draft_bytes_per_token,\n"
+            "                kernel_page_bytes,\n"
+            "                draft_tokens_per_mla_page,\n"
+            "                usable_draft_tokens,\n"
+            "                structural_padding_waste_bytes,\n"
+            "                100.0 * structural_padding_waste_bytes / mla_page,\n"
+            "                exact_fit_page_bytes,\n"
+            "                exact_fit_page_bytes - mla_page,\n"
+            "                100.0 * (exact_fit_page_bytes - mla_page) / mla_page,\n"
+            "            )\n"
+        )
+        upgraded = []
+        if v4_old in text:
+            text = text.replace(v4_old, v4_new, 1)
+            upgraded.append("allow padded draft in glm5 layout")
+        if v3_marker in text and waste_marker not in text:
+            if old_padded_log not in text:
+                raise AssertionError(
+                    f"{path}: padded slot-share marker present but exact legacy "
+                    "boot-log block is missing"
+                )
+            text = text.replace(old_padded_log, new_padded_log, 1)
+            upgraded.append("exact padding-waste boot accounting")
+        if v3_marker in text and upgraded:
+            try:
+                ast.parse(text, filename=path)
+            except SyntaxError as e:
+                raise AssertionError(
+                    f"POST-EDIT ast.parse FAILED for {path}: {e}"
+                ) from e
+            if dry_run:
+                print(f"[patch_glm5_drafter_group] DRY RUN -- {path} not written.")
+            else:
+                with open(path, "w", encoding="utf-8") as f:
+                    f.write(text)
+            print(
+                f"[patch_glm5_drafter_group] {path}: upgraded "
+                + ", ".join(upgraded)
+                + "."
+            )
+            return 0
+        if v3_marker in text and waste_marker in text:
+            print(
+                f"[patch_glm5_drafter_group] {path}: already patched "
+                f"({MARKER} + padded slot-share + padding-waste accounting); "
+                "no-op."
+            )
+            return 0
+
+        new_padded = (
+            "            # PADDED SLOT-SHARE: 656 vs 4096 cannot exact-fill on this MLA\n"
+            "            # block. Manager 64 matches the SWA kernel, so padding the page\n"
+            "            # to mla_page is a safe strided view (boot 8 OOB was kernel 64\n"
+            "            # inside a 2304-token manager). Layer i co-owns MLA tensor i.\n"
+            + new_padded_log
+            + "            new_draft_specs = {\n"
             "                name: replace(\n"
             "                    s,\n"
             "                    block_size=compact_block,\n"

--- a/tests/test_dflash_padding_waste.py
+++ b/tests/test_dflash_padding_waste.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PATCH = ROOT / "overlay" / "patch_glm5_drafter_group.py"
+
+
+def _load_patch_module():
+    spec = importlib.util.spec_from_file_location("patch_glm5_drafter_group", PATCH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_production_padding_waste_arithmetic() -> None:
+    mla_page = 2_351_104
+    draft_bytes_per_token = 2_048
+    kernel_block = 64
+
+    draft_tokens_per_page = mla_page // draft_bytes_per_token
+    usable_draft_tokens = draft_tokens_per_page // kernel_block * kernel_block
+    waste = (draft_tokens_per_page - usable_draft_tokens) * draft_bytes_per_token
+    exact_fit_page = (
+        (draft_tokens_per_page + kernel_block - 1)
+        // kernel_block
+        * kernel_block
+        * draft_bytes_per_token
+    )
+
+    assert draft_tokens_per_page == 1_148
+    assert usable_draft_tokens == 1_088
+    assert waste == 122_880
+    assert round(100 * waste / mla_page, 2) == 5.23
+    assert exact_fit_page == 2_359_296
+    assert exact_fit_page - mla_page == 8_192
+
+
+def test_fresh_patch_and_legacy_upgrade_include_exact_waste_receipt(tmp_path: Path) -> None:
+    module = _load_patch_module()
+    source = module.EDIT_GROUPS_RETURN_NEW
+
+    assert "structural_padding_waste_bytes = (" in source
+    assert '"structural_padding_waste_bytes=%d (%.2f%% of mla_page) "' in source
+    assert '"exact_fit_page=%d growth_bytes=%d (%.2f%%)"' in source
+
+    legacy = source.replace(
+        """            compact_block = 64
+            kernel_page_bytes = compact_block * draft_bytes_per_token
+            draft_tokens_per_mla_page = mla_page // draft_bytes_per_token
+            usable_draft_tokens = (
+                draft_tokens_per_mla_page // compact_block * compact_block
+            )
+            structural_padding_waste_bytes = (
+                draft_tokens_per_mla_page - usable_draft_tokens
+            ) * draft_bytes_per_token
+            exact_fit_draft_tokens = (
+                (draft_tokens_per_mla_page + compact_block - 1)
+                // compact_block
+                * compact_block
+            )
+            exact_fit_page_bytes = exact_fit_draft_tokens * draft_bytes_per_token
+            logger.info(
+                "DFlash2 drafter KV: padded slot-share block=%d "
+                "mla_page=%d (was block=%d); exact-fit page mismatch "
+                "draft_bytes/token=%d kernel_page=%d "
+                "draft_tokens/page=%d usable_draft_tokens=%d "
+                "structural_padding_waste_bytes=%d (%.2f%% of mla_page) "
+                "exact_fit_page=%d growth_bytes=%d (%.2f%%)",
+                compact_block,
+                mla_page,
+                any_draft.block_size,
+                draft_bytes_per_token,
+                kernel_page_bytes,
+                draft_tokens_per_mla_page,
+                usable_draft_tokens,
+                structural_padding_waste_bytes,
+                100.0 * structural_padding_waste_bytes / mla_page,
+                exact_fit_page_bytes,
+                exact_fit_page_bytes - mla_page,
+                100.0 * (exact_fit_page_bytes - mla_page) / mla_page,
+            )
+""",
+        """            compact_block = 64
+            logger.info(
+                "DFlash2 drafter KV: padded slot-share block=%d "
+                "mla_page=%d (was block=%d); exact-fit page mismatch "
+                "draft_bytes/token=%d",
+                compact_block,
+                mla_page,
+                any_draft.block_size,
+                draft_bytes_per_token,
+            )
+""",
+        1,
+    )
+    target = tmp_path / "kv_cache_utils.py"
+    target.write_text("def patched_function():\n" + legacy)
+
+    assert module.patch_file(str(target)) == 0
+    upgraded = target.read_text()
+    assert "structural_padding_waste_bytes=%d" in upgraded
+    assert "exact_fit_page=%d growth_bytes=%d" in upgraded
+
+    before = target.read_bytes()
+    assert module.patch_file(str(target)) == 0
+    assert target.read_bytes() == before

--- a/tests/test_exl3_overlay.py
+++ b/tests/test_exl3_overlay.py
@@ -590,6 +590,8 @@ def _check_dflash2() -> None:
     assert "compact_block = 64" in kv
     assert "page_size_padded=mla_page" in kv
     assert "padded slot-share block=%d" in kv
+    assert "structural_padding_waste_bytes=%d" in kv
+    assert "exact_fit_page=%d growth_bytes=%d" in kv
     assert "s.block_size != 64 or s.page_size_padded != mla_page" in kv
     standalone = kv.split("PADDED SLOT-SHARE:")[1].split("draft_uniform")[0]
     assert "compact_block" in standalone


### PR DESCRIPTION
## Summary

- close Task 7 after a guarded control/promote/control cluster A/B
- reject standalone 1,152-token DFlash2 pages because capacity, cold prefill, and prefix-cache replay regressed
- retain the production padded-slot-share geometry and add exact computed boot accounting for its structural waste
- cover fresh installs, exact legacy upgrades, arithmetic, drift refusal, and idempotence

## A/B decision

The promoted arm changed only the five drafter layers to standalone, unpadded 2,359,296-byte pages with a 1,152-token manager block split into 18×64 kernel blocks. MLA/Mamba remained at 2,351,104 bytes.

| Measure | Control | Promote | Delta |
|---|---:|---:|---:|
| total / usable block IDs | 567 / 566 | 395 / 394 | -30.3% usable |
| reported 1M-token admission | 1.40× | 1.22× | -12.9% |
| structured decode | 69.60 tok/s | 69.70 tok/s | +0.14% |
| acceptance / accepted drafts per step | 1.000 / 7.000 | 1.000 / 7.000 | unchanged |
| prose decode | 27.01 tok/s | 28.86 tok/s | +6.84% |
| 60k cold prefill | 1,115.3 tok/s | 1,060.4 tok/s | -4.92% |
| 240k cold prefill | 1,057.0 tok/s | 1,025.4 tok/s | -2.99% |
| 36,040-token APC replay | 36,032 hits, ~0.6 s | 32,256 hits, ~3.6 s | regressed |

Bounded control and two promoted-arm smokes passed acceptance 7/7 and quick tool calls 16/16 with zero preemptions or fatal logs. The prose gain did not outweigh the pool, max-context admission, prefill, and APC losses, so the arm was rejected.

## Retained fallback

The existing drafter overlay now computes and logs:

- MLA page: 2,351,104 bytes
- draft bytes/token: 2,048
- draft tokens/page: 1,148
- usable tokens at kernel block 64: 1,088
- structural tail waste: 122,880 bytes, 5.23%
- next exact-fit page: 2,359,296 bytes, +8,192 bytes / 0.35%

This is boot-log accounting only. It does not change allocation geometry, scheduling, launcher configuration, or the JIT shape.

## Validation

- `171 passed, 1 skipped, 4 subtests passed`
- focused fallback tests: `2 passed`
- Python compilation, Bash syntax, and `git diff --check` passed
- independent final review approved the complete candidate
- exact overlay SHA256 `d6634b8dbdb6858f1c98461d22dc7259d458fed6199b339d3e9e08e10c0a0e86` validated against temporary copies of both live scheduler sources

## Production receipt

Production was first restored to the exact pre-window launcher, restart script, and `.env`, and the rejected runtime experiment files were removed. The fallback overlay was then deployed alone.

The first fallback boot logged the exact values above while retaining 1,396,551 reported tokens and 566 usable block IDs. Post-deploy acceptance passed 7/7 and quick tool calls 16/16 with zero blank required arguments. Final health was 200 with running/waiting/preemptions zero, selected runtime errors and Xids zero, and the watchdog active.

Rollback: restore `overlay/patch_glm5_drafter_group.py.bak-20260906-task7` on spark1 and perform the guarded unit restart.
