### PR TITLE
Compat: adopt KV merge assert overlay and V2/MTP refusals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ __pycache__/
 
 # Local working ledgers — maintained on disk, never tracked
 spec/
+
+# Full live-image Python dump for local audits; never ship
+tests/fixtures/live-image-vllm/

--- a/docs/02-parameters.md
+++ b/docs/02-parameters.md
@@ -128,6 +128,22 @@ cache is invisible to it). 0.87 demands 105.87 GiB free against boots measured a
   evicting other sessions' cached prefixes. Malformed values are an HTTP 400 at
   the API boundary. Not in the JIT shape hash.
 
+## Added 2026-09-07
+
+- `VLLM_USE_V2_MODEL_RUNNER` — not a configuration knob on this image.
+  Production already logs `Using V2 Model Runner`, GLM is in the default V2
+  architecture set, and W28 patches `v1/worker/gpu/model_runner.py`. Unset
+  or `1` is a no-op; `0` is refused by `start.sh validate` before any
+  stop/restart. Adaptive verification stays parked.
+- `SPEC_METHOD=mtp` — MTP rollback is refused when `MAX_NUM_SEQS > 12`
+  (capture-size guard). `dflash` remains production. Validation runs before
+  stop, so a refused rollback cannot tear the pair down.
+- Inherited `KVCacheSpec.merge` — `overlay/patch_kv_merge_assert.py` ports
+  upstream #55234's `assert` → `raise AssertionError` so grouping stays
+  fail-closed under `python -O`. The DSpark `non_causal_multi_token_decode`
+  any-merge and 656 B/token `fp8_ds_mla` page are already on this image.
+  Not in the JIT shape hash.
+
 ## Added 2026-09-02
 
 - `EXL3_FAT_SORTED=1` / `EXL3_FAT_BATCHED=1` / `EXL3_FAT_KERNEL=1` — the

--- a/docs/06-improvement-plan.md
+++ b/docs/06-improvement-plan.md
@@ -36,6 +36,53 @@ Mainline GLM support (#53906) has merged, so model resolution is no longer the
 mainline blocker described in the historical section above; EXL3 integration
 and overlay compatibility still block a stock-image replacement.
 
+### 2026-09-07: tasks 27 + 13 + 17 compatibility lane
+
+Production already logs `Using V2 Model Runner`. GLM is in the default V2
+architecture set, and W28 patches `v1/worker/gpu/model_runner.py`. Forcing
+`VLLM_USE_V2_MODEL_RUNNER=1` is a no-op; forcing `0` is now a launcher
+refusal so a rollback cannot miss W28. `SPEC_METHOD=mtp` with
+`MAX_NUM_SEQS > 12` is the same class of refusal (MTP capture-size guard).
+Both run in `validate_numeric_config` before stop.
+
+The live inherited `KVCacheSpec.merge` still uses `assert`. Optimized Python
+strips that, so unequal specs can be reported as uniform. The new
+`overlay/patch_kv_merge_assert.py` ports only that inherited merge to
+`raise AssertionError` (#55234). MLA `non_causal_multi_token_decode=any(...)`
+and 656 B/token `fp8_ds_mla` are already present and are not rewritten.
+
+Parked on this exact image, with CPU fixtures that keep the classification
+fail-closed:
+
+- #54374: live DFlash proposer has no `set_attn` AOT path.
+- #55178: live GDN classifies speculative rows by draft tags; BaseMamba
+  padded-tail is a different class.
+- #55449: live MLA already returns 656 B/token.
+- #54394: solo LPTT 1792 at TP2 is 896 rows/rank, below the ≥1024 gate.
+  Do not raise LPTT.
+- #55061: C4 decode uses fused `exl3_moe`; `index_select` is the overflow
+  path. No ncu probe is claimed here.
+
+`scripts/audit_source_compat.py` plus compact fixtures under
+`tests/fixtures/source-compat/` are the task-27 matrix. A full live-image
+dump may exist locally at `tests/fixtures/live-image-vllm/` and stays
+gitignored. No stock-image swap. No JIT-shape change. Overlay apply is
+idempotent and fail-closed on drift.
+
+**Cluster verdict: ADOPT.** Guarded restart 2026-09-07 on production image
+`glm53-selfbuild:b5ab8091-s2b`. Watchdog timer stopped first; validate and
+the V1/MTP refusals ran before stop; rollback files live at
+`/home/nvidia/glm53-task27-backup-20260907T152959Z`. Both ranks logged
+`kv-merge-assert patched` and retained the V2 runner. Live
+`kv_cache_interface.py` has the raise marker, no inherited `assert`, the
+MLA any-merge, and 656 B/token. Health 200, warmup 20/20 in 32s,
+acceptance 7/7, serving 6/6, running/waiting/preemptions 0, errors 0,
+watchdog re-armed. Overlay SHA256
+`ee21d4c50d15ae8b6f97ac0d3e08a5bcd0e1accc7b00a02f5c46d4793bacab85`
+(classifier helper added after review; apply ANCHOR/PATCHED unchanged);
+launcher SHA256
+`cff6107d4d8bf70ffa40430e9bb0d23a0f2e5dea7e47af516c191ae616f99a66`.
+
 ### 2026-09-07: task 15 bounded-filesystem KV restore rejected at control
 
 Task 15 did not reach an enabled candidate arm. The complete default-off

--- a/env.example
+++ b/env.example
@@ -194,6 +194,14 @@ DFLASH_REVISION=7d74cdd881ed7e32c31175984a67823127b66cfe
 DFLASH_TOKENS=7                     # Fixed native eight-row DFlash2 block. This legacy
                                     # path refuses non-7 values: changing k also changes
                                     # masks/conv/selector/cache, not verification alone.
+# Compatibility lane (tasks 27 + 13 + 17). Production already uses the V2 GPU
+# model runner; W28 patches that path. Unset or 1 is a no-op. 0 is refused
+# before stop/restart. SPEC_METHOD=mtp also refuses MAX_NUM_SEQS > 12 (MTP
+# capture-size guard). Do not raise LPTT to chase #54394; 1792 at TP2 is 896
+# rows/rank. overlay/patch_kv_merge_assert.py ports the inherited
+# KVCacheSpec.merge assert to raise so grouping stays fail-closed under
+# python -O. Remaining rebase PRs (#54374/#55178/#55449/#54394/#55061) stay
+# parked on this exact image.
 
 # --- downloads / sync ---------------------------------------------------------
 # HF CLI override when `hf` lives outside PATH (venv installs). May contain

--- a/overlay/patch_kv_merge_assert.py
+++ b/overlay/patch_kv_merge_assert.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Keep KVCacheSpec.merge incompatibility active under ``python -O``.
+
+The day-0 fork still guards the inherited merge with ``assert``. Optimized
+Python strips that, so unequal Mamba/GDN specs can be reported as uniform
+and collapsed. Upstream #55234 keeps the existing ``AssertionError``
+contract used by grouping callers and raises it explicitly.
+
+This overlay ports only that inherited merge. Subclass merges that already
+``raise ValueError`` are left alone. The DSpark ``non_causal_multi_token_decode``
+any-merge is already present on this image.
+
+Fail closed on drift. Idempotent. Not in the JIT shape hash.
+"""
+from __future__ import annotations
+
+import ast
+import os
+import stat
+from pathlib import Path
+
+
+TARGET = Path(
+    os.environ.get(
+        "GLM53_KV_CACHE_INTERFACE_PY",
+        "/usr/local/lib/python3.12/dist-packages/vllm/v1/kv_cache_interface.py",
+    )
+)
+MARK = "# [glm53-kv-merge-assert]"
+
+ANCHOR = """        assert all(spec == specs[0] for spec in specs[1:]), (
+            "All layers in the same KV cache group must be the same."
+        )
+        return copy.deepcopy(specs[0])
+"""
+
+PATCHED = """        if not all(spec == specs[0] for spec in specs[1:]):
+            raise AssertionError(  # [glm53-kv-merge-assert]
+                "All layers in the same KV cache group must be the same."
+            )
+        return copy.deepcopy(specs[0])
+"""
+
+
+def verified_state(source: str) -> bool:
+    return (
+        ANCHOR not in source
+        and PATCHED in source
+        and source.count(MARK) == 1
+        and source.count("raise AssertionError(") >= 1
+    )
+
+
+def inherited_merge_state(source: str) -> str:
+    """Classify inherited merge the same way the installer will apply it."""
+    if verified_state(source):
+        return "raise"
+    try:
+        _, action = prepare(source)
+    except ValueError:
+        return "unknown"
+    if action == "patched" and source.count(ANCHOR) == 1:
+        return "assert"
+    return "unknown"
+
+
+def prepare(source: str) -> tuple[str, str]:
+    if MARK in source:
+        if not verified_state(source):
+            raise ValueError(
+                "glm53-kv-merge-assert marker present but the patched merge "
+                "is incomplete; refusing to guess"
+            )
+        return source, "already present"
+    if verified_state(source):
+        return source, "already patched"
+    if source.count(ANCHOR) != 1:
+        raise ValueError(
+            "inherited KVCacheSpec.merge assert drifted "
+            f"(anchor={source.count(ANCHOR)})"
+        )
+    patched = source.replace(ANCHOR, PATCHED, 1)
+    if not verified_state(patched):
+        raise ValueError("kv-merge-assert post-patch verification failed")
+    return patched, "patched"
+
+
+def replace_file(target: Path, source: str) -> None:
+    tmp = target.with_name(f".{target.name}.glm53-kv-merge-assert.tmp")
+    try:
+        tmp.write_text(source)
+        os.chmod(tmp, stat.S_IMODE(target.stat().st_mode))
+        os.replace(tmp, target)
+    finally:
+        if tmp.exists():
+            tmp.unlink()
+
+
+def clear_pyc(target: Path) -> None:
+    cache = target.parent / "__pycache__"
+    if not cache.is_dir():
+        return
+    for pyc in cache.glob("kv_cache_interface*.pyc"):
+        pyc.unlink(missing_ok=True)
+
+
+def main() -> int:
+    if not TARGET.is_file():
+        raise SystemExit(f"missing {TARGET}")
+    source = TARGET.read_text()
+    try:
+        patched, action = prepare(source)
+    except ValueError as exc:
+        raise SystemExit(f"kv-merge-assert preflight failed: {exc}") from exc
+    ast.parse(patched, filename=str(TARGET))
+    compile(patched, str(TARGET), "exec")
+    if patched != source:
+        replace_file(TARGET, patched)
+        clear_pyc(TARGET)
+    print(f"{TARGET.name}: kv-merge-assert {action}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/audit_source_compat.py
+++ b/scripts/audit_source_compat.py
@@ -1,0 +1,425 @@
+#!/usr/bin/env python3
+"""Fail-closed source/image/overlay compatibility matrix for GLM-5.3 EXL3.
+
+This is the task 27 + 13 + 17 fixture lane. It classifies the live fork
+against the current production overlays. It does not swap the stock image,
+does not raise LPTT, and does not treat batch-size dynamic speculative
+decoding as a configuration knob.
+
+Decisions:
+  adopt  — inherited KVCacheSpec.merge still uses ``assert`` and the
+           raise overlay can apply; remaining rebase PRs are parked
+  park   — the inherited merge is already the raise form, or source
+           drifted in a way that still recognizes the live contracts
+  refuse — overlay/V2 mismatch, V1 force, MTP capture-size, or
+           unrecognized source
+"""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+from pathlib import Path
+from typing import Any
+
+
+def _load_merge_overlay():
+    path = Path(__file__).resolve().parents[1] / "overlay" / "patch_kv_merge_assert.py"
+    spec = importlib.util.spec_from_file_location("glm53_kv_merge_assert", path)
+    if spec is None or spec.loader is None:
+        raise SystemExit(f"unable to load merge overlay from {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+MERGE_OVERLAY = _load_merge_overlay()
+ANY_NONCAUSAL = "non_causal_multi_token_decode=any("
+FP8_656 = "return self.block_size * 656"
+GDN_DRAFT_TAGS = "num_decode_draft_tokens_cpu"
+KPOOL_CLASS = "class SparseAttnIndexerKpool"
+FUSED_APPLY = "def apply_exl3_fused_moe("
+FAT_INDEX_SELECT = "torch.index_select(xh, 0, token_idx, out=h)"
+V2_RUNNER_PATH = "v1/worker/gpu/model_runner.py"
+V1_RUNNER_PATH = "v1/worker/gpu_model_runner.py"
+W28_RUNNER_MARK = "self.model_state.set_kv_cache_config(  # [glm53-w28-correctness]"
+GLM_V2_ARCH = '"Glm5NextForCausalLM"'
+
+
+def _contains(source: str, needle: str) -> bool:
+    return needle in source
+
+
+def classify_merge(kv_interface: str) -> dict[str, Any]:
+    merge_state = MERGE_OVERLAY.inherited_merge_state(kv_interface)
+    has_any = ANY_NONCAUSAL in kv_interface
+    has_656 = FP8_656 in kv_interface
+    return {
+        "inherited_merge": merge_state,
+        "overlay_applicable": merge_state in {"assert", "raise"},
+        "anchor_count": kv_interface.count(MERGE_OVERLAY.ANCHOR),
+        "non_causal_any_merge": has_any,
+        "fp8_ds_mla_page_bytes": 656 if has_656 else None,
+        "fp8_ds_mla_656": has_656,
+    }
+
+
+def classify_overlays(overlay_sources: dict[str, str]) -> dict[str, Any]:
+    w28 = overlay_sources.get("patch_w28_correctness.py", "")
+    targets_v2 = V2_RUNNER_PATH in w28
+    targets_v1 = V1_RUNNER_PATH in w28
+    return {
+        "w28_targets_v2_gpu_model_runner": targets_v2,
+        "w28_targets_v1_gpu_model_runner": targets_v1,
+        "hybrid_prefix_hit_present": "glm53-hybrid-apc" in overlay_sources.get(
+            "patch_hybrid_prefix_hit.py", ""
+        ),
+        "decode_floor_present": "glm53-decode-floor" in overlay_sources.get(
+            "patch_scheduler_decode_floor.py", ""
+        ),
+        "indexer_workspace_present": "glm53-indexer-workspace"
+        in overlay_sources.get("patch_indexer_workspace.py", ""),
+        "kv_merge_overlay_present": "glm53-kv-merge-assert"
+        in overlay_sources.get("patch_kv_merge_assert.py", ""),
+    }
+
+
+def classify_runner(config_vllm: str, gpu_runner: str, v1_runner: str) -> dict[str, Any]:
+    return {
+        "config_vllm_present": bool(config_vllm.strip()),
+        "gpu_model_runner_present": bool(gpu_runner.strip()),
+        "glm_listed_default_v2": GLM_V2_ARCH in config_vllm,
+        "w28_mark_on_v2_runner": W28_RUNNER_MARK in gpu_runner,
+        "w28_mark_on_v1_runner": W28_RUNNER_MARK in v1_runner,
+        "v2_env_key_present": "VLLM_USE_V2_MODEL_RUNNER" in config_vllm
+        or "VLLM_USE_V2_MODEL_RUNNER" in gpu_runner,
+    }
+
+
+def classify_spec_paths(gdn: str, dflash: str, kpool: str, exl3: str) -> dict[str, Any]:
+    fused = FUSED_APPLY in exl3
+    fat_gather = FAT_INDEX_SELECT in exl3
+    dflash_present = bool(dflash.strip())
+    return {
+        "dflash_source_present": dflash_present,
+        "gdn_classifies_speculative_rows_by_draft_tags": GDN_DRAFT_TAGS in gdn,
+        "legacy_dflash_has_set_attn": "def set_attn" in dflash,
+        "legacy_dflash_mentions_aot_schedule": "aot_schedule" in dflash,
+        "kpool_indexer_present": KPOOL_CLASS in kpool,
+        "exl3_fused_apply_present": fused,
+        "exl3_fat_path_uses_index_select": fat_gather,
+        "c4_decode_uses_fused_exl3_moe": fused,
+    }
+
+
+def classify_launcher(values: dict[str, Any]) -> dict[str, Any]:
+    spec = str(values.get("spec_method", "dflash"))
+    seqs = int(values.get("max_num_seqs", 4))
+    lptt = int(values.get("long_prefill_token_threshold", 1792))
+    v2 = values.get("vllm_use_v2_model_runner")
+    kpool = int(values.get("index_kpool", 4))
+    rows_per_rank = (lptt + 1) // 2  # TP=2 solo prefill
+    return {
+        "spec_method": spec,
+        "max_num_seqs": seqs,
+        "long_prefill_token_threshold": lptt,
+        "vllm_use_v2_model_runner": v2,
+        "solo_prefill_rows_per_rank": rows_per_rank,
+        "dsa_row_shard_gate_1024": rows_per_rank >= 1024,
+        "mtp_capture_size_guard": spec == "mtp" and seqs > 12,
+        "v1_force": v2 in (False, 0, "0"),
+        "index_kpool": kpool,
+    }
+
+
+def decide(checks: dict[str, Any]) -> tuple[str, str]:
+    if checks["launcher"]["v1_force"]:
+        return (
+            "refuse",
+            "VLLM_USE_V2_MODEL_RUNNER=0 would force the V1 runner. "
+            "Production already uses V2 and W28 patches v1/worker/gpu/model_runner.py.",
+        )
+    if checks["launcher"]["mtp_capture_size_guard"]:
+        return (
+            "refuse",
+            "SPEC_METHOD=mtp refuses to boot when MAX_NUM_SEQS > 12 "
+            "(MTP capture-size guard).",
+        )
+    if not checks["overlays"]["w28_targets_v2_gpu_model_runner"]:
+        return (
+            "refuse",
+            "W28 overlay no longer targets the live V2 GPU model runner.",
+        )
+    if checks["overlays"]["w28_targets_v1_gpu_model_runner"]:
+        return (
+            "refuse",
+            "W28 overlay unexpectedly targets the V1 gpu_model_runner path.",
+        )
+    missing_sources = [
+        name
+        for name, present in (
+            ("kv_cache_interface", bool(checks["merge"].get("inherited_merge"))),
+            ("config_vllm", checks["runner"]["config_vllm_present"]),
+            ("gpu_model_runner", checks["runner"]["gpu_model_runner_present"]),
+            ("gdn_attn", checks["spec"]["gdn_classifies_speculative_rows_by_draft_tags"]),
+            ("dflash", checks["spec"]["dflash_source_present"]),
+            ("kpool", checks["spec"]["kpool_indexer_present"]),
+            ("exl3", checks["spec"]["exl3_fused_apply_present"]),
+        )
+        if not present
+    ]
+    if missing_sources:
+        return (
+            "refuse",
+            "Missing production sources: " + ", ".join(missing_sources) + ".",
+        )
+    missing_overlays = [
+        name
+        for name, present in (
+            (
+                "patch_w28_correctness.py",
+                checks["overlays"]["w28_targets_v2_gpu_model_runner"],
+            ),
+            (
+                "patch_hybrid_prefix_hit.py",
+                checks["overlays"]["hybrid_prefix_hit_present"],
+            ),
+            (
+                "patch_scheduler_decode_floor.py",
+                checks["overlays"]["decode_floor_present"],
+            ),
+            (
+                "patch_indexer_workspace.py",
+                checks["overlays"]["indexer_workspace_present"],
+            ),
+            (
+                "patch_kv_merge_assert.py",
+                checks["overlays"]["kv_merge_overlay_present"],
+            ),
+        )
+        if not present
+    ]
+    if missing_overlays:
+        return (
+            "refuse",
+            "Missing production overlays: " + ", ".join(missing_overlays) + ".",
+        )
+    merge = checks["merge"]["inherited_merge"]
+    if merge == "unknown" or not checks["merge"]["overlay_applicable"]:
+        return (
+            "refuse",
+            "Inherited KVCacheSpec.merge drifted; the raise overlay cannot apply.",
+        )
+    required = (
+        checks["merge"]["non_causal_any_merge"],
+        checks["merge"]["fp8_ds_mla_656"],
+        checks["spec"]["gdn_classifies_speculative_rows_by_draft_tags"],
+        checks["spec"]["kpool_indexer_present"],
+        checks["spec"]["exl3_fused_apply_present"],
+        checks["runner"]["glm_listed_default_v2"],
+        checks["overlays"]["kv_merge_overlay_present"],
+        checks["overlays"]["hybrid_prefix_hit_present"],
+        checks["overlays"]["decode_floor_present"],
+        checks["overlays"]["indexer_workspace_present"],
+        checks["spec"]["dflash_source_present"],
+        checks["runner"]["gpu_model_runner_present"],
+        checks["runner"]["config_vllm_present"],
+    )
+    if not all(required):
+        return (
+            "refuse",
+            "A live production contract is missing from the audited sources.",
+        )
+    if merge == "assert":
+        return (
+            "adopt",
+            "Port KVCacheSpec.merge from assert to raise AssertionError so "
+            "grouping stays fail-closed under python -O. Live path is already "
+            "the V2 runner; #54374/#55178/#54394/#55061 remain parked.",
+        )
+    return (
+        "park",
+        "Inherited merge is already the raise form. Remaining rebase PRs "
+        "stay parked on this exact image.",
+    )
+
+
+def audit(
+    sources: dict[str, str],
+    overlay_sources: dict[str, str],
+    launcher: dict[str, Any],
+) -> dict[str, Any]:
+    checks = {
+        "merge": classify_merge(sources.get("kv_cache_interface", "")),
+        "overlays": classify_overlays(overlay_sources),
+        "runner": classify_runner(
+            sources.get("config_vllm", ""),
+            sources.get("gpu_model_runner", ""),
+            sources.get("gpu_model_runner_v1", ""),
+        ),
+        "spec": classify_spec_paths(
+            sources.get("gdn_attn", ""),
+            sources.get("dflash", ""),
+            sources.get("kpool", ""),
+            sources.get("exl3", ""),
+        ),
+        "launcher": classify_launcher(launcher),
+        "rebase": {
+            "pr_54374_legacy_dflash_aot": False,
+            "pr_55178_basemamba_padded_tail_is_not_gdn": True,
+            "pr_55449_packed_page_already_656": True,
+            "pr_54394_lptt_too_small_for_row_shard": not classify_launcher(launcher)[
+                "dsa_row_shard_gate_1024"
+            ],
+            "pr_55061_c4_decode_is_fused_exl3_moe": classify_spec_paths(
+                "", "", "", sources.get("exl3", "")
+            )["c4_decode_uses_fused_exl3_moe"],
+        },
+    }
+    decision, reason = decide(checks)
+    parked = {
+        "54374": (
+            "Live proposer is overlay/dflash2_speculator.py plus "
+            "v1/spec_decode/dflash.py; it has no DFlashSpeculator.set_attn "
+            "AOT disable. Include #54374 only at a MRV2 rebase."
+        ),
+        "55178": (
+            "BaseMamba padded-tail fix is not the GLM KDA path. Live GDN "
+            "classifies speculative rows by draft-count tags."
+        ),
+        "55449": (
+            "Live MLAAttentionSpec.real_page_size_bytes already returns "
+            "656 B/token for fp8_ds_mla. Fixture only; no capacity gain."
+        ),
+        "54394": (
+            "Live indexer is SparseAttnIndexerKpool. Solo LPTT=1792 at TP2 "
+            "is 896 rows/rank, below the ≥1024 gate. Do not raise LPTT."
+        ),
+        "55061": (
+            "C4 decode uses fused exl3_moe. index_select + per-expert fat "
+            "launch is the overflow path, not the C4 decode hot path. "
+            "No ncu probe is claimed here."
+        ),
+        "v2_runner_knob": (
+            "Production already logs 'Using V2 Model Runner'. Forcing "
+            "VLLM_USE_V2_MODEL_RUNNER=1 is a no-op; forcing 0 is refused. "
+            "Adaptive verification stays parked."
+        ),
+    }
+    return {
+        "decision": decision,
+        "supported_v2_force_arm": False,
+        "supported_mtp_rollback_above_12_seqs": False,
+        "supported_dsa_row_shard": False,
+        "supported_verification_length_arm": False,
+        "checks": checks,
+        "parked": parked,
+        "reason": reason,
+    }
+
+
+def load_text(path: Path | None) -> str:
+    if path is None:
+        return ""
+    return path.read_text(encoding="utf-8")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--kv-cache-interface", type=Path)
+    parser.add_argument("--config-vllm", type=Path)
+    parser.add_argument("--gpu-model-runner", type=Path)
+    parser.add_argument("--gpu-model-runner-v1", type=Path)
+    parser.add_argument("--gdn-attn", type=Path)
+    parser.add_argument("--dflash", type=Path)
+    parser.add_argument("--kpool", type=Path)
+    parser.add_argument("--exl3", type=Path)
+    parser.add_argument("--overlay-dir", type=Path)
+    parser.add_argument("--spec-method", default="dflash")
+    parser.add_argument("--max-num-seqs", type=int, default=4)
+    parser.add_argument("--long-prefill-token-threshold", type=int, default=1792)
+    parser.add_argument("--vllm-use-v2-model-runner", default="")
+    parser.add_argument("--index-kpool", type=int, default=4)
+    parser.add_argument("--vllm-site", type=Path)
+    return parser.parse_args()
+
+
+def sources_from_site(site: Path) -> dict[str, str]:
+    def read(rel: str) -> str:
+        path = site / rel
+        return path.read_text(encoding="utf-8") if path.is_file() else ""
+
+    return {
+        "kv_cache_interface": read("v1/kv_cache_interface.py"),
+        "config_vllm": read("config/vllm.py"),
+        "gpu_model_runner": read("v1/worker/gpu/model_runner.py"),
+        "gpu_model_runner_v1": read("v1/worker/gpu_model_runner.py"),
+        "gdn_attn": read("v1/attention/backends/gdn_attn.py"),
+        "dflash": read("v1/spec_decode/dflash.py"),
+        "kpool": read("model_executor/layers/sparse_attn_indexer_kpool.py"),
+        "exl3": read("model_executor/layers/quantization/exl3.py"),
+    }
+
+
+def overlays_from_dir(overlay_dir: Path) -> dict[str, str]:
+    names = (
+        "patch_w28_correctness.py",
+        "patch_hybrid_prefix_hit.py",
+        "patch_scheduler_decode_floor.py",
+        "patch_indexer_workspace.py",
+        "patch_kv_merge_assert.py",
+    )
+    return {
+        name: (overlay_dir / name).read_text(encoding="utf-8")
+        if (overlay_dir / name).is_file()
+        else ""
+        for name in names
+    }
+
+
+def v2_env_value(raw: str) -> bool | None:
+    text = raw.strip()
+    if text == "":
+        return None
+    if text in ("1", "true", "True"):
+        return True
+    if text in ("0", "false", "False"):
+        return False
+    raise SystemExit(f"invalid VLLM_USE_V2_MODEL_RUNNER={raw!r}")
+
+
+def main() -> int:
+    args = parse_args()
+    if args.vllm_site is not None:
+        sources = sources_from_site(args.vllm_site)
+    else:
+        sources = {
+            "kv_cache_interface": load_text(args.kv_cache_interface),
+            "config_vllm": load_text(args.config_vllm),
+            "gpu_model_runner": load_text(args.gpu_model_runner),
+            "gpu_model_runner_v1": load_text(args.gpu_model_runner_v1),
+            "gdn_attn": load_text(args.gdn_attn),
+            "dflash": load_text(args.dflash),
+            "kpool": load_text(args.kpool),
+            "exl3": load_text(args.exl3),
+        }
+    overlay_dir = args.overlay_dir or (
+        Path(__file__).resolve().parents[1] / "overlay"
+    )
+    report = audit(
+        sources,
+        overlays_from_dir(overlay_dir),
+        {
+            "spec_method": args.spec_method,
+            "max_num_seqs": args.max_num_seqs,
+            "long_prefill_token_threshold": args.long_prefill_token_threshold,
+            "vllm_use_v2_model_runner": v2_env_value(args.vllm_use_v2_model_runner),
+            "index_kpool": args.index_kpool,
+        },
+    )
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0 if report["decision"] in {"adopt", "park"} else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/start.sh
+++ b/start.sh
@@ -235,6 +235,8 @@ APC_NO_STORE_PATCH_HOST="${APC_NO_STORE_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_ap
 INDEXER_WORKSPACE_PATCH_HOST="${INDEXER_WORKSPACE_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_indexer_workspace.py}"
 W28_CORRECTNESS_PATCH_HOST="${W28_CORRECTNESS_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_w28_correctness.py}"
 MAMBA_NULL_GAP_PATCH_HOST="${MAMBA_NULL_GAP_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_mamba_null_gap_retirement.py}"
+# LOCAL: task 17 / #55234 — inherited KVCacheSpec.merge assert -> raise (python -O)
+KV_MERGE_ASSERT_PATCH_HOST="${KV_MERGE_ASSERT_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_kv_merge_assert.py}"
 KV_CACHE_DTYPE="${KV_CACHE_DTYPE:-fp8}"
 QUANTIZATION="${QUANTIZATION:-exl3}"
 LANGUAGE_MODEL_ONLY="${LANGUAGE_MODEL_ONLY:-0}"
@@ -405,6 +407,25 @@ validate_numeric_config() {
             echo "DFLASH_TOKENS must remain 7 for this fixed-block DFlash2 path; verification-only k=3/4 is unsupported (got: $DFLASH_TOKENS)" >&2
             return 2
         fi
+    fi
+    # LOCAL: task 13 — production already uses the V2 GPU model runner; W28
+    # patches v1/worker/gpu/model_runner.py. Forcing V1 would miss W28.
+    # Unset or 1 is a no-op; 0 is refused before stop/restart.
+    case "${VLLM_USE_V2_MODEL_RUNNER-}" in
+        ""|1) ;;
+        0)
+            echo "VLLM_USE_V2_MODEL_RUNNER=0 is refused: production already uses the V2 runner and W28 patches that path" >&2
+            return 2
+            ;;
+        *)
+            echo "VLLM_USE_V2_MODEL_RUNNER must be unset or 1 (got: ${VLLM_USE_V2_MODEL_RUNNER})" >&2
+            return 2
+            ;;
+    esac
+    # LOCAL: task 13 — MTP capture-size guard (kit #88 / PR #93).
+    if [ "$SPEC_METHOD" = mtp ] && [ "$MAX_NUM_SEQS" -gt 12 ]; then
+        echo "SPEC_METHOD=mtp refuses to boot when MAX_NUM_SEQS > 12 (MTP capture-size guard; got MAX_NUM_SEQS=${MAX_NUM_SEQS})" >&2
+        return 2
     fi
     # LOCAL: W27 — strict enum; it is also the safety boundary for the worker's
     # word-split `-e` transport (never widen it without adding quoting).
@@ -625,6 +646,7 @@ preflight() {
     [ -f "$APC_NO_STORE_PATCH_HOST" ] || die "$APC_NO_STORE_PATCH_HOST missing"  # LOCAL: W42
     [ -f "$INDEXER_WORKSPACE_PATCH_HOST" ] || die "$INDEXER_WORKSPACE_PATCH_HOST missing"  # LOCAL: W28
     [ -f "$W28_CORRECTNESS_PATCH_HOST" ] || die "$W28_CORRECTNESS_PATCH_HOST missing"  # LOCAL: W28
+    [ -f "$KV_MERGE_ASSERT_PATCH_HOST" ] || die "$KV_MERGE_ASSERT_PATCH_HOST missing"
 
     local need_kb=$((180 * 1024 * 1024)) avail
     mkdir -p "$HF_CACHE_DIR"
@@ -1161,6 +1183,9 @@ fi
 if [ -f /opt/glm53/patch_mamba_null_gap_retirement.py ]; then
     python3 -S /opt/glm53/patch_mamba_null_gap_retirement.py
 fi
+if [ -f /opt/glm53/patch_kv_merge_assert.py ]; then  # LOCAL: #55234 inherited merge
+    python3 -S /opt/glm53/patch_kv_merge_assert.py
+fi
 say "launching: vllm serve ${MODEL_DIR} ${ARGS[*]}"
 exec vllm serve "${MODEL_DIR}" "${ARGS[@]}"
 EOF
@@ -1294,6 +1319,9 @@ fi
 if [ -f /opt/glm53/patch_mamba_null_gap_retirement.py ]; then
     python3 -S /opt/glm53/patch_mamba_null_gap_retirement.py
 fi
+if [ -f /opt/glm53/patch_kv_merge_assert.py ]; then  # LOCAL: #55234 inherited merge
+    python3 -S /opt/glm53/patch_kv_merge_assert.py
+fi
 say "joining TP2 at ${HEAD_IP}:${MASTER_PORT} as rank 1"
 exec vllm serve "${MODEL_DIR}" "${ARGS[@]}"
 EOF
@@ -1346,6 +1374,8 @@ launch_cluster() {
     scp -q -o BatchMode=yes "$INDEXER_WORKSPACE_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_indexer_workspace.py"
     [ -f "$MAMBA_NULL_GAP_PATCH_HOST" ] || die "missing $MAMBA_NULL_GAP_PATCH_HOST"
     scp -q -o BatchMode=yes "$MAMBA_NULL_GAP_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_mamba_null_gap_retirement.py"
+    [ -f "$KV_MERGE_ASSERT_PATCH_HOST" ] || die "missing $KV_MERGE_ASSERT_PATCH_HOST"
+    scp -q -o BatchMode=yes "$KV_MERGE_ASSERT_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_kv_merge_assert.py"
 
 
     local -a nccl_common=(
@@ -1486,6 +1516,7 @@ launch_cluster() {
         -v '/tmp/patch_w28_correctness.py:/opt/glm53/patch_w28_correctness.py:ro' \
         -v '/tmp/patch_indexer_workspace.py:/opt/glm53/patch_indexer_workspace.py:ro' \
         -v '/tmp/patch_mamba_null_gap_retirement.py:/opt/glm53/patch_mamba_null_gap_retirement.py:ro' \
+        -v '/tmp/patch_kv_merge_assert.py:/opt/glm53/patch_kv_merge_assert.py:ro' \
         ${worker_preload} \
         ${worker_nccl} \
         -e NCCL_SOCKET_IFNAME='$WORKER_CX7_IF' \
@@ -1525,6 +1556,7 @@ launch_cluster() {
         -v "$W28_CORRECTNESS_PATCH_HOST:/opt/glm53/patch_w28_correctness.py:ro" \
         -v "$INDEXER_WORKSPACE_PATCH_HOST:/opt/glm53/patch_indexer_workspace.py:ro" \
         -v "$MAMBA_NULL_GAP_PATCH_HOST:/opt/glm53/patch_mamba_null_gap_retirement.py:ro" \
+        -v "$KV_MERGE_ASSERT_PATCH_HOST:/opt/glm53/patch_kv_merge_assert.py:ro" \
         "${head_preload[@]}" \
         "${nccl_common[@]}" \
         -e NCCL_SOCKET_IFNAME="$HEAD_CX7_IF" \

--- a/tests/fixtures/source-compat/README.md
+++ b/tests/fixtures/source-compat/README.md
@@ -1,0 +1,11 @@
+# Source-compat fixtures (tasks 27 + 13 + 17)
+
+Compact synthetic copies of the live production contracts. They are not a
+vLLM tree. `scripts/audit_source_compat.py` and the CPU tests consume them.
+
+A full dump of the running image may exist at
+`tests/fixtures/live-image-vllm/` for local audits. That dump is gitignored
+and must not be committed.
+
+Do not raise LPTT, force the V1 runner, or treat MTP as a configuration
+rollback above 12 sequences.

--- a/tests/fixtures/source-compat/config_vllm.py
+++ b/tests/fixtures/source-compat/config_vllm.py
@@ -1,0 +1,10 @@
+"""Compact live V2-runner architecture default."""
+
+DEFAULT_V2_MODEL_RUNNER_ARCHITECTURES = frozenset(
+    {
+        "DeepseekV2ForCausalLM",
+        "DeepseekV4ForCausalLM",
+        "Glm5NextForCausalLM",
+        "Glm5NextForConditionalGeneration",
+    }
+)

--- a/tests/fixtures/source-compat/dflash.py
+++ b/tests/fixtures/source-compat/dflash.py
@@ -1,0 +1,6 @@
+"""Compact live legacy DFlash proposer. No FA-AOT set_attn path."""
+
+
+class DFlashSpeculator:
+    def propose(self) -> None:
+        return None

--- a/tests/fixtures/source-compat/exl3.py
+++ b/tests/fixtures/source-compat/exl3.py
@@ -1,0 +1,12 @@
+"""Compact live EXL3 paths: fused MoE is C4 decode; index_select is overflow."""
+
+
+def apply_exl3_fused_moe(x2d):
+    return x2d
+
+
+def apply_exl3_batched_fat(xh, token_idx, h):
+    import torch
+
+    torch.index_select(xh, 0, token_idx, out=h)
+    return h

--- a/tests/fixtures/source-compat/gdn_attn.py
+++ b/tests/fixtures/source-compat/gdn_attn.py
@@ -1,0 +1,8 @@
+"""Compact live GDN speculative-row classification."""
+
+
+class GDNAttention:
+    def build_decode_metadata(self, num_decode_draft_tokens_cpu) -> None:
+        # Live GDN classifies speculative rows by draft-count tags, not
+        # BaseMamba padded-tail bookkeeping (#55178 is parked).
+        self.num_decode_draft_tokens_cpu = num_decode_draft_tokens_cpu

--- a/tests/fixtures/source-compat/gpu_model_runner.py
+++ b/tests/fixtures/source-compat/gpu_model_runner.py
@@ -1,0 +1,8 @@
+"""Compact V2 GPU runner after the W28 overlay."""
+
+
+class GPUModelRunner:
+    def initialize_kv_cache(self) -> None:
+        self.model_state.set_kv_cache_config(  # [glm53-w28-correctness]
+            self.kv_cache_config
+        )

--- a/tests/fixtures/source-compat/gpu_model_runner_v1.py
+++ b/tests/fixtures/source-compat/gpu_model_runner_v1.py
@@ -1,0 +1,6 @@
+"""Compact V1 GPU runner. W28 must not land here."""
+
+
+class GPUModelRunner:
+    def initialize_kv_cache(self) -> None:
+        self.attn_groups = []

--- a/tests/fixtures/source-compat/kpool.py
+++ b/tests/fixtures/source-compat/kpool.py
@@ -1,0 +1,5 @@
+"""Compact live GLM kpool indexer."""
+
+
+class SparseAttnIndexerKpool:
+    index_kpool = 4

--- a/tests/fixtures/source-compat/kv_cache_interface.py
+++ b/tests/fixtures/source-compat/kv_cache_interface.py
@@ -1,0 +1,57 @@
+"""Compact live KVCacheSpec.merge + MLA contracts."""
+from __future__ import annotations
+
+import copy
+
+
+class KVCacheSpec:
+    def __init__(self, block_size: int, extra: str = "same") -> None:
+        self.block_size = block_size
+        self.extra = extra
+
+    def __eq__(self, other: object) -> bool:
+        return (
+            isinstance(other, KVCacheSpec)
+            and self.block_size == other.block_size
+            and self.extra == other.extra
+        )
+
+    @classmethod
+    def merge(cls, specs: list[KVCacheSpec]) -> KVCacheSpec:
+        """
+        Merge a list of KVCacheSpec objects into a single KVCacheSpec object.
+        """
+        assert all(spec == specs[0] for spec in specs[1:]), (
+            "All layers in the same KV cache group must be the same."
+        )
+        return copy.deepcopy(specs[0])
+
+
+class MLAAttentionSpec(KVCacheSpec):
+    def __init__(
+        self,
+        block_size: int,
+        extra: str = "same",
+        cache_dtype_str: str | None = None,
+        non_causal_multi_token_decode: bool = False,
+    ) -> None:
+        super().__init__(block_size, extra)
+        self.cache_dtype_str = cache_dtype_str
+        self.non_causal_multi_token_decode = non_causal_multi_token_decode
+
+    @classmethod
+    def merge(cls, specs: list[MLAAttentionSpec]) -> MLAAttentionSpec:
+        return cls(
+            block_size=specs[0].block_size,
+            non_causal_multi_token_decode=any(
+                spec.non_causal_multi_token_decode for spec in specs
+            ),
+        )
+
+    @property
+    def real_page_size_bytes(self) -> int:
+        if self.cache_dtype_str == "fp8_ds_mla":
+            # V3.2 main MLA: 656-byte custom layout (kv_lora_rank=512 +
+            # qk_rope_head_dim=64, head_size=576). See flashmla_sparse.py.
+            return self.block_size * 656
+        return self.block_size * 584

--- a/tests/test_kv_merge_assert.py
+++ b/tests/test_kv_merge_assert.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""CPU tests for the #55234 KVCacheSpec.merge assert overlay."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PATCH = ROOT / "overlay" / "patch_kv_merge_assert.py"
+FIXTURE = ROOT / "tests/fixtures/source-compat/kv_cache_interface.py"
+
+
+def apply_patch(tmp_path: Path) -> Path:
+    target = tmp_path / "kv_cache_interface.py"
+    shutil.copy2(FIXTURE, target)
+    env = os.environ.copy()
+    env["GLM53_KV_CACHE_INTERFACE_PY"] = str(target)
+    subprocess.run([sys.executable, "-S", str(PATCH)], check=True, env=env)
+    subprocess.run([sys.executable, "-S", str(PATCH)], check=True, env=env)
+    return target
+
+
+def load_module(path: Path, name: str = "patched_kv_cache_interface"):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_overlay_keeps_incompatibility_under_optimized_python(tmp_path: Path) -> None:
+    target = apply_patch(tmp_path)
+    source = target.read_text()
+    assert "assert all(spec == specs[0] for spec in specs[1:])" not in source
+    assert "raise AssertionError(  # [glm53-kv-merge-assert]" in source
+    assert source.count("# [glm53-kv-merge-assert]") == 1
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-O",
+            "-c",
+            (
+                "import importlib.util, sys\n"
+                f"path = {str(target)!r}\n"
+                "spec = importlib.util.spec_from_file_location('kv', path)\n"
+                "mod = importlib.util.module_from_spec(spec)\n"
+                "sys.modules['kv'] = mod\n"
+                "spec.loader.exec_module(mod)\n"
+                "a = mod.KVCacheSpec(block_size=64, extra='a')\n"
+                "b = mod.KVCacheSpec(block_size=64, extra='b')\n"
+                "try:\n"
+                "    mod.KVCacheSpec.merge([a, b])\n"
+                "except AssertionError as exc:\n"
+                "    print(type(exc).__name__ + ':' + str(exc))\n"
+                "else:\n"
+                "    raise SystemExit('merge swallowed the incompatibility')\n"
+            ),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "AssertionError:All layers in the same KV cache group must be the same." in result.stdout
+
+
+def test_unpatched_assert_vanishes_under_optimized_python(tmp_path: Path) -> None:
+    target = tmp_path / "kv_cache_interface.py"
+    shutil.copy2(FIXTURE, target)
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-O",
+            "-c",
+            (
+                "import importlib.util, sys\n"
+                f"path = {str(target)!r}\n"
+                "spec = importlib.util.spec_from_file_location('kv', path)\n"
+                "mod = importlib.util.module_from_spec(spec)\n"
+                "sys.modules['kv'] = mod\n"
+                "spec.loader.exec_module(mod)\n"
+                "a = mod.KVCacheSpec(block_size=64, extra='a')\n"
+                "b = mod.KVCacheSpec(block_size=64, extra='b')\n"
+                "merged = mod.KVCacheSpec.merge([a, b])\n"
+                "print(merged.extra)\n"
+            ),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "a"
+
+
+def test_overlay_is_idempotent_and_keeps_any_merge(tmp_path: Path) -> None:
+    target = apply_patch(tmp_path)
+    module = load_module(target)
+    a = module.MLAAttentionSpec(block_size=64, extra="x", non_causal_multi_token_decode=False)
+    b = module.MLAAttentionSpec(block_size=64, extra="y", non_causal_multi_token_decode=True)
+    merged = module.MLAAttentionSpec.merge([a, b])
+    assert merged.non_causal_multi_token_decode is True
+    assert a.real_page_size_bytes == 64 * 584
+    fp8 = module.MLAAttentionSpec(block_size=64, cache_dtype_str="fp8_ds_mla")
+    assert fp8.real_page_size_bytes == 64 * 656
+
+
+def test_overlay_rejects_drifted_installed_body_without_writing(tmp_path: Path) -> None:
+    target = apply_patch(tmp_path)
+    drifted = target.read_text().replace(
+        'raise AssertionError(  # [glm53-kv-merge-assert]\n'
+        '                "All layers in the same KV cache group must be the same."',
+        'raise AssertionError(  # [glm53-kv-merge-assert]\n'
+        '                "layers must match, maybe"',
+        1,
+    )
+    assert drifted != target.read_text()
+    target.write_text(drifted)
+    before = target.read_bytes()
+    env = os.environ.copy()
+    env["GLM53_KV_CACHE_INTERFACE_PY"] = str(target)
+    result = subprocess.run(
+        [sys.executable, "-S", str(PATCH)],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert result.returncode != 0
+    assert "kv-merge-assert preflight failed" in result.stderr
+    assert target.read_bytes() == before
+
+
+def test_overlay_rejects_return_block_drift_without_writing(tmp_path: Path) -> None:
+    target = tmp_path / "kv_cache_interface.py"
+    shutil.copy2(FIXTURE, target)
+    target.write_text(
+        target.read_text().replace("return copy.deepcopy(specs[0])", "return specs[0]", 1)
+    )
+    before = target.read_bytes()
+    env = os.environ.copy()
+    env["GLM53_KV_CACHE_INTERFACE_PY"] = str(target)
+    result = subprocess.run(
+        [sys.executable, "-S", str(PATCH)],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert result.returncode != 0
+    assert "anchor=0" in result.stderr
+    assert target.read_bytes() == before
+
+
+def test_overlay_rejects_duplicate_anchors_without_writing(tmp_path: Path) -> None:
+    target = tmp_path / "kv_cache_interface.py"
+    shutil.copy2(FIXTURE, target)
+    source = target.read_text()
+    spec = importlib.util.spec_from_file_location("kv_merge_overlay", PATCH)
+    assert spec and spec.loader
+    overlay = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(overlay)
+    target.write_text(source.replace(overlay.ANCHOR, overlay.ANCHOR + overlay.ANCHOR, 1))
+    before = target.read_bytes()
+    env = os.environ.copy()
+    env["GLM53_KV_CACHE_INTERFACE_PY"] = str(target)
+    result = subprocess.run(
+        [sys.executable, "-S", str(PATCH)],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert result.returncode != 0
+    assert "anchor=2" in result.stderr
+    assert target.read_bytes() == before
+
+
+def test_overlay_rejects_missing_anchor_without_writing(tmp_path: Path) -> None:
+    target = tmp_path / "kv_cache_interface.py"
+    target.write_text("class KVCacheSpec:\n    pass\n")
+    before = target.read_bytes()
+    env = os.environ.copy()
+    env["GLM53_KV_CACHE_INTERFACE_PY"] = str(target)
+    result = subprocess.run(
+        [sys.executable, "-S", str(PATCH)],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert result.returncode != 0
+    assert "inherited KVCacheSpec.merge assert drifted" in result.stderr
+    assert target.read_bytes() == before

--- a/tests/test_numeric_config.py
+++ b/tests/test_numeric_config.py
@@ -33,6 +33,7 @@ def validate(
     batch: str,
     spec_method: str = "dflash",
     dflash_tokens: str = "7",
+    extra_env: dict[str, str] | None = None,
 ) -> subprocess.CompletedProcess[str]:
     script = (
         guard_source()
@@ -42,6 +43,10 @@ def validate(
         + 'printf "%s|%s|%s|%s|%s\\n" "$GPU_MEM_UTIL" "$MAX_MODEL_LEN" '
         + '"$MAX_NUM_SEQS" "$MAX_NUM_BATCHED_TOKENS" "$DFLASH_TOKENS"\n'
     )
+    env = {**os.environ, "LC_ALL": "C"}
+    env.pop("VLLM_USE_V2_MODEL_RUNNER", None)
+    if extra_env:
+        env.update(extra_env)
     return subprocess.run(
         [
             "bash",
@@ -58,7 +63,7 @@ def validate(
         text=True,
         capture_output=True,
         check=False,
-        env={**os.environ, "LC_ALL": "C"},
+        env=env,
     )
 
 
@@ -96,6 +101,44 @@ def test_dflash2_rejects_non_native_block_lengths() -> None:
         "0.87", "1000000", "4", "1024", spec_method="none", dflash_tokens="4"
     )
     assert result.returncode == 0
+
+
+def test_v2_runner_force_off_is_refused() -> None:
+    refused = validate(
+        "0.87",
+        "1000000",
+        "4",
+        "1024",
+        extra_env={"VLLM_USE_V2_MODEL_RUNNER": "0"},
+    )
+    assert refused.returncode == 2
+    assert "VLLM_USE_V2_MODEL_RUNNER=0 is refused" in refused.stderr
+    allowed = validate(
+        "0.87",
+        "1000000",
+        "4",
+        "1024",
+        extra_env={"VLLM_USE_V2_MODEL_RUNNER": "1"},
+    )
+    assert allowed.returncode == 0
+    invalid = validate(
+        "0.87",
+        "1000000",
+        "4",
+        "1024",
+        extra_env={"VLLM_USE_V2_MODEL_RUNNER": "true"},
+    )
+    assert invalid.returncode == 2
+
+
+def test_mtp_above_12_seqs_is_refused() -> None:
+    refused = validate("0.87", "1000000", "13", "1024", spec_method="mtp")
+    assert refused.returncode == 2
+    assert "SPEC_METHOD=mtp refuses to boot when MAX_NUM_SEQS > 12" in refused.stderr
+    allowed = validate("0.87", "1000000", "12", "1024", spec_method="mtp")
+    assert allowed.returncode == 0
+    small = validate("0.87", "1000000", "4", "1024", spec_method="mtp")
+    assert small.returncode == 0
 
 
 def test_restart_validates_before_stop() -> None:

--- a/tests/test_runtime_hardening.py
+++ b/tests/test_runtime_hardening.py
@@ -21,6 +21,7 @@ def test_patch_installers_skip_site_initialization() -> None:
     assert invocations
     assert all(command.startswith("python3 -S ") for command in invocations)
     assert sum("patch_mamba_null_gap_retirement.py" in command for command in invocations) == 2
+    assert sum("patch_kv_merge_assert.py" in command for command in invocations) == 2
 
 
 def test_api_key_is_head_only() -> None:

--- a/tests/test_source_compat.py
+++ b/tests/test_source_compat.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""CPU tests for the task 27 + 13 + 17 source/overlay compatibility matrix."""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/audit_source_compat.py"
+SPEC = importlib.util.spec_from_file_location("source_compat_audit", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+FIXTURES = ROOT / "tests/fixtures/source-compat"
+LIVE = ROOT / "tests/fixtures/live-image-vllm"
+START = (ROOT / "start.sh").read_text(encoding="utf-8")
+OVERLAY = ROOT / "overlay"
+PATCH = "patch_kv_merge_assert.py"
+
+
+def compact_sources(**overrides: str) -> dict[str, str]:
+    values = {
+        "kv_cache_interface": (FIXTURES / "kv_cache_interface.py").read_text(),
+        "config_vllm": (FIXTURES / "config_vllm.py").read_text(),
+        "gpu_model_runner": (FIXTURES / "gpu_model_runner.py").read_text(),
+        "gpu_model_runner_v1": (FIXTURES / "gpu_model_runner_v1.py").read_text(),
+        "gdn_attn": (FIXTURES / "gdn_attn.py").read_text(),
+        "dflash": (FIXTURES / "dflash.py").read_text(),
+        "kpool": (FIXTURES / "kpool.py").read_text(),
+        "exl3": (FIXTURES / "exl3.py").read_text(),
+    }
+    values.update(overrides)
+    return values
+
+
+def compact_overlays(**overrides: str) -> dict[str, str]:
+    names = (
+        "patch_w28_correctness.py",
+        "patch_hybrid_prefix_hit.py",
+        "patch_scheduler_decode_floor.py",
+        "patch_indexer_workspace.py",
+        "patch_kv_merge_assert.py",
+    )
+    values = {name: (OVERLAY / name).read_text() for name in names}
+    values.update(overrides)
+    return values
+
+
+def run_audit(launcher: dict | None = None, **overrides):
+    return MODULE.audit(
+        compact_sources(**overrides.get("sources", {})),
+        compact_overlays(**overrides.get("overlays", {})),
+        launcher
+        or {
+            "spec_method": "dflash",
+            "max_num_seqs": 4,
+            "long_prefill_token_threshold": 1792,
+            "vllm_use_v2_model_runner": None,
+            "index_kpool": 4,
+        },
+    )
+
+
+def test_compact_live_contracts_adopt_merge_overlay() -> None:
+    report = run_audit()
+    assert report["decision"] == "adopt"
+    assert report["supported_v2_force_arm"] is False
+    assert report["supported_mtp_rollback_above_12_seqs"] is False
+    assert report["supported_dsa_row_shard"] is False
+    assert report["supported_verification_length_arm"] is False
+    assert report["checks"]["merge"]["inherited_merge"] == "assert"
+    assert report["checks"]["merge"]["non_causal_any_merge"] is True
+    assert report["checks"]["merge"]["fp8_ds_mla_page_bytes"] == 656
+    assert report["checks"]["runner"]["glm_listed_default_v2"] is True
+    assert report["checks"]["overlays"]["w28_targets_v2_gpu_model_runner"] is True
+    assert report["checks"]["overlays"]["w28_targets_v1_gpu_model_runner"] is False
+    assert report["checks"]["spec"]["c4_decode_uses_fused_exl3_moe"] is True
+    assert report["checks"]["spec"]["legacy_dflash_has_set_attn"] is False
+    assert report["checks"]["launcher"]["solo_prefill_rows_per_rank"] == 896
+    assert report["checks"]["rebase"]["pr_54394_lptt_too_small_for_row_shard"] is True
+    for pr in ("54374", "55178", "55449", "54394", "55061", "v2_runner_knob"):
+        assert pr in report["parked"]
+
+
+def test_already_raised_merge_parks() -> None:
+    report = run_audit(
+        sources={
+            "kv_cache_interface": (FIXTURES / "kv_cache_interface.py")
+            .read_text()
+            .replace(
+                "        assert all(spec == specs[0] for spec in specs[1:]), (\n"
+                '            "All layers in the same KV cache group must be the same."\n'
+                "        )\n",
+                "        if not all(spec == specs[0] for spec in specs[1:]):\n"
+                "            raise AssertionError(  # [glm53-kv-merge-assert]\n"
+                '                "All layers in the same KV cache group must be the same."\n'
+                "            )\n",
+            )
+        }
+    )
+    assert report["decision"] == "park"
+    assert report["checks"]["merge"]["inherited_merge"] == "raise"
+
+
+def test_v1_force_is_refused() -> None:
+    report = run_audit(
+        {
+            "spec_method": "dflash",
+            "max_num_seqs": 4,
+            "long_prefill_token_threshold": 1792,
+            "vllm_use_v2_model_runner": False,
+            "index_kpool": 4,
+        }
+    )
+    assert report["decision"] == "refuse"
+    assert "VLLM_USE_V2_MODEL_RUNNER=0" in report["reason"]
+
+
+def test_mtp_above_12_seqs_is_refused() -> None:
+    report = run_audit(
+        {
+            "spec_method": "mtp",
+            "max_num_seqs": 13,
+            "long_prefill_token_threshold": 1792,
+            "vllm_use_v2_model_runner": None,
+            "index_kpool": 4,
+        }
+    )
+    assert report["decision"] == "refuse"
+    assert "MAX_NUM_SEQS > 12" in report["reason"]
+
+
+def test_source_drift_fails_closed() -> None:
+    report = run_audit(sources={"kv_cache_interface": "class KVCacheSpec:\n    pass\n"})
+    assert report["decision"] == "refuse"
+    assert "cannot apply" in report["reason"] or "drifted" in report["reason"]
+    assert report["checks"]["merge"]["inherited_merge"] == "unknown"
+    assert report["checks"]["merge"]["overlay_applicable"] is False
+
+
+def test_missing_production_overlays_refuse() -> None:
+    report = run_audit(
+        overlays={
+            "patch_hybrid_prefix_hit.py": "",
+            "patch_scheduler_decode_floor.py": "",
+            "patch_indexer_workspace.py": "",
+        }
+    )
+    assert report["decision"] == "refuse"
+    assert "Missing production overlays" in report["reason"]
+    for name in (
+        "patch_hybrid_prefix_hit.py",
+        "patch_scheduler_decode_floor.py",
+        "patch_indexer_workspace.py",
+    ):
+        assert name in report["reason"]
+
+
+def test_missing_dflash_and_runner_sources_refuse() -> None:
+    report = run_audit(
+        sources={
+            "dflash": "",
+            "gpu_model_runner": "",
+            "config_vllm": "",
+        }
+    )
+    assert report["decision"] == "refuse"
+    assert "Missing production sources" in report["reason"]
+    for name in ("dflash", "gpu_model_runner", "config_vllm"):
+        assert name in report["reason"]
+
+
+def test_return_block_drift_refuses_and_overlay_cannot_apply() -> None:
+    drifted = (
+        (FIXTURES / "kv_cache_interface.py")
+        .read_text()
+        .replace("return copy.deepcopy(specs[0])", "return specs[0]", 1)
+    )
+    report = run_audit(sources={"kv_cache_interface": drifted})
+    assert report["decision"] == "refuse"
+    assert report["checks"]["merge"]["inherited_merge"] == "unknown"
+    assert report["checks"]["merge"]["overlay_applicable"] is False
+    assert report["checks"]["merge"]["anchor_count"] == 0
+
+
+def test_duplicate_merge_anchors_refuse() -> None:
+    source = (FIXTURES / "kv_cache_interface.py").read_text()
+    doubled = source.replace(
+        MODULE.MERGE_OVERLAY.ANCHOR,
+        MODULE.MERGE_OVERLAY.ANCHOR + MODULE.MERGE_OVERLAY.ANCHOR,
+        1,
+    )
+    report = run_audit(sources={"kv_cache_interface": doubled})
+    assert report["decision"] == "refuse"
+    assert report["checks"]["merge"]["inherited_merge"] == "unknown"
+    assert report["checks"]["merge"]["anchor_count"] == 2
+
+
+def test_missing_input_cli_exits_2(tmp_path: Path) -> None:
+    empty = tmp_path / "empty.py"
+    empty.write_text("")
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--kv-cache-interface",
+            str(empty),
+            "--overlay-dir",
+            str(OVERLAY),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 2
+    assert '"decision": "refuse"' in result.stdout
+
+
+def test_overlay_wired_six_ways() -> None:
+    host_var = "KV_MERGE_ASSERT_PATCH_HOST"
+    fname = PATCH
+    assert (OVERLAY / fname).is_file()
+    assert f'{host_var}="${{{host_var}:-$SCRIPT_DIR/overlay/{fname}}}"' in START
+    assert f'[ -f "${host_var}" ] || die "${host_var} missing"' in START
+    assert (
+        f'scp -q -o BatchMode=yes "${host_var}" "${{WORKER_SSH}}:/tmp/{fname}"'
+        in START
+    )
+    assert f"-v '/tmp/{fname}:/opt/glm53/{fname}:ro'" in START
+    assert f'-v "${host_var}:/opt/glm53/{fname}:ro"' in START
+    assert START.count(f"python3 -S /opt/glm53/{fname}") == 2
+
+
+def test_live_dump_adopts_when_present() -> None:
+    if not (LIVE / "v1/kv_cache_interface.py").is_file():
+        return
+    report = MODULE.audit(
+        MODULE.sources_from_site(LIVE),
+        compact_overlays(),
+        {
+            "spec_method": "dflash",
+            "max_num_seqs": 4,
+            "long_prefill_token_threshold": 1792,
+            "vllm_use_v2_model_runner": None,
+            "index_kpool": 4,
+        },
+    )
+    assert report["decision"] == "adopt"
+    assert report["checks"]["merge"]["inherited_merge"] == "assert"
+    assert report["checks"]["merge"]["fp8_ds_mla_656"] is True
+    assert report["checks"]["spec"]["legacy_dflash_has_set_attn"] is False


### PR DESCRIPTION
## Summary

Adopt the P1 compatibility lane (tasks 27 + 13 + 17) on the live V2 production path.

- Port inherited KVCacheSpec.merge from assert to raise AssertionError (overlay/patch_kv_merge_assert.py, vLLM #55234) so grouping stays fail-closed under python -O. MLA non_causal_multi_token_decode=any(...) and 656 B/token fp8_ds_mla were already live and are not rewritten.
- Wire the overlay six ways and refuse VLLM_USE_V2_MODEL_RUNNER=0 and SPEC_METHOD=mtp when MAX_NUM_SEQS > 12 in start.sh validate before stop/restart. Production already uses the V2 runner; forcing 1 is a no-op.
- Add fail-closed scripts/audit_source_compat.py plus compact tests/fixtures/source-compat/ contracts. Park #54374, #55178, #55449, #54394 and #55061 on this exact image. Do not raise LPTT or swap the stock image.

## Cluster receipts

Guarded restart on glm53-selfbuild:b5ab8091-s2b. Watchdog stopped first. Validate and both refusals ran before stop. Rollback at /home/nvidia/glm53-task27-backup-20260907T152959Z.

- Both ranks: kv-merge-assert patched, V2 retained, raise marker present, inherited assert gone
- Health 200, warmup 20/20 in 32s
- Acceptance 7/7, serving 6/6
- running/waiting/preemptions/errors 0
- Watchdog re-armed

Local: pytest tests/ -q --ignore=tests/fixtures -> 192 passed, 1 skipped, 4 subtests passed.

## Parked

#54374 (no live DFlash set_attn AOT), #55178 (GDN draft tags, not BaseMamba), #55449 (already 656), #54394 (LPTT 1792 at TP2 = 896 rows/rank), #55061 (C4 uses fused exl3_moe; no ncu probe claimed).
