### PR TITLE
ExLlamaV3: adopt native v1.4.7 serving image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ tool-eval-bench/
 __pycache__/
 *.py[cod]
 .pytest_cache/
+.venv/
 
 
 # Local working ledgers — maintained on disk, never tracked

--- a/Dockerfile
+++ b/Dockerfile
@@ -375,9 +375,10 @@ COPY overlay/exl3_fat_gemm.cuh /opt/glm53/exl3-fat-kernel/exl3_fat_gemm.cuh
 COPY overlay/patch_exl3_ticket_scheduler.py /opt/glm53/patch_exl3_ticket_scheduler.py
 COPY overlay/exl3-ticket/ /opt/glm53/exl3-ticket/
 
-ARG EXLLAMAV3_COMMIT=c5d9c657966ffeeaa9353f0cc899f18629da4a13
-# Build-time opt-out for the S2a ticket-scheduler overlay (docs/11 S2a):
-# --build-arg GLM53_EXL3_TICKET_SCHEDULER=0 ships the pristine pin ext.
+ARG EXLLAMAV3_COMMIT=ca13bdd83a1f4a74fd817b88f49509e0f22a9b07
+# v1.4.7 already contains the d5e4361 ticket scheduler. The installer is
+# retained for the historical c5d9c657 pin and skips native v1.4.7 trees.
+# --build-arg GLM53_EXL3_TICKET_SCHEDULER=0 still skips the overlay.
 # Rollback at runtime = previous image tag + .env IMAGE= flip (the scheduler
 # is compile-time, not a runtime knob).
 ARG GLM53_EXL3_TICKET_SCHEDULER=1
@@ -420,16 +421,18 @@ print("registered exl3 in QUANTIZATION_METHODS (lazy import)")
 PY
 
 # The vLLM image keeps CUDA toolkit headers under nvidia/cu13 (cusparse.h), not
-# /usr/local/cuda/include. ExLlamaV3 also ships AVX2/AVX512 CPU targets that
-# do not compile on aarch64; stub them so the SM121 GEMM still builds.
+# /usr/local/cuda/include. ExLlamaV3 also ships AVX2/AVX512 CPU targets and,
+# from v1.4.7, an unguarded x86 CPU-MoE TU; stub them so the SM121 GEMM still
+# builds. Do not copy published x86_64 wheels onto these aarch64 nodes.
 RUN set -eux; \
     mkdir -p /tmp/exllamav3; \
     curl -fsSL "https://github.com/turboderp-org/exllamav3/archive/${EXLLAMAV3_COMMIT}.tar.gz" \
       | tar -xz -C /tmp/exllamav3 --strip-components=1; \
-    python3 -c "from pathlib import Path; assert (Path('/tmp/exllamav3')/'exllamav3/modules/quant/exl3.py').is_file()"; \
+    python3 -c "from pathlib import Path; p = Path('/tmp/exllamav3'); assert (p/'exllamav3/modules/quant/exl3.py').is_file(); ver = (p/'exllamav3/version.py').read_text(); assert '1.4.7' in ver, ver"; \
     python3 /opt/glm53/patch_exl3_ext_aarch64.py /tmp/exllamav3/exllamav3/exllamav3_ext; \
     python3 /opt/glm53/patch_exl3_fat_kernel.py /tmp/exllamav3/exllamav3/exllamav3_ext /opt/glm53/exl3-fat-kernel; \
     python3 /opt/glm53/patch_exl3_ticket_scheduler.py /tmp/exllamav3/exllamav3/exllamav3_ext; \
+    python3 -c "from pathlib import Path; root = Path('/tmp/exllamav3/exllamav3/exllamav3_ext'); markers=(b'immintrin.h', b'__builtin_ia32_pause', b'_mm_pause', b'__attribute__((target(\"avx', b'target_clones(\"avx', b'__builtin_cpu_supports'); hits=[p for p in root.rglob('*') if p.suffix in {'.c','.cpp','.h','.hpp','.cu','.cuh'} and any(m in p.read_bytes() for m in markers)]; assert not hits, hits; moe=(root/'cpu'/'moe_mul1.cpp'); assert moe.is_file() and 'GLM53_AARCH64_CPU_MOE_STUB' in moe.read_text(); handoff=(root/'cpu'/'moe_handoff.cu').read_text(); assert 'GLM53_AARCH64_CPU_PAUSE_STUB' in handoff; assert 'is_f16c_supported' in (root/'avx2_target.h').read_text(); assert 'bool is_f16c_supported() { return false; }' in (root/'avx2_target.cpp').read_text(); bind=(root/'bindings.cpp').read_text(); assert 'exl3_fat_gemm' in bind"; \
     export CPATH="/usr/local/lib/python3.12/dist-packages/nvidia/cu13/include${CPATH:+:$CPATH}"; \
     export CPLUS_INCLUDE_PATH="/usr/local/lib/python3.12/dist-packages/nvidia/cu13/include${CPLUS_INCLUDE_PATH:+:$CPLUS_INCLUDE_PATH}"; \
     export C_INCLUDE_PATH="/usr/local/lib/python3.12/dist-packages/nvidia/cu13/include${C_INCLUDE_PATH:+:$C_INCLUDE_PATH}"; \
@@ -448,6 +451,7 @@ RUN set -eux; \
 # rebuild exllamav3_ext. Exl3Config.override_quantization_method requires
 # "exl3" in ModelConfig's ordered overrides list.
 COPY overlay/exl3.py /usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/quantization/exl3.py
+COPY overlay/exl3_namespace.py /usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/quantization/exl3_namespace.py
 COPY overlay/patch_model_overrides.py /opt/glm53/patch_model_overrides.py
 COPY overlay/qwen3_dflash2.py /opt/glm53/qwen3_dflash2.py
 COPY overlay/dflash2_speculator.py /opt/glm53/dflash2_speculator.py

--- a/README.md
+++ b/README.md
@@ -115,8 +115,9 @@ the official enablement lineage **before** it merged upstream (#53906 is still o
 and the tree predates vLLM's native DFlash2). Preview code is why this kit pins the
 base **by digest** and adds every capability explicitly, verified on the real pair:
 
-- **EXL3 kernels** — `exllamav3` built for aarch64/sm_121 at a pinned commit; keeps
-  the 320B experts packed at 82 GiB/node, which is what leaves room for the 1M pool.
+- **EXL3 kernels** — `exllamav3` built for aarch64/sm_121 at pinned **v1.4.7
+  `ca13bdd`**; keeps the 320B experts packed at 82 GiB/node, which is what
+  leaves room for the 1M pool.
 - **MoE expert kernels, hand-tuned for GB10** — this repo's fat-expert GEMM for
   oversized prefill experts, upstream's dynamic ticket scheduler in the fused
   launch, and a 3-stage `cp.async` pipeline (+41% kernel throughput at production
@@ -207,8 +208,9 @@ clients. **Tokenize** is mounted at the root (`/v1/tokenize` is 404) and validat
 > code: this repo carries (1) the **fat-expert GEMM** (`overlay/exl3_fat_gemm.cu`
 > — oversized prefill experts run a fused trellis-GEMM + Hadamard + scatter
 > launch instead of per-expert reconstruction), (2) the **dynamic ticket
-> scheduler** in the fused `exl3_moe` kernel (upstream exllamav3 `d5e4361`,
-> cherry-picked — idle SM groups steal heavy experts instead of round-robin),
+> scheduler** in the fused `exl3_moe` kernel (native in v1.4.7; originally
+> cherry-picked from `d5e4361` onto `c5d9c657` — idle SM groups steal heavy
+> experts instead of round-robin),
 > and (3) a **3-stage `cp.async` pipeline** in the fat GEMM k-loop —
 > **+38.6/+41.4/+40.8%** kernel throughput at production shapes (52 → ~73.5
 > TFLOP/s), bit-exact vs the stock kernel over 56 comparisons,

--- a/docs/06-improvement-plan.md
+++ b/docs/06-improvement-plan.md
@@ -22,8 +22,9 @@ fusions, and all of EXL3 — zero EXL3 code exists in vLLM mainline). Consequenc
 
 ## Current queue (research refresh, 2026-09-05)
 
-The S1/S2 kernel program is closed. Production is `glm53-selfbuild:b5ab8091-s2b`
-(fat GEMM pipelined, ticket scheduler live). The initial contended **+0.3%**
+The S1/S2 kernel program is closed. Production is `glm53-selfbuild:ca13bdd-v147`
+(ExLlamaV3 v1.4.7 native pin, fat GEMM pipelined, ticket scheduler native).
+Rollback remains `glm53-selfbuild:b5ab8091-s2b`. The initial contended **+0.3%**
 end-to-end result is superseded by PR #32's powered re-window:
 **+5.3–5.6% cold prefill**. Further kernel work needs a new current-stack
 profile, not extrapolation from the isolated +41% kernel result.
@@ -35,6 +36,97 @@ implementation below still made no runtime/config change or performance claim.
 Mainline GLM support (#53906) has merged, so model resolution is no longer the
 mainline blocker described in the historical section above; EXL3 integration
 and overlay compatibility still block a stock-image replacement.
+
+### 2026-09-07: task 16 ExLlamaV3 v1.4.7 image qualification
+
+Bundled rebuilt-image qualification of ExLlamaV3 v1.4.7
+`ca13bdd83a1f4a74fd817b88f49509e0f22a9b07`. Not a standalone performance
+window: the v1.4.6→v1.4.7 release does not change the production K4/MCG
+`exl3_moe` hot path, and the custom fat-GEMM remains overlay-owned. Reachable
+release changes are bounds/device/allocation hardening and an autotune-cache
+race fix. Expected fused-MoE/decode gain is zero.
+
+Three build/runtime blockers, all fail-closed on the host before any cluster
+restart:
+
+1. `overlay/patch_exl3_ext_aarch64.py` now stubs the unguarded x86
+   `cpu/moe_mul1.cpp` (`<immintrin.h>` / AVX target attributes) in addition
+   to AVX CPU-target / all-reduce TUs. AVX2 stubs expose
+   `is_f16c_supported() { return false; }` so `all_reduce_cpu.cu` still
+   compiles (native-TP CPU reduce is not the serving path). Leftover
+   `__builtin_ia32_pause` / `_mm_pause` in `cpu/moe_handoff.cu` and
+   `parallel/all_reduce_cpu.cu` become `std::this_thread::yield()`.
+   Leftover `immintrin.h`, x86 pause, `target("avx...")` and
+   `__builtin_cpu_supports` fail closed. Callers of CPU MoE raise a
+   runtime error on aarch64 — fused GPU `exl3_moe` is the serving path.
+2. `overlay/patch_exl3_ticket_scheduler.py` skips the exact pinned v1.4.7
+   (`ca13bdd`) quant SHA256 set — including `exl3_moe.cuh`, which is
+   byte-identical to the historical patched header — instead of treating
+   that shared header as mixed native/c5d9 state. The byte-exact c5d9c657
+   installer is retained for that historical pin. Mixed native/pristine
+   trees and ordinary drift still fail closed. Host fixtures are the
+   exact `ca13bdd` quant sources under `tests/fixtures/exl3-v147/quant/`.
+3. `overlay/exl3_namespace.py` injects `NullConfig`/`InferParams` so
+   v1.4.7 `LinearEXL3(config=None)` can read `config.infer_params`. The
+   previous Config-only stub would AttributeError at first construction.
+
+Host fixtures under `tests/fixtures/exl3-v147/` cover those three
+conditions plus the existing fat-kernel binding anchors. Control remains
+`glm53-selfbuild:b5ab8091-s2b`. Candidate image tag is
+`glm53-selfbuild:ca13bdd-v147`. Same-day A-B-B-A gates: extension
+import/signature, fallback rows ≤144 and >144, structured/serving/tool/
+vision/thinking-SSE, acceptance 7/7, pool bytes and both-node memory
+headroom unchanged, cold 60k/240k prefill and decode non-inferior. Abort
+on any build assertion, ext exception, output mismatch/corruption,
+CUDA/Xid/IMA, worker loss, `MemFree < 2.5 GiB`, or >2% reproducible
+hot-path regression. Adopt for maintenance/hardening only after parity.
+
+Fused reconstruct (`d33be5c`) is expected dormant: it engages only
+through `LinearEXL3.forward` at rows ≥1024, while the primary production
+path is fused `exl3_moe`/`exl3_fat_gemm`. Prove whether fallback reaches
+it during the cluster window; if it does, compare
+`EXL3_NO_FUSED_RECONSTRUCT=1/0` for output parity instead of attributing
+an upstream-claimed fallback gain to the whole deployment. Autotune
+robustness (`d409d3d` + `555ee4f` + v1.4.7 atomic disk-cache update) rides
+this rebuild; re-prove bit-exact parity if tile/split selection changes.
+
+**Cluster verdict: ADOPT `glm53-selfbuild:ca13bdd-v147` for
+maintenance/hardening. No performance claim.**
+
+Guarded 2026-09-07 window versus control `glm53-selfbuild:b5ab8091-s2b`
+(digest `sha256:87a2cfd32aec…`). Candidate image digest
+`sha256:07ce8a41078a…`. Live production tree overlays were not mutated;
+the candidate was built from a sibling tree and selected only by
+`IMAGE=`.
+
+| Gate | A-control | B-candidate | Return-A | Adopt |
+|---|---|---|---|---|
+| Acceptance | 7/7 | 7/7 | 7/7 | 7/7 |
+| Serving (tunnel :18000) | 6/6 | 6/6 | 6/6 | 6/6 |
+| Pool | 1,396,551 / 1.40× | identical | identical | identical |
+| Structured median tok/s | 70.08 | 70.03 (b2; b1 69.29 with one 24 tok/s contended pass) | not re-sampled | 69.91 |
+| Accept / drafts | 1.0000 / 7.0 | 1.0000 / 7.0 | 1.0000 / 7.0 | 1.0000 / 7.0 |
+| Health / bind | 200 / loopback | 200 / loopback | 200 / loopback | 200 / loopback |
+| MemFree head/worker GiB | 4.9 / 5.2 | 4.7 / (B SSH awk miss) | 4.2 / 4.1 | 6.2 / 4.3 |
+
+B1's 24 tok/s pass kept accept 1.0000/7.0; b2 (70.03) matches control
+within 0.1%. Adopt structured 69.91 is −0.24% versus 70.08, inside the
+>2% abort. Routed experts logged `fused_moe=exl3_moe` with no BF16
+reconstruct at load, so the fused-reconstruct LinearEXL3 fallback
+(`d33be5c`) stayed dormant and `EXL3_NO_FUSED_RECONSTRUCT` was not
+toggled. Native ticket skip, `exl3_namespace.py`, fat GEMM, and
+30-arg `exl3_moe` pybind all present in-image.
+
+Cold 60k/240k prefill was **not** re-measured. This pin is
+maintenance/hardening with expected fused-MoE/decode gain of zero;
+decode, acceptance, serving and pool already matched. Do not read
+this adoption as a prefill win.
+
+Watchdog timer was re-armed only after `watchdog.service` was
+inactive. Rollback remains
+`IMAGE=glm53-selfbuild:b5ab8091-s2b` via
+`.env.bak-pre-task16-v147-20260907` (hash `6e7a206e…`). Do not copy
+v1.4.7's published x86_64 wheels onto the Sparks.
 
 ### 2026-09-07: tasks 27 + 13 + 17 compatibility lane
 

--- a/docs/10-selfbuild-production.md
+++ b/docs/10-selfbuild-production.md
@@ -27,7 +27,7 @@ upstream's).
 | Base image | `vllm/vllm-openai:glm53-flash-arm64-cu130` @ `sha256:905c0293…` (day-0 GLM-5.3 **preview** image, digest-pinned `FROM`) |
 | vLLM inside | `0.1.dev20051+g487ecf187` — pre-release dev build from the official enablement lineage, cut **before** #53906 merged and before vLLM's native DFlash2 |
 | Attention/CUDA stack | FlashInfer 0.6.17 (`FLASHINFER_MLA_SPARSE_SM120`), CUDA 13, CUDA graphs on (token-batch capture sizes 1–32 to cover k=7 verify) |
-| Quantization | EXL3 4 bpw (`--quantization exl3`, fused `exl3_moe`), `exllamav3` built in-image at commit `c5d9c657` for aarch64/sm_121 — weights load **82 GiB/node packed** |
+| Quantization | EXL3 4 bpw (`--quantization exl3`, fused `exl3_moe`), `exllamav3` built in-image at **v1.4.7 `ca13bdd`** for aarch64/sm_121 — weights load **82 GiB/node packed**. Cutover used `c5d9c657` (0.0.43); the ticket scheduler was later cherry-picked as S2a. Task 16 adopted the native v1.4.7 pin (`glm53-selfbuild:ca13bdd-v147`); rollback is `b5ab8091-s2b`. |
 | Weights | `brandonmusic/GLM-5.3-Flash-tr3-4bpw`, snapshot `1ae6d704…` (~164 GiB, 120 shards) |
 | Drafter | `incoai/GLM-5.3-Flash-DFlash2`, snapshot `7d74cdd8…`, BF16, k=7, draft TP=1, **#54282 noise salt applied** |
 | Topology | TP=2 across two GB10 nodes (`--nnodes 2`), single RoCE rail, MTU 9000 |

--- a/docs/11-gb10-kernel-program.md
+++ b/docs/11-gb10-kernel-program.md
@@ -2,8 +2,8 @@
 
 Written 2026-09-02. Companion to `docs/06-improvement-plan.md` (the A/B ledger) and
 `docs/07-rebase-plan.md`. Sources: local receipts, the local exllamav3 tree
-(`~/Developer/dgx-spark/exllamav3`, upstream master `499890c` v1.4.6, fetched
-2026-09-02), and web research (exa) — cited inline.
+(`~/Developer/dgx-spark/exllamav3`; survey freeze was master `499890c` v1.4.6 on
+2026-09-02; task 16 pins v1.4.7 `ca13bdd`), and web research (exa) — cited inline.
 
 ## 1. Scope
 
@@ -116,10 +116,13 @@ APC-hit-contaminated; ours are same-image, same-boot-class, warm-JIT A/Bs and st
 ## 5. New finding: the pinned exllamav3 ext is 27 kernel commits behind upstream
 
 Local tree `~/Developer/dgx-spark/exllamav3` = upstream master `499890c` (v1.4.6);
-production pins `c5d9c657` (0.0.43). **434 commits behind overall, 27 touching
-`exllamav3_ext/quant`** (+`ptx.cuh`/`util.cuh`). The fat-kernel overlay anchors
-(`bindings.cpp` `#include "quant/exl3_moe.cuh"` and `m.def("exl3_moe", …)`) **still
-hold verbatim on HEAD** — `patch_exl3_fat_kernel.py` applies cleanly to master.
+the 2026-09-02 survey freeze still pinned production at `c5d9c657` (0.0.43),
+**434 commits behind overall, 27 touching `exllamav3_ext/quant`**. Task 16
+(2026-09-07) adopted native v1.4.7 `ca13bdd` as `glm53-selfbuild:ca13bdd-v147`;
+ticket scheduling is now upstream in the pin, and the custom fat-GEMM remains
+overlay-owned. The fat-kernel overlay anchors (`bindings.cpp`
+`#include "quant/exl3_moe.cuh"` and `m.def("exl3_moe", …)`) **still hold
+verbatim on HEAD** — `patch_exl3_fat_kernel.py` applies cleanly to master.
 
 Ranked relevance to this deployment:
 
@@ -135,10 +138,15 @@ Ranked relevance to this deployment:
 | `56e0b84` | TP `pg_gather_kernel` missing `__syncthreads` race fix | vLLM serve does not use exllamav3's own TP; N/A likely |
 | `e82c1cf` | Extension split into `comp_units/` | Build restructuring; anchors verified OK |
 
-**Honest caveat:** a full pin advance (434 commits, python-side 0.0.43→1.4.6) is a
-rebase-scale change; the cheap path is an S2-window that cherry-picks the
-quant-kernel range onto the pinned ext (kernel sources are self-contained; overlay
-anchors verified). Both go through the standing protocol with a JIT wipe expected.
+**Honest caveat (2026-09-02):** a full pin advance (434 commits, python-side
+0.0.43→1.4.6) is a rebase-scale change; the cheap path then was an S2-window
+that cherry-picks the quant-kernel range onto the pinned ext. **Task 16
+(2026-09-07) now pins v1.4.7 `ca13bdd` as a bundled image rebuild.** The
+v1.4.6→v1.4.7 delta does not change the production K4/MCG `exl3_moe` hot
+path; ticket scheduling is native; the custom fat-GEMM remains overlay-owned.
+Expected fused-MoE/decode gain is zero. Cluster window adopted the pin
+for maintenance/hardening after acceptance/serving/pool/decode parity;
+not a performance claim.
 
 ## 6. Stage plans
 
@@ -222,10 +230,13 @@ rollback = `IMAGE=` flip to `b5ab8091-w24`.
   experts instead of serializing their statically assigned share under skewed
   agentic traffic). Dynamic group widening stays latent until a caller passes a
   real count (would need a D2H sync; deliberately not taken).
-- **Packaging:** `overlay/patch_exl3_ticket_scheduler.py` — byte-exact three-state
-  installer (patched→skip / pristine→atomic replace / anything else→fail closed)
-  over vendored `overlay/exl3-ticket/{pristine,patched}` sets (pin bytes vs
-  pin+d5e4361 bytes); build-time opt-out `GLM53_EXL3_TICKET_SCHEDULER=0` (real
+- **Packaging:** `overlay/patch_exl3_ticket_scheduler.py` — byte-exact four-state
+  installer. Native skip is SHA256-exact against the pinned v1.4.7 (`ca13bdd`)
+  quant set, including `exl3_moe.cuh` which is byte-identical to the historical
+  patched header. Historical c5d9c657: patched→skip / pristine→atomic replace.
+  Mixed native/c5d9 or any other drift fails closed with no writes. Vendored
+  sets live in `overlay/exl3-ticket/{pristine,patched}`; native hashes live in
+  the installer. Build-time opt-out `GLM53_EXL3_TICKET_SCHEDULER=0` (real
   `ARG`+`ENV` forwarding; the build assert skips on opt-out builds); Dockerfile
   wired after the fat-kernel step with a pybind-safe `__doc__`-based build assert
   on the `num_active` signature (`inspect.signature` raises on pybind11 builtins;

--- a/local/task16-a-control-20260907.txt
+++ b/local/task16-a-control-20260907.txt
@@ -1,0 +1,15 @@
+TASK16 A-CONTROL 2026-09-07
+image=glm53-selfbuild:b5ab8091-s2b  sha256:87a2cfd32aece0d9cf682fd3bc7821f9c074c7b3cb537017f8a1e9b96cdb80dc
+env=6e7a206ec05be1cf624df167128470a313d12566b744e1f542808373aaf0983a
+shape_stamp=91fbe73a55b2590a3009762603dff284
+pool=1,396,551 tokens / 1.40x
+bind=127.0.0.1:8000
+health=200
+running=0 waiting=0
+watchdog.timer=active
+acceptance=7/7
+serving=6/6 (tunnel :18000)
+structured_median_tok_s=70.07696140661014  accept=1.0000/7.0  nan=false
+exl3_commit_in_image=c5d9c657  version=0.0.43
+ticket_doc_num_active=False  fat_gemm=True
+MemFree_head_kB=5092668  MemFree_worker_kB=5440560

--- a/local/task16-a-structured-20260907.json
+++ b/local/task16-a-structured-20260907.json
@@ -1,0 +1,145 @@
+{
+  "phase": "a-control",
+  "health_code": 200,
+  "health_body": "",
+  "runs": [
+    {
+      "http": 200,
+      "ttft_s": 0.373138042,
+      "wall_s": 3.215131292,
+      "decode_s": 2.8419932500000002,
+      "tok_s": 70.0212781997283,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.44266466699999985,
+      "wall_s": 3.1946069169999998,
+      "decode_s": 2.75194225,
+      "tok_s": 72.31256397186388,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.3532718750000008,
+      "wall_s": 3.193006875,
+      "decode_s": 2.8397349999999992,
+      "tok_s": 70.07696140661014,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    }
+  ],
+  "ts": 1788801312.279074,
+  "prompt": "structured-count-1-200",
+  "thinking": false,
+  "temperature": 0,
+  "warmup": {
+    "tok_s": 86.71329690058315,
+    "ttft_s": 0.37201441700000004,
+    "completion_tokens": 32
+  },
+  "tok_s_median": 70.07696140661014,
+  "tok_s_min": 70.0212781997283,
+  "tok_s_max": 72.31256397186388,
+  "ttft_median_s": 0.373138042,
+  "completion_tokens_median": 200.0,
+  "accept_ratio_median": 1.0,
+  "accepted_per_step_median": 7.0,
+  "any_nan": false,
+  "health_code_after": 200,
+  "short_after": {
+    "http": 200,
+    "ttft_s": 0.3945190409999988,
+    "wall_s": 0.5226950829999986,
+    "decode_s": 0.12817604199999977,
+    "tok_s": 54.61239004399912,
+    "completion_tokens": 8,
+    "prompt_tokens": 40,
+    "finish_reason": "length",
+    "nan": false,
+    "text_head": "# How a Hash Map Works: A",
+    "text_len": 25,
+    "usage": {
+      "prompt_tokens": 40,
+      "total_tokens": 48,
+      "completion_tokens": 8
+    }
+  }
+}

--- a/local/task16-adopt-20260907.txt
+++ b/local/task16-adopt-20260907.txt
@@ -1,0 +1,25 @@
+TASK16 ADOPT 2026-09-07
+image=glm53-selfbuild:ca13bdd-v147
+digest=sha256:07ce8a41078ad4b28eb3dc629da51e736b0c530544b252922c7fd9dcf6f257d1
+env=1d7fe6d93459625274662f6875637dc28782156d6f048c950e99e309ca435de1
+rollback=.env.bak-pre-task16-v147-20260907 IMAGE=glm53-selfbuild:b5ab8091-s2b
+pool=1,396,551 tokens / 1.40x
+bind=127.0.0.1:8000
+health=200
+running=0
+unit=active
+watchdog.timer=active  (re-armed after watchdog.service inactive)
+acceptance=7/7
+serving=6/6 (tunnel :18000)
+structured_median_tok_s=69.90882813129107  min=69.786 max=70.046  accept=1.0000/7.0  nan=false
+control_structured_median=70.07696140661014
+exl3_commit_in_image=ca13bdd83a1f4a74fd817b88f49509e0f22a9b07  version=1.4.7
+namespace_exists=True
+ticket_doc_num_active=False  args=30  fat_gemm=True
+fused_moe=exl3_moe  no BF16 expert reconstruct at load
+warmup=20/20 in 25s
+content_warmup=droid-exec.json 9s
+MemFree_head_GiB=6.2
+MemFree_worker_GiB=4.3
+both_ranks=ca13bdd-v147
+prefill_60k_240k=not re-measured (maintenance/hardening pin; expected fused-MoE/decode gain zero)

--- a/local/task16-adopt-structured-20260907.json
+++ b/local/task16-adopt-structured-20260907.json
@@ -1,0 +1,145 @@
+{
+  "phase": "adopt",
+  "health_code": 200,
+  "health_body": "",
+  "runs": [
+    {
+      "http": 200,
+      "ttft_s": 0.36366983399999997,
+      "wall_s": 3.2102345000000003,
+      "decode_s": 2.8465646660000004,
+      "tok_s": 69.90882813129107,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.3580856250000002,
+      "wall_s": 3.2096483749999996,
+      "decode_s": 2.8515627499999994,
+      "tok_s": 69.78629525161249,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.3634743330000001,
+      "wall_s": 3.2044830419999997,
+      "decode_s": 2.8410087089999996,
+      "tok_s": 70.04554381322033,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    }
+  ],
+  "ts": 1788806860.1665769,
+  "prompt": "structured-count-1-200",
+  "thinking": false,
+  "temperature": 0,
+  "warmup": {
+    "tok_s": 86.13026121768995,
+    "ttft_s": 0.377087292,
+    "completion_tokens": 32
+  },
+  "tok_s_median": 69.90882813129107,
+  "tok_s_min": 69.78629525161249,
+  "tok_s_max": 70.04554381322033,
+  "ttft_median_s": 0.3634743330000001,
+  "completion_tokens_median": 200.0,
+  "accept_ratio_median": 1.0,
+  "accepted_per_step_median": 7.0,
+  "any_nan": false,
+  "health_code_after": 200,
+  "short_after": {
+    "http": 200,
+    "ttft_s": 0.3811989579999988,
+    "wall_s": 0.49701504099999916,
+    "decode_s": 0.11581608300000035,
+    "tok_s": 60.44065572481828,
+    "completion_tokens": 8,
+    "prompt_tokens": 40,
+    "finish_reason": "length",
+    "nan": false,
+    "text_head": "# How a Hash Map Works: A",
+    "text_len": 25,
+    "usage": {
+      "prompt_tokens": 40,
+      "total_tokens": 48,
+      "completion_tokens": 8
+    }
+  }
+}

--- a/local/task16-b-candidate-20260907.txt
+++ b/local/task16-b-candidate-20260907.txt
@@ -1,0 +1,24 @@
+TASK16 B-CANDIDATE 2026-09-07
+image=glm53-selfbuild:ca13bdd-v147  sha256:07ce8a41078ad4b28eb3dc629da51e736b0c530544b252922c7fd9dcf6f257d1
+env=1d7fe6d93459625274662f6875637dc28782156d6f048c950e99e309ca435de1
+control_env_backup=.env.bak-pre-task16-v147-20260907 6e7a206ec05be1cf624df167128470a313d12566b744e1f542808373aaf0983a
+shape_stamp=93eb38bbe6b5f7969a84a7fdf326322c  (IMAGE changed; JIT wipe both nodes)
+pool=1,396,551 tokens / 1.40x
+bind=127.0.0.1:8000
+health=200
+running=0
+unit=active
+watchdog.timer=inactive (window)
+acceptance=7/7
+serving=6/6 (tunnel :18000)
+structured_b1_median_tok_s=69.2887728150058  min=24.279 (contended) max=69.683  accept=1.0000/7.0  nan=false
+structured_b2_median_tok_s=70.0339434323071  min=69.591 max=70.119  accept=1.0000/7.0  nan=false
+control_structured_median=70.07696140661014
+exl3_commit_in_image=ca13bdd83a1f4a74fd817b88f49509e0f22a9b07  version=1.4.7
+namespace_exists=True
+ticket_doc_num_active=False  args=30  fat_gemm=True  (native v1.4.7 pybind names; Dockerfile accepted arg-count>=30)
+warmup=20/20 in 43s
+content_warmup=droid-exec.json 9s
+MemFree_head_GiB=4.7
+build=cpu_moe=stubbed x86_pause=all_reduce_cpu.cu,moe_handoff.cu f16c=stubbed native_ticket_skip
+wheel=exllamav3-1.4.7-cp312-cp312-linux_aarch64.whl

--- a/local/task16-b-structured-20260907.json
+++ b/local/task16-b-structured-20260907.json
@@ -1,0 +1,145 @@
+{
+  "phase": "b-candidate",
+  "health_code": 200,
+  "health_body": "",
+  "runs": [
+    {
+      "http": 200,
+      "ttft_s": 0.3672024999999999,
+      "wall_s": 3.223008667,
+      "decode_s": 2.8558061670000003,
+      "tok_s": 69.68260041578654,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.35390174999999946,
+      "wall_s": 8.550225667,
+      "decode_s": 8.196323917,
+      "tok_s": 24.279177106123633,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.48158954200000004,
+      "wall_s": 3.353627708000001,
+      "decode_s": 2.872038166000001,
+      "tok_s": 69.2887728150058,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    }
+  ],
+  "ts": 1788804937.0313542,
+  "prompt": "structured-count-1-200",
+  "thinking": false,
+  "temperature": 0,
+  "warmup": {
+    "tok_s": 87.07571654888038,
+    "ttft_s": 0.371985458,
+    "completion_tokens": 32
+  },
+  "tok_s_median": 69.2887728150058,
+  "tok_s_min": 24.279177106123633,
+  "tok_s_max": 69.68260041578654,
+  "ttft_median_s": 0.3672024999999999,
+  "completion_tokens_median": 200.0,
+  "accept_ratio_median": 1.0,
+  "accepted_per_step_median": 7.0,
+  "any_nan": false,
+  "health_code_after": 200,
+  "short_after": {
+    "http": 200,
+    "ttft_s": 0.38359791699999946,
+    "wall_s": 0.5033405420000001,
+    "decode_s": 0.11974262500000066,
+    "tok_s": 58.45871509831993,
+    "completion_tokens": 8,
+    "prompt_tokens": 40,
+    "finish_reason": "length",
+    "nan": false,
+    "text_head": "# How a Hash Map Works: A",
+    "text_len": 25,
+    "usage": {
+      "prompt_tokens": 40,
+      "total_tokens": 48,
+      "completion_tokens": 8
+    }
+  }
+}

--- a/local/task16-b2-structured-20260907.json
+++ b/local/task16-b2-structured-20260907.json
@@ -1,0 +1,145 @@
+{
+  "phase": "b2-candidate",
+  "health_code": 200,
+  "health_body": "",
+  "runs": [
+    {
+      "http": 200,
+      "ttft_s": 0.35751987499999993,
+      "wall_s": 3.198999167,
+      "decode_s": 2.841479292,
+      "tok_s": 70.0339434323071,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.3605879159999992,
+      "wall_s": 3.2201656659999998,
+      "decode_s": 2.8595777500000006,
+      "tok_s": 69.59069394074001,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.3600404580000003,
+      "wall_s": 3.1980640410000003,
+      "decode_s": 2.838023583,
+      "tok_s": 70.11922000649562,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    }
+  ],
+  "ts": 1788804984.422323,
+  "prompt": "structured-count-1-200",
+  "thinking": false,
+  "temperature": 0,
+  "warmup": {
+    "tok_s": 86.54956882261176,
+    "ttft_s": 0.36051775,
+    "completion_tokens": 32
+  },
+  "tok_s_median": 70.0339434323071,
+  "tok_s_min": 69.59069394074001,
+  "tok_s_max": 70.11922000649562,
+  "ttft_median_s": 0.3600404580000003,
+  "completion_tokens_median": 200.0,
+  "accept_ratio_median": 1.0,
+  "accepted_per_step_median": 7.0,
+  "any_nan": false,
+  "health_code_after": 200,
+  "short_after": {
+    "http": 200,
+    "ttft_s": 0.38358875000000126,
+    "wall_s": 0.5022948340000006,
+    "decode_s": 0.11870608399999938,
+    "tok_s": 58.9691763397741,
+    "completion_tokens": 8,
+    "prompt_tokens": 40,
+    "finish_reason": "length",
+    "nan": false,
+    "text_head": "# How a Hash Map Works: A",
+    "text_len": 25,
+    "usage": {
+      "prompt_tokens": 40,
+      "total_tokens": 48,
+      "completion_tokens": 8
+    }
+  }
+}

--- a/local/task16-return-a-20260907.txt
+++ b/local/task16-return-a-20260907.txt
@@ -1,0 +1,17 @@
+TASK16 RETURN-A CONTROL 2026-09-07
+image=glm53-selfbuild:b5ab8091-s2b
+env=6e7a206ec05be1cf624df167128470a313d12566b744e1f542808373aaf0983a
+backup=.env.bak-pre-task16-v147-20260907  identical
+pool=1,396,551 tokens / 1.40x
+bind=127.0.0.1:8000
+health=200
+running=0
+unit=active
+watchdog.timer=inactive (window; re-armed only after adopt)
+acceptance=7/7
+serving=6/6 (tunnel :18000)
+warmup=20/20 in 33s
+content_warmup=droid-exec.json 9s
+MemFree_head_GiB=4.2
+MemFree_worker_GiB=4.1
+both_ranks=b5ab8091-s2b

--- a/overlay/exl3.py
+++ b/overlay/exl3.py
@@ -13,12 +13,7 @@ runner all-reduces the combined output.
 
 from __future__ import annotations
 
-import importlib
-import importlib.util
 import os
-import sys
-import types
-from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import torch
@@ -35,6 +30,12 @@ from vllm.model_executor.layers.quantization.base_config import QuantizationConf
 from vllm.model_executor.layers.quantization import register_quantization_config
 from vllm.model_executor.utils import set_weight_attrs
 
+from vllm.model_executor.layers.quantization.exl3_namespace import (  # noqa: F401
+    InferParams,
+    NullConfig,
+    load_linear_exl3_cls,
+)
+
 if TYPE_CHECKING:
     from vllm.model_executor.layers.fused_moe.routed_experts import RoutedExperts
     from vllm.model_executor.layers.fused_moe.runner.shared_experts import (
@@ -43,8 +44,8 @@ if TYPE_CHECKING:
 
 logger = init_logger(__name__)
 
-EXLLAMAV3_COMMIT = "c5d9c657966ffeeaa9353f0cc899f18629da4a13"
-EXLLAMAV3_VERSION = "0.0.43"
+EXLLAMAV3_COMMIT = "ca13bdd83a1f4a74fd817b88f49509e0f22a9b07"
+EXLLAMAV3_VERSION = "1.4.7"
 MCG_MULTIPLIER = 0xCBAC1FED
 MCG_MARKER_SIGNED_INT32 = -877912083
 EXL3_SUFFIXES = ("trellis", "suh", "svh", "mcg")
@@ -195,45 +196,6 @@ def shard_exl3_row(loaded: torch.Tensor, suffix: str, tp_rank: int, tp_size: int
     if suffix == "suh":
         return _narrow_tp(loaded, 0, tp_rank, tp_size)
     return loaded.contiguous()
-
-
-def _install_exllamav3_namespace() -> None:
-    """Load LinearEXL3 without running exllamav3/__init__.py (FlashAttention)."""
-    if "exllamav3.modules.quant.exl3" in sys.modules:
-        return
-    import exllamav3_ext  # noqa: F401  — compiled extension must exist
-
-    spec = importlib.util.find_spec("exllamav3")
-    if spec is None or not spec.submodule_search_locations:
-        raise RuntimeError("exllamav3 package is not installed in this image")
-    package_root = Path(list(spec.submodule_search_locations)[0])
-
-    # Stub only packages whose __init__.py pulls FlashAttention / serving extras.
-    # Leave .ext, .util, and .modules.quant as real modules so LinearEXL3 loads.
-    for name, path in (
-        ("exllamav3", package_root),
-        ("exllamav3.modules", package_root / "modules"),
-        ("exllamav3.model", package_root / "model"),
-    ):
-        if name in sys.modules:
-            continue
-        module = types.ModuleType(name)
-        module.__file__ = str(path / "__init__.py")
-        module.__package__ = name
-        module.__path__ = [str(path)]
-        sys.modules[name] = module
-
-    if "exllamav3.model.config" not in sys.modules:
-        config = types.ModuleType("exllamav3.model.config")
-        config.__file__ = str(package_root / "model/config.py")
-        config.__package__ = "exllamav3.model"
-        config.Config = type("Config", (), {})
-        sys.modules[config.__name__] = config
-
-
-def load_linear_exl3_cls():
-    _install_exllamav3_namespace()
-    return importlib.import_module("exllamav3.modules.quant.exl3").LinearEXL3
 
 
 def make_linear_exl3(

--- a/overlay/exl3_namespace.py
+++ b/overlay/exl3_namespace.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Stdlib-only LinearEXL3 namespace stub for the vLLM EXL3 overlay.
+
+v1.4.7 LinearEXL3 imports ``Config`` from ``exllamav3.model.config`` and, when
+``config is None``, constructs ``NullConfig`` so ``forward()`` can read
+``config.infer_params``. Loading the real ``exllamav3`` package pulls
+FlashAttention, so the overlay stubs only the packages that do that and
+injects compatible ``NullConfig``/``InferParams``.
+"""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+class InferParams:
+    """Minimal InferParams compatible with v1.4.7 LinearEXL3.
+
+    Real ``exllamav3.model.config.InferParams`` also owns CPU-MoE/vision/n-gram
+    knobs. This serving path never constructs those modules; LinearEXL3 only
+    reads ``no_reconstruct`` on the reconstruct-vs-GEMM gate. Defaults match an
+    unset InferParams (``no_reconstruct=False``).
+    """
+
+    no_reconstruct: bool = False
+    mgemm_K_threshold: int = 0
+    mgemm_n_threshold: int = 0
+
+    def __init__(self) -> None:
+        self.no_reconstruct = False
+        self.mgemm_K_threshold = 0
+        self.mgemm_n_threshold = 0
+
+
+class NullConfig:
+    """Stand-in for ``exllamav3.model.config.NullConfig``.
+
+    v1.4.7 LinearEXL3 replaces ``config=None`` with ``NullConfig()`` because
+    ``forward()`` reads ``config.infer_params``. The previous Config-only stub
+    lacked both names and would raise AttributeError at first LinearEXL3
+    construction.
+    """
+
+    def __init__(self) -> None:
+        self.infer_params = InferParams()
+
+
+def inject_config_stub(package_root: Path, modules: dict | None = None) -> types.ModuleType:
+    """Install package stubs plus ``NullConfig``/``InferParams`` into ``modules``."""
+    modules = sys.modules if modules is None else modules
+    package_root = Path(package_root)
+    for name, path in (
+        ("exllamav3", package_root),
+        ("exllamav3.modules", package_root / "modules"),
+        ("exllamav3.model", package_root / "model"),
+    ):
+        if name in modules:
+            continue
+        module = types.ModuleType(name)
+        module.__file__ = str(path / "__init__.py")
+        module.__package__ = name
+        module.__path__ = [str(path)]
+        modules[name] = module
+
+    existing = modules.get("exllamav3.model.config")
+    if existing is not None:
+        if not hasattr(existing, "NullConfig") or not hasattr(existing, "InferParams"):
+            raise RuntimeError(
+                "exllamav3.model.config is already loaded without NullConfig/InferParams"
+            )
+        return existing
+    config = types.ModuleType("exllamav3.model.config")
+    config.__file__ = str(package_root / "model/config.py")
+    config.__package__ = "exllamav3.model"
+    config.Config = type("Config", (), {})
+    config.InferParams = InferParams
+    config.NullConfig = NullConfig
+    modules[config.__name__] = config
+    return config
+
+
+def install_exllamav3_namespace() -> None:
+    """Load LinearEXL3 without running ``exllamav3/__init__.py`` (FlashAttention)."""
+    if "exllamav3.modules.quant.exl3" in sys.modules:
+        return
+    import exllamav3_ext  # noqa: F401  — compiled extension must exist
+
+    spec = importlib.util.find_spec("exllamav3")
+    if spec is None or not spec.submodule_search_locations:
+        raise RuntimeError("exllamav3 package is not installed in this image")
+    package_root = Path(list(spec.submodule_search_locations)[0])
+    inject_config_stub(package_root)
+
+
+def load_linear_exl3_cls():
+    install_exllamav3_namespace()
+    return importlib.import_module("exllamav3.modules.quant.exl3").LinearEXL3

--- a/overlay/patch_exl3_ext_aarch64.py
+++ b/overlay/patch_exl3_ext_aarch64.py
@@ -1,40 +1,284 @@
 #!/usr/bin/env python3
-"""Stub AVX CPU targets so ExLlamaV3's extension compiles on aarch64/GB10."""
+"""Stub AVX CPU targets so ExLlamaV3's extension compiles on aarch64/GB10.
+
+v1.4.7 also ships an unguarded x86 CPU-MoE TU (`cpu/moe_mul1.cpp`) that
+includes `<immintrin.h>` and AVX target attributes. setup.py recursively
+compiles every `.cpp`, so the previous AVX-only stubs still leave that file
+in the build. Replace it with an ABI-compatible aarch64 stub before compile.
+
+v1.4.7 `cpu/moe_handoff.cu` and `parallel/all_reduce_cpu.cu` still compile
+on aarch64 except for `__builtin_ia32_pause` / `_mm_pause`. Rewrite those
+to `std::this_thread::yield()` and fail closed if any leftover remains.
+"""
 
 from pathlib import Path
 import sys
 
-root = Path(sys.argv[1] if len(sys.argv) > 1 else "/tmp/exllamav3/exllamav3/exllamav3_ext")
-(root / "avx2_target.cpp").write_text(
-    '#include "avx2_target.h"\nbool is_avx2_supported() { return false; }\n'
+MOE_MUL1_STUB = """\
+#include "moe_mul1.h"
+
+#include <c10/util/Half.h>
+#include <torch/extension.h>
+
+#include <cstdint>
+#include <stdexcept>
+
+/* GLM53_AARCH64_CPU_MOE_STUB */
+
+void exl3_moe_cpu_set_prof(bool) {}
+
+bool exl3_moe_cpu_has_avx2() { return false; }
+bool exl3_moe_cpu_has_avx512_vnni() { return false; }
+bool exl3_moe_cpu_has_avx512_vbmi() { return false; }
+
+static void _cpu_moe_unavailable()
+{
+    throw std::runtime_error(
+        "exl3 CPU MoE is unavailable on aarch64/GB10; fused GPU exl3_moe is the serving path"
+    );
+}
+
+int64_t exl3_moe_cpu_make_layer
+(
+    const std::vector<at::Tensor>&,
+    const std::vector<at::Tensor>&,
+    const std::vector<at::Tensor>&,
+    const std::vector<at::Tensor>&,
+    const std::vector<at::Tensor>&,
+    const std::vector<at::Tensor>&,
+    const std::vector<at::Tensor>&,
+    const std::vector<at::Tensor>&,
+    const std::vector<at::Tensor>&,
+    const std::vector<at::Tensor>&,
+    const std::vector<at::Tensor>&,
+    const std::vector<at::Tensor>&,
+    int64_t,
+    double,
+    int64_t
 )
-(root / "avx512_target.cpp").write_text(
-    '#include "avx512_target.h"\nbool is_avx512_supported() { return false; }\n'
+{
+    _cpu_moe_unavailable();
+    return -1;
+}
+
+void exl3_moe_cpu_free_layer(int64_t) {}
+
+void exl3_moe_cpu_forward
+(
+    int64_t,
+    const at::Tensor&,
+    const at::Tensor&,
+    const at::Tensor&,
+    at::Tensor&,
+    int64_t
 )
-(root / "parallel/all_reduce_cpu_avx2.cpp").write_text(
-    """#include "all_reduce_cpu_avx2.h"
+{
+    _cpu_moe_unavailable();
+}
+
+void exl3_moe_cpu_forward_raw
+(
+    int64_t,
+    const at::Half*,
+    const int32_t*,
+    const at::Half*,
+    float*,
+    int,
+    int,
+    int
+)
+{
+    _cpu_moe_unavailable();
+}
+
+void exl3_moe_cpu_stage_experts
+(
+    int64_t,
+    const uint32_t*,
+    int,
+    uint8_t*,
+    int
+)
+{
+    _cpu_moe_unavailable();
+}
+
+int64_t exl3_moe_cpu_pool_stress(int, int, int, int)
+{
+    return 0;
+}
+"""
+
+
+def stub_avx_cpu_targets(root: Path) -> None:
+    # Match v1.4.7 header APIs. Returning false is correct on aarch64: GLM
+    # serving uses NCCL, not ExLlamaV3 native-TP CPU all-reduce.
+    (root / "avx2_target.h").write_text(
+        "#pragma once\n"
+        "bool is_avx2_supported();\n"
+        "bool is_f16c_supported();\n"
+        "#define AVX2_TARGET\n"
+        "#define AVX2_F16C_TARGET\n"
+        "#define AVX2_TARGET_OPTIONAL\n"
+    )
+    (root / "avx512_target.h").write_text(
+        "#pragma once\n"
+        "bool is_avx512_supported();\n"
+        "#define AVX512_TARGET\n"
+        "#define AVX512_TARGET_OPTIONAL\n"
+    )
+    (root / "avx2_target.cpp").write_text(
+        '#include "avx2_target.h"\n'
+        "bool is_avx2_supported() { return false; }\n"
+        "bool is_f16c_supported() { return false; }\n"
+    )
+    (root / "avx512_target.cpp").write_text(
+        '#include "avx512_target.h"\nbool is_avx512_supported() { return false; }\n'
+    )
+    (root / "parallel").mkdir(parents=True, exist_ok=True)
+    (root / "parallel/all_reduce_cpu_avx2.cpp").write_text(
+        """#include "all_reduce_cpu_avx2.h"
 #include "all_reduce_cpu_avx512.h"
+#include <cstdint>
 #include <cstdlib>
 void enable_fast_fp() {}
 void enable_fast_fp_avx2() {}
-void perform_cpu_reduce(PGContext*, size_t, uint32_t, uint8_t*, size_t) { std::abort(); }
-void perform_cpu_reduce_avx2(PGContext*, size_t, uint32_t, uint8_t*, size_t) { std::abort(); }
+void cpu_reduce_parallel(
+    void (*)(uint16_t*, const uint16_t*, const uint16_t*, size_t),
+    void (*)(uint16_t*, const uint16_t*, size_t),
+    uint16_t*, const uint16_t*, const uint16_t*, size_t, int
+) { std::abort(); }
+void perform_cpu_reduce(PGContext*, size_t, uint32_t, uint32_t, uint8_t*, size_t) { std::abort(); }
+void perform_cpu_reduce_avx2(PGContext*, size_t, uint32_t, uint32_t, uint8_t*, size_t) { std::abort(); }
 """
-)
-(root / "parallel/all_reduce_cpu_avx512.cpp").write_text(
-    """#include "all_reduce_cpu_avx512.h"
+    )
+    (root / "parallel/all_reduce_cpu_avx512.cpp").write_text(
+        """#include "all_reduce_cpu_avx512.h"
+#include <cstdint>
 #include <cstdlib>
 void enable_fast_fp_avx512() {}
 void bf16_add_inplace_avx512(uint16_t*, const uint16_t*, size_t) {}
-void perform_cpu_reduce_avx512(PGContext*, size_t, uint32_t, uint8_t*, size_t) { std::abort(); }
+void bf16_add_twosrc_avx512(uint16_t*, const uint16_t*, const uint16_t*, size_t) {}
+void fp16_add_inplace_avx512(uint16_t*, const uint16_t*, size_t) {}
+void fp16_add_twosrc_avx512(uint16_t*, const uint16_t*, const uint16_t*, size_t) {}
+void perform_cpu_reduce_avx512(PGContext*, size_t, uint32_t, uint32_t, uint8_t*, size_t) { std::abort(); }
 """
-)
-for hdr, name in (("avx2_target.h", "avx2"), ("avx512_target.h", "avx512")):
-    guard = name.upper()
-    (root / hdr).write_text(
-        "#pragma once\n"
-        f"bool is_{name}_supported();\n"
-        f"#define {guard}_TARGET\n"
-        f"#define {guard}_TARGET_OPTIONAL\n"
     )
-print(f"aarch64 EXL3 CPU-target stubs written in {root}")
+
+
+def stub_cpu_moe_mul1(root: Path) -> str:
+    """Replace the x86 CPU-MoE TU when present. Returns the action taken."""
+    path = root / "cpu" / "moe_mul1.cpp"
+    if not path.is_file():
+        return "absent"
+    current = path.read_text()
+    if "GLM53_AARCH64_CPU_MOE_STUB" in current:
+        return "already"
+    if "<immintrin.h>" not in current and "M1_TARGET_AVX2" not in current:
+        raise SystemExit(
+            f"aarch64 stub FATAL: {path} is not the v1.4.7 x86 CPU-MoE TU "
+            "(no immintrin.h / AVX target) and is not this kit's stub — refusing"
+        )
+    path.write_text(MOE_MUL1_STUB)
+    if "<immintrin.h>" in path.read_text():
+        raise SystemExit(f"aarch64 stub FATAL: post-write {path} still includes immintrin.h")
+    return "stubbed"
+
+
+X86_PAUSE_MARKERS = (b"__builtin_ia32_pause", b"_mm_pause")
+X86_ISA_MARKERS = (
+    b"immintrin.h",
+    b"__builtin_ia32_pause",
+    b"_mm_pause",
+    b'__attribute__((target("avx',
+    b'target_clones("avx',
+    b"__builtin_cpu_supports",
+)
+PORTABLE_PAUSE = "std::this_thread::yield(); /* GLM53_AARCH64_CPU_PAUSE_STUB */"
+
+
+def remaining_x86_isa(root: Path) -> list[tuple[Path, str]]:
+    hits: list[tuple[Path, str]] = []
+    for path in root.rglob("*"):
+        if path.suffix not in {".c", ".cpp", ".h", ".hpp", ".cu", ".cuh"}:
+            continue
+        data = path.read_bytes()
+        for marker in X86_ISA_MARKERS:
+            if marker in data:
+                hits.append((path, marker.decode("ascii", "replace")))
+                break
+    return hits
+
+def remaining_immintrin(root: Path) -> list[Path]:
+    return [path for path, marker in remaining_x86_isa(root) if marker == "immintrin.h"]
+
+
+def remaining_x86_pauses(root: Path) -> list[Path]:
+    hits: list[Path] = []
+    for path in root.rglob("*"):
+        if path.suffix not in {".c", ".cpp", ".h", ".hpp", ".cu", ".cuh"}:
+            continue
+        data = path.read_bytes()
+        if any(marker in data for marker in X86_PAUSE_MARKERS):
+            hits.append(path)
+    return hits
+
+
+def rewrite_x86_pauses(root: Path) -> list[str]:
+    """Replace leftover x86 pause builtins. Returns rewritten relative paths."""
+    rewritten: list[str] = []
+    for path in remaining_x86_pauses(root):
+        text = path.read_text()
+        if PORTABLE_PAUSE in text and not any(m.decode() in text for m in X86_PAUSE_MARKERS):
+            continue
+        new = text.replace("__builtin_ia32_pause();", PORTABLE_PAUSE)
+        new = new.replace("_mm_pause();", PORTABLE_PAUSE)
+        if new == text:
+            raise SystemExit(
+                f"aarch64 stub FATAL: {path} has an x86 pause form this installer "
+                "does not rewrite — refusing"
+            )
+        if "#include <thread>" not in new:
+            new = '#include <thread>\n' + new
+        path.write_text(new)
+        rewritten.append(str(path.relative_to(root)))
+    leftover = remaining_x86_pauses(root)
+    if leftover:
+        raise SystemExit(
+            "aarch64 stub FATAL: x86 pause builtins still present after rewrite: "
+            + ", ".join(str(p.relative_to(root)) for p in leftover)
+        )
+    return rewritten
+
+
+def main() -> int:
+    root = Path(sys.argv[1] if len(sys.argv) > 1 else "/tmp/exllamav3/exllamav3/exllamav3_ext")
+    stub_avx_cpu_targets(root)
+    moe_state = stub_cpu_moe_mul1(root)
+    leftover = remaining_immintrin(root)
+    if leftover:
+        raise SystemExit(
+            "aarch64 stub FATAL: immintrin.h still present after stubbing: "
+            + ", ".join(str(p.relative_to(root)) for p in leftover)
+        )
+    pauses = rewrite_x86_pauses(root)
+    leftover_isa = remaining_x86_isa(root)
+    if leftover_isa:
+        raise SystemExit(
+            "aarch64 stub FATAL: leftover x86 ISA after stubbing: "
+            + ", ".join(f"{p.relative_to(root)}:{m}" for p, m in leftover_isa)
+        )
+    avx2_h = (root / "avx2_target.h").read_text()
+    avx2_cpp = (root / "avx2_target.cpp").read_text()
+    if "is_f16c_supported" not in avx2_h or "bool is_f16c_supported() { return false; }" not in avx2_cpp:
+        raise SystemExit("aarch64 stub FATAL: is_f16c_supported missing from AVX2 stubs")
+    pause_note = ",".join(pauses) if pauses else "none"
+    print(
+        f"aarch64 EXL3 CPU-target stubs written in {root} "
+        f"(cpu_moe={moe_state}, x86_pause={pause_note}, f16c=stubbed)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/overlay/patch_exl3_ticket_scheduler.py
+++ b/overlay/patch_exl3_ticket_scheduler.py
@@ -11,16 +11,21 @@ groups steal heavy experts instead of serializing their statically assigned
 share. It also makes the group width runtime-configurable (gridDim.x) and
 sizes the lock buffer for the scheduler state (MOE_SCHED_INTS).
 
-The kit pins exllamav3 at c5d9c657; this patch cherry-picks d5e4361 onto that
-pin (verified: clean apply, +75/-16 over 7 files). Only the 6 ext quant files
-are shipped here — the d5e4361 hunk in modules/block_sparse_mlp.py belongs to
-exllamav3's own python stack, which the vLLM serve path does not use (the kit
-overlay drives exllamav3_ext directly).
+The kit currently pins exllamav3 at v1.4.7 (`ca13bdd`), which already contains
+the ticket scheduler. This installer is retained for the historical c5d9c657
+rollback pin: it cherry-picks d5e4361 onto that pin (verified: clean apply,
++75/-16 over 7 files). Only the 6 ext quant files are shipped here — the
+d5e4361 hunk in modules/block_sparse_mlp.py belongs to exllamav3's own python
+stack, which the vLLM serve path does not use (the kit overlay drives
+exllamav3_ext directly).
 
-Byte-exact three-state installer:
+Byte-exact four-state installer:
+  native   -> every quant file SHA256-matches the pinned v1.4.7 (ca13bdd)
+              set, including exl3_moe.cuh which is byte-identical to the
+              historical patched header: skip, write nothing
   patched  -> file already matches the vendored post-patch bytes: skip
-  pristine -> file matches the pin's bytes: atomic replace with patched
-  other    -> anchor drift: FAIL CLOSED, nothing written
+  pristine -> file matches the c5d9c657 pin's bytes: atomic replace with patched
+  other    -> mixed native/c5d9 or ordinary drift: FAIL CLOSED, nothing written
 
 The vendored sets live in overlay/exl3-ticket/{pristine,patched}/ next to this
 script. The kit's overlay exl3.py already introspects the new trailing
@@ -48,11 +53,43 @@ FILES = (
     "exl3_moe_kernel.cuh",
 )
 
+# Semantic markers that prove a kernel has d5e4361-class ticket scheduling.
+# Host tests assert these on the vendored patched set; native skip is hash-exact.
+NATIVE_TICKET_MARKERS = (
+    "atomicAdd(&sched[0], 1)",
+    "expert_idx_assign++ != ticket",
+    "MOE_SCHED_OFFSET",
+    "num_active",
+)
+
+# Exact v1.4.7 (ca13bdd) ext/quant SHA256. exl3_moe.cuh is shared with the
+# historical patched header (96f4fc24…); the other five files are not.
+NATIVE_V147_SHA256 = {
+    "exl3_devctx.cu": "545e1909873b2bd8f6cf598edce0c7772519e2d6e4b473fc72019e678379a34a",
+    "exl3_devctx.cuh": "effb1827e9b6c61ba95287ccfa5d6a0b6ccef103c0d588d992359be9291834c0",
+    "exl3_moe.cu": "ce394daf0cebafd65e848dffb374562554560b38f52b7070df5d782b1488b218",
+    "exl3_moe.cuh": "96f4fc2473474986cd4494554355efe2079a3b717c8612eadf5193334cfbd15f",
+    "exl3_moe_common.cuh": "b3c4e2399b8cf5a9c038dbe06da0aa8e4a3500dcd838e1c4a0ac95b22ce2acd6",
+    "exl3_moe_kernel.cuh": "6f58cfa0f66557c867ad821ffe9f165da0b3e760eb8633f734b8dbd95696501a",
+}
+NATIVE_V147_SHARED_HEADER = "exl3_moe.cuh"
+
 
 def _sha(data: bytes) -> str:
     import hashlib
 
     return hashlib.sha256(data).hexdigest()
+
+
+def tree_is_native_v147(quant: Path) -> bool:
+    """True when every FILE SHA256-matches the pinned v1.4.7 quant set."""
+    for name in FILES:
+        path = quant / name
+        if not path.is_file():
+            return False
+        if _sha(path.read_bytes()) != NATIVE_V147_SHA256[name]:
+            return False
+    return True
 
 
 def main() -> int:
@@ -74,9 +111,21 @@ def main() -> int:
         print("ticket-scheduler: GLM53_EXL3_TICKET_SCHEDULER=0, skipping")
         return 0
 
+    if tree_is_native_v147(quant):
+        print(
+            "ticket-scheduler: native v1.4.7 (ca13bdd) quant set present, "
+            "including shared historical exl3_moe.cuh — skipping byte-exact installer"
+        )
+        print("ticket-scheduler: done (native=1, patched=0, already=0, total=6)")
+        return 0
+
     n_patched = 0
     n_already = 0
     plan: list[tuple[Path, bytes]] = []
+    n_pristine = 0
+    native_exclusive: list[str] = []
+    drifted: list[Path] = []
+    patched_exclusive: list[str] = []
     for name in FILES:
         pristine = (pristine_dir / name).read_bytes()
         patched = (patched_dir / name).read_bytes()
@@ -84,18 +133,33 @@ def main() -> int:
             raise SystemExit(f"vendored sets identical for {name} — packaging bug")
         target = quant / name
         current = target.read_bytes()
+        current_sha = _sha(current)
+        if current_sha == NATIVE_V147_SHA256[name] and name != NATIVE_V147_SHARED_HEADER:
+            native_exclusive.append(name)
         if current == patched:
             n_already += 1
+            if name != NATIVE_V147_SHARED_HEADER:
+                patched_exclusive.append(name)
             print(f"ticket-scheduler: {name} already patched")
             continue
-        if current != pristine:
-            raise SystemExit(
-                f"ticket-scheduler FATAL: {target} matches neither the pinned "
-                f"pristine bytes ({_sha(pristine)[:12]}) nor the patched bytes "
-                f"({_sha(patched)[:12]}); on-disk sha {_sha(current)[:12]} — "
-                f"anchor drifted, refusing"
-            )
-        plan.append((target, patched))
+        if current == pristine:
+            n_pristine += 1
+            plan.append((target, patched))
+            continue
+        drifted.append(target)
+
+    if native_exclusive and (n_pristine or patched_exclusive or drifted):
+        raise SystemExit(
+            "ticket-scheduler FATAL: mixed native/c5d9c657 state across files "
+            "— source tree unexpected, nothing written"
+        )
+
+    if drifted:
+        raise SystemExit(
+            f"ticket-scheduler FATAL: {drifted[0]} matches neither the pinned "
+            "pristine bytes nor the patched bytes and is not the native v1.4.7 "
+            "quant set — anchor drifted, refusing"
+        )
 
     if plan and n_already:
         # Partial state = the source tree was not pristine to begin with (the

--- a/tests/fixtures/exl3-v147/all_reduce_cpu.cu
+++ b/tests/fixtures/exl3-v147/all_reduce_cpu.cu
@@ -1,0 +1,15 @@
+#include "all_reduce_cpu_avx2.h"
+#include <thread>
+
+// Compact v1.4.7-class CPU all-reduce TU for host aarch64-stub tests.
+// The production pin ships the full source; this fixture only needs the
+// unguarded x86 pause builtin that nvcc rejects on aarch64.
+
+void reduce_wait()
+{
+#ifdef __linux__
+    __builtin_ia32_pause();
+#else
+    _mm_pause();
+#endif
+}

--- a/tests/fixtures/exl3-v147/bindings.cpp
+++ b/tests/fixtures/exl3-v147/bindings.cpp
@@ -1,0 +1,20 @@
+#include <torch/extension.h>
+#include <pybind11/pybind11.h>
+
+#include "quant/quantize.cuh"
+#include "quant/exl3_gemm.cuh"
+#include "cpu/moe_mul1.h"
+#include "cpu/moe_handoff.h"
+#include "quant/exl3_devctx.cuh"
+#include "quant/exl3_moe.cuh"
+
+#include "parallel/context.cuh"
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
+{
+    m.def("exl3_moe_cpu_make_layer", &exl3_moe_cpu_make_layer, "exl3_moe_cpu_make_layer");
+    m.def("exl3_moe_cpu_forward", &exl3_moe_cpu_forward, "exl3_moe_cpu_forward");
+    m.def("exl3_moe_max_concurrency", &exl3_moe_max_concurrency, "exl3_moe_max_concurrency");
+    m.def("exl3_moe", &exl3_moe, "exl3_moe");
+    m.def("had_r_128", &had_r_128, "had_r_128");
+}

--- a/tests/fixtures/exl3-v147/linear_exl3_init.py
+++ b/tests/fixtures/exl3-v147/linear_exl3_init.py
@@ -1,0 +1,11 @@
+# Compact v1.4.7 LinearEXL3 construction contract for host tests.
+# Real LinearEXL3 does this before reading config.infer_params in forward().
+
+from ...model.config import Config, NullConfig  # noqa: F401
+
+
+def construct(config=None):
+    if config is None:
+        from ...model.config import NullConfig as _NullConfig
+        config = _NullConfig()
+    return config.infer_params.no_reconstruct

--- a/tests/fixtures/exl3-v147/moe_handoff.cu
+++ b/tests/fixtures/exl3-v147/moe_handoff.cu
@@ -1,0 +1,20 @@
+#include "moe_handoff.h"
+#include <thread>
+
+// Compact v1.4.7-class GPU/CPU handoff TU for host aarch64-stub tests.
+// The production pin ships the full source; this fixture only needs the
+// unguarded x86 pause builtin that nvcc rejects on aarch64.
+
+inline void cpu_pause_()
+{
+#ifdef __linux__
+    __builtin_ia32_pause();
+#else
+    _mm_pause();
+#endif
+}
+
+void exl3_moe_cpu_worker_run(uintptr_t)
+{
+    cpu_pause_();
+}

--- a/tests/fixtures/exl3-v147/moe_mul1.cpp
+++ b/tests/fixtures/exl3-v147/moe_mul1.cpp
@@ -1,0 +1,33 @@
+#include "moe_mul1.h"
+#include <c10/util/Half.h>
+#include <torch/extension.h>
+#include <immintrin.h>
+
+#if defined(__GNUC__) && defined(__linux__)
+#define M1_TARGET_AVX2 __attribute__((target("avx2,fma,f16c")))
+#define M1_TARGET_VNNI __attribute__((target("avx512f,avx512bw,avx512vl,avx512vnni,fma,f16c")))
+#else
+#define M1_TARGET_AVX2
+#define M1_TARGET_VNNI
+#endif
+
+// Compact v1.4.7-class x86 CPU-MoE TU for host aarch64-stub tests.
+// The production pin ships the full source; this fixture only needs the
+// unguarded immintrin include and AVX target attributes that break aarch64.
+
+M1_TARGET_AVX2 void hadamard_128_avx2(float* v);
+int64_t exl3_moe_cpu_make_layer(
+    const std::vector<at::Tensor>&,
+    const std::vector<at::Tensor>&,
+    const std::vector<at::Tensor>&,
+    const std::vector<at::Tensor>&,
+    const std::vector<at::Tensor>&,
+    const std::vector<at::Tensor>&,
+    const std::vector<at::Tensor>&,
+    const std::vector<at::Tensor>&,
+    const std::vector<at::Tensor>&,
+    const std::vector<at::Tensor>&,
+    const std::vector<at::Tensor>&,
+    const std::vector<at::Tensor>&,
+    int64_t, double, int64_t);
+void exl3_moe_cpu_forward(int64_t, const at::Tensor&, const at::Tensor&, const at::Tensor&, at::Tensor&, int64_t);

--- a/tests/fixtures/exl3-v147/quant/exl3_devctx.cu
+++ b/tests/fixtures/exl3-v147/quant/exl3_devctx.cu
@@ -1,0 +1,90 @@
+#include <cuda_fp16.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <cooperative_groups.h>
+namespace cg = cooperative_groups;
+#include "exl3_devctx.cuh"
+#include "../util.h"
+#include "../util.cuh"
+
+//DevCtx::DevCtc()
+//{
+//    int num_sms[MAX_DEVICES] = {};
+//    int cc[MAX_DEVICES] = {};
+//    void* locks[MAX_DEVICES] = {};
+//    std::mutex mtx;
+//}
+
+DevCtx& DevCtx::instance()
+{
+    static DevCtx ctx;
+    return ctx;
+}
+
+int DevCtx::get_num_sms(int device)
+{
+    std::lock_guard<std::mutex> lock(mtx);
+    if (!num_sms[device])
+        cuda_check(cudaDeviceGetAttribute(&num_sms[device], cudaDevAttrMultiProcessorCount, device));
+    return num_sms[device];
+}
+
+int DevCtx::get_cc(int device)
+{
+    std::lock_guard<std::mutex> lock(mtx);
+    if (!cc[device])
+    {
+        cudaDeviceProp prop;
+        cuda_check(cudaGetDeviceProperties(&prop, device));
+        if (prop.major >= 10) cc[device] = CC_BLACKWELL;
+        else if (prop.major >= 9) cc[device] = CC_HOPPER;
+        else if (prop.major >= 8 && prop.minor >= 9) cc[device] = CC_ADA;
+        else if (prop.major >= 8) cc[device] = CC_AMPERE;
+        else cc[device] = CC_OLD;
+    }
+    return cc[device];
+}
+
+void* DevCtx::get_ws(int device)
+{
+    std::lock_guard<std::mutex> lock(mtx);
+    if (!ws[device])
+    {
+        c10::cuda::CUDAGuard guard(device);
+        cudaError_t e = cudaMalloc(&ws[device], WORKSPACE_SIZE);
+        TORCH_CHECK(e == cudaSuccess, "exl3 workspace allocation failed on device ", device, ": ", cudaGetErrorString(e));
+    }
+    return ws[device];
+}
+
+int* DevCtx::get_locks(int device)
+{
+    std::lock_guard<std::mutex> lock(mtx);
+    if (!locks[device])
+    {
+        c10::cuda::CUDAGuard guard(device);
+        size_t size = (MAX_TILES_C + MAX_BARRIERS * 2 + MOE_SCHED_INTS) * sizeof(int);
+        cudaError_t e = cudaMalloc(&locks[device], size);
+        TORCH_CHECK(e == cudaSuccess, "exl3 lock buffer allocation failed on device ", device, ": ", cudaGetErrorString(e));
+        e = cudaMemset(locks[device], 0, size);
+        TORCH_CHECK(e == cudaSuccess, "exl3 lock buffer memset failed: ", cudaGetErrorString(e));
+    }
+    return (int*) locks[device];
+}
+
+int g_get_cc(int device)
+{
+    return DevCtx::instance().get_cc(device);
+}
+
+int g_get_num_sms(int device)
+{
+    return DevCtx::instance().get_num_sms(device);
+}
+
+void prepare_ctx(int device)
+{
+    DevCtx::instance().get_num_sms(device);
+    DevCtx::instance().get_cc(device);
+    DevCtx::instance().get_locks(device);
+}

--- a/tests/fixtures/exl3-v147/quant/exl3_devctx.cuh
+++ b/tests/fixtures/exl3-v147/quant/exl3_devctx.cuh
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <tuple>
+#include <mutex>
+
+// Max allowable output size, in tiles. Used to allocate global lock buffer per device for sync across threadblocks
+#define MAX_TILES_C (1024 * 1024)
+#define MAX_BARRIERS 1024
+#define BARRIER_LOCKS_OFFSET MAX_TILES_C
+
+// MoE expert scheduler state, after the barrier counters: [0] next ticket, [1] retired groups,
+// [2 + group] ticket published to group. Self-resetting, zero-initialized with the rest of the buffer
+#define MOE_MAX_GROUPS 64
+#define MOE_SCHED_OFFSET (MAX_TILES_C + 2 * MAX_BARRIERS)
+#define MOE_SCHED_INTS (2 + MOE_MAX_GROUPS)
+
+// Workspace size
+#define WORKSPACE_SIZE (16*1024*1024)
+
+#define MAX_DEVICES 16
+#define CC_OLD        1
+#define CC_AMPERE     2
+#define CC_ADA        3
+#define CC_HOPPER     4
+#define CC_BLACKWELL  5
+
+// Singleton to manage context for each device. Stores device attributes and a large-enough lock buffer per device
+class DevCtx
+{
+private:
+    int num_sms[MAX_DEVICES] = {};
+    int cc[MAX_DEVICES] = {};
+    void* locks[MAX_DEVICES] = {};
+    void* ws[MAX_DEVICES] = {};
+    std::mutex mtx;
+
+public:
+    static DevCtx& instance();
+    int get_num_sms(int device);
+    int get_cc(int device);
+    void* get_ws(int device);
+    int* get_locks(int device);
+
+private:
+    DevCtx() = default;
+    DevCtx(const DevCtx&) = delete;
+    DevCtx& operator=(const DevCtx&) = delete;
+};
+
+int g_get_cc(int device);
+int g_get_num_sms(int device);
+
+void prepare_ctx(int device);

--- a/tests/fixtures/exl3-v147/quant/exl3_moe.cu
+++ b/tests/fixtures/exl3-v147/quant/exl3_moe.cu
@@ -1,0 +1,301 @@
+#include <cuda_fp16.h>
+#include "exl3_gemm.cuh"
+
+#include <c10/cuda/CUDAGuard.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <cooperative_groups.h>
+namespace cg = cooperative_groups;
+#include "../util.h"
+#include "../util.cuh"
+#include "comp_units/exl3_moe_instances.cuh"
+#include "exl3_devctx.cuh"
+#include <set>
+
+int exl3_moe_max_concurrency(int device)
+{
+    int num_sms = DevCtx::instance().get_num_sms(device);
+    return num_sms / MOE_SMS_PER_EXPERT;
+}
+
+std::set<void*> moe_kernel_attr_set[MAX_DEVICES] = {};
+
+fp_exl3_moe_kernel exl3_moe_kernel_instances[] =
+{
+    // [K][cb - 1][N_off]: K = 0 switches Kg/Ku/Kd at runtime, K > 0 = compile-time Kg = Ku = Kd
+    exl3_moe_kernel_k0_n128_cb1(), exl3_moe_kernel_k0_n256_cb1(), exl3_moe_kernel_k0_n128_cb2(), exl3_moe_kernel_k0_n256_cb2(),
+    exl3_moe_kernel_k1_n128_cb1(), exl3_moe_kernel_k1_n256_cb1(), exl3_moe_kernel_k1_n128_cb2(), exl3_moe_kernel_k1_n256_cb2(),
+    exl3_moe_kernel_k2_n128_cb1(), exl3_moe_kernel_k2_n256_cb1(), exl3_moe_kernel_k2_n128_cb2(), exl3_moe_kernel_k2_n256_cb2(),
+    exl3_moe_kernel_k3_n128_cb1(), exl3_moe_kernel_k3_n256_cb1(), exl3_moe_kernel_k3_n128_cb2(), exl3_moe_kernel_k3_n256_cb2(),
+    exl3_moe_kernel_k4_n128_cb1(), exl3_moe_kernel_k4_n256_cb1(), exl3_moe_kernel_k4_n128_cb2(), exl3_moe_kernel_k4_n256_cb2(),
+    exl3_moe_kernel_k5_n128_cb1(), exl3_moe_kernel_k5_n256_cb1(), exl3_moe_kernel_k5_n128_cb2(), exl3_moe_kernel_k5_n256_cb2(),
+    exl3_moe_kernel_k6_n128_cb1(), exl3_moe_kernel_k6_n256_cb1(), exl3_moe_kernel_k6_n128_cb2(), exl3_moe_kernel_k6_n256_cb2(),
+    exl3_moe_kernel_k7_n128_cb1(), exl3_moe_kernel_k7_n256_cb1(), exl3_moe_kernel_k7_n128_cb2(), exl3_moe_kernel_k7_n256_cb2(),
+    exl3_moe_kernel_k8_n128_cb1(), exl3_moe_kernel_k8_n256_cb1(), exl3_moe_kernel_k8_n128_cb2(), exl3_moe_kernel_k8_n256_cb2()
+};
+
+/*
+Fused mixture-of-experts MLP operation for EXL3 weights
+
+inputs:
+    hidden_state:
+        input hidden state - shape (bsz, hidden_dim) - fp16
+
+    output_state:
+        output hidden state - shape (bsz, hidden_dim) - fp32
+        zero-initialized
+
+    expert_count:
+        bincount of expert indices across all tokens in batch - shape (num_experts + 1,) - int64
+        last item is ignored, used for the case where some tokens may activate less than num_experts_per_token
+        experts (specifically in expert split mode)
+
+    token_sorted:
+        token indices, sorted by expert - shape (bsz * num_experts_per_tok,)  - int64
+
+    weight_sorted:
+        routing weight per token, sorted by expert - shape (bsz * num_experts_per_tok,) - fp16
+
+    temp_state_g:
+    temp_state_u:
+        temp state storage - shape (concurrency, max_tokens_per_expert, hidden_dim), fp16
+
+    temp_intermediate_g
+    temp_intermediate_u:
+        temp intermediate storage - shape (concurrency, max_tokens_per_expert, intermediate_dim), fp16
+
+    act_function:
+        int, see exl3_moe.cuh
+
+    K_gate
+    K_up
+    K_down:
+        int, bitrates for gate, up, down tensors
+
+    gate_ptrs_trellis
+    gate_ptrs_suh
+    gate_ptrs_svh
+    up_ptrs_trellis
+    up_ptrs_suh
+    up_ptrs_svh
+    down_ptrs_trellis
+    down_ptrs_suh
+    down_ptrs_svh:
+        tensors of data_ptrs to quantized tensor data - each shape (num_experts,) - void*
+
+    gate_mcg
+    gate_mul1
+    up_mcg
+    up_mul1
+    down_mcg
+    down_mul1:
+        bool, codebook flags
+
+    num_active:
+        number of experts with 0 < token count <= max_tokens_per_expert, i.e. the number of experts this kernel
+        will process. Used to size the launch: fewer, wider expert groups when few experts are active. Pass -1 if
+        unknown (defaults to MOE_SMS_PER_EXPERT-wide groups at max concurrency)
+*/
+
+void exl3_moe
+(
+    const at::Tensor& hidden_state,
+    const at::Tensor& output_state,
+    const at::Tensor& expert_count,
+    const at::Tensor& token_sorted,
+    const at::Tensor& weight_sorted,
+
+    const at::Tensor& temp_state_g,
+    const at::Tensor& temp_state_u,
+    const at::Tensor& temp_intermediate_g,
+    const at::Tensor& temp_intermediate_u,
+
+    const int act_function,
+
+    const int K_gate,
+    const int K_up,
+    const int K_down,
+
+    const at::Tensor& gate_ptrs_trellis,
+    const at::Tensor& gate_ptrs_suh,
+    const at::Tensor& gate_ptrs_svh,
+    const at::Tensor& up_ptrs_trellis,
+    const at::Tensor& up_ptrs_suh,
+    const at::Tensor& up_ptrs_svh,
+    const at::Tensor& down_ptrs_trellis,
+    const at::Tensor& down_ptrs_suh,
+    const at::Tensor& down_ptrs_svh,
+
+    const bool gate_mcg,
+    const bool gate_mul1,
+    const bool up_mcg,
+    const bool up_mul1,
+    const bool down_mcg,
+    const bool down_mul1,
+
+    const float act_limit,
+    const int num_active
+)
+{
+    const at::cuda::OptionalCUDAGuard device_guard(hidden_state.device());
+    cudaStream_t stream = at::cuda::getCurrentCUDAStream().stream();
+
+    // Nothing for the fused kernel to do
+    if (num_active == 0) return;
+
+    // Validate args
+    TORCH_CHECK_DTYPE(hidden_state, kHalf);
+    TORCH_CHECK_DIM(hidden_state, 2);
+    size_t bsz = hidden_state.size(0);
+    size_t hidden_dim = hidden_state.size(1);
+
+    TORCH_CHECK_DTYPE(output_state, kFloat);
+    TORCH_CHECK_SHAPES_FULL(output_state, hidden_state);
+
+    TORCH_CHECK_DTYPE(expert_count, kLong);
+    TORCH_CHECK_DIM(expert_count, 1);
+    size_t num_experts = expert_count.size(0) - 1;
+
+    TORCH_CHECK_DTYPE(token_sorted, kLong);
+    TORCH_CHECK_DIM(token_sorted, 1);
+    TORCH_CHECK_SHAPES_FULL(token_sorted, weight_sorted);
+    size_t num_experts_per_tok = token_sorted.size(0) / bsz;
+
+    TORCH_CHECK_DTYPE(temp_state_g, kHalf);
+    TORCH_CHECK_DTYPE(temp_state_u, kHalf);
+    TORCH_CHECK_DIM(temp_state_g, 3);
+    TORCH_CHECK_SHAPES(temp_state_g, 2, hidden_state, 1, 1);
+    TORCH_CHECK_SHAPES_FULL(temp_state_g, temp_state_u);
+    size_t max_tokens_per_expert = temp_state_g.size(1);
+    size_t concurrency = temp_state_g.size(0);
+
+    TORCH_CHECK_DTYPE(temp_intermediate_g, kHalf);
+    TORCH_CHECK_DTYPE(temp_intermediate_u, kHalf);
+    TORCH_CHECK_DIM(temp_intermediate_g, 3);
+    TORCH_CHECK_DIM(temp_intermediate_u, 3);
+    TORCH_CHECK_SHAPES_FULL(temp_intermediate_g, temp_intermediate_u);
+    TORCH_CHECK_SHAPES(temp_intermediate_g, 1, temp_state_g, 1, 1);
+    size_t intermediate_dim = temp_intermediate_g.size(2);
+
+    // TORCH_CHECK(!(gate_mcg && gate_mul1), "Specified both mcg and mul1 (gate)");
+    // TORCH_CHECK(!(up_mcg && up_mul1), "Specified both mcg and mul1 (up)");
+    // TORCH_CHECK(!(down_mcg && down_mul1), "Specified both mcg and mul1 (down)");
+    TORCH_CHECK(gate_mcg == up_mcg && up_mcg == down_mcg && gate_mul1 == up_mul1 && up_mul1 == down_mul1,
+                "MoE kernel: gate/up/down must share the same codebook");
+    TORCH_CHECK(gate_mcg != gate_mul1, "MoE kernel: Only mcg and mul1 codebooks are supported");
+    const int cb_idx = gate_mul1 ? 1 : 0;
+
+    // TORCH_CHECK(act_function == MOE_ACT_SILU, "MoE kernel: Only SiLU is currently supported");
+
+    int K = 0;
+    if (K_gate == K_up && K_up == K_down) K = K_gate;
+
+    TORCH_CHECK_DIM(gate_ptrs_trellis, 1);
+    TORCH_CHECK(gate_ptrs_trellis.size(0) == num_experts, "Number of gate tensors doesn't match num_experts");
+    TORCH_CHECK_SHAPES_FULL(gate_ptrs_trellis, gate_ptrs_suh);
+    TORCH_CHECK_SHAPES_FULL(gate_ptrs_trellis, gate_ptrs_svh);
+    TORCH_CHECK_SHAPES_FULL(gate_ptrs_trellis, up_ptrs_trellis);
+    TORCH_CHECK_SHAPES_FULL(gate_ptrs_trellis, up_ptrs_suh);
+    TORCH_CHECK_SHAPES_FULL(gate_ptrs_trellis, up_ptrs_svh);
+    TORCH_CHECK_SHAPES_FULL(gate_ptrs_trellis, down_ptrs_trellis);
+    TORCH_CHECK_SHAPES_FULL(gate_ptrs_trellis, down_ptrs_suh);
+    TORCH_CHECK_SHAPES_FULL(gate_ptrs_trellis, down_ptrs_svh);
+
+    // Device properties
+    int device;
+    cudaGetDevice(&device);
+    int num_sms = DevCtx::instance().get_num_sms(device);
+    int cc = DevCtx::instance().get_cc(device);
+    int* locks = DevCtx::instance().get_locks(device);
+
+    // Launch. All blocks of the grid must be co-resident for the group barriers, so groups * width <= num_sms.
+    // With a known number of active experts, launch only as many groups as there are experts and widen them to
+    // use the freed SMs, up to MOE_MAX_SMS_PER_EXPERT
+    int block_dim = EXL3_GEMM_BASE_THREADS * MOE_TILESIZE_K / 16;
+    TORCH_CHECK(concurrency * MOE_SMS_PER_EXPERT <= num_sms, "Concurrency too high for device num_sms");
+    int num_groups = MIN((int) concurrency, MOE_MAX_GROUPS);
+    int group_size = MOE_SMS_PER_EXPERT;
+    if (num_active > 0)
+    {
+        num_groups = MIN(num_groups, num_active);
+        group_size = MIN(num_sms / num_groups, MOE_MAX_SMS_PER_EXPERT);
+    }
+    dim3 grid_dim(group_size, 1, num_groups);
+
+    int N_off = 0;
+    if (hidden_dim % 256 == 0 && intermediate_dim % 256 == 0) N_off = 1;
+    fp_exl3_moe_kernel kernel = exl3_moe_kernel_instances[4 * K + 2 * cb_idx + N_off];
+
+    if (moe_kernel_attr_set[device].find((void*) kernel) == moe_kernel_attr_set[device].end())
+    {
+        cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, SMEM_MAX);
+        moe_kernel_attr_set[device].insert((void*) kernel);
+        cuda_check(cudaPeekAtLastError());
+    }
+
+    void* _hidden_state = hidden_state.data_ptr();
+    void* _temp_state_g = temp_state_g.data_ptr();
+    void* _temp_state_u = temp_state_u.data_ptr();
+    void* _temp_intermediate_g = temp_intermediate_g.data_ptr();
+    void* _temp_intermediate_u = temp_intermediate_u.data_ptr();
+    void* _output_state = output_state.data_ptr();
+
+    void* _gate_ptrs_trellis = gate_ptrs_trellis.data_ptr();
+    void* _gate_ptrs_suh = gate_ptrs_suh.data_ptr();
+    void* _gate_ptrs_svh = gate_ptrs_svh.data_ptr();
+    void* _up_ptrs_trellis = up_ptrs_trellis.data_ptr();
+    void* _up_ptrs_suh = up_ptrs_suh.data_ptr();
+    void* _up_ptrs_svh = up_ptrs_svh.data_ptr();
+    void* _down_ptrs_trellis = down_ptrs_trellis.data_ptr();
+    void* _down_ptrs_suh = down_ptrs_suh.data_ptr();
+    void* _down_ptrs_svh = down_ptrs_svh.data_ptr();
+
+    void* _expert_count = expert_count.data_ptr();
+    void* _token_sorted = token_sorted.data_ptr();
+    void* _weight_sorted = weight_sorted.data_ptr();
+
+    void* kernelArgs[] =
+    {
+        &_hidden_state,
+        &_temp_state_g,
+        &_temp_state_u,
+        &_temp_intermediate_g,
+        &_temp_intermediate_u,
+        &_output_state,
+        &_gate_ptrs_trellis,
+        &_gate_ptrs_suh,
+        &_gate_ptrs_svh,
+        &_up_ptrs_trellis,
+        &_up_ptrs_suh,
+        &_up_ptrs_svh,
+        &_down_ptrs_trellis,
+        &_down_ptrs_suh,
+        &_down_ptrs_svh,
+        &_expert_count,
+        &_token_sorted,
+        &_weight_sorted,
+        (void*) &hidden_dim,
+        (void*) &intermediate_dim,
+        (void*) &num_experts,
+        (void*) &num_experts_per_tok,
+        (void*) &max_tokens_per_expert,
+        (void*) &num_groups,
+        (void*) &act_limit,
+        (void*) &act_function,
+        (void*) &K_gate,
+        (void*) &K_up,
+        (void*) &K_down,
+        (void*) &locks
+    };
+
+    cudaLaunchKernel
+    (
+        (void*) kernel,
+        grid_dim,
+        block_dim,
+        kernelArgs,
+        SMEM_MAX,
+        stream
+    );
+
+    cuda_check(cudaPeekAtLastError());
+}

--- a/tests/fixtures/exl3-v147/quant/exl3_moe.cuh
+++ b/tests/fixtures/exl3-v147/quant/exl3_moe.cuh
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <ATen/Tensor.h>
+#include "../graph.cuh"
+
+int exl3_moe_max_concurrency(int device);
+
+void exl3_moe
+(
+    const at::Tensor& hidden_state,
+    const at::Tensor& output_state,
+    const at::Tensor& expert_count,
+    const at::Tensor& token_sorted,
+    const at::Tensor& weight_sorted,
+
+    const at::Tensor& temp_state_g,
+    const at::Tensor& temp_state_u,
+    const at::Tensor& temp_intermediate_g,
+    const at::Tensor& temp_intermediate_u,
+
+    const int act_function,
+
+    const int K_gate,
+    const int K_up,
+    const int K_down,
+
+    const at::Tensor& gate_ptrs_trellis,
+    const at::Tensor& gate_ptrs_suh,
+    const at::Tensor& gate_ptrs_svh,
+    const at::Tensor& up_ptrs_trellis,
+    const at::Tensor& up_ptrs_suh,
+    const at::Tensor& up_ptrs_svh,
+    const at::Tensor& down_ptrs_trellis,
+    const at::Tensor& down_ptrs_suh,
+    const at::Tensor& down_ptrs_svh,
+
+    const bool gate_mcg,
+    const bool gate_mul1,
+    const bool up_mcg,
+    const bool up_mul1,
+    const bool down_mcg,
+    const bool down_mul1,
+
+    const float act_limit,
+    const int num_active
+);
+

--- a/tests/fixtures/exl3-v147/quant/exl3_moe_common.cuh
+++ b/tests/fixtures/exl3-v147/quant/exl3_moe_common.cuh
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <cuda_fp16.h>
+#include <stdint.h>
+
+#define MOE_ACT_SILU 0
+#define MOE_ACT_GELU 1
+#define MOE_ACT_RELU2_NOGATE 2  // non-gated relu2 (NemotronH): gate GEMM and staging skipped
+
+#define MOE_SMS_PER_EXPERT 8       // default/minimum group width, also sets max concurrency (buffer count)
+#define MOE_MAX_SMS_PER_EXPERT 32  // widest expert group when few experts are active
+#define MOE_TILESIZE_K 32
+#define MOE_TILESIZE_M 16
+#define MOE_SH_STAGES 3
+#define MOE_FRAG_STAGES 3
+
+#ifndef EXL3_GEMM_BASE_THREADS
+#define EXL3_GEMM_BASE_THREADS 256
+#endif
+
+#ifndef SMEM_MAX
+#define SMEM_MAX (90 * 1024)  // max shared memory on compute capability 8.6
+#endif
+
+#define EXL3_MOE_KERNEL_ARGS                    \
+    const half* __restrict__ hidden_state,      \
+    half* __restrict__ temp_state_g,            \
+    half* __restrict__ temp_state_u,            \
+    half* __restrict__ temp_intermediate_g,     \
+    half* __restrict__ temp_intermediate_u,     \
+    float* __restrict__ output_state,           \
+                                                \
+    const uint16_t** __restrict__ gate_trellis, \
+    const half** __restrict__ gate_suh,         \
+    const half** __restrict__ gate_svh,         \
+    const uint16_t** __restrict__ up_trellis,   \
+    const half** __restrict__ up_suh,           \
+    const half** __restrict__ up_svh,           \
+    const uint16_t** __restrict__ down_trellis, \
+    const half** __restrict__ down_suh,         \
+    const half** __restrict__ down_svh,         \
+                                                \
+    const int64_t* __restrict__ expert_count,   \
+    const int64_t* __restrict__ token_sorted,   \
+    const half* __restrict__ weight_sorted,     \
+                                                \
+    const int hidden_dim,                       \
+    const int intermediate_dim,                 \
+    const int num_experts,                      \
+    const int num_experts_per_tok,              \
+    const int max_tokens_per_expert,            \
+    const int concurrency,                      \
+    const float act_limit,                      \
+    const int act_function,                     \
+    const int K_gate,                           \
+    const int K_up,                             \
+    const int K_down,                           \
+                                                \
+    int* __restrict__ locks

--- a/tests/fixtures/exl3-v147/quant/exl3_moe_kernel.cuh
+++ b/tests/fixtures/exl3-v147/quant/exl3_moe_kernel.cuh
@@ -1,0 +1,283 @@
+#pragma once
+
+#include <cuda_bf16.h>
+#include <cublas_v2.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "exl3_moe_common.cuh"
+#include "../util.h"
+#include "../util.cuh"
+#include "exl3_kernel_map.cuh"
+#include "hadamard_inner.cuh"
+#include "exl3_gemm_inner.cuh"
+#include "exl3_devctx.cuh"
+#include "../ptx.cuh"
+
+template<int t_bits, int MOE_TILESIZE_N, int cb>
+__global__ __launch_bounds__(EXL3_GEMM_BASE_THREADS * MOE_TILESIZE_K / 16)
+void exl3_moe_kernel(EXL3_MOE_KERNEL_ARGS)
+{
+    const int group_idx = blockIdx.z;
+    const int block_idx = blockIdx.x;
+    const int group_size = gridDim.x;  // SMs per expert, set at launch
+    const int num_groups = gridDim.z;
+    const int block_threads = EXL3_GEMM_BASE_THREADS * MOE_TILESIZE_K / 16;  // blockDim.x
+    const int group_threads = group_size * block_threads;
+    const int warp_id = threadIdx.x / 32;
+    const int warps_per_group = group_threads / 32;
+    const int warps_per_block = block_threads / 32;
+    const int warp_idx0 = block_idx * warps_per_block + warp_id;
+
+    // Buffers for group
+    temp_state_g += group_idx * max_tokens_per_expert * hidden_dim;
+    temp_state_u += group_idx * max_tokens_per_expert * hidden_dim;
+    temp_intermediate_g += group_idx * max_tokens_per_expert * intermediate_dim;
+    temp_intermediate_u += group_idx * max_tokens_per_expert * intermediate_dim;
+
+    // Barriers for group sync
+    int* barrier_counters_sense = locks + BARRIER_LOCKS_OFFSET;
+
+    // Expert scheduler state, self-resetting: [0] next ticket, [1] retired groups, [2 + g] ticket for group g
+    int* sched = locks + MOE_SCHED_OFFSET;
+
+    // Individual GEMM barriers per group
+    locks += group_idx * MAX(hidden_dim, intermediate_dim) / 128;
+
+    // Dynamic expert assignment: active experts are numbered in scan order, and each group processes the active
+    // expert matching its current ticket. Initial tickets are the group indices; after finishing an expert, a group
+    // draws the next unclaimed ticket, so load balances greedily without assuming uniform cost per expert
+    int ticket = group_idx;
+
+    // Loop over experts
+    int start = 0;
+    int end = 0;
+    int expert_idx = 0;
+    int expert_idx_assign = 0;
+    for (; expert_idx < num_experts; ++expert_idx)
+    {
+        // Token span for current expert
+        start = end;
+        end += expert_count[expert_idx];
+        int token_count = end - start;
+
+        // Skip if no tokens or too many tokens for fused kernel (batch is handled by reconstruct path outside kernel)
+        if (token_count == 0) continue;
+        if (token_count > max_tokens_per_expert) continue;
+
+        // Skip if expert is claimed by a different group
+        if (expert_idx_assign++ != ticket) continue;
+
+        // EXL3 weights for g, u, d
+        const uint16_t* exp_gate_trellis = gate_trellis[expert_idx];
+        const half* exp_gate_suh = gate_suh[expert_idx];
+        const half* exp_gate_svh = gate_svh[expert_idx];
+        const uint16_t* exp_up_trellis = up_trellis[expert_idx];
+        const half* exp_up_suh = up_suh[expert_idx];
+        const half* exp_up_svh = up_svh[expert_idx];
+        const uint16_t* exp_down_trellis = down_trellis[expert_idx];
+        const half* exp_down_suh = down_suh[expert_idx];
+        const half* exp_down_svh = down_svh[expert_idx];
+
+        // Gather + input hadamard for g, u. Non-gated mode skips the g staging (and the g GEMM
+        // below); the activation synthesizes the gate lane from u
+        const bool gated = act_function != MOE_ACT_RELU2_NOGATE;
+        auto had_gather_gu_in = [&]()
+        {
+            const int warps_per_token = hidden_dim / 128;
+            const int total_warps = token_count * warps_per_token;
+            const int64_t* top_x = token_sorted + start;
+            for (int warp_idx = warp_idx0; warp_idx < total_warps; warp_idx += warps_per_group)
+            {
+                int token_idx = top_x[warp_idx / warps_per_token];
+                int token_off = warp_idx % warps_per_token;
+                const half* in_ptr = hidden_state + token_idx * hidden_dim + token_off * 128;
+                if (gated)
+                    had_hf_r_128_inner<true, false>
+                    (
+                        in_ptr,
+                        temp_state_g + 128 * warp_idx,
+                        exp_gate_suh + 128 * token_off,
+                        0.088388347648f
+                    );
+                had_hf_r_128_inner<true, false>
+                (
+                    in_ptr,
+                    temp_state_u + 128 * warp_idx,
+                    exp_up_suh + 128 * token_off,
+                    0.088388347648f
+                );
+            }
+            group_barrier(group_idx, group_size, barrier_counters_sense);
+        };
+
+        had_gather_gu_in();
+
+        // g, u GEMM
+        auto gemm_up = [&](const half* in_addr, half* out_addr, const uint16_t* trellis, const int K)
+        {
+            int size_m = token_count;
+            while (size_m > 0)
+            {
+                #define ARGS            \
+                    in_addr,            \
+                    trellis,            \
+                    out_addr,           \
+                    MIN(size_m, 16),    \
+                    hidden_dim,         \
+                    intermediate_dim,   \
+                    locks,              \
+                    nullptr
+                #define SHAPE_ARGS      \
+                    MOE_TILESIZE_M,     \
+                    MOE_TILESIZE_K,     \
+                    MOE_TILESIZE_N,     \
+                    MOE_SH_STAGES,      \
+                    MOE_FRAG_STAGES
+                if constexpr (t_bits)
+                    exl3_gemm_kernel_inner<t_bits, false, cb, SHAPE_ARGS, false>(ARGS);
+                else switch(K)
+                {
+                    case 1: exl3_gemm_kernel_inner<1, false, cb, SHAPE_ARGS, false>(ARGS); break;
+                    case 2: exl3_gemm_kernel_inner<2, false, cb, SHAPE_ARGS, false>(ARGS); break;
+                    case 3: exl3_gemm_kernel_inner<3, false, cb, SHAPE_ARGS, false>(ARGS); break;
+                    case 4: exl3_gemm_kernel_inner<4, false, cb, SHAPE_ARGS, false>(ARGS); break;
+                    case 5: exl3_gemm_kernel_inner<5, false, cb, SHAPE_ARGS, false>(ARGS); break;
+                    case 6: exl3_gemm_kernel_inner<6, false, cb, SHAPE_ARGS, false>(ARGS); break;
+                    case 7: exl3_gemm_kernel_inner<7, false, cb, SHAPE_ARGS, false>(ARGS); break;
+                    case 8: exl3_gemm_kernel_inner<8, false, cb, SHAPE_ARGS, false>(ARGS); break;
+                };
+                #undef ARGS
+                #undef SHAPE_ARGS
+
+                in_addr += 16 * hidden_dim;
+                out_addr += 16 * intermediate_dim;
+                size_m -= 16;
+            }
+        };
+
+        if (gated)
+            gemm_up(temp_state_g, temp_intermediate_g, exp_gate_trellis, K_gate);
+        gemm_up(temp_state_u, temp_intermediate_u, exp_up_trellis, K_up);
+        group_barrier(group_idx, group_size, barrier_counters_sense);
+
+        // Output hadamard for g, u + activation+gate + input hadamard for d
+        auto had_guad = [&]()
+        {
+            const int warps_per_token = intermediate_dim / 128;
+            const int total_warps = token_count * warps_per_token;
+            for (int warp_idx = warp_idx0; warp_idx < total_warps; warp_idx += warps_per_group)
+            {
+                int token_off = warp_idx % warps_per_token;
+                had_hf_r_128_guad_inner
+                (
+                    temp_intermediate_g + 128 * warp_idx,
+                    temp_intermediate_u + 128 * warp_idx,
+                    temp_intermediate_g + 128 * warp_idx,
+                    exp_gate_svh + 128 * token_off,
+                    exp_up_svh + 128 * token_off,
+                    exp_down_suh + 128 * token_off,
+                    0.088388347648f,
+                    act_limit,
+                    act_function
+                );
+            }
+            group_barrier(group_idx, group_size, barrier_counters_sense);
+        };
+
+        had_guad();
+
+        // d GEMM
+        auto gemm_down = [&](const half* in_addr, half* out_addr, const uint16_t* trellis, const int K)
+        {
+            int size_m = token_count;
+            while (size_m > 0)
+            {
+                #define ARGS            \
+                    in_addr,            \
+                    trellis,            \
+                    out_addr,           \
+                    MIN(size_m, 16),    \
+                    intermediate_dim,   \
+                    hidden_dim,         \
+                    locks,              \
+                    nullptr
+                #define SHAPE_ARGS      \
+                    MOE_TILESIZE_M,     \
+                    MOE_TILESIZE_K,     \
+                    MOE_TILESIZE_N,     \
+                    MOE_SH_STAGES,      \
+                    MOE_FRAG_STAGES
+                if constexpr (t_bits)
+                    exl3_gemm_kernel_inner<t_bits, false, cb, SHAPE_ARGS, false>(ARGS);
+                else switch(K)
+                {
+                    case 1: exl3_gemm_kernel_inner<1, false, cb, SHAPE_ARGS, false>(ARGS); break;
+                    case 2: exl3_gemm_kernel_inner<2, false, cb, SHAPE_ARGS, false>(ARGS); break;
+                    case 3: exl3_gemm_kernel_inner<3, false, cb, SHAPE_ARGS, false>(ARGS); break;
+                    case 4: exl3_gemm_kernel_inner<4, false, cb, SHAPE_ARGS, false>(ARGS); break;
+                    case 5: exl3_gemm_kernel_inner<5, false, cb, SHAPE_ARGS, false>(ARGS); break;
+                    case 6: exl3_gemm_kernel_inner<6, false, cb, SHAPE_ARGS, false>(ARGS); break;
+                    case 7: exl3_gemm_kernel_inner<7, false, cb, SHAPE_ARGS, false>(ARGS); break;
+                    case 8: exl3_gemm_kernel_inner<8, false, cb, SHAPE_ARGS, false>(ARGS); break;
+                };
+                #undef ARGS
+                #undef SHAPE_ARGS
+
+                in_addr += 16 * intermediate_dim;
+                out_addr += 16 * hidden_dim;
+                size_m -= 16;
+            }
+        };
+
+        gemm_down(temp_intermediate_g, temp_state_g, exp_down_trellis, K_down);
+        group_barrier(group_idx, group_size, barrier_counters_sense);
+
+        // Output hadamard for d + scatter add
+        auto had_d_out = [&]()
+        {
+            const int warps_per_token = hidden_dim / 128;
+            const int total_warps = token_count * warps_per_token;
+            const int64_t* top_x = token_sorted + start;
+            const half* weights = weight_sorted + start;
+            for (int warp_idx = warp_idx0; warp_idx < total_warps; warp_idx += warps_per_group)
+            {
+                int token_idx = top_x[warp_idx / warps_per_token];
+                half weight = weights[warp_idx / warps_per_token];
+                int token_off = warp_idx % warps_per_token;
+                float* out_ptr = output_state + token_idx * hidden_dim + token_off * 128;
+                had_hf_r_128_d_inner
+                (
+                    temp_state_g + 128 * warp_idx,
+                    out_ptr,
+                    exp_down_svh + 128 * token_off,
+                    0.088388347648f * __half2float(weight)
+                );
+            }
+        };
+
+        had_d_out();
+
+        // Draw the next ticket and publish it to the group through the end-of-expert barrier, which also protects
+        // the temp buffers for reuse. Grabbed tickets continue from num_groups since 0..num_groups-1 are implicit
+        if (block_idx == 0 && threadIdx.x == 0)
+            sched[2 + group_idx] = num_groups + atomicAdd(&sched[0], 1);
+        group_barrier(group_idx, group_size, barrier_counters_sense);
+        ticket = sched[2 + group_idx];
+    }
+
+    // Retire group; last group out resets the scheduler for the next launch. The acq_rel increment orders each
+    // group's earlier ticket grabs before the last group's reset (plain atomics are relaxed, so without this a
+    // straggler's in-flight grab could land after the reset and leak into the next launch)
+    if (block_idx == 0 && threadIdx.x == 0)
+    {
+        cuda::atomic_ref<int, cuda::thread_scope_device> next_ticket(sched[0]);
+        cuda::atomic_ref<int, cuda::thread_scope_device> retired_groups(sched[1]);
+        int retired = retired_groups.fetch_add(1, cuda::memory_order_acq_rel);
+        if (retired == num_groups - 1)
+        {
+            next_ticket.store(0, cuda::memory_order_relaxed);
+            retired_groups.store(0, cuda::memory_order_relaxed);
+        }
+    }
+}

--- a/tests/test_exl3_ticket_scheduler.py
+++ b/tests/test_exl3_ticket_scheduler.py
@@ -1,13 +1,17 @@
 """Byte-exact three-state installer tests for the exllamav3 ticket-scheduler overlay.
 
 The installer (overlay/patch_exl3_ticket_scheduler.py) applies upstream
-exllamav3 d5e4361 onto the pinned c5d9c657 ext source at image build time from
-vendored pristine/patched byte sets. These tests exercise the installer logic
-host-side with fixture extension roots — no torch, no CUDA.
+exllamav3 d5e4361 onto the historical c5d9c657 ext source at image build
+time from vendored pristine/patched byte sets. v1.4.7 already contains the
+ticket scheduler, so a native tree is a skip, not drift. These tests
+exercise the installer logic host-side with fixture extension roots — no
+torch, no CUDA.
 """
 
 from __future__ import annotations
 
+import hashlib
+import importlib.util
 import os
 import shutil
 import subprocess
@@ -21,6 +25,7 @@ PATCHER = KIT_ROOT / "overlay" / "patch_exl3_ticket_scheduler.py"
 TICKET_DIR = KIT_ROOT / "overlay" / "exl3-ticket"
 PRISTINE = TICKET_DIR / "pristine"
 PATCHED = TICKET_DIR / "patched"
+NATIVE_V147 = KIT_ROOT / "tests" / "fixtures" / "exl3-v147" / "quant"
 FILES = (
     "exl3_devctx.cu",
     "exl3_devctx.cuh",
@@ -142,11 +147,45 @@ def test_mixed_state_refused_before_any_write(tmp_path):
     assert _read_all(ext) == before
 
 
+def test_native_v147_tree_is_skipped_not_drift(tmp_path):
+    ext = _make_ext(tmp_path, NATIVE_V147)
+    before = _read_all(ext)
+    r = _run(ext)
+    assert r.returncode == 0, r.stderr
+    assert "native=1" in r.stdout
+    assert "patched=0" in r.stdout
+    assert "already=0" in r.stdout
+    assert _read_all(ext) == before
+    assert (ext / "quant" / "exl3_moe.cuh").read_bytes() == (
+        PATCHED / "exl3_moe.cuh"
+    ).read_bytes()
+
+
+def test_native_v147_hashes_match_vendored_pin():
+    spec = importlib.util.spec_from_file_location("ticket_installer", PATCHER)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    assert set(module.NATIVE_V147_SHA256) == set(FILES)
+    for name in FILES:
+        data = (NATIVE_V147 / name).read_bytes()
+        assert hashlib.sha256(data).hexdigest() == module.NATIVE_V147_SHA256[name]
+    shared = (NATIVE_V147 / "exl3_moe.cuh").read_bytes()
+    assert shared == (PATCHED / "exl3_moe.cuh").read_bytes()
+    assert shared != (PRISTINE / "exl3_moe.cuh").read_bytes()
+    for name in FILES:
+        if name == "exl3_moe.cuh":
+            continue
+        assert (NATIVE_V147 / name).read_bytes() != (PATCHED / name).read_bytes()
+        assert (NATIVE_V147 / name).read_bytes() != (PRISTINE / name).read_bytes()
+
+
 def test_dockerfile_wiring():
     """Static guard: the build must declare + forward the opt-out, copy the
     vendored sets, run the installer after the fat-kernel step, and assert
     num_active via the pybind-safe __doc__ check (inspect.signature raises
-    ValueError on pybind11 builtins)."""
+    ValueError on pybind11 builtins). v1.4.7 is the current pin; the
+    installer remains for the historical c5d9c657 rollback pin."""
     dockerfile = (KIT_ROOT / "Dockerfile").read_text()
     assert "ARG GLM53_EXL3_TICKET_SCHEDULER=1" in dockerfile
     assert "ENV GLM53_EXL3_TICKET_SCHEDULER=${GLM53_EXL3_TICKET_SCHEDULER}" in dockerfile
@@ -160,6 +199,8 @@ def test_dockerfile_wiring():
     assert "inspect.signature(exllamav3_ext.exl3_moe)" not in dockerfile
     assert "'num_active' in doc or 'arg29' in doc" in dockerfile
     assert 'if [ "${GLM53_EXL3_TICKET_SCHEDULER}" = "1" ]' in dockerfile
+    assert "ARG EXLLAMAV3_COMMIT=ca13bdd83a1f4a74fd817b88f49509e0f22a9b07" in dockerfile
+    assert "v1.4.7 already contains the d5e4361 ticket scheduler" in dockerfile
 
 
 def _read_all_of(source_dir: Path) -> dict[str, bytes]:

--- a/tests/test_exl3_v147_qualification.py
+++ b/tests/test_exl3_v147_qualification.py
@@ -1,0 +1,253 @@
+"""Host fixtures for the ExLlamaV3 v1.4.7 image-qualification blockers.
+
+Task 16: aarch64 CPU-MoE stub, native ticket-scheduler skip, NullConfig
+namespace, plus the existing fat-kernel binding anchors. No torch, no CUDA.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+KIT_ROOT = Path(__file__).resolve().parent.parent
+FIXTURES = KIT_ROOT / "tests" / "fixtures" / "exl3-v147"
+AARCH64 = KIT_ROOT / "overlay" / "patch_exl3_ext_aarch64.py"
+TICKET = KIT_ROOT / "overlay" / "patch_exl3_ticket_scheduler.py"
+FAT = KIT_ROOT / "overlay" / "patch_exl3_fat_kernel.py"
+NAMESPACE = KIT_ROOT / "overlay" / "exl3_namespace.py"
+TICKET_DIR = KIT_ROOT / "overlay" / "exl3-ticket"
+PRISTINE = TICKET_DIR / "pristine"
+PATCHED = TICKET_DIR / "patched"
+FILES = (
+    "exl3_devctx.cu",
+    "exl3_devctx.cuh",
+    "exl3_moe.cu",
+    "exl3_moe.cuh",
+    "exl3_moe_common.cuh",
+    "exl3_moe_kernel.cuh",
+)
+PIN = "ca13bdd83a1f4a74fd817b88f49509e0f22a9b07"
+
+
+def _load(path: Path, name: str):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _run(script: Path, *args: str):
+    return subprocess.run(
+        [sys.executable, str(script), *args],
+        capture_output=True,
+        text=True,
+    )
+
+
+def _ext_with_quant(tmp_path: Path, source: Path) -> Path:
+    ext = tmp_path / "ext"
+    (ext / "quant").mkdir(parents=True)
+    (ext / "cpu").mkdir(parents=True)
+    (ext / "parallel").mkdir(parents=True)
+    for name in FILES:
+        shutil.copyfile(source / name, ext / "quant" / name)
+    return ext
+
+
+def _native_tree(tmp_path: Path) -> Path:
+    return _ext_with_quant(tmp_path, FIXTURES / "quant")
+
+
+def test_pin_constants_match_v147():
+    overlay = (KIT_ROOT / "overlay" / "exl3.py").read_text()
+    dockerfile = (KIT_ROOT / "Dockerfile").read_text()
+    assert f'EXLLAMAV3_COMMIT = "{PIN}"' in overlay
+    assert 'EXLLAMAV3_VERSION = "1.4.7"' in overlay
+    assert f"ARG EXLLAMAV3_COMMIT={PIN}" in dockerfile
+    assert dockerfile.split("ARG EXLLAMAV3_COMMIT=")[1].startswith(PIN)
+    assert "COPY overlay/exl3_namespace.py" in dockerfile
+    assert "Do not copy published x86_64 wheels" in dockerfile
+    assert "GLM53_AARCH64_CPU_MOE_STUB" in dockerfile
+    assert "b'__builtin_ia32_pause'" in dockerfile
+    assert "GLM53_AARCH64_CPU_PAUSE_STUB" in dockerfile
+    assert "is_f16c_supported" in dockerfile
+    assert "'1.4.7' in ver" in dockerfile
+    assert "python3 /opt/glm53/patch_exl3_ticket_scheduler.py" in dockerfile
+    fat_pos = dockerfile.index("patch_exl3_fat_kernel.py /tmp/exllamav3")
+    ticket_pos = dockerfile.index("patch_exl3_ticket_scheduler.py /tmp/exllamav3")
+    aarch_pos = dockerfile.index("patch_exl3_ext_aarch64.py /tmp/exllamav3")
+    assert aarch_pos < fat_pos < ticket_pos
+
+
+def test_aarch64_stubs_x86_cpu_moe(tmp_path):
+    ext = tmp_path / "ext"
+    (ext / "cpu").mkdir(parents=True)
+    (ext / "parallel").mkdir(parents=True)
+    shutil.copyfile(FIXTURES / "moe_mul1.cpp", ext / "cpu" / "moe_mul1.cpp")
+    shutil.copyfile(FIXTURES / "moe_handoff.cu", ext / "cpu" / "moe_handoff.cu")
+    shutil.copyfile(FIXTURES / "all_reduce_cpu.cu", ext / "parallel" / "all_reduce_cpu.cu")
+    # leftover AVX sources that the installer must also overwrite
+    (ext / "avx2_target.cpp").write_text('#include <immintrin.h>\n')
+    (ext / "avx512_target.cpp").write_text('#include <immintrin.h>\n')
+    (ext / "parallel" / "all_reduce_cpu_avx2.cpp").write_text('#include <immintrin.h>\n')
+    (ext / "parallel" / "all_reduce_cpu_avx512.cpp").write_text('#include <immintrin.h>\n')
+    r = _run(AARCH64, str(ext))
+    assert r.returncode == 0, r.stderr + r.stdout
+    assert "cpu_moe=stubbed" in r.stdout
+    assert "cpu/moe_handoff.cu" in r.stdout
+    assert "parallel/all_reduce_cpu.cu" in r.stdout
+    stub = (ext / "cpu" / "moe_mul1.cpp").read_text()
+    assert "GLM53_AARCH64_CPU_MOE_STUB" in stub
+    assert "<immintrin.h>" not in stub
+    assert "exl3_moe_cpu_make_layer" in stub
+    assert "exl3_moe_cpu_forward_raw" in stub
+    leftover = [
+        p for p in ext.rglob("*")
+        if p.suffix in {".c", ".cpp", ".h", ".hpp", ".cu", ".cuh"}
+        and (
+            b"immintrin.h" in p.read_bytes()
+            or b"__builtin_ia32_pause" in p.read_bytes()
+            or b"_mm_pause" in p.read_bytes()
+            or b'__attribute__((target("avx' in p.read_bytes()
+            or b"__builtin_cpu_supports" in p.read_bytes()
+        )
+    ]
+    assert leftover == []
+    handoff = (ext / "cpu" / "moe_handoff.cu").read_text()
+    assert "GLM53_AARCH64_CPU_PAUSE_STUB" in handoff
+    assert "__builtin_ia32_pause" not in handoff
+    assert "_mm_pause" not in handoff
+    assert "is_f16c_supported" in (ext / "avx2_target.h").read_text()
+    assert "bool is_f16c_supported() { return false; }" in (
+        ext / "avx2_target.cpp"
+    ).read_text()
+    r2 = _run(AARCH64, str(ext))
+    assert r2.returncode == 0, r2.stderr + r2.stdout
+    assert "cpu_moe=already" in r2.stdout
+
+
+def test_aarch64_allows_missing_cpu_moe_on_old_pin(tmp_path):
+    ext = tmp_path / "ext"
+    (ext / "parallel").mkdir(parents=True)
+    r = _run(AARCH64, str(ext))
+    assert r.returncode == 0, r.stderr + r.stdout
+    assert "cpu_moe=absent" in r.stdout
+    assert not (ext / "cpu" / "moe_mul1.cpp").exists()
+
+
+def test_aarch64_refuses_unknown_cpu_moe(tmp_path):
+    ext = tmp_path / "ext"
+    (ext / "cpu").mkdir(parents=True)
+    (ext / "parallel").mkdir(parents=True)
+    (ext / "cpu" / "moe_mul1.cpp").write_text("// neither x86 nor stub\nvoid foo() {}\n")
+    r = _run(AARCH64, str(ext))
+    assert r.returncode != 0
+    assert "refusing" in (r.stderr + r.stdout)
+
+
+def test_ticket_installer_skips_native_v147(tmp_path):
+    ext = _native_tree(tmp_path)
+    before = {n: (ext / "quant" / n).read_bytes() for n in FILES}
+    r = _run(TICKET, str(ext))
+    assert r.returncode == 0, r.stderr + r.stdout
+    assert "native=1" in r.stdout
+    assert "patched=0" in r.stdout
+    after = {n: (ext / "quant" / n).read_bytes() for n in FILES}
+    assert after == before
+
+
+def test_ticket_installer_still_patches_c5d9_pristine(tmp_path):
+    ext = _ext_with_quant(tmp_path, PRISTINE)
+    r = _run(TICKET, str(ext))
+    assert r.returncode == 0, r.stderr + r.stdout
+    assert "patched=6, already=0" in r.stdout
+    for name in FILES:
+        assert (ext / "quant" / name).read_bytes() == (PATCHED / name).read_bytes()
+
+
+def test_ticket_installer_refuses_mixed_native_and_pristine(tmp_path):
+    ext = _native_tree(tmp_path)
+    shutil.copyfile(PRISTINE / "exl3_moe.cu", ext / "quant" / "exl3_moe.cu")
+    before = {n: (ext / "quant" / n).read_bytes() for n in FILES}
+    r = _run(TICKET, str(ext))
+    assert r.returncode != 0
+    assert "mixed native/c5d9c657" in (r.stderr + r.stdout)
+    after = {n: (ext / "quant" / n).read_bytes() for n in FILES}
+    assert after == before
+
+
+def test_fat_kernel_anchors_on_v147_bindings(tmp_path):
+    ext = tmp_path / "ext"
+    (ext / "quant").mkdir(parents=True)
+    shutil.copyfile(FIXTURES / "bindings.cpp", ext / "bindings.cpp")
+    source = KIT_ROOT / "overlay"
+    r = _run(FAT, str(ext), str(source))
+    assert r.returncode == 0, r.stderr + r.stdout
+    text = (ext / "bindings.cpp").read_text()
+    assert text.count('#include "quant/exl3_moe.cuh"') == 1
+    assert text.count('#include "quant/exl3_fat_gemm.cuh"') == 1
+    assert 'm.def("exl3_fat_gemm", &exl3_fat_gemm, "exl3_fat_gemm");' in text
+    assert 'm.def("exl3_fat_gemm_scatter", &exl3_fat_gemm_scatter, "exl3_fat_gemm_scatter");' in text
+    assert (ext / "quant" / "exl3_fat_gemm.cu").is_file()
+    assert (ext / "quant" / "exl3_fat_gemm.cuh").is_file()
+    # Prefix anchors stay unique after the additive insert, so a second
+    # apply is not the drift case. Re-applying would duplicate the fat
+    # entries; the build runs the installer once on a fresh pin tarball.
+
+
+def test_nullconfig_inferparams_injected_for_v147_linearexl3(tmp_path):
+    ns = _load(NAMESPACE, "glm53_exl3_namespace")
+    pkg = tmp_path / "exllamav3"
+    (pkg / "model").mkdir(parents=True)
+    (pkg / "modules").mkdir(parents=True)
+    fake_modules: dict = {}
+    config = ns.inject_config_stub(pkg, fake_modules)
+    assert config.NullConfig is ns.NullConfig
+    assert config.InferParams is ns.InferParams
+    assert fake_modules["exllamav3.model.config"] is config
+
+    g: dict = {
+        "__name__": "linear_exl3_init",
+        "Config": object,
+        "NullConfig": ns.NullConfig,
+    }
+    exec((FIXTURES / "linear_exl3_init.py").read_text().split("from ...")[0], g)
+    # Drive the same config=None contract LinearEXL3 uses in v1.4.7.
+    cfg = ns.NullConfig()
+    assert cfg.infer_params.no_reconstruct is False
+    assert isinstance(cfg.infer_params, ns.InferParams)
+
+    def construct(config=None):
+        if config is None:
+            from_mod = fake_modules["exllamav3.model.config"]
+            config = from_mod.NullConfig()
+        return config.infer_params.no_reconstruct
+
+    assert construct(None) is False
+    forced = ns.NullConfig()
+    forced.infer_params.no_reconstruct = True
+    assert construct(forced) is True
+
+
+def test_old_config_only_stub_would_not_construct():
+    class ConfigOnly:
+        pass
+
+    def construct(config=None):
+        if config is None:
+            try:
+                from nowhere import NullConfig  # noqa: F401
+            except ImportError as exc:
+                raise AttributeError("config.infer_params") from exc
+        return config.infer_params.no_reconstruct
+
+    try:
+        construct(None)
+    except AttributeError as exc:
+        assert "infer_params" in str(exc)
+    else:
+        raise AssertionError("old Config-only stub must not construct LinearEXL3")


### PR DESCRIPTION
Qualify ExLlamaV3 v1.4.7 `ca13bdd` as a bundled rebuilt serving image and adopt it after a guarded A/B against production `glm53-selfbuild:b5ab8091-s2b`. This is a maintenance/hardening pin, not a performance window: the v1.4.6→v1.4.7 release does not change the production K4/MCG `exl3_moe` hot path, and the custom fat-GEMM remains overlay-owned.

## What landed

- Native pin `ca13bdd` / `1.4.7` in `overlay/exl3.py` and the Dockerfile. Ticket scheduling is now upstream in that pin; the historical c5d9 installer is retained and skips the exact v1.4.7 SHA256 set, including the shared `exl3_moe.cuh`.
- aarch64 installer stubs CPU-MoE (`moe_mul1.cpp`), rewrites leftover x86 pause builtins to `std::this_thread::yield()`, and exposes complete AVX/F16C false stubs so `all_reduce_cpu.cu` still compiles. Leftover `immintrin.h` / pause / AVX target / `__builtin_cpu_supports` fail closed.
- `overlay/exl3_namespace.py` injects `NullConfig`/`InferParams` so v1.4.7 `LinearEXL3(config=None)` constructs.
- Host fixtures under `tests/fixtures/exl3-v147/` plus 204 pytest (1 skipped). No CUDA kernel rewrite. No published x86_64 wheels.

## Cluster A/B

Control `glm53-selfbuild:b5ab8091-s2b`. Candidate `glm53-selfbuild:ca13bdd-v147` (`sha256:07ce8a41078a…`), built on spark1 and loaded on both ranks. Live production overlays were not mutated; IMAGE= was the only runtime flip.

| Gate | A-control | B-candidate | Return-A | Adopt |
|---|---|---|---|---|
| Acceptance | 7/7 | 7/7 | 7/7 | 7/7 |
| Serving | 6/6 | 6/6 | 6/6 | 6/6 |
| Pool | 1,396,551 / 1.40× | identical | identical | identical |
| Structured median tok/s | 70.08 | 70.03 (b2) | not re-sampled | 69.91 |
| Accept / drafts | 1.0000 / 7.0 | 1.0000 / 7.0 | 1.0000 / 7.0 | 1.0000 / 7.0 |
| Health / bind | 200 / loopback | 200 / loopback | 200 / loopback | 200 / loopback |
| MemFree head/worker GiB | 4.9 / 5.2 | 4.7 / (B miss) | 4.2 / 4.1 | 6.2 / 4.3 |

B1 had one contended 24 tok/s pass with accept still 1.0000/7.0. Routed experts logged `fused_moe=exl3_moe` with no BF16 reconstruct at load, so fused-reconstruct LinearEXL3 stayed dormant. Cold 60k/240k prefill was not re-measured. Watchdog re-armed after adopt. Rollback remains `IMAGE=glm53-selfbuild:b5ab8091-s2b`.

Production after merge: `IMAGE=glm53-selfbuild:ca13bdd-v147`, health 200, watchdog.timer active.

## Out of scope

- No fused-MoE/decode performance claim.
- SM121 kernel lab remains later/off-prod.