### PR TITLE
EXL3: adopt E3 grouped fat-expert MoE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -372,6 +372,8 @@ COPY overlay/patch_exl3_ext_aarch64.py /opt/glm53/patch_exl3_ext_aarch64.py
 COPY overlay/patch_exl3_fat_kernel.py /opt/glm53/patch_exl3_fat_kernel.py
 COPY overlay/exl3_fat_gemm.cu /opt/glm53/exl3-fat-kernel/exl3_fat_gemm.cu
 COPY overlay/exl3_fat_gemm.cuh /opt/glm53/exl3-fat-kernel/exl3_fat_gemm.cuh
+COPY overlay/exl3_fat_moe.cu /opt/glm53/exl3-fat-kernel/exl3_fat_moe.cu
+COPY overlay/exl3_fat_moe.cuh /opt/glm53/exl3-fat-kernel/exl3_fat_moe.cuh
 COPY overlay/patch_exl3_ticket_scheduler.py /opt/glm53/patch_exl3_ticket_scheduler.py
 COPY overlay/exl3-ticket/ /opt/glm53/exl3-ticket/
 
@@ -432,14 +434,14 @@ RUN set -eux; \
     python3 /opt/glm53/patch_exl3_ext_aarch64.py /tmp/exllamav3/exllamav3/exllamav3_ext; \
     python3 /opt/glm53/patch_exl3_fat_kernel.py /tmp/exllamav3/exllamav3/exllamav3_ext /opt/glm53/exl3-fat-kernel; \
     python3 /opt/glm53/patch_exl3_ticket_scheduler.py /tmp/exllamav3/exllamav3/exllamav3_ext; \
-    python3 -c "from pathlib import Path; root = Path('/tmp/exllamav3/exllamav3/exllamav3_ext'); markers=(b'immintrin.h', b'__builtin_ia32_pause', b'_mm_pause', b'__attribute__((target(\"avx', b'target_clones(\"avx', b'__builtin_cpu_supports'); hits=[p for p in root.rglob('*') if p.suffix in {'.c','.cpp','.h','.hpp','.cu','.cuh'} and any(m in p.read_bytes() for m in markers)]; assert not hits, hits; moe=(root/'cpu'/'moe_mul1.cpp'); assert moe.is_file() and 'GLM53_AARCH64_CPU_MOE_STUB' in moe.read_text(); handoff=(root/'cpu'/'moe_handoff.cu').read_text(); assert 'GLM53_AARCH64_CPU_PAUSE_STUB' in handoff; assert 'is_f16c_supported' in (root/'avx2_target.h').read_text(); assert 'bool is_f16c_supported() { return false; }' in (root/'avx2_target.cpp').read_text(); bind=(root/'bindings.cpp').read_text(); assert 'exl3_fat_gemm' in bind"; \
+    python3 -c "from pathlib import Path; root = Path('/tmp/exllamav3/exllamav3/exllamav3_ext'); markers=(b'immintrin.h', b'__builtin_ia32_pause', b'_mm_pause', b'__attribute__((target(\"avx', b'target_clones(\"avx', b'__builtin_cpu_supports'); hits=[p for p in root.rglob('*') if p.suffix in {'.c','.cpp','.h','.hpp','.cu','.cuh'} and any(m in p.read_bytes() for m in markers)]; assert not hits, hits; moe=(root/'cpu'/'moe_mul1.cpp'); assert moe.is_file() and 'GLM53_AARCH64_CPU_MOE_STUB' in moe.read_text(); handoff=(root/'cpu'/'moe_handoff.cu').read_text(); assert 'GLM53_AARCH64_CPU_PAUSE_STUB' in handoff; assert 'is_f16c_supported' in (root/'avx2_target.h').read_text(); assert 'bool is_f16c_supported() { return false; }' in (root/'avx2_target.cpp').read_text(); bind=(root/'bindings.cpp').read_text(); assert 'exl3_fat_gemm' in bind and 'exl3_fat_moe' in bind"; \
     export CPATH="/usr/local/lib/python3.12/dist-packages/nvidia/cu13/include${CPATH:+:$CPATH}"; \
     export CPLUS_INCLUDE_PATH="/usr/local/lib/python3.12/dist-packages/nvidia/cu13/include${CPLUS_INCLUDE_PATH:+:$CPLUS_INCLUDE_PATH}"; \
     export C_INCLUDE_PATH="/usr/local/lib/python3.12/dist-packages/nvidia/cu13/include${C_INCLUDE_PATH:+:$C_INCLUDE_PATH}"; \
     cd /tmp/exllamav3; \
     TORCH_CUDA_ARCH_LIST=12.1a MAX_JOBS=8 \
       pip install --no-deps --no-build-isolation --no-cache-dir .; \
-    python3 -c "import torch; import exllamav3_ext; assert hasattr(exllamav3_ext, 'exl3_moe'), dir(exllamav3_ext); assert hasattr(exllamav3_ext, 'exl3_fat_gemm'), dir(exllamav3_ext); assert hasattr(exllamav3_ext, 'exl3_fat_gemm_scatter'), dir(exllamav3_ext); print('exllamav3_ext', exllamav3_ext.__file__, 'exl3_moe=yes fat_gemm=yes')"; \
+    python3 -c "import torch; import exllamav3_ext; assert hasattr(exllamav3_ext, 'exl3_moe'), dir(exllamav3_ext); assert hasattr(exllamav3_ext, 'exl3_fat_gemm'), dir(exllamav3_ext); assert hasattr(exllamav3_ext, 'exl3_fat_gemm_scatter'), dir(exllamav3_ext); assert hasattr(exllamav3_ext, 'exl3_fat_moe_gather'), dir(exllamav3_ext); print('exllamav3_ext', exllamav3_ext.__file__, 'exl3_moe=yes fat_gemm=yes fat_moe=yes')"; \
     if [ "${GLM53_EXL3_TICKET_SCHEDULER}" = "1" ]; then \
       python3 -c "import torch, exllamav3_ext; doc = exllamav3_ext.exl3_moe.__doc__ or ''; assert 'num_active' in doc or 'arg29' in doc or doc.count('arg') >= 30, 'ticket scheduler (d5e4361) not applied'; print('exl3_moe num_active=yes (ticket scheduler)')"; \
     else \

--- a/Dockerfile.e3-layer
+++ b/Dockerfile.e3-layer
@@ -1,0 +1,38 @@
+# E3 grouped fat-expert CANDIDATE image, layered on the verified baseline image.
+#
+# Experimental. Adds the additive `exl3_fat_moe_ext` module (built from
+# overlay/exl3_fat_moe.cu inside a copy of the installed exllamav3_ext source
+# tree, WITHOUT --use_fast_math), the updated exl3.py overlay (EXL3_FAT_GROUPED,
+# default off) and its self-check. The preferred cubin vehicle for the first
+# A/B: it does not recompile exllamav3_ext. Independent variable remains
+# EXL3_FAT_GROUPED=1 on the current 1M / pin / TRF=128 / C4 geometry.
+#
+# Build (repo root of the experiment worktree):
+#   docker build -f Dockerfile.e3-layer \
+#     --build-arg BASE=glm53-selfbuild:ca13bdd-v147 \
+#     --build-arg GLM53_RECIPE_STAMP=$(git rev-parse --short HEAD) \
+#     -t glm53-selfbuild:e3-grouped .
+ARG BASE=glm53-selfbuild:ca13bdd-v147
+FROM ${BASE}
+
+COPY overlay/exl3_fat_moe.cu /opt/glm53/exl3-fat-kernel/exl3_fat_moe.cu
+COPY overlay/exl3_fat_moe.cuh /opt/glm53/exl3-fat-kernel/exl3_fat_moe.cuh
+COPY overlay/build_exl3_fat_moe_ext.py /opt/glm53/build_exl3_fat_moe_ext.py
+COPY overlay/patch_exl3_fat_kernel.py /opt/glm53/patch_exl3_fat_kernel.py
+
+# Single translation unit; keep the compile light on a UMA host.
+ENV MAX_JOBS=2
+RUN python3 /opt/glm53/build_exl3_fat_moe_ext.py \
+        --src /opt/glm53/exl3-fat-kernel --out /tmp/e3build \
+        --install /usr/local/lib/python3.12/dist-packages \
+    && python3 -c "import torch, exl3_fat_moe_ext as m; print('exl3_fat_moe_ext OK tile_gu', m.exl3_fat_moe_tile_rows_gateup(), 'tile_dn', m.exl3_fat_moe_tile_rows_down())" \
+    && rm -rf /tmp/e3build
+
+COPY overlay/exl3.py /usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/quantization/exl3.py
+COPY tests/test_exl3_overlay.py /opt/glm53/test_exl3_overlay.py
+
+# Static self-check (no GPU at build time). GPU parity runs on-cluster.
+RUN EXL3_SELFCHECK_GPU=0 python3 /opt/glm53/test_exl3_overlay.py
+
+ARG GLM53_RECIPE_STAMP=unknown
+LABEL glm53.recipe.stamp=${GLM53_RECIPE_STAMP} glm53.e3.candidate=1

--- a/docs/02-parameters.md
+++ b/docs/02-parameters.md
@@ -164,3 +164,14 @@ cache is invisible to it). 0.87 demands 105.87 GiB free against boots measured a
   Ticket-scheduler cherry-pick (`d5e4361`) is baked at image build
   (`GLM53_EXL3_TICKET_SCHEDULER=1`, not an env.example knob). Rollback of
   the kernel stack is an `IMAGE=` flip, not a flag.
+
+- `EXL3_FAT_GROUPED=0` — E3 grouped fat-expert MoE, **default off**. Prefill
+  only: device-side segment tables plus three launches (gather / gate+up+SwiGLU
+  / down+`float4` atomic scatter) instead of the E2 host loop over fat
+  experts. Decode stays fused `exl3_moe`. Requires the additive
+  `exl3_fat_moe` symbols (layered candidate `Dockerfile.e3-layer`, or a
+  later full rebuild). Missing symbols fail closed. Predicted persistent
+  scratch at MNBT × top-8 = 28,672 rows is **336 MiB/rank**; the 1M KV pin
+  does not move. Independent A/B variable on the current 1M / pin / TRF=128
+  / C4 geometry. Rollback: `EXL3_FAT_GROUPED=0` and
+  `IMAGE=glm53-selfbuild:ca13bdd-v147`.

--- a/docs/02-parameters.md
+++ b/docs/02-parameters.md
@@ -165,13 +165,15 @@ cache is invisible to it). 0.87 demands 105.87 GiB free against boots measured a
   (`GLM53_EXL3_TICKET_SCHEDULER=1`, not an env.example knob). Rollback of
   the kernel stack is an `IMAGE=` flip, not a flag.
 
-- `EXL3_FAT_GROUPED=0` — E3 grouped fat-expert MoE, **default off**. Prefill
-  only: device-side segment tables plus three launches (gather / gate+up+SwiGLU
-  / down+`float4` atomic scatter) instead of the E2 host loop over fat
-  experts. Decode stays fused `exl3_moe`. Requires the additive
-  `exl3_fat_moe` symbols (layered candidate `Dockerfile.e3-layer`, or a
-  later full rebuild). Missing symbols fail closed. Predicted persistent
-  scratch at MNBT × top-8 = 28,672 rows is **336 MiB/rank**; the 1M KV pin
-  does not move. Independent A/B variable on the current 1M / pin / TRF=128
-  / C4 geometry. Rollback: `EXL3_FAT_GROUPED=0` and
-  `IMAGE=glm53-selfbuild:ca13bdd-v147`.
+- `EXL3_FAT_GROUPED=1` — E3 grouped fat-expert MoE, **adopted 2026-09-07**.
+  Prefill only: device-side segment tables plus three launches (gather /
+  gate+up+SwiGLU / down+`float4` atomic scatter) instead of the E2 host
+  loop over fat experts. Decode stays fused `exl3_moe`. Requires the
+  additive `exl3_fat_moe` symbols from `glm53-selfbuild:e3-grouped`
+  (`Dockerfile.e3-layer` on `ca13bdd-v147`). Missing symbols fail closed.
+  Predicted persistent scratch at MNBT × top-8 = 28,672 rows is
+  **336 MiB/rank**; the 1M KV pin did not move. Same-day A-B-B-A: 240k
+  cold prefill **+19.6%** (1075 → 1286 tok/s), structured decode
+  non-inferior, pool 1,396,551 / 1.40×. Rollback: `EXL3_FAT_GROUPED=0`
+  and `IMAGE=glm53-selfbuild:ca13bdd-v147`. GHCR/old images must leave
+  this 0.

--- a/docs/06-improvement-plan.md
+++ b/docs/06-improvement-plan.md
@@ -37,6 +37,25 @@ Mainline GLM support (#53906) has merged, so model resolution is no longer the
 mainline blocker described in the historical section above; EXL3 integration
 and overlay compatibility still block a stock-image replacement.
 
+### 2026-09-07: task 23 E3 grouped fat-expert MoE (prepared)
+
+Additive overlay + layered candidate for the grouping step in docs/11 §5.
+Independent variable is `EXL3_FAT_GROUPED=1` on the current 1M / pin /
+TRF=128 / C4 geometry. Control remains `glm53-selfbuild:ca13bdd-v147` with
+`EXL3_FAT_GROUPED=0`. Candidate vehicle: `Dockerfile.e3-layer` →
+`glm53-selfbuild:e3-grouped`. Do not bundle the rest of kit PR #132
+(900k/850k default, GPU_MEM_UTIL, TRF=32, clock-lock, client docs).
+
+Intake already on this tree: warp-MMA + 4-stage `cp.async`, SMEM 32,768 B,
+CUDA 13 / `sm_121a`, K4/MCG no-mul1, hidden % 256, intermediate % 128,
+`min(K) ≥ 128`, fail-closed missing symbols, SiLU `exp(double)` +
+`__fdiv_rn`, `atomicAdd(float4*)`. Predicted scratch 336 MiB/rank at
+28,672 rows. `EXL3_FAT_GROUPED=0` is the E2 path (ROW_TILE
+short-circuit and `_exl3_last_fat_fallback` retained). Cluster window
+not yet run: adopt only on ≥5% 240k cold-prefill gain with pool
+1,396,551 / 1.40× and both-node MemFree ≥ 2.5 GiB; otherwise restore
+`IMAGE=glm53-selfbuild:ca13bdd-v147` and `EXL3_FAT_GROUPED=0`.
+
 ### 2026-09-07: task 9 spec-graph probe (eager arm parked)
 
 Kit PR #70's read-only gate fails when pos0 acceptance is ~1.00. That rule

--- a/docs/06-improvement-plan.md
+++ b/docs/06-improvement-plan.md
@@ -22,9 +22,10 @@ fusions, and all of EXL3 — zero EXL3 code exists in vLLM mainline). Consequenc
 
 ## Current queue (research refresh, 2026-09-05)
 
-The S1/S2 kernel program is closed. Production is `glm53-selfbuild:ca13bdd-v147`
-(ExLlamaV3 v1.4.7 native pin, fat GEMM pipelined, ticket scheduler native).
-Rollback remains `glm53-selfbuild:b5ab8091-s2b`. The initial contended **+0.3%**
+The S1/S2 kernel program is closed. Production is `glm53-selfbuild:e3-grouped`
+(ExLlamaV3 v1.4.7 native pin, E2 fat GEMM pipelined, E3 grouped fat-expert
+MoE on). Rollback remains `glm53-selfbuild:ca13bdd-v147` with
+`EXL3_FAT_GROUPED=0`. The initial contended **+0.3%**
 end-to-end result is superseded by PR #32's powered re-window:
 **+5.3–5.6% cold prefill**. Further kernel work needs a new current-stack
 profile, not extrapolation from the isolated +41% kernel result.
@@ -37,24 +38,39 @@ Mainline GLM support (#53906) has merged, so model resolution is no longer the
 mainline blocker described in the historical section above; EXL3 integration
 and overlay compatibility still block a stock-image replacement.
 
-### 2026-09-07: task 23 E3 grouped fat-expert MoE (prepared)
+### 2026-09-07: task 23 E3 grouped fat-expert MoE ADOPTED
 
-Additive overlay + layered candidate for the grouping step in docs/11 §5.
-Independent variable is `EXL3_FAT_GROUPED=1` on the current 1M / pin /
-TRF=128 / C4 geometry. Control remains `glm53-selfbuild:ca13bdd-v147` with
-`EXL3_FAT_GROUPED=0`. Candidate vehicle: `Dockerfile.e3-layer` →
-`glm53-selfbuild:e3-grouped`. Do not bundle the rest of kit PR #132
-(900k/850k default, GPU_MEM_UTIL, TRF=32, clock-lock, client docs).
+Additive overlay + layered cubin for the grouping step in docs/11 §5.
+Independent variable was `EXL3_FAT_GROUPED=1` on the current 1M / pin /
+TRF=128 / C4 geometry. Control: `glm53-selfbuild:ca13bdd-v147` /
+`EXL3_FAT_GROUPED=0`. Candidate: `Dockerfile.e3-layer` →
+`glm53-selfbuild:e3-grouped` (`sha256:bd711518d87f…`, stamp `189b653`).
+Did not bundle the rest of kit PR #132.
 
-Intake already on this tree: warp-MMA + 4-stage `cp.async`, SMEM 32,768 B,
-CUDA 13 / `sm_121a`, K4/MCG no-mul1, hidden % 256, intermediate % 128,
-`min(K) ≥ 128`, fail-closed missing symbols, SiLU `exp(double)` +
-`__fdiv_rn`, `atomicAdd(float4*)`. Predicted scratch 336 MiB/rank at
-28,672 rows. `EXL3_FAT_GROUPED=0` is the E2 path (ROW_TILE
-short-circuit and `_exl3_last_fat_fallback` retained). Cluster window
-not yet run: adopt only on ≥5% 240k cold-prefill gain with pool
-1,396,551 / 1.40× and both-node MemFree ≥ 2.5 GiB; otherwise restore
-`IMAGE=glm53-selfbuild:ca13bdd-v147` and `EXL3_FAT_GROUPED=0`.
+**Cluster verdict: ADOPT.** Same-day A-B-B-A. Both ranks `grouped_ok`
+/ `sym_fat_moe=1`. Isolated GPU microbench: PARITY OK vs LinearEXL3
+and E2; Zipf-1.0 cap=32 median 29.0 vs 54.3 ms (**1.87×**). End-to-end
+240k cold prefill **+19.6% / +19.5%** (B/B2) vs the 5% adopt bar.
+
+| Gate | A-control | B | B2 | Return-A | Adopt |
+|---|---|---|---|---|---|
+| Acceptance | (pre-window healthy) | 7/7 | — | 7/7 | 7/7 |
+| Serving (:18000) | — | 6/6 | — | 6/6 | 6/6 |
+| Toolcall | — | 23/23 | — | — | — |
+| Pool | 1,396,551 / 1.40× | identical | identical | identical | identical |
+| 60k median tok/s | 1108.8 | 1330.3 | 1328.2 | — | — |
+| 240k median tok/s | 1075.0 | 1285.7 | 1284.2 | — | — |
+| Structured median | 69.79 @ 7.0/1.000 | 69.18 (one 25.6 contended; rest 69.0–69.7) | — | 69.98 | 69.62 |
+| Health / bind | 200 / loopback | 200 / loopback | 200 / loopback | 200 / loopback | 200 / loopback |
+| MemFree head/worker GiB | 6.0–7.0 / 4.3–4.5 | 5.3–6.3 / 4.1–4.5 | — | 3.34 / 4.08 | 4.51 / 3.98 |
+
+Host suite 233 passed / 1 skipped / 4 subtests. CUDA review APPROVED;
+final review APPROVED after two P2s (microbench schema key; missing-symbol
+fail-closed before SUH downgrade). Watchdog re-armed after
+`watchdog.service` inactive. Rollback:
+`.env.bak-pre-task23-e3-20260907-175016` +
+`start.sh.bak-pre-task23-e3-20260907` (`IMAGE=glm53-selfbuild:ca13bdd-v147`,
+`EXL3_FAT_GROUPED=0`).
 
 ### 2026-09-07: task 9 spec-graph probe (eager arm parked)
 

--- a/docs/11-gb10-kernel-program.md
+++ b/docs/11-gb10-kernel-program.md
@@ -330,15 +330,13 @@ Operator queue lives in `docs/06` (night rewrite) and `spec/TODO.md`.
    change is a separate guarded window.
 8. **S3** Trellis — **PARKED** (`docs/12`). Re-open only on the existing
    trigger (≥ ~80 TFLOP/s rank-sliced, or s2b idle e2e < 5%).
-9. **E3 grouped fat-expert MoE (task 23 / kit PR #132 grouping step).**
-   Additive `overlay/exl3_fat_moe.cu`: warp-MMA + 4-stage `cp.async`,
-   SMEM **32,768 B** (gate 101,376 B), CUDA 13 / `sm_121a`, SiLU
-   `exp(double)` + `__fdiv_rn`, `atomicAdd(float4*)`. Eligibility
-   documents `min(K) ≥ 128` (`FM_STAGES × FM_TILE_K`); this geometry is
-   4096/2048 so the A-pipeline cannot run dry. Default off
-   (`EXL3_FAT_GROUPED=0`). Preferred cubin vehicle:
-   `Dockerfile.e3-layer` on `glm53-selfbuild:ca13bdd-v147`. This is the
-   grouping step, not a Trellis substitute.
+9. ~~**E3 grouped fat-expert MoE (task 23)**~~ — **ADOPTED 2026-09-07**
+   (`glm53-selfbuild:e3-grouped`, `EXL3_FAT_GROUPED=1`). Additive
+   `overlay/exl3_fat_moe.cu`: warp-MMA + 4-stage `cp.async`, SMEM
+   **32,768 B**, CUDA 13 / `sm_121a`. End-to-end 240k cold prefill
+   **+19.6%** vs `ca13bdd-v147` E2; decode non-inferior; pool unchanged.
+   This is the grouping step, not a Trellis substitute. Rollback:
+   `EXL3_FAT_GROUPED=0` + `IMAGE=glm53-selfbuild:ca13bdd-v147`.
 10. Watch (not EXL3 kernels): adaptive-K at **verification** #52228/#52559,
    CUTLASS sm120 grouped GEMM #43814 (FP8 path only), DeepGEMM sm120, Marlin
    sm121 W4A8 corruption #49546 (**do not adopt**).

--- a/docs/11-gb10-kernel-program.md
+++ b/docs/11-gb10-kernel-program.md
@@ -330,6 +330,15 @@ Operator queue lives in `docs/06` (night rewrite) and `spec/TODO.md`.
    change is a separate guarded window.
 8. **S3** Trellis — **PARKED** (`docs/12`). Re-open only on the existing
    trigger (≥ ~80 TFLOP/s rank-sliced, or s2b idle e2e < 5%).
-9. Watch (not EXL3 kernels): adaptive-K at **verification** #52228/#52559,
+9. **E3 grouped fat-expert MoE (task 23 / kit PR #132 grouping step).**
+   Additive `overlay/exl3_fat_moe.cu`: warp-MMA + 4-stage `cp.async`,
+   SMEM **32,768 B** (gate 101,376 B), CUDA 13 / `sm_121a`, SiLU
+   `exp(double)` + `__fdiv_rn`, `atomicAdd(float4*)`. Eligibility
+   documents `min(K) ≥ 128` (`FM_STAGES × FM_TILE_K`); this geometry is
+   4096/2048 so the A-pipeline cannot run dry. Default off
+   (`EXL3_FAT_GROUPED=0`). Preferred cubin vehicle:
+   `Dockerfile.e3-layer` on `glm53-selfbuild:ca13bdd-v147`. This is the
+   grouping step, not a Trellis substitute.
+10. Watch (not EXL3 kernels): adaptive-K at **verification** #52228/#52559,
    CUTLASS sm120 grouped GEMM #43814 (FP8 path only), DeepGEMM sm120, Marlin
    sm121 W4A8 corruption #49546 (**do not adopt**).

--- a/env.example
+++ b/env.example
@@ -45,7 +45,7 @@ SERVED_MODEL_NAME=GLM-5.3-Flash-EXL3
 PORT=8000
 # PROD since 2026-08-30 is a local Dockerfile build, not a pulled artifact.
 # After `docker build -t glm53-selfbuild .` (README), this name matches.
-# Production currently runs the tagged build `glm53-selfbuild:b5ab8091-s2b`.
+# Production currently runs the tagged build `glm53-selfbuild:e3-grouped`.
 # Last public GHCR digest (pre-kernel-stack, no exl3_fat_gemm — leave the
 # EXL3_FAT_* flags off if you boot it):
 # IMAGE=ghcr.io/miaai-lab/glm-5.3-flash-2x-dgx-sparks@sha256:9bb1557a4234fce63d59599e44d10747eabd742beb337eebf9e7070be8a0fd58
@@ -233,9 +233,9 @@ VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=1800
 EXL3_FAT_SORTED=1     # contiguous expert slices of the existing sort
 EXL3_FAT_BATCHED=1    # E1: persistent scratch + concatenated gate+up trellis
 EXL3_FAT_KERNEL=1     # E2: fused direct/scatter trellis GEMM (SM121; pipelined)
-# E3 grouped fat-expert MoE (prefill). Default OFF. Needs the additive
-# exl3_fat_moe kernels (layered candidate image Dockerfile.e3-layer, or a
-# later full rebuild). Does not rewrite E2. Decode never takes this path.
-# Independent A/B variable on the current 1M / pin / TRF=128 / C4 geometry.
+# E3 grouped fat-expert MoE (prefill). ADOPTED 2026-09-07. Needs the additive
+# exl3_fat_moe kernels (layered image glm53-selfbuild:e3-grouped). Does not
+# rewrite E2. Decode never takes this path. 1M / pin / TRF=128 / C4 unchanged.
 # Rollback: EXL3_FAT_GROUPED=0 and IMAGE=glm53-selfbuild:ca13bdd-v147.
-EXL3_FAT_GROUPED=0
+# GHCR/old images without exl3_fat_moe must leave this 0 (fail-closed).
+EXL3_FAT_GROUPED=1

--- a/env.example
+++ b/env.example
@@ -233,3 +233,9 @@ VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=1800
 EXL3_FAT_SORTED=1     # contiguous expert slices of the existing sort
 EXL3_FAT_BATCHED=1    # E1: persistent scratch + concatenated gate+up trellis
 EXL3_FAT_KERNEL=1     # E2: fused direct/scatter trellis GEMM (SM121; pipelined)
+# E3 grouped fat-expert MoE (prefill). Default OFF. Needs the additive
+# exl3_fat_moe kernels (layered candidate image Dockerfile.e3-layer, or a
+# later full rebuild). Does not rewrite E2. Decode never takes this path.
+# Independent A/B variable on the current 1M / pin / TRF=128 / C4 geometry.
+# Rollback: EXL3_FAT_GROUPED=0 and IMAGE=glm53-selfbuild:ca13bdd-v147.
+EXL3_FAT_GROUPED=0

--- a/local/task23-a-control-prefill-20260907.json
+++ b/local/task23-a-control-prefill-20260907.json
@@ -1,0 +1,144 @@
+{
+  "phase": "a-control",
+  "image": "glm53-selfbuild:ca13bdd-v147",
+  "ts": 1788818026.701025,
+  "cases": [
+    {
+      "tokens": 60000,
+      "runs": [
+        {
+          "prompt_tokens": 80173,
+          "ttft_s": 76.61,
+          "prefill_tok_s": 1046.6,
+          "total_s": 76.95,
+          "i": 1,
+          "metrics_before": {
+            "running": 0.0,
+            "waiting": 0.0,
+            "kv_usage": 0.0
+          }
+        },
+        {
+          "prompt_tokens": 79821,
+          "ttft_s": 76.5,
+          "prefill_tok_s": 1043.4,
+          "total_s": 76.8,
+          "i": 2,
+          "metrics_before": {
+            "running": 0.0,
+            "waiting": 0.0,
+            "kv_usage": 0.0
+          }
+        },
+        {
+          "prompt_tokens": 79888,
+          "ttft_s": 71.93,
+          "prefill_tok_s": 1110.6,
+          "total_s": 72.14,
+          "i": 3,
+          "metrics_before": {
+            "running": 0.0,
+            "waiting": 0.0,
+            "kv_usage": 0.0
+          }
+        },
+        {
+          "prompt_tokens": 79867,
+          "ttft_s": 71.99,
+          "prefill_tok_s": 1109.5,
+          "total_s": 72.44,
+          "i": 4,
+          "metrics_before": {
+            "running": 0.0,
+            "waiting": 0.0,
+            "kv_usage": 0.0
+          }
+        },
+        {
+          "prompt_tokens": 79654,
+          "ttft_s": 71.84,
+          "prefill_tok_s": 1108.8,
+          "total_s": 72.58,
+          "i": 5,
+          "metrics_before": {
+            "running": 0.0,
+            "waiting": 0.0,
+            "kv_usage": 0.0
+          }
+        }
+      ],
+      "median_tok_s": 1108.8,
+      "min_tok_s": 1043.4,
+      "max_tok_s": 1110.6
+    },
+    {
+      "tokens": 240000,
+      "runs": [
+        {
+          "prompt_tokens": 319467,
+          "ttft_s": 298.22,
+          "prefill_tok_s": 1071.2,
+          "total_s": 298.49,
+          "i": 1,
+          "metrics_before": {
+            "running": 0.0,
+            "waiting": 0.0,
+            "kv_usage": 0.0
+          }
+        },
+        {
+          "prompt_tokens": 319143,
+          "ttft_s": 296.88,
+          "prefill_tok_s": 1075.0,
+          "total_s": 302.15,
+          "i": 2,
+          "metrics_before": {
+            "running": 0.0,
+            "waiting": 0.0,
+            "kv_usage": 0.0
+          }
+        },
+        {
+          "prompt_tokens": 319469,
+          "ttft_s": 296.63,
+          "prefill_tok_s": 1077.0,
+          "total_s": 296.95,
+          "i": 3,
+          "metrics_before": {
+            "running": 0.0,
+            "waiting": 0.0,
+            "kv_usage": 0.0
+          }
+        },
+        {
+          "prompt_tokens": 319263,
+          "ttft_s": 296.81,
+          "prefill_tok_s": 1075.6,
+          "total_s": 296.93,
+          "i": 4,
+          "metrics_before": {
+            "running": 0.0,
+            "waiting": 0.0,
+            "kv_usage": 0.0
+          }
+        },
+        {
+          "prompt_tokens": 319502,
+          "ttft_s": 301.2,
+          "prefill_tok_s": 1060.8,
+          "total_s": 301.42,
+          "i": 5,
+          "metrics_before": {
+            "running": 0.0,
+            "waiting": 0.0,
+            "kv_usage": 0.0
+          }
+        }
+      ],
+      "median_tok_s": 1075.0,
+      "min_tok_s": 1060.8,
+      "max_tok_s": 1077.0
+    }
+  ],
+  "done_ts": 1788820177.7492638
+}

--- a/local/task23-a-structured-20260907.json
+++ b/local/task23-a-structured-20260907.json
@@ -1,0 +1,213 @@
+{
+  "phase": "a-control",
+  "health_code": 200,
+  "health_body": "",
+  "runs": [
+    {
+      "http": 200,
+      "ttft_s": 0.354985208,
+      "wall_s": 3.1981984170000004,
+      "decode_s": 2.8432132090000004,
+      "tok_s": 69.99123364019232,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.3554499999999994,
+      "wall_s": 3.211403208,
+      "decode_s": 2.8559532080000007,
+      "tok_s": 69.67901275222852,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.3552297919999994,
+      "wall_s": 3.2090847920000005,
+      "decode_s": 2.853855000000001,
+      "tok_s": 69.730242076069,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.3743388329999995,
+      "wall_s": 3.2122198750000006,
+      "decode_s": 2.837881042000001,
+      "tok_s": 70.1227419524796,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.3602749160000016,
+      "wall_s": 3.2116967909999996,
+      "decode_s": 2.851421874999998,
+      "tok_s": 69.78974305582199,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    }
+  ],
+  "ts": 1788817925.004823,
+  "prompt": "structured-count-1-200",
+  "thinking": false,
+  "temperature": 0,
+  "warmup": {
+    "tok_s": 86.78590163028015,
+    "ttft_s": 0.383512125,
+    "completion_tokens": 32
+  },
+  "tok_s_median": 69.78974305582199,
+  "tok_s_min": 69.67901275222852,
+  "tok_s_max": 70.1227419524796,
+  "ttft_median_s": 0.3554499999999994,
+  "completion_tokens_median": 200.0,
+  "accept_ratio_median": 1.0,
+  "accepted_per_step_median": 7.0,
+  "any_nan": false,
+  "health_code_after": 200,
+  "short_after": {
+    "http": 200,
+    "ttft_s": 0.38243262499999986,
+    "wall_s": 0.5020710840000007,
+    "decode_s": 0.11963845900000081,
+    "tok_s": 58.50961353489142,
+    "completion_tokens": 8,
+    "prompt_tokens": 40,
+    "finish_reason": "length",
+    "nan": false,
+    "text_head": "# How a Hash Map Works: A",
+    "text_len": 25,
+    "usage": {
+      "prompt_tokens": 40,
+      "total_tokens": 48,
+      "completion_tokens": 8
+    }
+  }
+}

--- a/local/task23-adopt-20260907.txt
+++ b/local/task23-adopt-20260907.txt
@@ -1,0 +1,30 @@
+TASK23 ADOPT 2026-09-07
+image=glm53-selfbuild:e3-grouped
+digest=sha256:bd711518d87fd324fd8956e3422cda924b2c6d033da273d0627f28997c14c2ae
+stamp=189b653
+env_sha=3eca3f0aa719b763fd737b0ce7b5bb294a474f4570c855f6d2ebcf01ac9347b4
+rollback=.env.bak-pre-task23-e3-20260907-175016 IMAGE=glm53-selfbuild:ca13bdd-v147 EXL3_FAT_GROUPED=0
+rollback_start=start.sh.bak-pre-task23-e3-20260907
+pool=1,396,551 tokens / 1.40x
+bind=127.0.0.1:8000
+health=200
+unit=active
+watchdog.timer=active  (re-armed after watchdog.service inactive)
+acceptance=7/7 (B, return-A, adopt)
+serving=6/6 (tunnel :18000; B, return-A, adopt)
+toolcall=23/23 blank-required-arg turns=0
+fat_diag=schema=2 configured_tier=grouped effective_tier=grouped grouped_ok both ranks
+prefill_60k_control_median=1108.8
+prefill_60k_B_median=1330.3
+prefill_60k_B2_median=1328.2
+prefill_240k_control_median=1075.0
+prefill_240k_B_median=1285.7  (+19.6%)
+prefill_240k_B2_median=1284.2  (+19.5%)
+structured_control_median=69.79  accept=1.0000/7.0
+structured_B_median=69.18  (one 25.6 contended; rest 69.0-69.7)
+structured_returnA_median=69.98
+structured_adopt_median=69.62
+isolated_microbench=PARITY OK  E2 54.25ms vs E3 29.04ms  1.87x Zipf-1.0 cap=32
+MemFree_adopt_head_GiB=4.51
+MemFree_adopt_worker_GiB=3.98
+geometry_unchanged=MAX_MODEL_LEN=1000000 MNBT=3584 MAX_NUM_SEQS=4 DFLASH_TOKENS=7 TRF=128 KV pin 15414698763

--- a/local/task23-adopt-structured-20260907.json
+++ b/local/task23-adopt-structured-20260907.json
@@ -1,0 +1,145 @@
+{
+  "phase": "adopt",
+  "health_code": 200,
+  "health_body": "",
+  "runs": [
+    {
+      "http": 200,
+      "ttft_s": 0.3615482500000001,
+      "wall_s": 3.2126031250000002,
+      "decode_s": 2.851054875,
+      "tok_s": 69.79872669059027,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.35395145900000013,
+      "wall_s": 3.2124007089999997,
+      "decode_s": 2.8584492499999996,
+      "tok_s": 69.61816796292607,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.3602332920000002,
+      "wall_s": 3.2337915000000006,
+      "decode_s": 2.8735582080000004,
+      "tok_s": 69.25212074910576,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    }
+  ],
+  "ts": 1788826952.3832362,
+  "prompt": "structured-count-1-200",
+  "thinking": false,
+  "temperature": 0,
+  "warmup": {
+    "tok_s": 85.78803575147207,
+    "ttft_s": 0.37540229199999997,
+    "completion_tokens": 32
+  },
+  "tok_s_median": 69.61816796292607,
+  "tok_s_min": 69.25212074910576,
+  "tok_s_max": 69.79872669059027,
+  "ttft_median_s": 0.3602332920000002,
+  "completion_tokens_median": 200.0,
+  "accept_ratio_median": 1.0,
+  "accepted_per_step_median": 7.0,
+  "any_nan": false,
+  "health_code_after": 200,
+  "short_after": {
+    "http": 200,
+    "ttft_s": 0.38668783299999987,
+    "wall_s": 0.5043424160000001,
+    "decode_s": 0.1176545830000002,
+    "tok_s": 59.49619489110754,
+    "completion_tokens": 8,
+    "prompt_tokens": 40,
+    "finish_reason": "length",
+    "nan": false,
+    "text_head": "# How a Hash Map Works: A",
+    "text_len": 25,
+    "usage": {
+      "prompt_tokens": 40,
+      "total_tokens": 48,
+      "completion_tokens": 8
+    }
+  }
+}

--- a/local/task23-b-candidate-prefill-20260907.json
+++ b/local/task23-b-candidate-prefill-20260907.json
@@ -1,0 +1,144 @@
+{
+  "phase": "b-candidate",
+  "image": "glm53-selfbuild:e3-grouped",
+  "grouped": 1,
+  "ts": 1788821564.2015092,
+  "cases": [
+    {
+      "tokens": 60000,
+      "runs": [
+        {
+          "prompt_tokens": 79998,
+          "ttft_s": 64.59,
+          "prefill_tok_s": 1238.5,
+          "total_s": 64.91,
+          "i": 1,
+          "metrics_before": {
+            "running": 0.0,
+            "waiting": 0.0,
+            "kv_usage": 0.0
+          }
+        },
+        {
+          "prompt_tokens": 79807,
+          "ttft_s": 60.02,
+          "prefill_tok_s": 1329.7,
+          "total_s": 60.56,
+          "i": 2,
+          "metrics_before": {
+            "running": 0.0,
+            "waiting": 0.0,
+            "kv_usage": 0.0
+          }
+        },
+        {
+          "prompt_tokens": 79803,
+          "ttft_s": 59.99,
+          "prefill_tok_s": 1330.3,
+          "total_s": 60.4,
+          "i": 3,
+          "metrics_before": {
+            "running": 0.0,
+            "waiting": 0.0,
+            "kv_usage": 0.0
+          }
+        },
+        {
+          "prompt_tokens": 79987,
+          "ttft_s": 60.12,
+          "prefill_tok_s": 1330.4,
+          "total_s": 60.55,
+          "i": 4,
+          "metrics_before": {
+            "running": 0.0,
+            "waiting": 0.0,
+            "kv_usage": 0.0
+          }
+        },
+        {
+          "prompt_tokens": 79907,
+          "ttft_s": 60.01,
+          "prefill_tok_s": 1331.6,
+          "total_s": 60.54,
+          "i": 5,
+          "metrics_before": {
+            "running": 0.0,
+            "waiting": 0.0,
+            "kv_usage": 0.0
+          }
+        }
+      ],
+      "median_tok_s": 1330.3,
+      "min_tok_s": 1238.5,
+      "max_tok_s": 1331.6
+    },
+    {
+      "tokens": 240000,
+      "runs": [
+        {
+          "prompt_tokens": 319080,
+          "ttft_s": 248.17,
+          "prefill_tok_s": 1285.7,
+          "total_s": 248.32,
+          "i": 1,
+          "metrics_before": {
+            "running": 0.0,
+            "waiting": 0.0,
+            "kv_usage": 0.0
+          }
+        },
+        {
+          "prompt_tokens": 318762,
+          "ttft_s": 251.94,
+          "prefill_tok_s": 1265.2,
+          "total_s": 252.09,
+          "i": 2,
+          "metrics_before": {
+            "running": 0.0,
+            "waiting": 0.0,
+            "kv_usage": 0.0
+          }
+        },
+        {
+          "prompt_tokens": 318654,
+          "ttft_s": 246.8,
+          "prefill_tok_s": 1291.1,
+          "total_s": 252.06,
+          "i": 3,
+          "metrics_before": {
+            "running": 0.0,
+            "waiting": 0.0,
+            "kv_usage": 0.0
+          }
+        },
+        {
+          "prompt_tokens": 318776,
+          "ttft_s": 246.67,
+          "prefill_tok_s": 1292.3,
+          "total_s": 246.94,
+          "i": 4,
+          "metrics_before": {
+            "running": 0.0,
+            "waiting": 0.0,
+            "kv_usage": 0.0
+          }
+        },
+        {
+          "prompt_tokens": 319593,
+          "ttft_s": 252.58,
+          "prefill_tok_s": 1265.3,
+          "total_s": 252.91,
+          "i": 5,
+          "metrics_before": {
+            "running": 0.0,
+            "waiting": 0.0,
+            "kv_usage": 0.0
+          }
+        }
+      ],
+      "median_tok_s": 1285.7,
+      "min_tok_s": 1265.2,
+      "max_tok_s": 1292.3
+    }
+  ]
+}

--- a/local/task23-b-structured-20260907.json
+++ b/local/task23-b-structured-20260907.json
@@ -1,0 +1,213 @@
+{
+  "phase": "b-candidate",
+  "health_code": 200,
+  "health_body": "",
+  "runs": [
+    {
+      "http": 200,
+      "ttft_s": 0.36728033299999996,
+      "wall_s": 8.146412542,
+      "decode_s": 7.779132209,
+      "tok_s": 25.581259535577587,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.35922895900000107,
+      "wall_s": 3.227006709000001,
+      "decode_s": 2.86777775,
+      "tok_s": 69.39170931220175,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.35628037500000076,
+      "wall_s": 3.2328202500000014,
+      "decode_s": 2.8765398750000006,
+      "tok_s": 69.18033771390009,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.35534183300000066,
+      "wall_s": 3.209179208,
+      "decode_s": 2.8538373749999995,
+      "tok_s": 69.73067272272304,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.36425987499999835,
+      "wall_s": 3.2486090419999982,
+      "decode_s": 2.884349167,
+      "tok_s": 68.99303394913838,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    }
+  ],
+  "ts": 1788821459.623745,
+  "prompt": "structured-count-1-200",
+  "thinking": false,
+  "temperature": 0,
+  "warmup": {
+    "tok_s": 86.87135613192676,
+    "ttft_s": 0.357045375,
+    "completion_tokens": 32
+  },
+  "tok_s_median": 69.18033771390009,
+  "tok_s_min": 25.581259535577587,
+  "tok_s_max": 69.73067272272304,
+  "ttft_median_s": 0.35922895900000107,
+  "completion_tokens_median": 200.0,
+  "accept_ratio_median": 1.0,
+  "accepted_per_step_median": 7.0,
+  "any_nan": false,
+  "health_code_after": 200,
+  "short_after": {
+    "http": 200,
+    "ttft_s": 0.3871741249999978,
+    "wall_s": 0.5111290830000002,
+    "decode_s": 0.12395495800000234,
+    "tok_s": 56.47212594755482,
+    "completion_tokens": 8,
+    "prompt_tokens": 40,
+    "finish_reason": "length",
+    "nan": false,
+    "text_head": "# How a Hash Map Works: A",
+    "text_len": 25,
+    "usage": {
+      "prompt_tokens": 40,
+      "total_tokens": 48,
+      "completion_tokens": 8
+    }
+  }
+}

--- a/local/task23-b-toolcall-20260907.txt
+++ b/local/task23-b-toolcall-20260907.txt
@@ -1,0 +1,9 @@
+c=1 stream temp0 x3                          n= 3 bad_args=0 short=0 errors=0 wall=   9.2s
+c=1 non-stream temp0 x2                      n= 2 bad_args=0 short=0 errors=0 wall=   7.9s
+c=1 stream temp1 (prod sampling) x3          n= 3 bad_args=0 short=0 errors=0 wall=   4.3s
+c=4 homogeneous stream temp1 x8              n= 8 bad_args=0 short=0 errors=0 wall=   5.6s
+c=4 mixed: 2 cold ~60000 pads + 2 tool (wave 1) n= 2 bad_args=0 short=0 errors=0 wall=  79.6s
+c=4 mixed: 2 cold ~60000 pads + 2 tool (wave 2) n= 2 bad_args=0 short=0 errors=0 wall=  79.8s
+c=4 mixed: 1 cold pad + 3 tool                    n= 3 bad_args=0 short=0 errors=0 (continuation)
+
+TOTAL tool turns: 23, blank-required-arg turns: 0

--- a/local/task23-b2-candidate-prefill-20260907.json
+++ b/local/task23-b2-candidate-prefill-20260907.json
@@ -1,0 +1,144 @@
+{
+  "phase": "b2-candidate",
+  "image": "glm53-selfbuild:e3-grouped",
+  "grouped": 1,
+  "ts": 1788823819.663363,
+  "cases": [
+    {
+      "tokens": 60000,
+      "runs": [
+        {
+          "prompt_tokens": 79881,
+          "ttft_s": 59.84,
+          "prefill_tok_s": 1334.9,
+          "total_s": 60.32,
+          "i": 1,
+          "metrics_before": {
+            "running": 0.0,
+            "waiting": 0.0,
+            "kv_usage": 0.0
+          }
+        },
+        {
+          "prompt_tokens": 79814,
+          "ttft_s": 79.91,
+          "prefill_tok_s": 998.7,
+          "total_s": 80.34,
+          "i": 2,
+          "metrics_before": {
+            "running": 0.0,
+            "waiting": 0.0,
+            "kv_usage": 0.0
+          }
+        },
+        {
+          "prompt_tokens": 79840,
+          "ttft_s": 60.03,
+          "prefill_tok_s": 1330.0,
+          "total_s": 60.77,
+          "i": 3,
+          "metrics_before": {
+            "running": 0.0,
+            "waiting": 0.0,
+            "kv_usage": 0.0
+          }
+        },
+        {
+          "prompt_tokens": 79989,
+          "ttft_s": 60.22,
+          "prefill_tok_s": 1328.2,
+          "total_s": 60.61,
+          "i": 4,
+          "metrics_before": {
+            "running": 0.0,
+            "waiting": 0.0,
+            "kv_usage": 0.0
+          }
+        },
+        {
+          "prompt_tokens": 79768,
+          "ttft_s": 60.13,
+          "prefill_tok_s": 1326.6,
+          "total_s": 60.54,
+          "i": 5,
+          "metrics_before": {
+            "running": 0.0,
+            "waiting": 0.0,
+            "kv_usage": 0.0
+          }
+        }
+      ],
+      "median_tok_s": 1328.2,
+      "min_tok_s": 998.7,
+      "max_tok_s": 1334.9
+    },
+    {
+      "tokens": 240000,
+      "runs": [
+        {
+          "prompt_tokens": 318704,
+          "ttft_s": 248.53,
+          "prefill_tok_s": 1282.3,
+          "total_s": 248.71,
+          "i": 1,
+          "metrics_before": {
+            "running": 0.0,
+            "waiting": 0.0,
+            "kv_usage": 0.0
+          }
+        },
+        {
+          "prompt_tokens": 318890,
+          "ttft_s": 248.32,
+          "prefill_tok_s": 1284.2,
+          "total_s": 248.47,
+          "i": 2,
+          "metrics_before": {
+            "running": 0.0,
+            "waiting": 0.0,
+            "kv_usage": 0.0
+          }
+        },
+        {
+          "prompt_tokens": 319584,
+          "ttft_s": 250.82,
+          "prefill_tok_s": 1274.2,
+          "total_s": 251.19,
+          "i": 3,
+          "metrics_before": {
+            "running": 0.0,
+            "waiting": 0.0,
+            "kv_usage": 0.0
+          }
+        },
+        {
+          "prompt_tokens": 318739,
+          "ttft_s": 247.6,
+          "prefill_tok_s": 1287.3,
+          "total_s": 247.87,
+          "i": 4,
+          "metrics_before": {
+            "running": 0.0,
+            "waiting": 0.0,
+            "kv_usage": 0.0
+          }
+        },
+        {
+          "prompt_tokens": 318942,
+          "ttft_s": 248.03,
+          "prefill_tok_s": 1285.9,
+          "total_s": 248.22,
+          "i": 5,
+          "metrics_before": {
+            "running": 0.0,
+            "waiting": 0.0,
+            "kv_usage": 0.0
+          }
+        }
+      ],
+      "median_tok_s": 1284.2,
+      "min_tok_s": 1274.2,
+      "max_tok_s": 1287.3
+    }
+  ]
+}

--- a/local/task23-return-a-structured-20260907.json
+++ b/local/task23-return-a-structured-20260907.json
@@ -1,0 +1,145 @@
+{
+  "phase": "return-a",
+  "health_code": 200,
+  "health_body": "",
+  "runs": [
+    {
+      "http": 200,
+      "ttft_s": 0.37718904099999995,
+      "wall_s": 3.2210051660000003,
+      "decode_s": 2.843816125,
+      "tok_s": 69.97639483459923,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.35648454199999957,
+      "wall_s": 3.194910083,
+      "decode_s": 2.8384255410000003,
+      "tok_s": 70.10929021230928,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.35597429199999997,
+      "wall_s": 3.2101722919999993,
+      "decode_s": 2.8541979999999993,
+      "tok_s": 69.72186232349685,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    }
+  ],
+  "ts": 1788826114.039676,
+  "prompt": "structured-count-1-200",
+  "thinking": false,
+  "temperature": 0,
+  "warmup": {
+    "tok_s": 85.97551053589389,
+    "ttft_s": 0.372541291,
+    "completion_tokens": 32
+  },
+  "tok_s_median": 69.97639483459923,
+  "tok_s_min": 69.72186232349685,
+  "tok_s_max": 70.10929021230928,
+  "ttft_median_s": 0.35648454199999957,
+  "completion_tokens_median": 200.0,
+  "accept_ratio_median": 1.0,
+  "accepted_per_step_median": 7.0,
+  "any_nan": false,
+  "health_code_after": 200,
+  "short_after": {
+    "http": 200,
+    "ttft_s": 0.3913001250000008,
+    "wall_s": 0.5076319590000011,
+    "decode_s": 0.11633183400000036,
+    "tok_s": 60.17269529164286,
+    "completion_tokens": 8,
+    "prompt_tokens": 40,
+    "finish_reason": "length",
+    "nan": false,
+    "text_head": "# How a Hash Map Works: A",
+    "text_len": 25,
+    "usage": {
+      "prompt_tokens": 40,
+      "total_tokens": 48,
+      "completion_tokens": 8
+    }
+  }
+}

--- a/overlay/build_exl3_fat_moe_ext.py
+++ b/overlay/build_exl3_fat_moe_ext.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Build the additive `exl3_fat_moe_ext` module (E3 grouped fat-expert kernels).
+
+The kernel source is compiled inside a copy of the installed exllamav3_ext
+source tree so its relative includes (../ptx.cuh, exl3_dq.cuh,
+hadamard_inner.cuh, ...) resolve exactly as they would in a full
+patch_exl3_fat_kernel.py image build. This is the layered-image path: it
+does not recompile exllamav3_ext.
+
+Flags: -O3 -lineinfo, sm_121a. Deliberately WITHOUT --use_fast_math (which
+exllamav3's setup.py uses): the gate/up epilogue must reproduce torch.sigmoid's
+full-precision expf/division to keep the E2 rounding boundaries.
+
+Usage:
+  build_exl3_fat_moe_ext.py --src <dir with exl3_fat_moe.cu/.cuh> --out <build dir>
+                            [--install <site-packages dir>] [--arch 121a]
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import sys
+import time
+from pathlib import Path
+
+EXT_DEFAULT = "/usr/local/lib/python3.12/dist-packages/exllamav3/exllamav3_ext"
+MODULE = "exl3_fat_moe_ext"
+BINDING = """
+#include <torch/extension.h>
+#include "quant/exl3_fat_moe.cuh"
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+    m.def("exl3_fat_moe_gather", &exl3_fat_moe_gather, "exl3_fat_moe_gather");
+    m.def("exl3_fat_moe_gateup", &exl3_fat_moe_gateup, "exl3_fat_moe_gateup");
+    m.def("exl3_fat_moe_down", &exl3_fat_moe_down, "exl3_fat_moe_down");
+    m.def("exl3_fat_moe_tile_rows_gateup", &exl3_fat_moe_tile_rows_gateup, "exl3_fat_moe_tile_rows_gateup");
+    m.def("exl3_fat_moe_tile_rows_down", &exl3_fat_moe_tile_rows_down, "exl3_fat_moe_tile_rows_down");
+}
+"""
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--src", required=True)
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--ext", default=EXT_DEFAULT)
+    ap.add_argument("--install", default="")
+    ap.add_argument("--arch", default="121a")
+    ap.add_argument("--verbose", action="store_true")
+    args = ap.parse_args()
+
+    import torch  # noqa: F401  (libc10 must load before any ext)
+    from torch.utils.cpp_extension import load
+
+    src = Path(args.src)
+    out = Path(args.out)
+    out.mkdir(parents=True, exist_ok=True)
+    tree = out / "ext"
+    if tree.is_dir():
+        shutil.rmtree(tree)
+    shutil.copytree(args.ext, tree, ignore=shutil.ignore_patterns("*.so", "__pycache__"))
+    for name in ("exl3_fat_moe.cu", "exl3_fat_moe.cuh"):
+        source = src / name
+        if not source.is_file():
+            raise SystemExit(f"missing source: {source}")
+        shutil.copyfile(source, tree / "quant" / name)
+    binding = tree / f"{MODULE}_binding.cpp"
+    binding.write_text(BINDING)
+    cu13 = "/usr/local/lib/python3.12/dist-packages/nvidia/cu13/include"
+    for var in ("CPATH", "CPLUS_INCLUDE_PATH", "C_INCLUDE_PATH"):
+        os.environ[var] = cu13 + (":" + os.environ[var] if os.environ.get(var) else "")
+    t0 = time.time()
+    mod = load(
+        name=MODULE,
+        sources=[str(binding), str(tree / "quant" / "exl3_fat_moe.cu")],
+        extra_cuda_cflags=[
+            "-O3",
+            "-lineinfo",
+            f"-gencode=arch=compute_{args.arch},code=sm_{args.arch}",
+            "-Xcudafe", "--diag_suppress=177",
+            "-Xcudafe", "--diag_suppress=20012",
+        ],
+        extra_include_paths=[str(tree)],
+        build_directory=str(out),
+        verbose=args.verbose,
+    )
+    print(f"built {MODULE} in {time.time() - t0:.0f}s: {mod.__file__}", flush=True)
+    assert int(mod.exl3_fat_moe_tile_rows_gateup()) > 0
+    so = Path(mod.__file__)
+    if args.install:
+        dest = Path(args.install) / so.name
+        shutil.copyfile(so, dest)
+        print(f"installed {dest}", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/overlay/exl3.py
+++ b/overlay/exl3.py
@@ -58,6 +58,9 @@ MOE_ACT_SILU = 0
 _FUSED_TEMP_CACHE: dict[tuple, tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]] = {}
 _FAT_SCRATCH_CACHE: dict[tuple, dict[str, torch.Tensor]] = {}
 _FAT_COUNT_CACHE: dict[tuple, tuple[torch.Tensor, torch.cuda.Stream]] = {}
+# Grouped (E3) fat-expert scratch: fat-row activation buffers, grown once.
+_FAT_GROUPED_CACHE: dict[tuple, dict[str, torch.Tensor]] = {}
+_FAT_GROUPED_BYTES: dict[tuple, int] = {}
 _FAT_BUCKET_EDGES = (16, 32, 64, 128, 256, 512, 1024, 2048)
 _FAT_STATS: dict[str, Any] = {
     "layers": 0,
@@ -67,6 +70,66 @@ _FAT_STATS: dict[str, Any] = {
     "sum_max_rows": 0,
     "hist": [0] * (len(_FAT_BUCKET_EDGES) + 1),
 }
+_FAT_TIERS = ("grouped", "kernel", "batched", "sorted", "legacy")
+# Schema 2 adds the E3 grouped tier. Extend the key set only with a schema bump.
+EXL3_FAT_DIAG_SCHEMA = 2
+EXL3_FAT_DIAG_KEYS = (
+    "schema",
+    "configured_tier",
+    "effective_tier",
+    "tier_reason",
+    "shared_suh",
+    "shared_suh_layers",
+    "moe_layers_loaded",
+    "sym_exl3_moe",
+    "sym_fat_gemm",
+    "sym_fat_gemm_scatter",
+    "sym_fat_moe",
+    "grouped_calls",
+    "grouped_scratch_bytes",
+    "grouped_eligible",
+    "cap_major",
+    "cap_minor",
+    "cap_ok",
+    "tp_rank",
+    "tp_size",
+    "prefill_layer_calls",
+    "thin_calls",
+    "row_tile_calls",
+    "fallback_calls",
+    "fallback_reasons",
+    "fat_stat_layers",
+    "fat_layers",
+    "fat_expert_slots",
+    "max_rows",
+)
+_EXL3_FAT_DIAG: dict[str, Any] = {
+    "schema": EXL3_FAT_DIAG_SCHEMA,
+    "configured_tier": "legacy",
+    "effective_tier": "legacy",
+    "tier_reason": "unresolved",
+    "shared_suh": False,
+    "shared_suh_layers": 0,
+    "moe_layers_loaded": 0,
+    "sym_exl3_moe": False,
+    "sym_fat_gemm": False,
+    "sym_fat_gemm_scatter": False,
+    "sym_fat_moe": False,
+    "grouped_calls": 0,
+    "grouped_scratch_bytes": 0,
+    "grouped_eligible": False,
+    "cap_major": -1,
+    "cap_minor": -1,
+    "cap_ok": False,
+    "tp_rank": -1,
+    "tp_size": 1,
+    "prefill_layer_calls": 0,
+    "thin_calls": 0,
+    "row_tile_calls": 0,
+    "fallback_calls": {tier: 0 for tier in _FAT_TIERS},
+    "fallback_reasons": {},
+}
+_exl3_fat_tier_logged = False
 
 
 def fused_moe_row_tile_enabled() -> bool:
@@ -97,8 +160,382 @@ def fat_kernel_enabled() -> bool:
     return os.environ.get("EXL3_FAT_KERNEL", "0") != "0"
 
 
+def grouped_fat_enabled() -> bool:
+    """Enable the E3 grouped fat-expert kernels (experimental, default OFF).
+
+    One gather + one gate/up + one down launch cover every fat expert of a
+    layer from device-side segment tables. Needs the exl3_fat_moe kernels
+    (exllamav3_ext built with exl3_fat_moe.cu, or the additive
+    exl3_fat_moe_ext module). EXL3_FAT_GROUPED=0 (default) leaves the E2
+    path and its cap untouched.
+    """
+    return os.environ.get("EXL3_FAT_GROUPED", "0") != "0"
+
+
 def fat_expert_log_enabled() -> bool:
-    return os.environ.get("EXL3_FAT_EXPERT_LOG", "1") != "0"
+    """Per-step routing histogram. It costs one host sync per MoE layer under
+    the grouped tier (the grouped path has none of its own), so it defaults
+    off there."""
+    default = "0" if grouped_fat_enabled() else "1"
+    return os.environ.get("EXL3_FAT_EXPERT_LOG", default) != "0"
+
+
+def configured_fat_tier() -> str:
+    """Highest fat tier the env requests: grouped > kernel > batched > sorted > legacy."""
+    if grouped_fat_enabled():
+        return "grouped"
+    if fat_kernel_enabled():
+        return "kernel"
+    if batched_fat_fallback_enabled():
+        return "batched"
+    if sorted_fat_fallback_enabled():
+        return "sorted"
+    return "legacy"
+
+
+def exl3_fat_symbols() -> tuple[bool, bool, bool]:
+    """(exl3_moe, exl3_fat_gemm, exl3_fat_gemm_scatter) availability."""
+    try:
+        ext = load_exllamav3_ext()
+    except Exception:
+        return False, False, False
+    return (
+        hasattr(ext, "exl3_moe"),
+        hasattr(ext, "exl3_fat_gemm"),
+        hasattr(ext, "exl3_fat_gemm_scatter"),
+    )
+
+
+EXL3_FAT_MOE_SYMBOLS = (
+    "exl3_fat_moe_gather",
+    "exl3_fat_moe_gateup",
+    "exl3_fat_moe_down",
+    "exl3_fat_moe_tile_rows_gateup",
+    "exl3_fat_moe_tile_rows_down",
+)
+# Grouped kernels: 16 B vector atomics (sm_90+); the image builds sm_121a.
+EXL3_FAT_MOE_MIN_CAPABILITY = (9, 0)
+# A-pipeline: FM_STAGES * FM_TILE_K = 4 * 32. k_tiles in {3,4} can run dry.
+EXL3_FAT_MOE_MIN_K = 128
+_FAT_MOE_EXT_CACHE: list = []
+
+
+def load_fat_moe_ext():
+    """Module carrying the E3 kernels, or None.
+
+    Two supported sources: exllamav3_ext itself (bindings patched at the
+    full image build by patch_exl3_fat_kernel.py) or the additive
+    `exl3_fat_moe_ext` module (layered candidate image). Resolved once.
+    """
+    if _FAT_MOE_EXT_CACHE:
+        return _FAT_MOE_EXT_CACHE[0]
+    found = None
+    try:
+        ext = load_exllamav3_ext()
+        if all(hasattr(ext, name) for name in EXL3_FAT_MOE_SYMBOLS):
+            found = ext
+    except Exception:
+        found = None
+    if found is None:
+        try:
+            import exl3_fat_moe_ext  # noqa: F401
+
+            if all(hasattr(exl3_fat_moe_ext, name) for name in EXL3_FAT_MOE_SYMBOLS):
+                found = exl3_fat_moe_ext
+        except Exception:
+            found = None
+    _FAT_MOE_EXT_CACHE.append(found)
+    return found
+
+
+def exl3_fat_moe_symbols() -> bool:
+    """True when every E3 grouped kernel entry point is importable."""
+    return load_fat_moe_ext() is not None
+
+
+def grouped_fat_eligibility(layer: torch.nn.Module) -> tuple[bool, str]:
+    """Load-time checkpoint/device eligibility for the K4/MCG grouped kernels.
+
+    The grouped pointer-table interface does not carry K/mcg/mul1 like the E2
+    GEMM interface, so those invariants are checked here, once per layer,
+    before the tier is resolved: 4-bit trellis (64 int16 words per tile),
+    MCG codebook without mul1, shared gate/up SUH, tile-friendly dimensions
+    (hidden % 256 for the 2x128 down tile and the gather's 128-wide blocks,
+    intermediate % 128 for the gate/up tile), min(K) ≥ 128 so the 4-stage
+    A-pipeline cannot run dry, a device capability with 16 B vector atomics,
+    and every packed tensor on one CUDA device.
+    """
+    bits = int(getattr(layer, "_exl3_bits", 0) or 0)
+    if bits != 4:
+        return False, f"bits_{bits}"
+    k_words = int(getattr(layer, "_exl3_k_words", 0) or 0)
+    if k_words != 64:
+        return False, f"k_words_{k_words}"
+    inners = getattr(layer, "_exl3_inners", None) or []
+    if not inners:
+        return False, "no_inners"
+    min_k = None
+    for pack in inners:
+        for which in ("gate", "up", "down"):
+            inner = pack[which]
+            if int(getattr(inner, "K", 0)) != 4:
+                return False, f"K_{getattr(inner, 'K', '?')}"
+            if not bool(getattr(inner, "mcg", False)):
+                return False, "not_mcg"
+            if bool(getattr(inner, "mul1", False)):
+                return False, "mul1"
+            k_in = int(getattr(inner, "in_features", 0) or 0)
+            if min_k is None or k_in < min_k:
+                min_k = k_in
+    if min_k is None or min_k < EXL3_FAT_MOE_MIN_K:
+        return False, f"k_in_{min_k}"
+    if not bool(getattr(layer, "_exl3_shared_w13_suh", False)):
+        return False, "shared_suh_absent"
+    hidden = int(getattr(layer, "_exl3_hidden_size", 0) or 0)
+    inter = int(getattr(layer, "_exl3_intermediate_local", 0) or 0)
+    if hidden <= 0 or hidden % 256:
+        return False, f"hidden_{hidden}"
+    if inter <= 0 or inter % 128:
+        return False, f"intermediate_{inter}"
+    device = layer.w13_trellis.device
+    if device.type != "cuda":
+        return False, f"device_{device.type}"
+    for name in ("w13_trellis", "w13_suh", "w13_svh", "w2_trellis", "w2_suh", "w2_svh"):
+        if getattr(layer, name).device != device:
+            return False, f"device_mismatch_{name}"
+    cap = exl3_device_capability()
+    if cap < EXL3_FAT_MOE_MIN_CAPABILITY:
+        return False, f"capability_{cap[0]}.{cap[1]}"
+    return True, "eligible"
+
+
+def exl3_device_capability() -> tuple[int, int]:
+    """CUDA capability of the current device; (-1, -1) without a GPU."""
+    if not torch.cuda.is_available():
+        return -1, -1
+    try:
+        return tuple(int(v) for v in torch.cuda.get_device_capability())
+    except Exception:
+        return -1, -1
+
+
+def _exl3_tp_rank_size() -> tuple[int, int]:
+    """TP identity so each rank's diag line is attributable; -1 outside vLLM."""
+    try:
+        from vllm.distributed import (
+            get_tensor_model_parallel_rank,
+            get_tensor_model_parallel_world_size,
+        )
+
+        return (
+            int(get_tensor_model_parallel_rank()),
+            int(get_tensor_model_parallel_world_size()),
+        )
+    except Exception:
+        return -1, 1
+
+
+def resolve_exl3_fat_tier(
+    shared_suh: bool,
+    symbols: tuple[bool, bool, bool] | None = None,
+    fat_moe_symbols: bool | None = None,
+    grouped_eligible: tuple[bool, str] | None = None,
+) -> tuple[str, str]:
+    """Map the configured fat tier onto what this image + checkpoint can run.
+
+    Grouped: a request without the E3 symbols fails closed. A checkpoint or
+    device the grouped kernels cannot run deliberately falls back to the E2
+    kernel tier with the reason recorded, and that fallback is itself
+    subject to the E2 symbol check. EXL3_FAT_GROUPED=0 never inspects E3
+    symbols.
+    """
+    configured = configured_fat_tier()
+    if configured == "legacy":
+        return configured, "none_requested"
+    # GROUPED=1 must refuse a missing E3 image before any checkpoint
+    # downgrade (including nonshared SUH). GROUPED=0 never inspects E3.
+    if configured == "grouped":
+        if fat_moe_symbols is None:
+            fat_moe_symbols = exl3_fat_moe_symbols()
+        if not fat_moe_symbols:
+            raise RuntimeError(
+                "EXL3_FAT_GROUPED=1 requires "
+                + "/".join(EXL3_FAT_MOE_SYMBOLS)
+                + " (exllamav3_ext or exl3_fat_moe_ext); this image was built "
+                "without exl3_fat_moe.cu — set EXL3_FAT_GROUPED=0 (E2 kernel) "
+                "or build the E3 candidate image"
+            )
+    if not shared_suh and configured in ("grouped", "kernel", "batched"):
+        return "sorted", "shared_suh_absent"
+    reason_prefix = ""
+    if configured == "grouped":
+        if grouped_eligible is None:
+            grouped_eligible = (True, "eligible")
+        if grouped_eligible[0]:
+            return configured, "grouped_ok"
+        configured = "kernel"
+        reason_prefix = f"grouped_ineligible_{grouped_eligible[1]}:"
+    if symbols is None:
+        symbols = exl3_fat_symbols()
+    if configured == "kernel":
+        missing = [
+            name
+            for name, present in zip(
+                ("exl3_fat_gemm", "exl3_fat_gemm_scatter"), symbols[1:]
+            )
+            if not present
+        ]
+        if missing:
+            raise RuntimeError(
+                "EXL3_FAT_KERNEL=1 requires exllamav3_ext."
+                + "/".join(missing)
+                + "; this image was built without the fat kernel — unset "
+                "EXL3_FAT_KERNEL or serve an E2 image"
+            )
+    return configured, f"{reason_prefix}{configured}_ok"
+
+
+def exl3_fat_diag() -> dict[str, Any]:
+    """Snapshot of the fat-expert diagnostics; the key set is EXL3_FAT_DIAG_KEYS."""
+    diag = dict(_EXL3_FAT_DIAG)
+    diag["fallback_calls"] = dict(_EXL3_FAT_DIAG["fallback_calls"])
+    diag["fallback_reasons"] = dict(_EXL3_FAT_DIAG["fallback_reasons"])
+    diag.update(
+        fat_stat_layers=_FAT_STATS["layers"],
+        fat_layers=_FAT_STATS["fat_layers"],
+        fat_expert_slots=_FAT_STATS["fat_experts"],
+        max_rows=_FAT_STATS["max_rows"],
+    )
+    return diag
+
+
+def _exl3_fat_diag_line() -> str:
+    d = exl3_fat_diag()
+    parts = [
+        f"schema={d['schema']}",
+        f"configured_tier={d['configured_tier']}",
+        f"effective_tier={d['effective_tier']}",
+        f"tier_reason={d['tier_reason']}",
+        f"shared_suh={int(d['shared_suh'])}",
+        f"shared_suh_layers={d['shared_suh_layers']}/{d['moe_layers_loaded']}",
+        f"sym_exl3_moe={int(d['sym_exl3_moe'])}",
+        f"sym_fat_gemm={int(d['sym_fat_gemm'])}",
+        f"sym_fat_gemm_scatter={int(d['sym_fat_gemm_scatter'])}",
+        f"sym_fat_moe={int(d['sym_fat_moe'])}",
+        f"grouped_eligible={int(d['grouped_eligible'])}",
+        f"grouped_calls={d['grouped_calls']}",
+        f"grouped_scratch_bytes={d['grouped_scratch_bytes']}",
+        f"cap={d['cap_major']}.{d['cap_minor']}",
+        f"cap_ok={int(d['cap_ok'])}",
+        f"tp_rank={d['tp_rank']} tp_size={d['tp_size']}",
+        f"prefill_layer_calls={d['prefill_layer_calls']}",
+        f"thin_calls={d['thin_calls']}",
+        f"row_tile_calls={d['row_tile_calls']}",
+        "fallback_calls="
+        + ",".join(f"{t}={d['fallback_calls'][t]}" for t in _FAT_TIERS),
+        "fallback_reasons="
+        + (
+            ",".join(f"{r}={n}" for r, n in sorted(d["fallback_reasons"].items()))
+            or "none"
+        ),
+        f"fat_layers={d['fat_layers']}",
+        f"fat_expert_slots={d['fat_expert_slots']}",
+        f"max_rows={d['max_rows']}",
+    ]
+    return " ".join(parts)
+
+
+def _record_exl3_fat_reason(reason: str) -> None:
+    reasons = _EXL3_FAT_DIAG["fallback_reasons"]
+    reasons[reason] = reasons.get(reason, 0) + 1
+
+
+def _record_exl3_fat_tier(layer: torch.nn.Module, tier: str, reason: str) -> None:
+    if tier in _EXL3_FAT_DIAG["fallback_calls"]:
+        _EXL3_FAT_DIAG["fallback_calls"][tier] += 1
+    _record_exl3_fat_reason(reason)
+    layer._exl3_last_fat_fallback = tier
+    layer._exl3_last_fat_reason = reason
+
+
+def _record_exl3_fat_resolution(layer: torch.nn.Module) -> None:
+    """Resolve the fat tier once per MoE layer at weight load and log once."""
+    global _exl3_fat_tier_logged
+    shared_suh = bool(getattr(layer, "_exl3_shared_w13_suh", False))
+    if grouped_fat_enabled():
+        grouped_eligible = grouped_fat_eligibility(layer)
+    else:
+        grouped_eligible = (False, "grouped_off")
+    layer._exl3_grouped_eligible = grouped_eligible
+    effective_tier, tier_reason = resolve_exl3_fat_tier(
+        shared_suh, grouped_eligible=grouped_eligible
+    )
+    layer._exl3_fat_effective_tier = effective_tier
+    layer._exl3_fat_tier_reason = tier_reason
+
+    diag = _EXL3_FAT_DIAG
+    sym_moe, sym_gemm, sym_scatter = exl3_fat_symbols()
+    cap_major, cap_minor = exl3_device_capability()
+    diag["moe_layers_loaded"] += 1
+    if shared_suh:
+        diag["shared_suh_layers"] += 1
+    diag["shared_suh"] = diag["shared_suh_layers"] == diag["moe_layers_loaded"]
+    diag["configured_tier"] = configured_fat_tier()
+    diag["sym_exl3_moe"] = sym_moe
+    diag["sym_fat_gemm"] = sym_gemm
+    diag["sym_fat_gemm_scatter"] = sym_scatter
+    diag["sym_fat_moe"] = (
+        exl3_fat_moe_symbols() if grouped_fat_enabled() else False
+    )
+    diag["grouped_eligible"] = bool(grouped_eligible[0])
+    diag["cap_major"] = cap_major
+    diag["cap_minor"] = cap_minor
+    diag["cap_ok"] = (cap_major, cap_minor) >= (8, 0)
+    diag["tp_rank"], diag["tp_size"] = _exl3_tp_rank_size()
+    diag["grouped_scratch_bytes"] = sum(_FAT_GROUPED_BYTES.values())
+
+    if diag["tier_reason"] == "unresolved":
+        diag["effective_tier"] = effective_tier
+        diag["tier_reason"] = tier_reason
+    elif diag["effective_tier"] != effective_tier:
+        logger.warning(
+            "exl3 fat diag tier changed %s -> %s (%s): %s",
+            diag["effective_tier"],
+            effective_tier,
+            tier_reason,
+            _exl3_fat_diag_line(),
+        )
+        diag["effective_tier"] = effective_tier
+        diag["tier_reason"] = tier_reason
+    if not _exl3_fat_tier_logged:
+        _exl3_fat_tier_logged = True
+        if (
+            diag["effective_tier"] != diag["configured_tier"]
+            and diag["configured_tier"] != "legacy"
+        ):
+            logger.warning("exl3 fat diag degraded %s", _exl3_fat_diag_line())
+        else:
+            logger.info("exl3 fat diag %s", _exl3_fat_diag_line())
+
+
+def reset_exl3_fat_diag_counters() -> None:
+    """Zero the runtime counters; load-time fields and live bytes stay."""
+    diag = _EXL3_FAT_DIAG
+    for key in (
+        "prefill_layer_calls",
+        "thin_calls",
+        "row_tile_calls",
+        "grouped_calls",
+    ):
+        diag[key] = 0
+    diag["fallback_calls"] = {tier: 0 for tier in _FAT_TIERS}
+    diag["fallback_reasons"] = {}
+    diag["grouped_scratch_bytes"] = sum(_FAT_GROUPED_BYTES.values())
+
+
+def grouped_scratch_bytes_for(hidden: int, intermediate: int, rows: int) -> int:
+    """Persistent E3 buffers: h13[rows, hidden] fp16 + h2[rows, intermediate] fp16."""
+    return int(rows) * int(hidden) * 2 + int(rows) * int(intermediate) * 2
 
 
 def reset_exl3_fat_expert_stats() -> None:
@@ -557,6 +994,177 @@ def apply_exl3_batched_fat(
     return out
 
 
+def _grouped_scratch(
+    device: torch.device, rows: int, hidden: int, intermediate: int
+) -> dict[str, torch.Tensor]:
+    """Fat-row activation buffers for the grouped tier, grown once.
+
+    Capacity covers every routed slot of the configured prefill chunk
+    (MAX_NUM_BATCHED_TOKENS x top-k, EXL3_FAT_GROUPED_TOPK, default 8) so
+    steady-state prefill never reallocates; a larger request grows it once
+    more (outside CUDA graph capture, where growth would be illegal).
+    Persistent: h13 [rows, hidden] fp16 + h2 [rows, intermediate] fp16.
+    Predicted production bytes at MNBT=3584 × topk=8 = 28,672 rows:
+    hidden=4096 → 224 MiB, intermediate=2048 → 112 MiB, ≈336 MiB/rank.
+    """
+    configured = int(
+        os.environ.get(
+            "EXL3_FAT_SCRATCH_ROWS",
+            os.environ.get("MAX_NUM_BATCHED_TOKENS", "0"),
+        )
+        or 0
+    )
+    topk = int(os.environ.get("EXL3_FAT_GROUPED_TOPK", "8") or 8)
+    needed = max(256, rows)
+    key = (str(device), hidden, intermediate)
+    scratch = _FAT_GROUPED_CACHE.get(key)
+    if scratch is not None and int(scratch["h13"].shape[0]) >= needed:
+        return scratch
+    if torch.cuda.is_available() and torch.cuda.is_current_stream_capturing():
+        raise RuntimeError(
+            "EXL3 grouped scratch growth during CUDA graph capture; warm the "
+            f"largest shape first (need {needed} rows)"
+        )
+    capacity = max(needed, configured * topk)
+    scratch = {
+        "h13": torch.empty((capacity, hidden), dtype=torch.float16, device=device),
+        "h2": torch.empty(
+            (capacity, intermediate), dtype=torch.float16, device=device
+        ),
+    }
+    _FAT_GROUPED_CACHE[key] = scratch
+    _FAT_GROUPED_BYTES[key] = sum(
+        t.numel() * t.element_size() for t in scratch.values()
+    )
+    _EXL3_FAT_DIAG["grouped_scratch_bytes"] = sum(_FAT_GROUPED_BYTES.values())
+    return scratch
+
+
+def _excl_cumsum(x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    inclusive = torch.cumsum(x, 0)
+    return inclusive - x, inclusive
+
+
+def build_grouped_fat_tables(
+    counts: torch.Tensor,
+    cap: int,
+    token_sorted: torch.Tensor,
+    weight_sorted: torch.Tensor,
+    rows_cap: int,
+    tile_rows: int,
+) -> dict[str, torch.Tensor]:
+    """Device-side row/segment tables for the grouped fat kernels.
+
+    Fat experts (count > cap) are laid out back to back in expert order in a
+    fat-row buffer; each kernel CTA owns one `tile_rows` slice of one expert.
+    Everything is computed with device ops on capacity-sized tensors and the
+    kernels read the live `num_rows` / `num_segs`, so no host sync happens.
+    `counts` excludes the invalid/nonlocal sentinel bucket.
+    """
+    n_exp = int(counts.numel())
+    device = counts.device
+    fat_rows = torch.where(counts > cap, counts, torch.zeros_like(counts))
+    row_off, row_cum = _excl_cumsum(fat_rows)
+    sorted_off, _ = _excl_cumsum(counts)
+    tiles = (fat_rows + (tile_rows - 1)) // tile_rows
+    tile_off, tile_cum = _excl_cumsum(tiles)
+    num_segs = tile_cum[-1:].to(torch.int32)
+    num_rows = row_cum[-1:].to(torch.int32)
+    max_segs = (rows_cap + tile_rows - 1) // tile_rows + n_exp
+    seg = torch.arange(max_segs, device=device)
+    e = torch.searchsorted(tile_cum, seg, right=True).clamp_(max=n_exp - 1)
+    local_tile = seg - tile_off[e]
+    seg_row0 = row_off[e] + local_tile * tile_rows
+    seg_rows = torch.clamp(fat_rows[e] - local_tile * tile_rows, min=0, max=tile_rows)
+    r = torch.arange(rows_cap, device=device)
+    re = torch.searchsorted(row_cum, r, right=True).clamp_(max=n_exp - 1)
+    src = (sorted_off[re] + (r - row_off[re])).clamp_(max=rows_cap - 1)
+    return {
+        "seg_expert": e.to(torch.int32),
+        "seg_row0": seg_row0.to(torch.int32),
+        "seg_rows": seg_rows.to(torch.int32),
+        "num_segs": num_segs,
+        "num_rows": num_rows,
+        "row_expert": re.to(torch.int32),
+        "row_token": token_sorted.index_select(0, src),
+        "row_weight": weight_sorted.index_select(0, src),
+    }
+
+
+def apply_exl3_grouped_fat(
+    xh: torch.Tensor,
+    out: torch.Tensor,
+    counts: torch.Tensor,
+    token_sorted: torch.Tensor,
+    weight_sorted: torch.Tensor,
+    layer: torch.nn.Module,
+    cap: int,
+    limit: float,
+) -> None:
+    """E3: every fat expert of the layer in three launches, no host sync."""
+    ext = load_fat_moe_ext()
+    if ext is None:
+        raise RuntimeError("EXL3 grouped tier selected but the E3 kernels are not loaded")
+    ptrs = layer._exl3_ptrs
+    device = ptrs["gate_trellis"].device
+    if xh.device != device or out.device != device or counts.device != device:
+        raise RuntimeError(
+            f"EXL3 grouped tier: activations on {xh.device}, experts on {device}"
+        )
+    if not (xh.is_contiguous() and out.is_contiguous() and out.dtype == torch.float32):
+        raise RuntimeError("EXL3 grouped tier needs contiguous fp16 input / fp32 output")
+    hidden = int(xh.shape[1])
+    intermediate = int(layer._exl3_intermediate_local)
+    rows_cap = int(token_sorted.numel())
+    scratch = _grouped_scratch(device, rows_cap, hidden, intermediate)
+    h13 = scratch["h13"][:rows_cap]
+    h2 = scratch["h2"][:rows_cap]
+    tile_gu = int(ext.exl3_fat_moe_tile_rows_gateup())
+    tile_dn = int(ext.exl3_fat_moe_tile_rows_down())
+    token_sorted = token_sorted.contiguous()
+    weight_sorted = weight_sorted.contiguous()
+    tg = build_grouped_fat_tables(
+        counts, cap, token_sorted, weight_sorted, rows_cap, tile_gu
+    )
+    td = (
+        tg
+        if tile_dn == tile_gu
+        else build_grouped_fat_tables(
+            counts, cap, token_sorted, weight_sorted, rows_cap, tile_dn
+        )
+    )
+    ext.exl3_fat_moe_gather(
+        xh, tg["row_token"], tg["row_expert"], ptrs["gate_suh"], h13, tg["num_rows"]
+    )
+    ext.exl3_fat_moe_gateup(
+        h13,
+        ptrs["gate_trellis"],
+        ptrs["up_trellis"],
+        ptrs["gate_svh"],
+        ptrs["up_svh"],
+        ptrs["down_suh"],
+        h2,
+        tg["seg_expert"],
+        tg["seg_row0"],
+        tg["seg_rows"],
+        tg["num_segs"],
+        float(limit),
+    )
+    ext.exl3_fat_moe_down(
+        h2,
+        ptrs["down_trellis"],
+        ptrs["down_svh"],
+        out,
+        td["row_token"],
+        td["row_weight"],
+        td["seg_expert"],
+        td["seg_row0"],
+        td["seg_rows"],
+        td["num_segs"],
+    )
+    _EXL3_FAT_DIAG["grouped_calls"] += 1
+
+
 def build_exl3_fused_state(layer: torch.nn.Module, inners: list[dict[str, Any]]) -> None:
     """Pointer tables + fused temps, once after load. No per-token alloc."""
     import exllamav3_ext
@@ -722,8 +1330,9 @@ def apply_exl3_fused_moe(
 
     Cap is temps dim1 (`EXL3_TEMP_ROWS_FUSED`, default 128). Overflow uses GPU
     row tiles if `EXL3_MOE_ROW_TILE=1`; otherwise fat experts use the highest
-    enabled tier: kernel implies batched, batched implies sorted, then legacy.
-    Decode (tokens ≤ cap) stays a single graph-safe launch.
+    enabled tier: grouped > kernel > batched > sorted > legacy.
+    Decode (tokens ≤ cap) stays a single graph-safe launch. E3 never
+    engages on decode.
     """
     import exllamav3_ext
 
@@ -757,6 +1366,11 @@ def apply_exl3_fused_moe(
     # Actual kernel cap is the allocated temp dim1 (env-selected at load).
     cap = int(temps[0].shape[1])
 
+    # Reset per call so a "kernel"/"grouped" label from an earlier prefill
+    # cannot masquerade through later decode/thin/row-tile calls.
+    layer._exl3_last_fat_fallback = "none"
+    layer._exl3_last_fat_reason = "no_fat_experts"
+
     if tokens <= cap:
         _exl3_moe_launch(
             fn, xh, out, expert_count, token_sorted, weight_sorted,
@@ -767,7 +1381,28 @@ def apply_exl3_fused_moe(
     # Prefill larger than temps. E1 copies routing counts on a side stream and
     # launches thin experts immediately, overlapping the D2H synchronization.
     # Decode never reaches here (capture sizes << cap).
-    want_fat_kernel = fat_kernel_enabled()
+    _EXL3_FAT_DIAG["prefill_layer_calls"] += 1
+    use_row_tiles = fused_moe_row_tile_enabled()
+    if (
+        grouped_fat_enabled()
+        and not use_row_tiles
+        and getattr(layer, "_exl3_fat_effective_tier", None) == "grouped"
+    ):
+        # E3: thin experts in the fused kernel (it skips count > cap), every
+        # fat expert in three grouped launches driven by device-side tables.
+        # No host sync, so this branch is CUDA-graph capturable.
+        _exl3_moe_launch(
+            fn, xh, out, expert_count, token_sorted, weight_sorted,
+            temps, ptrs, k, limit, n_active_host,
+        )
+        apply_exl3_grouped_fat(
+            xh, out, counts, token_sorted, weight_sorted, layer, cap, limit
+        )
+        _record_exl3_fat_tier(layer, "grouped", "grouped_ok")
+        if fat_expert_log_enabled():
+            record_exl3_fat_expert_stats(counts)
+        return out
+    want_fat_kernel = fat_kernel_enabled() or grouped_fat_enabled()
     want_batched_fat = batched_fat_fallback_enabled() or want_fat_kernel
     use_sorted_fat = sorted_fat_fallback_enabled() or want_batched_fat
     use_batched_fat = (
@@ -775,7 +1410,6 @@ def apply_exl3_fused_moe(
         and bool(getattr(layer, "_exl3_shared_w13_suh", False))
     )
     use_fat_kernel = use_batched_fat and want_fat_kernel
-    use_row_tiles = fused_moe_row_tile_enabled()
     launched = False
     counts_host = None
     if use_batched_fat and not use_row_tiles:
@@ -801,6 +1435,8 @@ def apply_exl3_fused_moe(
         )
 
     if max_rows <= cap:
+        _EXL3_FAT_DIAG["thin_calls"] += 1
+        _record_exl3_fat_reason("thin_only")
         if not launched:
             _exl3_moe_launch(
                 fn, xh, out, expert_count, token_sorted, weight_sorted,
@@ -809,6 +1445,8 @@ def apply_exl3_fused_moe(
         return out
 
     if use_row_tiles:
+        _EXL3_FAT_DIAG["row_tile_calls"] += 1
+        _record_exl3_fat_tier(layer, "row_tile", "row_tile_preempts_fat")
         _exl3_moe_row_tiles(
             fn, xh, out, counts, token_sorted, weight_sorted,
             temps, ptrs, k, limit, n_active_host, max_rows,
@@ -821,9 +1459,10 @@ def apply_exl3_fused_moe(
             temps, ptrs, k, limit, n_active_host,
         )
     if use_batched_fat:
-        layer._exl3_last_fat_fallback = (
-            "kernel" if use_fat_kernel else "batched"
-        )
+        if use_fat_kernel:
+            _record_exl3_fat_tier(layer, "kernel", "kernel_ok")
+        else:
+            _record_exl3_fat_tier(layer, "batched", "batched_ok")
         assert counts_host is not None
         apply_exl3_batched_fat(
             xh,
@@ -837,7 +1476,11 @@ def apply_exl3_fused_moe(
             use_kernel=use_fat_kernel,
         )
     elif use_sorted_fat:
-        layer._exl3_last_fat_fallback = "sorted"
+        _record_exl3_fat_tier(
+            layer,
+            "sorted",
+            "degraded_shared_suh" if want_batched_fat else "sorted_ok",
+        )
         assert counts_host is not None
         apply_exl3_sorted_fat(
             xh,
@@ -850,7 +1493,7 @@ def apply_exl3_fused_moe(
             out,
         )
     else:
-        layer._exl3_last_fat_fallback = "legacy"
+        _record_exl3_fat_tier(layer, "legacy", "legacy_default")
         fat = (counts > cap).nonzero(as_tuple=False).view(-1)
         if fat.numel():
             apply_exl3_python_loop(
@@ -1190,6 +1833,9 @@ class Exl3MoEMethod(FusedMoEMethodBase):
             )
             inners.append({"gate": gate, "up": up, "down": down})
         layer._exl3_inners = inners
+        # Tier resolution needs the LinearEXL3 handles (K/mcg/mul1) for the
+        # grouped eligibility check, so it runs once the inners exist.
+        _record_exl3_fat_resolution(layer)
         fused_ok = False
         fused_err = None
         if fused_moe_enabled():

--- a/overlay/exl3_fat_moe.cu
+++ b/overlay/exl3_fat_moe.cu
@@ -1,0 +1,656 @@
+#include <cuda_fp16.h>
+#include <c10/cuda/CUDAGuard.h>
+#include <ATen/cuda/CUDAContext.h>
+
+#include "../util.h"
+#include "../util.cuh"
+#include "../ptx.cuh"
+#include "exl3_dq.cuh"
+#include "hadamard_inner.cuh"
+#include "exl3_fat_moe.cuh"
+
+// Grouped fat-expert kernels. See exl3_fat_moe.cuh for the contract.
+//
+// Mainloop: TILE_M rows x 128 columns per CTA, K advanced 32 per pipeline
+// stage with cp.async multi-buffering. B tiles (16x16 K4/MCG trellis tiles,
+// 64 int16 words each) are staged through shared memory and dequantized in
+// registers by the warp that owns that 16-column block, once per 16 K, and
+// reused across all M blocks of the tile. The gate/up kernel runs two B
+// streams (gate, up) for the same 128 intermediate columns so the SwiGLU and
+// the down-projection input Hadamard fuse into its epilogue.
+
+namespace {
+
+constexpr int FM_THREADS = 256;                 // 8 warps
+constexpr int FM_WARPS = FM_THREADS / 32;
+constexpr int FM_TILE_N = 128;                  // one 16-col block per warp
+constexpr int FM_TILE_K = 32;                   // per pipeline stage
+constexpr int FM_STAGES = 4;
+constexpr int FM_PACKED_WORDS = 64;             // int16 words per 16x16 K4 tile
+constexpr int FM_B_STAGE_WORDS = 2 * FM_WARPS * FM_PACKED_WORDS;  // 2 k16 sub-steps
+constexpr float FM_HAD_SCALE = 0.088388347648f; // 1/sqrt(128)
+
+constexpr int FM_MB_GATEUP = 4;                 // 64-row tiles, 2 B streams
+constexpr int FM_MB_DOWN = 4;                   // 64-row tiles, 2 B streams (256 cols)
+
+template <int MB, int NS>
+constexpr int fm_smem_bytes()
+{
+    constexpr int a_stage = MB * 16 * FM_TILE_K * 2;
+    constexpr int b_stage = NS * FM_B_STAGE_WORDS * 2;
+    constexpr int pipe = FM_STAGES * (a_stage + b_stage);
+    constexpr int epi = 16 * NS * FM_TILE_N * 4;
+    return pipe > epi ? pipe : epi;
+}
+
+// 128-element Hadamard over one row held as float4 per lane, then optional
+// per-column scale. Same arithmetic as fat_had_ff_128 / had_ff_r_128_inner.
+__device__ __forceinline__ void fm_had_row(float4& v, int lane)
+{
+    float s0 = v.x + v.y;
+    float d0 = v.x - v.y;
+    float s1 = v.z + v.w;
+    float d1 = v.z - v.w;
+    v.x = s0 + s1;
+    v.y = d0 + d1;
+    v.z = s0 - s1;
+    v.w = d0 - d1;
+    shuffle_had_f2x32(v.x, v.y, lane);
+    shuffle_had_f2x32(v.z, v.w, lane);
+    v.x *= FM_HAD_SCALE;
+    v.y *= FM_HAD_SCALE;
+    v.z *= FM_HAD_SCALE;
+    v.w *= FM_HAD_SCALE;
+}
+
+__device__ __forceinline__ float4 fm_load_half4(const half* p)
+{
+    half4 h = *reinterpret_cast<const half4*>(p);
+    return make_float4(__low2float(h.x), __high2float(h.x), __low2float(h.y), __high2float(h.y));
+}
+
+__device__ __forceinline__ void fm_mul_half4(float4& v, const half* p)
+{
+    float4 s = fm_load_half4(p);
+    v.x *= s.x; v.y *= s.y; v.z *= s.z; v.w *= s.w;
+}
+
+__device__ __forceinline__ void fm_store_half4(half* p, const float4& v)
+{
+    half4 h(__floats2half2_rn(v.x, v.y), __floats2half2_rn(v.z, v.w));
+    *reinterpret_cast<half4*>(p) = h;
+}
+
+// XOR swizzle of the 16-byte chunk column inside a 32-wide (64 B) A row so
+// ldmatrix phases (8 consecutive rows, one chunk) hit 8 distinct bank groups.
+__device__ __forceinline__ int fm_swz(int row, int chunk)
+{
+    return chunk ^ ((row >> 1) & 3);
+}
+
+// ---------------------------------------------------------------------------
+// Gather + input Hadamard: h13[row] = had128(x[token[row]] * suh[expert[row]])
+// ---------------------------------------------------------------------------
+
+__global__ __launch_bounds__(FM_THREADS)
+void fm_gather_kernel(
+    const half* __restrict__ x,
+    const int64_t* __restrict__ row_token,
+    const int* __restrict__ row_expert,
+    const half* const* __restrict__ suh_ptrs,
+    half* __restrict__ h13,
+    const int* __restrict__ num_rows_ptr,
+    int size_k)
+{
+    const int num_rows = *num_rows_ptr;
+    const int warp = threadIdx.x >> 5;
+    const int lane = threadIdx.x & 31;
+    const int blk = blockIdx.y;             // 128-wide K block
+    for (int row = blockIdx.x * FM_WARPS + warp; row < num_rows; row += gridDim.x * FM_WARPS)
+    {
+        const int64_t token = row_token[row];
+        const half* suh = suh_ptrs[row_expert[row]] + blk * 128;
+        const half* src = x + token * (int64_t) size_k + blk * 128;
+        half* dst = h13 + (int64_t) row * size_k + blk * 128;
+        // E2 boundary (had_hf_r_128_inner<pre_scale>): the input scale is a
+        // fp16 x fp16 multiply, rounded, BEFORE the fp32 Hadamard.
+        half4 hv = *reinterpret_cast<const half4*>(src + lane * 4);
+        half4 hs = *reinterpret_cast<const half4*>(suh + lane * 4);
+        hv.x = __hmul2(hv.x, hs.x);
+        hv.y = __hmul2(hv.y, hs.y);
+        float4 v = make_float4(__low2float(hv.x), __high2float(hv.x),
+                               __low2float(hv.y), __high2float(hv.y));
+        fm_had_row(v, lane);
+        fm_store_half4(dst + lane * 4, v);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Shared mainloop: acc[NS][MB][2] += A(tile rows, K) @ B_ns(K, 128 cols)
+// ---------------------------------------------------------------------------
+
+// NB_STRIDE: 16-col block offset between streams (0 = different matrices
+// over the same columns, 8 = adjacent 128-col halves of one matrix).
+template <int MB, int NS, int NB_STRIDE>
+__device__ __forceinline__ void fm_mainloop(
+    const half* __restrict__ a,          // fat-row buffer [rows_cap, size_k]
+    int size_k,
+    int row0,
+    int rows,
+    const uint16_t* const (&packed)[NS], // per-stream trellis, (K/16, tiles_n, 64)
+    int tiles_n,
+    int n_block0,                        // first 16-col block of this tile
+    half* sh_a,                          // FM_STAGES * MB*16*32 halves
+    uint16_t* sh_b,                      // FM_STAGES * NS * FM_B_STAGE_WORDS
+    FragC (&acc)[NS][MB][2])
+{
+    constexpr int TILE_M = MB * 16;
+    constexpr int A_STAGE = TILE_M * FM_TILE_K;          // halves
+    constexpr int A_CHUNKS = TILE_M * 4;                 // 16 B chunks per stage
+    constexpr int A_ITERS = (A_CHUNKS + FM_THREADS - 1) / FM_THREADS;
+    constexpr int B_STAGE = NS * FM_B_STAGE_WORDS;       // int16 words
+    constexpr int B_CHUNKS = NS * 2 * FM_WARPS * 8;      // 16 B chunks per stage
+    constexpr int B_ITERS = (B_CHUNKS + FM_THREADS - 1) / FM_THREADS;
+
+    const int t = threadIdx.x;
+    const int warp = t >> 5;
+    const int lane = t & 31;
+    const int k_tiles = size_k / FM_TILE_K;
+
+    #pragma unroll
+    for (int s = 0; s < NS; ++s)
+        #pragma unroll
+        for (int mb = 0; mb < MB; ++mb)
+        {
+            acc[s][mb][0] = {};
+            acc[s][mb][1] = {};
+        }
+
+    auto load_stage = [&](int stage, int kt)
+    {
+        half* sa = sh_a + stage * A_STAGE;
+        #pragma unroll
+        for (int i = 0; i < A_ITERS; ++i)
+        {
+            int c = i * FM_THREADS + t;
+            if (c < A_CHUNKS)
+            {
+                int row = c >> 2;
+                int chunk = c & 3;
+                int src_row = row < rows ? row : rows - 1;
+                const half* src = a + (int64_t) (row0 + src_row) * size_k + kt * FM_TILE_K + chunk * 8;
+                half* dst = sa + row * FM_TILE_K + fm_swz(row, chunk) * 8;
+                cp_async(dst, src);
+            }
+        }
+        uint16_t* sb = sh_b + stage * B_STAGE;
+        #pragma unroll
+        for (int i = 0; i < B_ITERS; ++i)
+        {
+            int c = i * FM_THREADS + t;
+            if (c < B_CHUNKS)
+            {
+                int s = c / (2 * FM_WARPS * 8);
+                int r = c % (2 * FM_WARPS * 8);
+                int j = r / (FM_WARPS * 8);          // k16 sub-step
+                int nb = (r / 8) % FM_WARPS;         // 16-col block (= warp)
+                int q = r % 8;                       // 16 B chunk of the 128 B tile
+                const uint16_t* src = packed[s]
+                    + ((int64_t) (kt * 2 + j) * tiles_n + n_block0 + s * NB_STRIDE + nb) * FM_PACKED_WORDS + q * 8;
+                uint16_t* dst = sb + (s * 2 + j) * (FM_WARPS * FM_PACKED_WORDS) + nb * FM_PACKED_WORDS + q * 8;
+                cp_async(dst, src);
+            }
+        }
+    };
+
+    #pragma unroll
+    for (int s = 0; s < FM_STAGES - 1; ++s)
+    {
+        if (s < k_tiles) load_stage(s, s);
+        cp_async_fence();
+    }
+
+    const int a_row = (lane & 7) + 8 * ((lane >> 3) & 1);
+    const int a_chunk_hi = lane >> 4;
+
+    for (int kt = 0; kt < k_tiles; ++kt)
+    {
+        cp_async_wait<FM_STAGES - 2>();
+        __syncthreads();
+        int nk = kt + FM_STAGES - 1;
+        if (nk < k_tiles) load_stage(nk % FM_STAGES, nk);
+        cp_async_fence();
+
+        const int stage = kt % FM_STAGES;
+        const half* sa = sh_a + stage * A_STAGE;
+        const uint16_t* sb = sh_b + stage * B_STAGE;
+
+        #pragma unroll
+        for (int j = 0; j < 2; ++j)
+        {
+            FragB fb[NS][2];
+            #pragma unroll
+            for (int s = 0; s < NS; ++s)
+            {
+                const uint32_t* wb = reinterpret_cast<const uint32_t*>(
+                    sb + (s * 2 + j) * (FM_WARPS * FM_PACKED_WORDS) + warp * FM_PACKED_WORDS);
+                dq_dispatch<4, 1>(wb, lane << 3, fb[s][0], fb[s][1]);
+            }
+            #pragma unroll
+            for (int mb = 0; mb < MB; ++mb)
+            {
+                FragA fa;
+                int row = mb * 16 + a_row;
+                int chunk = j * 2 + a_chunk_hi;
+                ldsm4(fa, sa + row * FM_TILE_K + fm_swz(row, chunk) * 8);
+                #pragma unroll
+                for (int s = 0; s < NS; ++s)
+                {
+                    ptx_mma_m16n8k16(fa, fb[s][0], acc[s][mb][0]);
+                    ptx_mma_m16n8k16(fa, fb[s][1], acc[s][mb][1]);
+                }
+            }
+        }
+    }
+    cp_async_wait<0>();
+    __syncthreads();
+}
+
+// Stage one 16-row block of accumulators into sh_c[16][NS * 128] (fp32).
+template <int NS>
+__device__ __forceinline__ void fm_stage_acc(
+    float* sh_c, FragC (&acc0)[2], FragC (&acc1)[2], int warp, int lane)
+{
+    constexpr int W = NS * FM_TILE_N;
+    int r0 = lane >> 2;
+    int col = (lane & 3) * 2 + warp * 16;
+    {
+        float* d0 = sh_c + r0 * W + col;
+        float* d1 = sh_c + (r0 + 8) * W + col;
+        d0[0] = acc0[0][0]; d0[1] = acc0[0][1]; d0[8] = acc0[1][0]; d0[9] = acc0[1][1];
+        d1[0] = acc0[0][2]; d1[1] = acc0[0][3]; d1[8] = acc0[1][2]; d1[9] = acc0[1][3];
+    }
+    if constexpr (NS == 2)
+    {
+        float* d0 = sh_c + r0 * W + FM_TILE_N + col;
+        float* d1 = sh_c + (r0 + 8) * W + FM_TILE_N + col;
+        d0[0] = acc1[0][0]; d0[1] = acc1[0][1]; d0[8] = acc1[1][0]; d0[9] = acc1[1][1];
+        d1[0] = acc1[0][2]; d1[1] = acc1[0][3]; d1[8] = acc1[1][2]; d1[9] = acc1[1][3];
+    }
+}
+
+// ---------------------------------------------------------------------------
+// gate/up GEMM + SwiGLU + down-input Hadamard
+// ---------------------------------------------------------------------------
+
+__global__ __launch_bounds__(FM_THREADS, 2)
+void fm_gateup_kernel(
+    const half* __restrict__ h13,
+    const uint16_t* const* __restrict__ gate_ptrs,
+    const uint16_t* const* __restrict__ up_ptrs,
+    const half* const* __restrict__ gate_svh_ptrs,
+    const half* const* __restrict__ up_svh_ptrs,
+    const half* const* __restrict__ down_suh_ptrs,
+    half* __restrict__ h2,
+    const int* __restrict__ seg_expert,
+    const int* __restrict__ seg_row0,
+    const int* __restrict__ seg_rows,
+    const int* __restrict__ num_segs_ptr,
+    int size_k,
+    int size_n,
+    float act_limit)
+{
+    constexpr int MB = FM_MB_GATEUP;
+    constexpr int NS = 2;
+    extern __shared__ __align__(16) unsigned char fm_smem[];
+    half* sh_a = reinterpret_cast<half*>(fm_smem);
+    uint16_t* sh_b = reinterpret_cast<uint16_t*>(sh_a + FM_STAGES * MB * 16 * FM_TILE_K);
+    float* sh_c = reinterpret_cast<float*>(fm_smem);
+
+    const int num_segs = *num_segs_ptr;
+    const int warp = threadIdx.x >> 5;
+    const int lane = threadIdx.x & 31;
+    const int tiles_n = size_n / 16;
+    const int n_base = blockIdx.x * FM_TILE_N;
+
+    for (int seg = blockIdx.y; seg < num_segs; seg += gridDim.y)
+    {
+        const int e = seg_expert[seg];
+        const int row0 = seg_row0[seg];
+        const int rows = seg_rows[seg];
+        const uint16_t* const packed[NS] = { gate_ptrs[e], up_ptrs[e] };
+        const half* svh_g = gate_svh_ptrs[e] + n_base;
+        const half* svh_u = up_svh_ptrs[e] + n_base;
+        const half* suh_d = down_suh_ptrs[e] + n_base;
+
+        FragC acc[NS][MB][2];
+        fm_mainloop<MB, NS, 0>(h13, size_k, row0, rows, packed, tiles_n, n_base / 16, sh_a, sh_b, acc);
+
+        #pragma unroll
+        for (int mb = 0; mb < MB; ++mb)
+        {
+            int rows_mb = rows - mb * 16;
+            if (rows_mb <= 0) break;
+            fm_stage_acc<NS>(sh_c, acc[0][mb], acc[1][mb], warp, lane);
+            __syncthreads();
+            #pragma unroll
+            for (int rr = 0; rr < 2; ++rr)
+            {
+                int r = warp + rr * FM_WARPS;
+                if (r < rows_mb)
+                {
+                    const float* src = sh_c + r * (NS * FM_TILE_N) + lane * 4;
+                    float4 g = *reinterpret_cast<const float4*>(src);
+                    float4 u = *reinterpret_cast<const float4*>(src + FM_TILE_N);
+                    fm_had_row(g, lane);
+                    fm_mul_half4(g, svh_g + lane * 4);
+                    fm_had_row(u, lane);
+                    fm_mul_half4(u, svh_u + lane * 4);
+                    // silu(min(g, limit)) * clamp(u, -limit, limit)
+                    g.x = fminf(g.x, act_limit); g.y = fminf(g.y, act_limit);
+                    g.z = fminf(g.z, act_limit); g.w = fminf(g.w, act_limit);
+                    u.x = fminf(fmaxf(u.x, -act_limit), act_limit);
+                    u.y = fminf(fmaxf(u.y, -act_limit), act_limit);
+                    u.z = fminf(fmaxf(u.z, -act_limit), act_limit);
+                    u.w = fminf(fmaxf(u.w, -act_limit), act_limit);
+                    // E2 boundaries, in order: torch.sigmoid (1/(1+exp(-g)) at
+                    // full precision) * g * u in fp32; act_h.copy_() rounds to
+                    // fp16; had_hf_r_128_inner<pre_scale> multiplies by
+                    // down.suh in fp16; fp32 Hadamard; fp16 store.
+                    // exllamav3 builds with --use_fast_math (expf -> __expf,
+                    // approximate division); the double-precision exp and the
+                    // IEEE-rounded __fdiv_rn are immune to that flag, so the
+                    // result is the same whether this file is compiled inside
+                    // exllamav3_ext or as the standalone module.
+                    float4 act;
+                    act.x = __fdiv_rn(1.0f, 1.0f + (float) exp(-(double) g.x)) * g.x * u.x;
+                    act.y = __fdiv_rn(1.0f, 1.0f + (float) exp(-(double) g.y)) * g.y * u.y;
+                    act.z = __fdiv_rn(1.0f, 1.0f + (float) exp(-(double) g.z)) * g.z * u.z;
+                    act.w = __fdiv_rn(1.0f, 1.0f + (float) exp(-(double) g.w)) * g.w * u.w;
+                    half4 ha(__floats2half2_rn(act.x, act.y), __floats2half2_rn(act.z, act.w));
+                    half4 hs = *reinterpret_cast<const half4*>(suh_d + lane * 4);
+                    ha.x = __hmul2(ha.x, hs.x);
+                    ha.y = __hmul2(ha.y, hs.y);
+                    act = make_float4(__low2float(ha.x), __high2float(ha.x),
+                                      __low2float(ha.y), __high2float(ha.y));
+                    fm_had_row(act, lane);
+                    half* dst = h2 + (int64_t) (row0 + mb * 16 + r) * size_n + n_base + lane * 4;
+                    fm_store_half4(dst, act);
+                }
+            }
+            __syncthreads();
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// down GEMM + output Hadamard + route weight + scatter-add
+// ---------------------------------------------------------------------------
+
+__global__ __launch_bounds__(FM_THREADS, 2)
+void fm_down_kernel(
+    const half* __restrict__ h2,
+    const uint16_t* const* __restrict__ down_ptrs,
+    const half* const* __restrict__ down_svh_ptrs,
+    float* __restrict__ out,
+    const int64_t* __restrict__ row_token,
+    const half* __restrict__ row_weight,
+    const int* __restrict__ seg_expert,
+    const int* __restrict__ seg_row0,
+    const int* __restrict__ seg_rows,
+    const int* __restrict__ num_segs_ptr,
+    int size_k,
+    int size_n)
+{
+    constexpr int MB = FM_MB_DOWN;
+    constexpr int NS = 2;                       // two adjacent 128-col halves
+    constexpr int TILE_N2 = NS * FM_TILE_N;
+    extern __shared__ __align__(16) unsigned char fm_smem[];
+    half* sh_a = reinterpret_cast<half*>(fm_smem);
+    uint16_t* sh_b = reinterpret_cast<uint16_t*>(sh_a + FM_STAGES * MB * 16 * FM_TILE_K);
+    float* sh_c = reinterpret_cast<float*>(fm_smem);
+
+    const int num_segs = *num_segs_ptr;
+    const int warp = threadIdx.x >> 5;
+    const int lane = threadIdx.x & 31;
+    const int tiles_n = size_n / 16;
+    const int n_base = blockIdx.x * TILE_N2;
+
+    for (int seg = blockIdx.y; seg < num_segs; seg += gridDim.y)
+    {
+        const int e = seg_expert[seg];
+        const int row0 = seg_row0[seg];
+        const int rows = seg_rows[seg];
+        const uint16_t* const packed[NS] = { down_ptrs[e], down_ptrs[e] };
+        const half* svh = down_svh_ptrs[e] + n_base;
+
+        FragC acc[NS][MB][2];
+        fm_mainloop<MB, NS, FM_TILE_N / 16>(h2, size_k, row0, rows, packed, tiles_n, n_base / 16, sh_a, sh_b, acc);
+
+        #pragma unroll
+        for (int mb = 0; mb < MB; ++mb)
+        {
+            int rows_mb = rows - mb * 16;
+            if (rows_mb <= 0) break;
+            fm_stage_acc<NS>(sh_c, acc[0][mb], acc[1][mb], warp, lane);
+            __syncthreads();
+            #pragma unroll
+            for (int rr = 0; rr < 2; ++rr)
+            {
+                int r = warp + rr * FM_WARPS;
+                if (r < rows_mb)
+                {
+                    const float* srow = sh_c + r * TILE_N2;
+                    int frow = row0 + mb * 16 + r;
+                    float w = __half2float(row_weight[frow]);
+                    float* dst = out + row_token[frow] * (int64_t) size_n + n_base + lane * 4;
+                    #pragma unroll
+                    for (int s = 0; s < NS; ++s)
+                    {
+                        float4 v = *reinterpret_cast<const float4*>(srow + s * FM_TILE_N + lane * 4);
+                        fm_had_row(v, lane);
+                        fm_mul_half4(v, svh + s * FM_TILE_N + lane * 4);
+                        v.x *= w; v.y *= w; v.z *= w; v.w *= w;
+                        // Lane-contiguous 16 B vector atomics (sm_90+): one
+                        // red.v4 per lane covers the warp's 512 B row span.
+                        atomicAdd(reinterpret_cast<float4*>(dst + s * FM_TILE_N), v);
+                    }
+                }
+            }
+            __syncthreads();
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Host side
+// ---------------------------------------------------------------------------
+
+void check_ptr_table(const at::Tensor& t, const char* name, int64_t n)
+{
+    TORCH_CHECK(t.is_cuda() && t.is_contiguous(), name, " must be a contiguous CUDA tensor");
+    TORCH_CHECK(t.scalar_type() == at::kLong && t.dim() == 1 && t.size(0) >= n,
+                name, " must be int64[n_exp]");
+}
+
+void check_seg(const at::Tensor& t, const char* name)
+{
+    TORCH_CHECK(t.is_cuda() && t.is_contiguous() && t.scalar_type() == at::kInt && t.dim() == 1,
+                name, " must be a contiguous int32 CUDA vector");
+}
+
+int fm_grid_y(int64_t max_segs)
+{
+    // Grid-strided over segments: cap the launch so idle CTAs stay cheap.
+    int64_t g = max_segs < 1 ? 1 : max_segs;
+    if (g > 512) g = 512;
+    return (int) g;
+}
+
+bool fm_attr_set[2] = { false, false };
+
+}  // namespace
+
+int64_t exl3_fat_moe_tile_rows_gateup() { return FM_MB_GATEUP * 16; }
+int64_t exl3_fat_moe_tile_rows_down() { return FM_MB_DOWN * 16; }
+
+void exl3_fat_moe_gather(
+    at::Tensor x,
+    at::Tensor row_token,
+    at::Tensor row_expert,
+    at::Tensor suh_ptrs,
+    at::Tensor h13,
+    at::Tensor num_rows)
+{
+    const at::cuda::OptionalCUDAGuard device_guard(x.device());
+    cudaStream_t stream = at::cuda::getCurrentCUDAStream().stream();
+    TORCH_CHECK(x.is_cuda() && x.is_contiguous() && x.scalar_type() == at::kHalf && x.dim() == 2,
+                "x must be a contiguous half [tokens, K] CUDA tensor");
+    TORCH_CHECK(h13.is_cuda() && h13.is_contiguous() && h13.scalar_type() == at::kHalf && h13.dim() == 2,
+                "h13 must be a contiguous half [rows_cap, K] CUDA tensor");
+    TORCH_CHECK(h13.size(1) == x.size(1) && x.size(1) % 128 == 0, "K must match and be a multiple of 128");
+    TORCH_CHECK(row_token.is_cuda() && row_token.scalar_type() == at::kLong && row_token.is_contiguous(),
+                "row_token must be int64");
+    TORCH_CHECK(row_expert.is_cuda() && row_expert.scalar_type() == at::kInt && row_expert.is_contiguous(),
+                "row_expert must be int32");
+    TORCH_CHECK(row_token.size(0) >= h13.size(0) && row_expert.size(0) >= h13.size(0),
+                "row tables must cover rows_cap");
+    check_ptr_table(suh_ptrs, "suh_ptrs", 1);
+    check_seg(num_rows, "num_rows");
+    int size_k = (int) x.size(1);
+    int64_t rows_cap = h13.size(0);
+    int64_t gx = (rows_cap + FM_WARPS - 1) / FM_WARPS;
+    if (gx > 1024) gx = 1024;
+    if (gx < 1) gx = 1;
+    dim3 grid((unsigned) gx, size_k / 128);
+    fm_gather_kernel<<<grid, FM_THREADS, 0, stream>>>(
+        reinterpret_cast<const half*>(x.data_ptr()),
+        reinterpret_cast<const int64_t*>(row_token.data_ptr()),
+        reinterpret_cast<const int*>(row_expert.data_ptr()),
+        reinterpret_cast<const half* const*>(suh_ptrs.data_ptr()),
+        reinterpret_cast<half*>(h13.data_ptr()),
+        reinterpret_cast<const int*>(num_rows.data_ptr()),
+        size_k);
+    cuda_check(cudaPeekAtLastError());
+}
+
+void exl3_fat_moe_gateup(
+    at::Tensor h13,
+    at::Tensor gate_ptrs,
+    at::Tensor up_ptrs,
+    at::Tensor gate_svh_ptrs,
+    at::Tensor up_svh_ptrs,
+    at::Tensor down_suh_ptrs,
+    at::Tensor h2,
+    at::Tensor seg_expert,
+    at::Tensor seg_row0,
+    at::Tensor seg_rows,
+    at::Tensor num_segs,
+    double act_limit)
+{
+    const at::cuda::OptionalCUDAGuard device_guard(h13.device());
+    cudaStream_t stream = at::cuda::getCurrentCUDAStream().stream();
+    TORCH_CHECK(h13.is_cuda() && h13.is_contiguous() && h13.scalar_type() == at::kHalf && h13.dim() == 2,
+                "h13 must be a contiguous half [rows_cap, K] CUDA tensor");
+    TORCH_CHECK(h2.is_cuda() && h2.is_contiguous() && h2.scalar_type() == at::kHalf && h2.dim() == 2,
+                "h2 must be a contiguous half [rows_cap, N] CUDA tensor");
+    TORCH_CHECK(h2.size(0) == h13.size(0), "h2 / h13 row capacity mismatch");
+    int size_k = (int) h13.size(1);
+    int size_n = (int) h2.size(1);
+    TORCH_CHECK(size_k % FM_TILE_K == 0 && size_k >= FM_TILE_K, "K must be a multiple of 32");
+    TORCH_CHECK(size_n % FM_TILE_N == 0, "N must be a multiple of 128");
+    check_ptr_table(gate_ptrs, "gate_ptrs", 1);
+    check_ptr_table(up_ptrs, "up_ptrs", gate_ptrs.size(0));
+    check_ptr_table(gate_svh_ptrs, "gate_svh_ptrs", gate_ptrs.size(0));
+    check_ptr_table(up_svh_ptrs, "up_svh_ptrs", gate_ptrs.size(0));
+    check_ptr_table(down_suh_ptrs, "down_suh_ptrs", gate_ptrs.size(0));
+    check_seg(seg_expert, "seg_expert");
+    check_seg(seg_row0, "seg_row0");
+    check_seg(seg_rows, "seg_rows");
+    check_seg(num_segs, "num_segs");
+    TORCH_CHECK(seg_row0.size(0) == seg_expert.size(0) && seg_rows.size(0) == seg_expert.size(0),
+                "segment tables must share a length");
+
+    constexpr int smem = fm_smem_bytes<FM_MB_GATEUP, 2>();
+    if (!fm_attr_set[0])
+    {
+        cudaFuncSetAttribute(fm_gateup_kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem);
+        fm_attr_set[0] = true;
+    }
+    dim3 grid(size_n / FM_TILE_N, fm_grid_y(seg_expert.size(0)));
+    fm_gateup_kernel<<<grid, FM_THREADS, smem, stream>>>(
+        reinterpret_cast<const half*>(h13.data_ptr()),
+        reinterpret_cast<const uint16_t* const*>(gate_ptrs.data_ptr()),
+        reinterpret_cast<const uint16_t* const*>(up_ptrs.data_ptr()),
+        reinterpret_cast<const half* const*>(gate_svh_ptrs.data_ptr()),
+        reinterpret_cast<const half* const*>(up_svh_ptrs.data_ptr()),
+        reinterpret_cast<const half* const*>(down_suh_ptrs.data_ptr()),
+        reinterpret_cast<half*>(h2.data_ptr()),
+        reinterpret_cast<const int*>(seg_expert.data_ptr()),
+        reinterpret_cast<const int*>(seg_row0.data_ptr()),
+        reinterpret_cast<const int*>(seg_rows.data_ptr()),
+        reinterpret_cast<const int*>(num_segs.data_ptr()),
+        size_k,
+        size_n,
+        (float) act_limit);
+    cuda_check(cudaPeekAtLastError());
+}
+
+void exl3_fat_moe_down(
+    at::Tensor h2,
+    at::Tensor down_ptrs,
+    at::Tensor down_svh_ptrs,
+    at::Tensor out,
+    at::Tensor row_token,
+    at::Tensor row_weight,
+    at::Tensor seg_expert,
+    at::Tensor seg_row0,
+    at::Tensor seg_rows,
+    at::Tensor num_segs)
+{
+    const at::cuda::OptionalCUDAGuard device_guard(h2.device());
+    cudaStream_t stream = at::cuda::getCurrentCUDAStream().stream();
+    TORCH_CHECK(h2.is_cuda() && h2.is_contiguous() && h2.scalar_type() == at::kHalf && h2.dim() == 2,
+                "h2 must be a contiguous half [rows_cap, K] CUDA tensor");
+    TORCH_CHECK(out.is_cuda() && out.is_contiguous() && out.scalar_type() == at::kFloat && out.dim() == 2,
+                "out must be a contiguous float [tokens, N] CUDA tensor");
+    int size_k = (int) h2.size(1);
+    int size_n = (int) out.size(1);
+    TORCH_CHECK(size_k % FM_TILE_K == 0 && size_k >= FM_TILE_K, "K must be a multiple of 32");
+    TORCH_CHECK(size_n % FM_TILE_N == 0, "N must be a multiple of 128");
+    TORCH_CHECK(row_token.is_cuda() && row_token.scalar_type() == at::kLong && row_token.is_contiguous()
+                && row_token.size(0) >= h2.size(0), "row_token must be int64[rows_cap]");
+    TORCH_CHECK(row_weight.is_cuda() && row_weight.scalar_type() == at::kHalf && row_weight.is_contiguous()
+                && row_weight.size(0) >= h2.size(0), "row_weight must be half[rows_cap]");
+    check_ptr_table(down_ptrs, "down_ptrs", 1);
+    check_ptr_table(down_svh_ptrs, "down_svh_ptrs", down_ptrs.size(0));
+    check_seg(seg_expert, "seg_expert");
+    check_seg(seg_row0, "seg_row0");
+    check_seg(seg_rows, "seg_rows");
+    check_seg(num_segs, "num_segs");
+    TORCH_CHECK(seg_row0.size(0) == seg_expert.size(0) && seg_rows.size(0) == seg_expert.size(0),
+                "segment tables must share a length");
+
+    TORCH_CHECK(size_n % (2 * FM_TILE_N) == 0, "N must be a multiple of 256");
+    constexpr int smem = fm_smem_bytes<FM_MB_DOWN, 2>();
+    if (!fm_attr_set[1])
+    {
+        cudaFuncSetAttribute(fm_down_kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem);
+        fm_attr_set[1] = true;
+    }
+    dim3 grid(size_n / (2 * FM_TILE_N), fm_grid_y(seg_expert.size(0)));
+    fm_down_kernel<<<grid, FM_THREADS, smem, stream>>>(
+        reinterpret_cast<const half*>(h2.data_ptr()),
+        reinterpret_cast<const uint16_t* const*>(down_ptrs.data_ptr()),
+        reinterpret_cast<const half* const*>(down_svh_ptrs.data_ptr()),
+        reinterpret_cast<float*>(out.data_ptr()),
+        reinterpret_cast<const int64_t*>(row_token.data_ptr()),
+        reinterpret_cast<const half*>(row_weight.data_ptr()),
+        reinterpret_cast<const int*>(seg_expert.data_ptr()),
+        reinterpret_cast<const int*>(seg_row0.data_ptr()),
+        reinterpret_cast<const int*>(seg_rows.data_ptr()),
+        reinterpret_cast<const int*>(num_segs.data_ptr()),
+        size_k,
+        size_n);
+    cuda_check(cudaPeekAtLastError());
+}

--- a/overlay/exl3_fat_moe.cuh
+++ b/overlay/exl3_fat_moe.cuh
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <torch/extension.h>
+
+// Grouped fat-expert MoE for EXL3 K4/MCG trellis experts (prefill).
+//
+// One launch per phase covers every "fat" expert of a layer (an expert whose
+// token count exceeds the fused exl3_moe temp rows). Work is described by
+// device-side segment tables, so the host never synchronizes on routing.
+//
+//   exl3_fat_moe_gather   : h13[row] = had128(x[token[row]] * gate_suh[expert[row]])
+//   exl3_fat_moe_gateup   : h2 = had128(silu(clamp(had(g)*svh_g)) * clamp(had(u)*svh_u) * down_suh)
+//   exl3_fat_moe_down     : out[token] += had128(h2 @ W_down) * svh_d * route_weight
+//
+// Segment tables (int32, device): seg_expert / seg_row0 / seg_rows describe
+// row tiles of the fat-row buffer (rows are grouped by expert, expert order).
+// num_segs / num_rows are 1-element int32 device tensors; kernels are launched
+// with capacity-sized, grid-strided grids and read the live counts.
+
+void exl3_fat_moe_gather(
+    at::Tensor x,            // [tokens, K] half
+    at::Tensor row_token,    // [rows_cap] int64
+    at::Tensor row_expert,   // [rows_cap] int32
+    at::Tensor suh_ptrs,     // [n_exp] int64 (device pointers, half[K])
+    at::Tensor h13,          // [rows_cap, K] half (out)
+    at::Tensor num_rows);    // [1] int32 device
+
+void exl3_fat_moe_gateup(
+    at::Tensor h13,          // [rows_cap, K] half
+    at::Tensor gate_ptrs,    // [n_exp] int64 trellis pointers (K/16, N/16, 64) int16
+    at::Tensor up_ptrs,
+    at::Tensor gate_svh_ptrs,
+    at::Tensor up_svh_ptrs,
+    at::Tensor down_suh_ptrs,
+    at::Tensor h2,           // [rows_cap, N] half (out)
+    at::Tensor seg_expert,
+    at::Tensor seg_row0,
+    at::Tensor seg_rows,
+    at::Tensor num_segs,
+    double act_limit);
+
+void exl3_fat_moe_down(
+    at::Tensor h2,           // [rows_cap, K] half
+    at::Tensor down_ptrs,    // trellis pointers (K/16, N/16, 64)
+    at::Tensor down_svh_ptrs,
+    at::Tensor out,          // [tokens, N] float (accumulated)
+    at::Tensor row_token,    // [rows_cap] int64
+    at::Tensor row_weight,   // [rows_cap] half
+    at::Tensor seg_expert,
+    at::Tensor seg_row0,
+    at::Tensor seg_rows,
+    at::Tensor num_segs);
+
+// Row tile sizes the segment tables must be built with.
+int64_t exl3_fat_moe_tile_rows_gateup();
+int64_t exl3_fat_moe_tile_rows_down();

--- a/overlay/patch_exl3_fat_kernel.py
+++ b/overlay/patch_exl3_fat_kernel.py
@@ -23,7 +23,12 @@ def main() -> int:
     if not quant.is_dir() or not bindings.is_file():
         raise RuntimeError(f"invalid extension root: {ext_root}")
 
-    for name in ("exl3_fat_gemm.cu", "exl3_fat_gemm.cuh"):
+    for name in (
+        "exl3_fat_gemm.cu",
+        "exl3_fat_gemm.cuh",
+        "exl3_fat_moe.cu",
+        "exl3_fat_moe.cuh",
+    ):
         source = source_dir / name
         if not source.is_file():
             raise RuntimeError(f"missing additive source: {source}")
@@ -33,14 +38,21 @@ def main() -> int:
     text = replace_once(
         text,
         '#include "quant/exl3_moe.cuh"',
-        '#include "quant/exl3_moe.cuh"\n#include "quant/exl3_fat_gemm.cuh"',
+        '#include "quant/exl3_moe.cuh"\n'
+        '#include "quant/exl3_fat_gemm.cuh"\n'
+        '#include "quant/exl3_fat_moe.cuh"',
     )
     text = replace_once(
         text,
         '    m.def("exl3_moe", &exl3_moe, "exl3_moe");',
         '    m.def("exl3_moe", &exl3_moe, "exl3_moe");\n'
         '    m.def("exl3_fat_gemm", &exl3_fat_gemm, "exl3_fat_gemm");\n'
-        '    m.def("exl3_fat_gemm_scatter", &exl3_fat_gemm_scatter, "exl3_fat_gemm_scatter");',
+        '    m.def("exl3_fat_gemm_scatter", &exl3_fat_gemm_scatter, "exl3_fat_gemm_scatter");\n'
+        '    m.def("exl3_fat_moe_gather", &exl3_fat_moe_gather, "exl3_fat_moe_gather");\n'
+        '    m.def("exl3_fat_moe_gateup", &exl3_fat_moe_gateup, "exl3_fat_moe_gateup");\n'
+        '    m.def("exl3_fat_moe_down", &exl3_fat_moe_down, "exl3_fat_moe_down");\n'
+        '    m.def("exl3_fat_moe_tile_rows_gateup", &exl3_fat_moe_tile_rows_gateup, "exl3_fat_moe_tile_rows_gateup");\n'
+        '    m.def("exl3_fat_moe_tile_rows_down", &exl3_fat_moe_tile_rows_down, "exl3_fat_moe_tile_rows_down");',
     )
     bindings.write_text(text)
     return 0

--- a/start.sh
+++ b/start.sh
@@ -277,6 +277,10 @@ EXL3_FAT_SORTED="${EXL3_FAT_SORTED:-0}"
 EXL3_FAT_BATCHED="${EXL3_FAT_BATCHED:-0}"
 # E2 direct trellis kernel; implies BATCHED=1 and SORTED=1.
 EXL3_FAT_KERNEL="${EXL3_FAT_KERNEL:-0}"
+# E3 grouped fat-expert MoE (prefill). Default off; needs exl3_fat_moe
+# symbols (layered candidate or a rebuilt image). Implies KERNEL=1 when
+# the checkpoint is ineligible. Decode never takes this path.
+EXL3_FAT_GROUPED="${EXL3_FAT_GROUPED:-0}"
 
 # recipe: layers 15-45 edited with the dealign direction, 0-14 stay stock
 # safety anchors, MTP block included. 0 = stock weights. Applied identically
@@ -444,6 +448,10 @@ validate_numeric_config() {
     case "${GLM53_INDEXER_WORKSPACE-stock}" in
         stock|rightsize) ;;
         *) echo "GLM53_INDEXER_WORKSPACE must be exactly one of: stock rightsize (got: '${GLM53_INDEXER_WORKSPACE-<unset>}')" >&2; return 2 ;;
+    esac
+    case "${EXL3_FAT_GROUPED-0}" in
+        0|1) ;;
+        *) echo "EXL3_FAT_GROUPED must be exactly 0 or 1 (got: '${EXL3_FAT_GROUPED-<unset>}')" >&2; return 2 ;;
     esac
     # LOCAL: W41/W42 strict-bool validation (end)
     # LOCAL: DEFAULT_MAX_NEW_TOKENS is spliced into generated shell + JSON; empty = off.
@@ -1481,7 +1489,7 @@ launch_cluster() {
              KV_CACHE_DTYPE MTP_TOKENS SPEC_METHOD DFLASH_TOKENS DFLASH_MODEL_DIR \
              DFLASH_DRAFT_TP \
              LANGUAGE_MODEL_ONLY SKIP_MM_PROFILING \
-             LIMIT_MM CHAT_TEMPLATE ENFORCE_EAGER EXL3_FUSED_MOE EXL3_MOE_ROW_TILE EXL3_TEMP_ROWS_FUSED EXL3_FAT_SORTED EXL3_FAT_BATCHED EXL3_FAT_KERNEL MODEL_DIR EXTRA_ARGS; do
+             LIMIT_MM CHAT_TEMPLATE ENFORCE_EAGER EXL3_FUSED_MOE EXL3_MOE_ROW_TILE EXL3_TEMP_ROWS_FUSED EXL3_FAT_SORTED EXL3_FAT_BATCHED EXL3_FAT_KERNEL EXL3_FAT_GROUPED MODEL_DIR EXTRA_ARGS; do
         serve_env+=" -e $v='${!v:-}'"
     done
     # VLLM_API_KEY belongs only on rank 0, which owns the API server. Never send
@@ -1588,6 +1596,7 @@ launch_cluster() {
         -e EXL3_FAT_SORTED="$EXL3_FAT_SORTED" \
         -e EXL3_FAT_BATCHED="$EXL3_FAT_BATCHED" \
         -e EXL3_FAT_KERNEL="$EXL3_FAT_KERNEL" \
+        -e EXL3_FAT_GROUPED="$EXL3_FAT_GROUPED" \
         -e MODEL_DIR="$MODEL_DIR" \
         -e VLLM_API_KEY="$VLLM_API_KEY" \
         -e EXTRA_ARGS="${EXTRA_ARGS:-}" \

--- a/tests/bench_e3_microbench.py
+++ b/tests/bench_e3_microbench.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""Isolated MoE-layer timing: E2 (shipped) vs E3 grouped at TP2 per-rank shapes.
+
+Reproducible replacement for the prototype harness (random K4 trellises,
+random-normal scales, shared gate/up SUH). Timing uses CUDA events around the
+full apply (thin fused kernel + fat path + routing glue, i.e. one MoE layer's
+expert work), explicit warmup, and saved repetitions. Routing: a Zipf skew
+ladder plus a uniform case; the actual served routing distribution is NOT
+reproduced here (no live fixture). Parity at production geometry is asserted
+against the LinearEXL3 loop with the frozen E2-derived tolerances.
+
+Synthetic numbers here are NOT end-to-end prefill measurements.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import statistics
+import sys
+import time
+import types
+
+os.environ.setdefault("EXL3_FAT_EXPERT_LOG", "0")
+
+import torch  # noqa: E402
+
+# Production TP2 per-rank shape: hidden 4096, down-shard intermediate 2048.
+HID, INTER, NEXP, TOPK = 4096, 2048, 288, 8
+
+
+def make_layer(n_exp=NEXP, hidden=HID, inter=INTER, seed=0):
+    from vllm.model_executor.layers.quantization.exl3 import (
+        MCG_MARKER_SIGNED_INT32, Exl3Config, Exl3MoEMethod,
+    )
+
+    moe = types.SimpleNamespace(swiglu_limit=10.0)
+    method = Exl3MoEMethod(moe, Exl3Config())
+    layer = torch.nn.Module()
+    method.create_weights(layer, num_experts=n_exp, hidden_size=hidden,
+                          intermediate_size_per_partition=inter, params_dtype=torch.float16)
+    g = torch.Generator(device="cpu")
+    g.manual_seed(seed)
+    with torch.no_grad():
+        layer.w13_trellis.copy_(torch.randint(-30000, 30000, tuple(layer.w13_trellis.shape), dtype=torch.int16, generator=g))
+        layer.w2_trellis.copy_(torch.randint(-30000, 30000, tuple(layer.w2_trellis.shape), dtype=torch.int16, generator=g))
+        for p in (layer.w13_suh, layer.w13_svh, layer.w2_suh, layer.w2_svh):
+            p.copy_((torch.randn(tuple(p.shape), generator=g) * 0.5).half())
+        layer.w13_suh[:, 1].copy_(layer.w13_suh[:, 0])
+        layer.w13_mcg.fill_(MCG_MARKER_SIGNED_INT32)
+        layer.w2_mcg.fill_(MCG_MARKER_SIGNED_INT32)
+    layer = layer.to("cuda:0")
+    method.process_weights_after_loading(layer)
+    return layer
+
+
+def routing(tokens, n_exp=NEXP, topk=TOPK, skew=1.0, seed=0):
+    g = torch.Generator(device="cpu")
+    g.manual_seed(seed)
+    p = 1.0 / torch.arange(1, n_exp + 1).float() ** skew
+    p = p[torch.randperm(n_exp, generator=g)]
+    ids = torch.multinomial(p.expand(tokens, -1), topk, replacement=False, generator=g)
+    w = torch.rand(tokens, topk, generator=g).softmax(-1).half()
+    return ids.cuda(), w.cuda()
+
+
+def _err_stats(ref, got) -> dict[str, float]:
+    da = ref.float()
+    db = got.float()
+    diff = (da - db).abs()
+    rms = float(diff.square().mean().sqrt())
+    scale = float(da.abs().mean().clamp_min(1e-3))
+    return {
+        "maxabs": float(diff.max()),
+        "nrmse": rms / scale,
+        "meanabs": float(diff.mean()),
+    }
+
+
+def _assert_e3_within(name: str, e2: dict, e3: dict) -> None:
+    """E3 vs LinearEXL3 must stay inside the frozen E2-vs-loop envelope."""
+    max_bound = max(0.15, 1.5 * float(e2["maxabs"]))
+    nrmse_bound = max(0.02, 1.5 * float(e2["nrmse"]))
+    assert e3["maxabs"] <= max_bound, (name, e2, e3, max_bound)
+    assert e3["nrmse"] <= nrmse_bound, (name, e2, e3, nrmse_bound)
+
+
+def time_fn(fn, iters=5, warm=2):
+    for _ in range(warm):
+        fn()
+    torch.cuda.synchronize()
+    times = []
+    for _ in range(iters):
+        s = torch.cuda.Event(enable_timing=True)
+        e = torch.cuda.Event(enable_timing=True)
+        s.record()
+        fn()
+        e.record()
+        torch.cuda.synchronize()
+        times.append(s.elapsed_time(e))
+    return times
+
+
+def set_cap(layer, cap):
+    from vllm.model_executor.layers.quantization.exl3 import _FUSED_TEMP_CACHE, build_exl3_fused_state
+
+    os.environ["EXL3_TEMP_ROWS_FUSED"] = str(cap)
+    _FUSED_TEMP_CACHE.clear()
+    build_exl3_fused_state(layer, layer._exl3_inners)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--tokens", type=int, default=7168)
+    ap.add_argument("--iters", type=int, default=5)
+    ap.add_argument("--skews", default="0.5,1.0,1.5,0.0")
+    ap.add_argument("--e3-caps", default="32,64,128")
+    ap.add_argument("--e2-caps", default="256,32")
+    ap.add_argument("--parity-tokens", type=int, default=1024)
+    args = ap.parse_args()
+    from vllm.model_executor.layers.quantization.exl3 import (
+        _record_exl3_fat_resolution, apply_exl3_experts, apply_exl3_python_loop, exl3_fat_diag,
+        exl3_fat_moe_symbols,
+    )
+    assert exl3_fat_moe_symbols(), "E3 kernels are not loaded"
+    os.environ.update({"EXL3_FAT_KERNEL": "1", "EXL3_FAT_SORTED": "0", "EXL3_FAT_BATCHED": "0", "EXL3_MOE_ROW_TILE": "0"})
+    rec: dict = {"tokens": args.tokens, "iters": args.iters, "hidden": HID, "intermediate": INTER, "n_exp": NEXP, "topk": TOPK,
+                 "device": torch.cuda.get_device_name(0), "capability": list(torch.cuda.get_device_capability()),
+                 "scales": "random-normal*0.5 (shared gate/up suh), random K4 trellis", "cases": [], "parity": {}}
+
+    # --- parity at production geometry (before any timing; tolerances frozen from E2) ---
+    os.environ["EXL3_FAT_GROUPED"] = "1"
+    layer = make_layer()
+    _record_exl3_fat_resolution(layer)
+    assert layer._exl3_fat_effective_tier == "grouped", (layer._exl3_fat_effective_tier, layer._exl3_fat_tier_reason)
+    pt = args.parity_tokens
+    x = (torch.randn(pt, HID, generator=torch.Generator().manual_seed(3))).half().cuda()
+    ids, w = routing(pt, skew=1.0, seed=3)
+    y_loop = apply_exl3_python_loop(x, ids.long(), w, layer._exl3_inners, None, 10.0)
+    set_cap(layer, 32)
+    os.environ["EXL3_FAT_GROUPED"] = "0"
+    _record_exl3_fat_resolution(layer)
+    y_e2 = apply_exl3_experts(x, ids, w, layer)
+    assert layer._exl3_last_fat_fallback == "kernel", layer._exl3_last_fat_fallback
+    y_e2b = apply_exl3_experts(x, ids, w, layer)
+    e2 = _err_stats(y_loop, y_e2)
+    os.environ["EXL3_FAT_GROUPED"] = "1"
+    _record_exl3_fat_resolution(layer)
+    y_e3 = apply_exl3_experts(x, ids, w, layer)
+    assert layer._exl3_last_fat_fallback == "grouped", layer._exl3_last_fat_fallback
+    y_e3b = apply_exl3_experts(x, ids, w, layer)
+    e3 = _err_stats(y_loop, y_e3)
+    counts = torch.bincount(ids.reshape(-1), minlength=NEXP)
+    rec["parity"] = {"tokens": pt, "cap": 32, "fat_experts": int((counts > 32).sum()), "max_rows": int(counts.max()),
+                     "e2_vs_loop": e2, "e2_repeat": _err_stats(y_e2, y_e2b), "e3_vs_loop": e3,
+                     "e3_repeat": _err_stats(y_e3, y_e3b), "e3_vs_e2": _err_stats(y_e2, y_e3)}
+    try:
+        _assert_e3_within("prod_geometry", e2, e3)
+        rec["parity"]["ok"] = True
+    except AssertionError as exc:
+        rec["parity"]["ok"] = False
+        rec["parity"]["error"] = str(exc)
+    print("PARITY", "OK" if rec["parity"]["ok"] else "FAIL", json.dumps({k: rec["parity"][k] for k in ("fat_experts", "max_rows")}),
+          "e2 maxabs=%.4f nrmse=%.6f | e3 maxabs=%.4f nrmse=%.6f" % (e2["maxabs"], e2["nrmse"], e3["maxabs"], e3["nrmse"]), flush=True)
+    del x, y_loop, y_e2, y_e2b, y_e3, y_e3b
+    torch.cuda.empty_cache()
+
+    # --- timing ladder ---
+    x = torch.randn(args.tokens, HID, dtype=torch.float16, device="cuda")
+    gflop = args.tokens * TOPK * 3 * 2 * HID * INTER / 1e9
+    for skew in [float(s) for s in args.skews.split(",")]:
+        ids, w = routing(args.tokens, skew=skew, seed=1)
+        counts = torch.bincount(ids.reshape(-1), minlength=NEXP)
+        dist = {"skew": skew, "max_rows": int(counts.max()), "mean_rows": float(counts.float().mean()),
+                "n_gt_256": int((counts > 256).sum()), "n_gt_128": int((counts > 128).sum()),
+                "n_gt_64": int((counts > 64).sum()), "n_gt_32": int((counts > 32).sum())}
+        print(f"\n== routing {dist}", flush=True)
+        for tier, caps in (("E2", args.e2_caps), ("E3", args.e3_caps)):
+            for cap in [int(c) for c in caps.split(",")]:
+                os.environ["EXL3_FAT_GROUPED"] = "1" if tier == "E3" else "0"
+                _record_exl3_fat_resolution(layer)
+                set_cap(layer, cap)
+                torch.cuda.synchronize()
+                mem0 = torch.cuda.memory_allocated()
+                times = time_fn(lambda: apply_exl3_experts(x, ids, w, layer), iters=args.iters)
+                torch.cuda.synchronize()
+                peak = torch.cuda.max_memory_allocated()
+                fb = layer._exl3_last_fat_fallback
+                med = statistics.median(times)
+                case = {"tier": tier, "cap": cap, "routing": dist, "times_ms": times, "median_ms": med,
+                        "tflops": gflop / med, "last_fat_fallback": fb, "mem_allocated_before": mem0,
+                        "peak_allocated": peak, "diag_grouped_scratch_bytes": exl3_fat_diag()["grouped_scratch_bytes"]}
+                rec["cases"].append(case)
+                print(f"{tier} cap={cap:4d} median={med:8.2f} ms  ({gflop/med:6.1f} TFLOPS) times={['%.1f' % t for t in times]} path={fb}", flush=True)
+                with open(args.out, "w") as f:
+                    json.dump(rec, f, indent=2)
+    # summary: best E2 vs best E3 per skew
+    rec["summary"] = []
+    for skew in [float(s) for s in args.skews.split(",")]:
+        cs = [c for c in rec["cases"] if c["routing"]["skew"] == skew]
+        e2 = min((c for c in cs if c["tier"] == "E2"), key=lambda c: c["median_ms"])
+        e3 = min((c for c in cs if c["tier"] == "E3"), key=lambda c: c["median_ms"])
+        rec["summary"].append({"skew": skew, "best_e2": {"cap": e2["cap"], "ms": e2["median_ms"]},
+                               "best_e3": {"cap": e3["cap"], "ms": e3["median_ms"]}, "speedup": e2["median_ms"] / e3["median_ms"]})
+    with open(args.out, "w") as f:
+        json.dump(rec, f, indent=2)
+    print("SUMMARY", json.dumps(rec["summary"]), flush=True)
+    return 0 if rec["parity"]["ok"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_exl3_grouped.py
+++ b/tests/test_exl3_grouped.py
@@ -250,11 +250,13 @@ def test_kernel_intake_and_float4_atomic() -> None:
     assert "EXL3_SELFCHECK_GPU=0" in layer
 
 
-def test_launcher_and_env_keep_grouped_off() -> None:
+def test_launcher_and_env_grouped_adopted() -> None:
     start = LAUNCHER.read_text()
     env = ENV_EXAMPLE.read_text()
+    # Launcher default stays 0 so GHCR/old images fail closed; env.example
+    # documents the adopted production arm.
     assert 'EXL3_FAT_GROUPED="${EXL3_FAT_GROUPED:-0}"' in start
-    assert "EXL3_FAT_GROUPED=0" in env
+    assert "EXL3_FAT_GROUPED=1" in env
     assert "EXL3_FAT_GROUPED" in start
     assert "-e EXL3_FAT_GROUPED=" in start
     assert "must be exactly 0 or 1" in start

--- a/tests/test_exl3_grouped.py
+++ b/tests/test_exl3_grouped.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+"""CPU-only E3 grouped-tier eligibility, dispatch, and scratch accounting.
+
+No CUDA and no vLLM import. Confirms EXL3_FAT_GROUPED=0 never inspects E3
+symbols, missing symbols fail closed when grouped is requested, min(K) ≥ 128
+is documented in eligibility, and production TP2 shapes predict 336 MiB/rank.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+KIT_ROOT = Path(__file__).resolve().parents[1]
+OVERLAY = KIT_ROOT / "overlay" / "exl3.py"
+KERNEL = KIT_ROOT / "overlay" / "exl3_fat_moe.cu"
+LAUNCHER = KIT_ROOT / "start.sh"
+ENV_EXAMPLE = KIT_ROOT / "env.example"
+DOCKERFILE = KIT_ROOT / "Dockerfile"
+LAYER = KIT_ROOT / "Dockerfile.e3-layer"
+PATCHER = KIT_ROOT / "overlay" / "patch_exl3_fat_kernel.py"
+BUILDER = KIT_ROOT / "overlay" / "build_exl3_fat_moe_ext.py"
+
+
+def _exec_helpers():
+    src = OVERLAY.read_text()
+    tree = ast.parse(src)
+    keep: list[str] = []
+    wanted_fn = {
+        "grouped_fat_enabled",
+        "fat_kernel_enabled",
+        "batched_fat_fallback_enabled",
+        "sorted_fat_fallback_enabled",
+        "configured_fat_tier",
+        "grouped_fat_eligibility",
+        "resolve_exl3_fat_tier",
+        "grouped_scratch_bytes_for",
+    }
+    wanted_assign = {
+        "EXL3_FAT_MOE_SYMBOLS",
+        "EXL3_FAT_MOE_MIN_CAPABILITY",
+        "EXL3_FAT_MOE_MIN_K",
+        "EXL3_FAT_DIAG_SCHEMA",
+        "EXL3_FAT_DIAG_KEYS",
+        "_FAT_TIERS",
+    }
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef) and node.name in wanted_fn:
+            keep.append(ast.get_source_segment(src, node) or "")
+        elif isinstance(node, ast.Assign):
+            names = [
+                t.id for t in node.targets if isinstance(t, ast.Name)
+            ]
+            if any(name in wanted_assign for name in names):
+                keep.append(ast.get_source_segment(src, node) or "")
+    ns: dict = {"os": os}
+    exec("\n\n".join(keep), ns, ns)
+    return ns
+
+
+HELPERS = _exec_helpers()
+
+
+def _inner(k_in: int = 4096, mcg: bool = True, mul1: bool = False, bits: int = 4):
+    return SimpleNamespace(K=bits, mcg=mcg, mul1=mul1, in_features=k_in)
+
+
+def _layer(
+    *,
+    bits: int = 4,
+    k_words: int = 64,
+    hidden: int = 4096,
+    inter: int = 2048,
+    shared: bool = True,
+    k_in: int = 4096,
+    cuda: bool = True,
+):
+    pack = {
+        "gate": _inner(k_in),
+        "up": _inner(k_in),
+        "down": _inner(k_in),
+    }
+    device = SimpleNamespace(type="cuda" if cuda else "cpu")
+    tensor = SimpleNamespace(device=device)
+    return SimpleNamespace(
+        _exl3_bits=bits,
+        _exl3_k_words=k_words,
+        _exl3_inners=[pack],
+        _exl3_shared_w13_suh=shared,
+        _exl3_hidden_size=hidden,
+        _exl3_intermediate_local=inter,
+        w13_trellis=tensor,
+        w13_suh=tensor,
+        w13_svh=tensor,
+        w2_trellis=tensor,
+        w2_suh=tensor,
+        w2_svh=tensor,
+    )
+
+
+def test_schema_keys_include_grouped() -> None:
+    assert HELPERS["EXL3_FAT_DIAG_SCHEMA"] == 2
+    for key in (
+        "sym_fat_moe",
+        "grouped_calls",
+        "grouped_scratch_bytes",
+        "grouped_eligible",
+    ):
+        assert key in HELPERS["EXL3_FAT_DIAG_KEYS"]
+    assert "grouped" in HELPERS["_FAT_TIERS"]
+    assert HELPERS["EXL3_FAT_MOE_MIN_K"] == 128
+    src = OVERLAY.read_text()
+    assert "_exl3_last_fat_fallback" in src
+    assert "row_tile" in src
+    assert "EXL3_FAT_GROUPED" in src
+    assert src.count("EXLLAMAV3_COMMIT = ") == 1
+    assert "ca13bdd83a1f4a74fd817b88f49509e0f22a9b07" in src
+
+
+def test_grouped_off_is_kernel_without_e3_symbols(monkeypatch) -> None:
+    monkeypatch.setenv("EXL3_FAT_GROUPED", "0")
+    monkeypatch.setenv("EXL3_FAT_KERNEL", "1")
+    monkeypatch.setenv("EXL3_FAT_BATCHED", "1")
+    monkeypatch.setenv("EXL3_FAT_SORTED", "1")
+    called = {"moe": 0}
+
+    def boom(*_a, **_k):
+        called["moe"] += 1
+        raise AssertionError("E3 symbol lookup must not run when grouped is off")
+
+    monkeypatch.setitem(HELPERS, "exl3_fat_moe_symbols", boom)
+    monkeypatch.setitem(
+        HELPERS, "exl3_fat_symbols", lambda * _a, **_k: (True, True, True)
+    )
+    # Rebind names used inside resolve via defaults / global lookup.
+    resolve = HELPERS["resolve_exl3_fat_tier"]
+    resolve.__globals__["exl3_fat_moe_symbols"] = boom
+    resolve.__globals__["exl3_fat_symbols"] = lambda * _a, **_k: (True, True, True)
+    tier, reason = resolve(True)
+    assert called["moe"] == 0
+    assert (tier, reason) == ("kernel", "kernel_ok")
+    assert HELPERS["configured_fat_tier"]() == "kernel"
+
+
+def test_grouped_on_without_symbols_fails_closed(monkeypatch) -> None:
+    monkeypatch.setenv("EXL3_FAT_GROUPED", "1")
+    resolve = HELPERS["resolve_exl3_fat_tier"]
+    resolve.__globals__["exl3_fat_moe_symbols"] = lambda * _a, **_k: False
+    with pytest.raises(RuntimeError, match="EXL3_FAT_GROUPED=1 requires"):
+        resolve(True, grouped_eligible=(True, "eligible"))
+
+
+def test_grouped_on_without_symbols_fails_closed_nonshared_suh(monkeypatch) -> None:
+    """Missing E3 symbols fail closed even when the checkpoint would also drop SUH."""
+    monkeypatch.setenv("EXL3_FAT_GROUPED", "1")
+    resolve = HELPERS["resolve_exl3_fat_tier"]
+    resolve.__globals__["exl3_fat_moe_symbols"] = lambda * _a, **_k: False
+    with pytest.raises(RuntimeError, match="EXL3_FAT_GROUPED=1 requires"):
+        resolve(False, grouped_eligible=(False, "shared_suh_absent"))
+
+
+def test_grouped_off_nonshared_suh_still_skips_e3(monkeypatch) -> None:
+    monkeypatch.setenv("EXL3_FAT_GROUPED", "0")
+    monkeypatch.setenv("EXL3_FAT_KERNEL", "1")
+    monkeypatch.setenv("EXL3_FAT_BATCHED", "1")
+    monkeypatch.setenv("EXL3_FAT_SORTED", "1")
+    called = {"moe": 0}
+
+    def boom(*_a, **_k):
+        called["moe"] += 1
+        raise AssertionError("E3 symbol lookup must not run when grouped is off")
+
+    resolve = HELPERS["resolve_exl3_fat_tier"]
+    resolve.__globals__["exl3_fat_moe_symbols"] = boom
+    resolve.__globals__["exl3_fat_symbols"] = lambda * _a, **_k: (True, True, True)
+    tier, reason = resolve(False)
+    assert called["moe"] == 0
+    assert (tier, reason) == ("sorted", "shared_suh_absent")
+
+
+def test_microbench_diag_keys_match_schema() -> None:
+    bench = (KIT_ROOT / "tests" / "bench_e3_microbench.py").read_text()
+    assert 'exl3_fat_diag()["grouped_scratch_bytes"]' in bench
+    assert "fat_scratch_bytes" not in bench
+    assert "grouped_scratch_bytes" in HELPERS["EXL3_FAT_DIAG_KEYS"]
+    assert "fat_scratch_bytes" not in HELPERS["EXL3_FAT_DIAG_KEYS"]
+
+
+def test_grouped_ineligible_falls_back_to_e2(monkeypatch) -> None:
+    monkeypatch.setenv("EXL3_FAT_GROUPED", "1")
+    resolve = HELPERS["resolve_exl3_fat_tier"]
+    resolve.__globals__["exl3_fat_moe_symbols"] = lambda * _a, **_k: True
+    resolve.__globals__["exl3_fat_symbols"] = lambda * _a, **_k: (True, True, True)
+    tier, reason = resolve(True, grouped_eligible=(False, "k_in_96"))
+    assert tier == "kernel"
+    assert reason.startswith("grouped_ineligible_k_in_96:")
+
+
+def test_eligibility_documents_min_k(monkeypatch) -> None:
+    layer = _layer(k_in=96, hidden=256, inter=128)
+    fn = HELPERS["grouped_fat_eligibility"]
+    fn.__globals__["exl3_device_capability"] = lambda: (12, 1)
+    ok, reason = fn(layer)
+    assert (ok, reason) == (False, "k_in_96")
+    src = OVERLAY.read_text()
+    assert "min(K) ≥ 128" in src or "min(K) >= 128" in src
+    assert "FM_STAGES" in src
+    assert "k_tiles" in src
+
+
+def test_eligibility_accepts_production_tp2_shape() -> None:
+    layer = _layer()
+    fn = HELPERS["grouped_fat_eligibility"]
+    fn.__globals__["exl3_device_capability"] = lambda: (12, 1)
+    ok, reason = fn(layer)
+    assert (ok, reason) == (True, "eligible")
+
+
+def test_grouped_scratch_bytes_336mib_at_production() -> None:
+    hidden, inter, mnbt, topk = 4096, 2048, 3584, 8
+    rows = mnbt * topk
+    bytes_ = HELPERS["grouped_scratch_bytes_for"](hidden, inter, rows)
+    assert bytes_ == 352_321_536
+    assert bytes_ == 336 * 1024 * 1024
+    assert hidden % 256 == 0
+    assert inter % 128 == 0
+    assert inter % 256 == 0
+
+
+def test_kernel_intake_and_float4_atomic() -> None:
+    src = KERNEL.read_text()
+    assert "ptx_mma_m16n8k16" in src
+    assert "cp_async" in src
+    assert "FM_STAGES = 4" in src
+    assert "FM_TILE_K = 32" in src
+    assert "atomicAdd(reinterpret_cast<float4*>" in src
+    assert "exp(-(double)" in src
+    assert "__fdiv_rn" in src
+    assert "tcgen05" not in src.lower()
+    assert "TMEM" not in src
+    builder = BUILDER.read_text()
+    assert "121a" in builder
+    assert "--use_fast_math" in builder
+    layer = LAYER.read_text()
+    assert "BASE=glm53-selfbuild:ca13bdd-v147" in layer
+    assert "EXL3_SELFCHECK_GPU=0" in layer
+
+
+def test_launcher_and_env_keep_grouped_off() -> None:
+    start = LAUNCHER.read_text()
+    env = ENV_EXAMPLE.read_text()
+    assert 'EXL3_FAT_GROUPED="${EXL3_FAT_GROUPED:-0}"' in start
+    assert "EXL3_FAT_GROUPED=0" in env
+    assert "EXL3_FAT_GROUPED" in start
+    assert "-e EXL3_FAT_GROUPED=" in start
+    assert "must be exactly 0 or 1" in start
+    docker = DOCKERFILE.read_text()
+    assert "COPY overlay/exl3_fat_moe.cu" in docker
+    assert "exl3_fat_moe_gather" in docker
+    patch = PATCHER.read_text()
+    assert "exl3_fat_moe.cu" in patch
+    assert "exl3_fat_moe_gather" in patch
+
+
+def test_row_tile_still_short_circuits_grouped() -> None:
+    src = OVERLAY.read_text()
+    assert "and not use_row_tiles" in src
+    assert 'layer._exl3_last_fat_fallback = "none"' in src
+    assert "EXL3_MOE_ROW_TILE" in src

--- a/tests/test_exl3_v147_qualification.py
+++ b/tests/test_exl3_v147_qualification.py
@@ -190,10 +190,14 @@ def test_fat_kernel_anchors_on_v147_bindings(tmp_path):
     text = (ext / "bindings.cpp").read_text()
     assert text.count('#include "quant/exl3_moe.cuh"') == 1
     assert text.count('#include "quant/exl3_fat_gemm.cuh"') == 1
+    assert text.count('#include "quant/exl3_fat_moe.cuh"') == 1
     assert 'm.def("exl3_fat_gemm", &exl3_fat_gemm, "exl3_fat_gemm");' in text
     assert 'm.def("exl3_fat_gemm_scatter", &exl3_fat_gemm_scatter, "exl3_fat_gemm_scatter");' in text
+    assert 'm.def("exl3_fat_moe_gather", &exl3_fat_moe_gather, "exl3_fat_moe_gather");' in text
     assert (ext / "quant" / "exl3_fat_gemm.cu").is_file()
     assert (ext / "quant" / "exl3_fat_gemm.cuh").is_file()
+    assert (ext / "quant" / "exl3_fat_moe.cu").is_file()
+    assert (ext / "quant" / "exl3_fat_moe.cuh").is_file()
     # Prefix anchors stay unique after the additive insert, so a second
     # apply is not the drift case. Re-applying would duplicate the fat
     # entries; the build runs the installer once on a fresh pin tarball.

--- a/tests/test_numeric_config.py
+++ b/tests/test_numeric_config.py
@@ -131,6 +131,34 @@ def test_v2_runner_force_off_is_refused() -> None:
     assert invalid.returncode == 2
 
 
+def test_fat_grouped_is_strict_bool() -> None:
+    refused = validate(
+        "0.87",
+        "1000000",
+        "4",
+        "1024",
+        extra_env={"EXL3_FAT_GROUPED": "2"},
+    )
+    assert refused.returncode == 2
+    assert "EXL3_FAT_GROUPED must be exactly 0 or 1" in refused.stderr
+    allowed = validate(
+        "0.87",
+        "1000000",
+        "4",
+        "1024",
+        extra_env={"EXL3_FAT_GROUPED": "1"},
+    )
+    assert allowed.returncode == 0
+    off = validate(
+        "0.87",
+        "1000000",
+        "4",
+        "1024",
+        extra_env={"EXL3_FAT_GROUPED": "0"},
+    )
+    assert off.returncode == 0
+
+
 def test_mtp_above_12_seqs_is_refused() -> None:
     refused = validate("0.87", "1000000", "13", "1024", spec_method="mtp")
     assert refused.returncode == 2


### PR DESCRIPTION
Adds the E3 grouped fat-expert MoE overlay and adopts it on the current 1M / pin / TRF=128 / C4 geometry.

Independent variable is `EXL3_FAT_GROUPED=1` on layered image `glm53-selfbuild:e3-grouped` (`sha256:bd711518d87f…`) built from `Dockerfile.e3-layer` on `ca13bdd-v147`. Kit PR #132 grouping step only: no 900k/850k context, GPU_MEM_UTIL, TRF=32, clock-lock, or client-docs changes.

- Additive `overlay/exl3_fat_moe.cu` (warp-MMA, 4-stage cp.async, SMEM 32,768 B, SiLU `exp(double)+__fdiv_rn`, `atomicAdd(float4*)`). Production overlay rebased; kit overlay not copied wholesale. Missing E3 symbols fail closed before SUH downgrade. Launcher default stays 0 so GHCR/old images fail closed; `env.example` documents the adopted arm.
- Host tests 233 passed / 1 skipped / 4 subtests. Isolated GPU microbench PARITY OK vs LinearEXL3/E2; Zipf-1.0 cap=32 median 29.0 vs 54.3 ms (1.87×).
- Same-day A-B-B-A: 240k cold prefill 1075 → 1286/1284 tok/s (+19.6% / +19.5%). 60k 1109 → 1330/1328. Structured decode non-inferior (69.79 → 69.18/69.62, accept 7.0/1.000). Pool 1,396,551 / 1.40×. Acceptance 7/7, serving 6/6, toolcall 23/23. Both ranks `grouped_ok`. MemFree ≥ 2.5 GiB. Watchdog re-armed.

Rollback: `IMAGE=glm53-selfbuild:ca13bdd-v147` and `EXL3_FAT_GROUPED=0` (spark1 `.env.bak-pre-task23-e3-20260907-175016` + `start.sh.bak-pre-task23-e3-20260907`).