### PR TITLE
EXL3: W1 lazy grouped scratch measured and reverted

### DIFF
--- a/Dockerfile.e3-py-layer
+++ b/Dockerfile.e3-py-layer
@@ -1,0 +1,18 @@
+# E3 overlay-only layer. Copies Python `exl3.py` onto the adopted grouped
+# image without rebuilding the cubin. Vehicle for W1 lazy scratch.
+#
+# Build (repo root of the experiment worktree):
+#   docker build -f Dockerfile.e3-py-layer \
+#     --build-arg BASE=glm53-selfbuild:e3-grouped \
+#     --build-arg GLM53_RECIPE_STAMP=$(git rev-parse --short HEAD) \
+#     -t glm53-selfbuild:e3-w1-scratch .
+ARG BASE=glm53-selfbuild:e3-grouped
+FROM ${BASE}
+
+COPY overlay/exl3.py /usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/quantization/exl3.py
+COPY tests/test_exl3_overlay.py /opt/glm53/test_exl3_overlay.py
+
+RUN EXL3_SELFCHECK_GPU=0 python3 /opt/glm53/test_exl3_overlay.py
+
+ARG GLM53_RECIPE_STAMP=unknown
+LABEL glm53.recipe.stamp=${GLM53_RECIPE_STAMP} glm53.e3.w1=1

--- a/docs/02-parameters.md
+++ b/docs/02-parameters.md
@@ -171,9 +171,14 @@ cache is invisible to it). 0.87 demands 105.87 GiB free against boots measured a
   loop over fat experts. Decode stays fused `exl3_moe`. Requires the
   additive `exl3_fat_moe` symbols from `glm53-selfbuild:e3-grouped`
   (`Dockerfile.e3-layer` on `ca13bdd-v147`). Missing symbols fail closed.
-  Predicted persistent scratch at MNBT × top-8 = 28,672 rows is
-  **336 MiB/rank**; the 1M KV pin did not move. Same-day A-B-B-A: 240k
-  cold prefill **+19.6%** (1075 → 1286 tok/s), structured decode
-  non-inferior, pool 1,396,551 / 1.40×. Rollback: `EXL3_FAT_GROUPED=0`
-  and `IMAGE=glm53-selfbuild:ca13bdd-v147`. GHCR/old images must leave
-  this 0.
+  Live TP2 scratch is h13 + h2 at `intermediate_size_per_partition=1024`.
+  Production (`e3-grouped`) **pre-sizes** that to MNBT × top-8 =
+  28,672 rows ≈ **280 MiB/rank**. W1 lazy grow-only was **REVERTED
+  2026-09-07**: CUDA-graph capture already requests 28,672 rows, so
+  idle MemFree did not shrink. Overlay vehicle
+  `Dockerfile.e3-py-layer` / `EXL3_FAT_SCRATCH_ROWS` remains in-tree
+  for a later capture-aware window; do not set it on production.
+  Same-day A-B-B-A (E3 adopt): 240k cold prefill **+19.6%** (1075 →
+  1286 tok/s), structured decode non-inferior, pool 1,396,551 / 1.40×.
+  Rollback: `EXL3_FAT_GROUPED=0` and `IMAGE=glm53-selfbuild:ca13bdd-v147`.
+  GHCR/old images must leave this 0.

--- a/docs/06-improvement-plan.md
+++ b/docs/06-improvement-plan.md
@@ -73,9 +73,36 @@ fail-closed before SUH downgrade). Watchdog re-armed after
 `EXL3_FAT_GROUPED=0`).
 
 E3 follow-ups are **not automatic-next**. Ranked TEST-NEXT queue (cuda-reviewer
-2026-09-07, `docs/11` §8): W1 lazy scratch → W2 TRF=32 (decode-skip gate) →
-W3 zero-fill A-pad → W4 fused gather → W5 occupancy (ncu gate). Decode is
-fused `exl3_moe`; do not retune E3 for prose.
+2026-09-07, `docs/11` §8): ~~W1 lazy scratch~~ **REVERTED** → W2 TRF=32
+(decode-skip gate) → W3 zero-fill A-pad → W4 fused gather → W5 occupancy
+(ncu gate). Decode is fused `exl3_moe`; do not retune E3 for prose.
+
+**W1 lazy scratch REVERTED 2026-09-07.** Overlay-only grow-only capacity
+`max(256, this-call rows)` on `glm53-selfbuild:e3-w1-scratch`
+(`sha256:26b674c2f0c5…`, Python layer on `e3-grouped`, cubin unchanged).
+Same-day A-control vs B:
+
+| Gate | A `e3-grouped` | B `e3-w1-scratch` | Return-A |
+|---|---|---|---|
+| Acceptance | — | 7/7 | 7/7 |
+| Serving (:18000) | — | 6/6 | 6/6 |
+| Pool | 1,396,551 / 1.40× | identical | identical |
+| 60k median tok/s | 1344.0 | 1284.5 (−4.4%) | — |
+| 240k median tok/s | 1296.2 | 1259.7 (−2.8%) | — |
+| Structured median | 70.28 @ 7.0/1.000 | 69.81 (two contended 55.98/58.81; rest 69.8–70.1) | 70.14 |
+| MemFree head/worker GiB | 5.0 / 4.1 after B-ladder | 3.61 / 3.19 after B | 5.01 / 4.30 restored |
+| Scratch | schema=2 MNBT pre-size | schema=3 grew **rows=28672 / 280 MiB / growths=1 during CUDA-graph capture** | schema=2 |
+
+Idle MemFree was the decision variable and did **not** improve: capture
+warmup already requested MNBT×topk, so lazy never stayed at LPTT=1792
+(14,336 rows / ~140 MiB). Prefill wash expected; observed −2.8% at
+240k is inside same-day noise vs adopt-day 1285, not a reason to keep
+the image. Decode non-inferior. Production restored
+`IMAGE=glm53-selfbuild:e3-grouped` (`bd711518d87f`),
+`EXL3_FAT_GROUPED=1`, empty `EXL3_FAT_SCRATCH_ROWS` omitted. Watchdog
+re-armed. Next E3 window is **not** W1 again unless capture is excluded
+from the grow trigger (separate design). Do not start W2 without the
+decode-skip probe.
 
 ### 2026-09-07: task 9 spec-graph probe (eager arm parked)
 

--- a/docs/11-gb10-kernel-program.md
+++ b/docs/11-gb10-kernel-program.md
@@ -354,12 +354,13 @@ Live TP2 scratch is **~280 MiB/rank**, not the 336 MiB microbench figure:
 `h13` 28,672 × 4096 × 2 B = 224 MiB plus `h2` 28,672 ×
 `intermediate_size_per_partition` (1024) × 2 B = 56 MiB.
 
-**Queue:** W1 lazy scratch → W2 isolated TRF=32 (gated) → W3 zero-fill
-A-pad → W4 fused gather → W5 occupancy (gated). Not automatic-next.
+**Queue:** ~~W1 lazy scratch~~ **REVERTED 2026-09-07** → W2 isolated TRF=32
+(gated) → W3 zero-fill A-pad → W4 fused gather → W5 occupancy (gated).
+Not automatic-next.
 
 | Window | Path it can move | Rebuild | Expected sign |
 |---|---|---|---|
-| **W1 lazy scratch** (first) | MemFree / 1M-pin headroom. Wash on 60k/240k at full chunks. Decode-neutral. | overlay Python | wash speed, win MemFree |
+| ~~**W1 lazy scratch**~~ **REVERTED** | CUDA-graph capture already requests MNBT×topk (28,672 rows / 280 MiB). Idle MemFree unchanged. | overlay Python | no MemFree win |
 | **W2 TRF=32 vs E3@128** (cheap 2nd, env) | Cold prefill (S1 trend: lose). Mixed TTFT / C4 co-batch (plausible win). **Decode leak.** | env only | unknown, leaning lose on cold |
 | **W3 zero-fill A-pad** | Hygiene; tiny LPDDR save on <64-row tails. Outputs bit-identical. | cubin | wash |
 | **W4 fuse gather into gate/up A-tile** | Reclaim 224 MiB `h13`. Prefill not obviously faster (8× redundant gather). | cubin | MemFree win; speed unknown |
@@ -385,12 +386,16 @@ A-pad → W4 fused gather → W5 occupancy (gated). Not automatic-next.
 
 ### Per-window contract
 
-**W1 — lazy scratch.** Independent variable: `_grouped_scratch` capacity
-= `max(256, needed)` grow-only, not `max(needed, MNBT × topk)`. Size from
-host-known `tokens × topk`, **not** actual fat rows (that needs D2H and
-breaks E3's no-sync property). Keep the capture-time realloc raise.
-Add a growth counter to `_EXL3_FAT_DIAG`. Abort: that raise fires, or
-pool/MemFree regression. Rollback: the policy line.
+**W1 — lazy scratch. REVERTED 2026-09-07.** Independent variable was
+`_grouped_scratch` capacity = `max(256, needed)` grow-only. Sized from
+host-known `tokens × topk`, capture-time realloc still raised, schema 3
+`grouped_scratch_growths`. Cluster: both ranks logged
+`grow rows=28672 bytes=293601280 growths=1` during CUDA-graph capture,
+before any serving request. Idle MemFree therefore matched the MNBT
+pre-size (~280 MiB/rank). 240k −2.8% vs same-boot control; structured
+non-inferior; pool identical. Production stays `e3-grouped`. A later
+attempt must not grow from capture dummy shapes (or must size capture
+to LPTT, not MNBT). Do not re-run the same grow-from-this-call design.
 
 **W2 — isolated TRF=32.** Independent variable: `EXL3_TEMP_ROWS_FUSED=32`.
 Floor is `MAX_NUM_SEQS × (DFLASH_TOKENS+1) = 32`, so C4 capture still

--- a/env.example
+++ b/env.example
@@ -239,3 +239,10 @@ EXL3_FAT_KERNEL=1     # E2: fused direct/scatter trellis GEMM (SM121; pipelined)
 # Rollback: EXL3_FAT_GROUPED=0 and IMAGE=glm53-selfbuild:ca13bdd-v147.
 # GHCR/old images without exl3_fat_moe must leave this 0 (fail-closed).
 EXL3_FAT_GROUPED=1
+# Optional E3 grouped-scratch row floor. Leave UNSET on production:
+# e3-grouped pre-sizes to MNBT×topk (28,672 rows / ~280 MiB/rank).
+# W1 lazy grow was REVERTED 2026-09-07 — CUDA-graph capture already
+# requests 28,672 rows, so idle MemFree did not shrink. Empty is omitted
+# from docker -e so IMAGE=e3-grouped keeps MNBT pre-size. Not in the JIT
+# shape hash.
+# EXL3_FAT_SCRATCH_ROWS=

--- a/overlay/exl3.py
+++ b/overlay/exl3.py
@@ -71,8 +71,9 @@ _FAT_STATS: dict[str, Any] = {
     "hist": [0] * (len(_FAT_BUCKET_EDGES) + 1),
 }
 _FAT_TIERS = ("grouped", "kernel", "batched", "sorted", "legacy")
-# Schema 2 adds the E3 grouped tier. Extend the key set only with a schema bump.
-EXL3_FAT_DIAG_SCHEMA = 2
+# Schema 3 adds grouped_scratch_growths (W1 lazy scratch). Extend the
+# key set only with a schema bump.
+EXL3_FAT_DIAG_SCHEMA = 3
 EXL3_FAT_DIAG_KEYS = (
     "schema",
     "configured_tier",
@@ -87,6 +88,7 @@ EXL3_FAT_DIAG_KEYS = (
     "sym_fat_moe",
     "grouped_calls",
     "grouped_scratch_bytes",
+    "grouped_scratch_growths",
     "grouped_eligible",
     "cap_major",
     "cap_minor",
@@ -117,6 +119,7 @@ _EXL3_FAT_DIAG: dict[str, Any] = {
     "sym_fat_moe": False,
     "grouped_calls": 0,
     "grouped_scratch_bytes": 0,
+    "grouped_scratch_growths": 0,
     "grouped_eligible": False,
     "cap_major": -1,
     "cap_minor": -1,
@@ -425,6 +428,7 @@ def _exl3_fat_diag_line() -> str:
         f"grouped_eligible={int(d['grouped_eligible'])}",
         f"grouped_calls={d['grouped_calls']}",
         f"grouped_scratch_bytes={d['grouped_scratch_bytes']}",
+        f"grouped_scratch_growths={d['grouped_scratch_growths']}",
         f"cap={d['cap_major']}.{d['cap_minor']}",
         f"cap_ok={int(d['cap_ok'])}",
         f"tp_rank={d['tp_rank']} tp_size={d['tp_size']}",
@@ -531,6 +535,22 @@ def reset_exl3_fat_diag_counters() -> None:
     diag["fallback_calls"] = {tier: 0 for tier in _FAT_TIERS}
     diag["fallback_reasons"] = {}
     diag["grouped_scratch_bytes"] = sum(_FAT_GROUPED_BYTES.values())
+    # Growths stay: they are lifetime alloc events, like the live byte total.
+
+
+GROUPED_SCRATCH_MIN_ROWS = 256
+
+
+def grouped_scratch_capacity(rows: int, scratch_rows: int = 0) -> int:
+    """Grow-only row capacity from host-known routed slots.
+
+    Default is max(256, this-call rows). Does not pre-size to MNBT × top-k.
+    `scratch_rows` is the explicit EXL3_FAT_SCRATCH_ROWS floor in row units
+    (0 = lazy). Never size from a D2H fat-count.
+    """
+    needed = max(GROUPED_SCRATCH_MIN_ROWS, int(rows))
+    floor = max(0, int(scratch_rows))
+    return max(needed, floor)
 
 
 def grouped_scratch_bytes_for(hidden: int, intermediate: int, rows: int) -> int:
@@ -994,28 +1014,27 @@ def apply_exl3_batched_fat(
     return out
 
 
+def _grouped_scratch_rows_env() -> int:
+    raw = os.environ.get("EXL3_FAT_SCRATCH_ROWS", "").strip()
+    if not raw:
+        return 0
+    return max(0, int(raw))
+
+
 def _grouped_scratch(
     device: torch.device, rows: int, hidden: int, intermediate: int
 ) -> dict[str, torch.Tensor]:
-    """Fat-row activation buffers for the grouped tier, grown once.
+    """Fat-row activation buffers for the grouped tier, grown outside capture.
 
-    Capacity covers every routed slot of the configured prefill chunk
-    (MAX_NUM_BATCHED_TOKENS x top-k, EXL3_FAT_GROUPED_TOPK, default 8) so
-    steady-state prefill never reallocates; a larger request grows it once
-    more (outside CUDA graph capture, where growth would be illegal).
+    Capacity is max(256, this-call routed slots). It does not pre-size to
+    MNBT × top-k. A larger later call grows once (illegal during CUDA graph
+    capture). EXL3_FAT_SCRATCH_ROWS, if set, is an explicit row floor.
+
     Persistent: h13 [rows, hidden] fp16 + h2 [rows, intermediate] fp16.
-    Predicted production bytes at MNBT=3584 × topk=8 = 28,672 rows:
-    hidden=4096 → 224 MiB, intermediate=2048 → 112 MiB, ≈336 MiB/rank.
+    Live TP2 (hidden=4096, intermediate=1024): LPTT=1792 × topk=8 = 14,336
+    rows → ~140 MiB/rank; a full MNBT=3584 step → 28,672 rows → ~280 MiB.
     """
-    configured = int(
-        os.environ.get(
-            "EXL3_FAT_SCRATCH_ROWS",
-            os.environ.get("MAX_NUM_BATCHED_TOKENS", "0"),
-        )
-        or 0
-    )
-    topk = int(os.environ.get("EXL3_FAT_GROUPED_TOPK", "8") or 8)
-    needed = max(256, rows)
+    needed = grouped_scratch_capacity(rows, _grouped_scratch_rows_env())
     key = (str(device), hidden, intermediate)
     scratch = _FAT_GROUPED_CACHE.get(key)
     if scratch is not None and int(scratch["h13"].shape[0]) >= needed:
@@ -1025,7 +1044,7 @@ def _grouped_scratch(
             "EXL3 grouped scratch growth during CUDA graph capture; warm the "
             f"largest shape first (need {needed} rows)"
         )
-    capacity = max(needed, configured * topk)
+    capacity = needed
     scratch = {
         "h13": torch.empty((capacity, hidden), dtype=torch.float16, device=device),
         "h2": torch.empty(
@@ -1037,6 +1056,17 @@ def _grouped_scratch(
         t.numel() * t.element_size() for t in scratch.values()
     )
     _EXL3_FAT_DIAG["grouped_scratch_bytes"] = sum(_FAT_GROUPED_BYTES.values())
+    _EXL3_FAT_DIAG["grouped_scratch_growths"] = (
+        int(_EXL3_FAT_DIAG.get("grouped_scratch_growths", 0)) + 1
+    )
+    logger.info(
+        "EXL3 grouped scratch grow rows=%d hidden=%d intermediate=%d bytes=%d growths=%d",
+        capacity,
+        hidden,
+        intermediate,
+        _FAT_GROUPED_BYTES[key],
+        _EXL3_FAT_DIAG["grouped_scratch_growths"],
+    )
     return scratch
 
 

--- a/start.sh
+++ b/start.sh
@@ -281,6 +281,11 @@ EXL3_FAT_KERNEL="${EXL3_FAT_KERNEL:-0}"
 # symbols (layered candidate or a rebuilt image). Implies KERNEL=1 when
 # the checkpoint is ineligible. Decode never takes this path.
 EXL3_FAT_GROUPED="${EXL3_FAT_GROUPED:-0}"
+# Optional grouped-scratch row floor. Empty = omit from docker env so
+# IMAGE=e3-grouped keeps MNBT×topk pre-size. W1 lazy grow was REVERTED
+# 2026-09-07 (CUDA-graph capture already requested 28672 rows). Do not
+# set this on production. Capture-time growth still fail-closed.
+EXL3_FAT_SCRATCH_ROWS="${EXL3_FAT_SCRATCH_ROWS:-}"
 
 # recipe: layers 15-45 edited with the dealign direction, 0-14 stay stock
 # safety anchors, MTP block included. 0 = stock weights. Applied identically
@@ -453,6 +458,14 @@ validate_numeric_config() {
         0|1) ;;
         *) echo "EXL3_FAT_GROUPED must be exactly 0 or 1 (got: '${EXL3_FAT_GROUPED-<unset>}')" >&2; return 2 ;;
     esac
+    if [ -n "${EXL3_FAT_SCRATCH_ROWS:-}" ]; then
+        if ! [[ "$EXL3_FAT_SCRATCH_ROWS" =~ ^[0-9]+$ ]] \
+           || [ "${#EXL3_FAT_SCRATCH_ROWS}" -gt 7 ] \
+           || [ "$((10#$EXL3_FAT_SCRATCH_ROWS))" -gt 8388608 ]; then
+            echo "EXL3_FAT_SCRATCH_ROWS must be empty (lazy) or a base-10 integer 0..8388608 (got: '${EXL3_FAT_SCRATCH_ROWS}')" >&2
+            return 2
+        fi
+    fi
     # LOCAL: W41/W42 strict-bool validation (end)
     # LOCAL: DEFAULT_MAX_NEW_TOKENS is spliced into generated shell + JSON; empty = off.
     if [ -n "${DEFAULT_MAX_NEW_TOKENS:-}" ]; then
@@ -1492,6 +1505,11 @@ launch_cluster() {
              LIMIT_MM CHAT_TEMPLATE ENFORCE_EAGER EXL3_FUSED_MOE EXL3_MOE_ROW_TILE EXL3_TEMP_ROWS_FUSED EXL3_FAT_SORTED EXL3_FAT_BATCHED EXL3_FAT_KERNEL EXL3_FAT_GROUPED MODEL_DIR EXTRA_ARGS; do
         serve_env+=" -e $v='${!v:-}'"
     done
+    # Omit empty EXL3_FAT_SCRATCH_ROWS so IMAGE=e3-grouped keeps MNBT×topk
+    # pre-size (old overlay treats empty as 0). Forward only a real floor.
+    if [ -n "${EXL3_FAT_SCRATCH_ROWS:-}" ]; then
+        serve_env+=" -e EXL3_FAT_SCRATCH_ROWS='${EXL3_FAT_SCRATCH_ROWS}'"
+    fi
     # VLLM_API_KEY belongs only on rank 0, which owns the API server. Never send
     # the bearer credential to the headless worker.
 
@@ -1597,6 +1615,7 @@ launch_cluster() {
         -e EXL3_FAT_BATCHED="$EXL3_FAT_BATCHED" \
         -e EXL3_FAT_KERNEL="$EXL3_FAT_KERNEL" \
         -e EXL3_FAT_GROUPED="$EXL3_FAT_GROUPED" \
+        ${EXL3_FAT_SCRATCH_ROWS:+-e EXL3_FAT_SCRATCH_ROWS="$EXL3_FAT_SCRATCH_ROWS"} \
         -e MODEL_DIR="$MODEL_DIR" \
         -e VLLM_API_KEY="$VLLM_API_KEY" \
         -e EXTRA_ARGS="${EXTRA_ARGS:-}" \

--- a/tests/test_exl3_grouped.py
+++ b/tests/test_exl3_grouped.py
@@ -3,7 +3,7 @@
 
 No CUDA and no vLLM import. Confirms EXL3_FAT_GROUPED=0 never inspects E3
 symbols, missing symbols fail closed when grouped is requested, min(K) ≥ 128
-is documented in eligibility, and production TP2 shapes predict 336 MiB/rank.
+is documented in eligibility, and scratch is lazy grow-only (not MNBT × top-k).
 """
 
 from __future__ import annotations
@@ -39,6 +39,7 @@ def _exec_helpers():
         "grouped_fat_eligibility",
         "resolve_exl3_fat_tier",
         "grouped_scratch_bytes_for",
+        "grouped_scratch_capacity",
     }
     wanted_assign = {
         "EXL3_FAT_MOE_SYMBOLS",
@@ -47,6 +48,7 @@ def _exec_helpers():
         "EXL3_FAT_DIAG_SCHEMA",
         "EXL3_FAT_DIAG_KEYS",
         "_FAT_TIERS",
+        "GROUPED_SCRATCH_MIN_ROWS",
     }
     for node in tree.body:
         if isinstance(node, ast.FunctionDef) and node.name in wanted_fn:
@@ -103,11 +105,12 @@ def _layer(
 
 
 def test_schema_keys_include_grouped() -> None:
-    assert HELPERS["EXL3_FAT_DIAG_SCHEMA"] == 2
+    assert HELPERS["EXL3_FAT_DIAG_SCHEMA"] == 3
     for key in (
         "sym_fat_moe",
         "grouped_calls",
         "grouped_scratch_bytes",
+        "grouped_scratch_growths",
         "grouped_eligible",
     ):
         assert key in HELPERS["EXL3_FAT_DIAG_KEYS"]
@@ -220,15 +223,36 @@ def test_eligibility_accepts_production_tp2_shape() -> None:
     assert (ok, reason) == (True, "eligible")
 
 
-def test_grouped_scratch_bytes_336mib_at_production() -> None:
-    hidden, inter, mnbt, topk = 4096, 2048, 3584, 8
-    rows = mnbt * topk
-    bytes_ = HELPERS["grouped_scratch_bytes_for"](hidden, inter, rows)
-    assert bytes_ == 352_321_536
-    assert bytes_ == 336 * 1024 * 1024
+def test_grouped_scratch_is_lazy_not_mnbt_topk() -> None:
+    cap = HELPERS["grouped_scratch_capacity"]
+    min_rows = HELPERS["GROUPED_SCRATCH_MIN_ROWS"]
+    assert min_rows == 256
+    assert cap(0) == 256
+    assert cap(255) == 256
+    assert cap(256) == 256
+    assert cap(14_336) == 14_336
+    assert cap(28_672) == 28_672
+    assert cap(1_000, scratch_rows=28_672) == 28_672
+    assert cap(40_000, scratch_rows=28_672) == 40_000
+    src = OVERLAY.read_text()
+    body = src[src.index("def grouped_scratch_capacity") : src.index("def grouped_scratch_bytes_for")]
+    assert "MAX_NUM_BATCHED_TOKENS" not in body
+    assert "EXL3_FAT_GROUPED_TOPK" not in body
+    alloc = src[src.index("def _grouped_scratch(") : src.index("def _excl_cumsum")]
+    assert "is_current_stream_capturing" in alloc
+    assert "grouped_scratch_growths" in alloc
+    hidden, inter_full, inter_tp2, mnbt, lptt, topk = 4096, 2048, 1024, 3584, 1792, 8
+    full_rows = mnbt * topk
+    lptt_rows = lptt * topk
+    bytes_full = HELPERS["grouped_scratch_bytes_for"](hidden, inter_full, full_rows)
+    assert bytes_full == 352_321_536
+    assert bytes_full == 336 * 1024 * 1024
+    bytes_live = HELPERS["grouped_scratch_bytes_for"](hidden, inter_tp2, full_rows)
+    assert bytes_live == 293_601_280
+    bytes_lptt = HELPERS["grouped_scratch_bytes_for"](hidden, inter_tp2, lptt_rows)
+    assert bytes_lptt == 146_800_640
     assert hidden % 256 == 0
-    assert inter % 128 == 0
-    assert inter % 256 == 0
+    assert inter_tp2 % 128 == 0
 
 
 def test_kernel_intake_and_float4_atomic() -> None:
@@ -248,6 +272,10 @@ def test_kernel_intake_and_float4_atomic() -> None:
     layer = LAYER.read_text()
     assert "BASE=glm53-selfbuild:ca13bdd-v147" in layer
     assert "EXL3_SELFCHECK_GPU=0" in layer
+    py_layer = (KIT_ROOT / "Dockerfile.e3-py-layer").read_text()
+    assert "BASE=glm53-selfbuild:e3-grouped" in py_layer
+    assert "COPY overlay/exl3.py" in py_layer
+    assert "exl3_fat_moe.cu" not in py_layer
 
 
 def test_launcher_and_env_grouped_adopted() -> None:
@@ -260,6 +288,13 @@ def test_launcher_and_env_grouped_adopted() -> None:
     assert "EXL3_FAT_GROUPED" in start
     assert "-e EXL3_FAT_GROUPED=" in start
     assert "must be exactly 0 or 1" in start
+    assert 'EXL3_FAT_SCRATCH_ROWS="${EXL3_FAT_SCRATCH_ROWS:-}"' in start
+    assert "EXL3_FAT_SCRATCH_ROWS" in env
+    # Empty must stay unset in the container: the adopted e3-grouped overlay
+    # treats empty as 0 and skips MNBT×topk, which would contaminate image A/B.
+    assert "EXL3_FAT_KERNEL EXL3_FAT_GROUPED EXL3_FAT_SCRATCH_ROWS MODEL_DIR" not in start
+    assert '[ -n "${EXL3_FAT_SCRATCH_ROWS:-}" ]' in start
+    assert '${EXL3_FAT_SCRATCH_ROWS:+-e EXL3_FAT_SCRATCH_ROWS="$EXL3_FAT_SCRATCH_ROWS"}' in start
     docker = DOCKERFILE.read_text()
     assert "COPY overlay/exl3_fat_moe.cu" in docker
     assert "exl3_fat_moe_gather" in docker

--- a/tests/test_numeric_config.py
+++ b/tests/test_numeric_config.py
@@ -159,6 +159,34 @@ def test_fat_grouped_is_strict_bool() -> None:
     assert off.returncode == 0
 
 
+def test_fat_scratch_rows_optional_int() -> None:
+    allowed = validate(
+        "0.87",
+        "1000000",
+        "4",
+        "1024",
+        extra_env={"EXL3_FAT_SCRATCH_ROWS": "28672"},
+    )
+    assert allowed.returncode == 0
+    empty = validate(
+        "0.87",
+        "1000000",
+        "4",
+        "1024",
+        extra_env={"EXL3_FAT_SCRATCH_ROWS": ""},
+    )
+    assert empty.returncode == 0
+    refused = validate(
+        "0.87",
+        "1000000",
+        "4",
+        "1024",
+        extra_env={"EXL3_FAT_SCRATCH_ROWS": "nope"},
+    )
+    assert refused.returncode == 2
+    assert "EXL3_FAT_SCRATCH_ROWS must be empty" in refused.stderr
+
+
 def test_mtp_above_12_seqs_is_refused() -> None:
     refused = validate("0.87", "1000000", "13", "1024", spec_method="mtp")
     assert refused.returncode == 2


### PR DESCRIPTION
## Summary

Task 24 window **W1** (lazy grow-only E3 grouped scratch) was implemented overlay-only, cluster-tested on `glm53-selfbuild:e3-w1-scratch` (`sha256:26b674c2f0c5…`, Python layer on adopted `e3-grouped`, cubin unchanged), and **reverted**. Production stays `IMAGE=glm53-selfbuild:e3-grouped` / `EXL3_FAT_GROUPED=1`.

Independent variable: `_grouped_scratch` capacity is `max(256, this-call rows)` grow-only, never MNBT×topk and never a D2H fat-count. Schema 3 adds `grouped_scratch_growths`. Optional `EXL3_FAT_SCRATCH_ROWS` is an explicit row floor; **empty is omitted** from both ranks’ docker `-e` so `IMAGE=e3-grouped` keeps MNBT pre-size (and does not contaminate E2 `_fat_scratch`). Capture-time realloc still fail-closed.

## Cluster receipts

| Gate | A `e3-grouped` | B `e3-w1-scratch` | Return-A |
|---|---|---|---|
| Acceptance | — | 7/7 | 7/7 |
| Serving (:18000) | — | 6/6 | 6/6 |
| Pool | 1,396,551 / 1.40× | identical | identical |
| 60k median tok/s | 1344.0 | 1284.5 | — |
| 240k median tok/s | 1296.2 | 1259.7 (−2.8%) | — |
| Structured median | 70.28 @ 7.0/1.000 | 69.81 | 70.14 |
| Scratch | schema=2 MNBT pre-size | schema=3 `grow rows=28672 bytes=293601280 growths=1` during CUDA-graph capture | schema=2 |

**Why revert:** idle MemFree was the decision variable. CUDA-graph capture already requested 28,672 rows / 280 MiB on both ranks before any serving request, so lazy never stayed at LPTT=1792 (~140 MiB). Decode non-inferior; 240k wash is not a keep reason.

Overlay + `Dockerfile.e3-py-layer` remain in-tree as opt-in for a later **capture-aware** window. Do not re-run the same grow-from-this-call design. Do not set `EXL3_FAT_SCRATCH_ROWS` on production.

## Tests

- `bash -n start.sh`
- `.venv/bin/pytest tests/test_exl3_grouped.py tests/test_numeric_config.py` — 21 passed
- Final review APPROVED after empty-env omit P2 (`e6a5115b…`). CUDA files unchanged.

## Rollback

Already restored: `IMAGE=glm53-selfbuild:e3-grouped` (`bd711518d87f`). Backup `.env.bak-pre-task24-w1-20260907-222522`. Watchdog re-armed.