### PR TITLE
EXL3: W2 fused decode-skip probe (TRF not armed)

### DIFF
--- a/docs/06-improvement-plan.md
+++ b/docs/06-improvement-plan.md
@@ -74,8 +74,10 @@ fail-closed before SUH downgrade). Watchdog re-armed after
 
 E3 follow-ups are **not automatic-next**. Ranked TEST-NEXT queue (cuda-reviewer
 2026-09-07, `docs/11` §8): ~~W1 lazy scratch~~ **REVERTED** → W2 TRF=32
-(decode-skip gate) → W3 zero-fill A-pad → W4 fused gather → W5 occupancy
-(ncu gate). Decode is fused `exl3_moe`; do not retune E3 for prose.
+(decode-skip probe 2026-09-07: C4 T=32 does **not** skip at TRF=32 because
+the kernel uses `>`; not armed) → W3 zero-fill A-pad → W4 fused gather →
+W5 occupancy (ncu gate). Decode is fused `exl3_moe`; do not retune E3
+for prose. Production TRF stays 128.
 
 **W1 lazy scratch REVERTED 2026-09-07.** Overlay-only grow-only capacity
 `max(256, this-call rows)` on `glm53-selfbuild:e3-w1-scratch`

--- a/docs/11-gb10-kernel-program.md
+++ b/docs/11-gb10-kernel-program.md
@@ -374,11 +374,18 @@ Not automatic-next.
   `token_count > max_tokens_per_expert` (`exl3_moe_kernel.cuh`; comment:
   "batch is handled by reconstruct path outside kernel"). Decode has **no
   fat tier** behind that skip (`tokens <= cap` returns after the fused
-  launch). C4 can route 4 × 8 × topk 8 = 256 slots; TRF=32 makes
-  `count > 32` reachable under Zipf. Latent today at TRF=128 (`count > 128`
-  of 256). **Hard gate before any TRF=32 arm:** synthetic skewed-routing
-  decode probe vs TRF=128 logits. If any skip, abort the window. Do not
-  ship a decode-fat guard as a ride-along.
+  launch). Hottest count is tokens that routed to one expert, **not**
+  T×topk slots. Distinguish fused-kernel skip **with fallback** (prefill
+  T > cap → fat/grouped) from dropped experts **without fallback**
+  (tokens ≤ cap and hottest > cap). C4 decode T = 4 × 8 = 32, so
+  TRF=32 does **not** drop experts (`32 > 32` is false) even
+  Zipf-all-to-one unique-per-token. No-fallback skip needs non-unique
+  top-k (hottest > T while T ≤ cap). Extra sequences are prefill
+  (T > cap) and take the fat path. **Hard gate before any TRF=32 arm:**
+  `fused_moe_decode_skips_fat` on the live decode shape, plus a
+  skewed-routing logit probe vs TRF=128. If any no-fallback skip,
+  abort. Do not ship a decode-fat guard as a ride-along. Production
+  TRF stays 128.
 - **Mixed C4 / LPTT=1792:** W2 increases fat-path share during co-batched
   prefills (its actual upside hypothesis). W1 changes MemFree headroom
   for C4. W4's 224 MiB is the only reclaim that could later fund capacity
@@ -397,14 +404,18 @@ non-inferior; pool identical. Production stays `e3-grouped`. A later
 attempt must not grow from capture dummy shapes (or must size capture
 to LPTT, not MNBT). Do not re-run the same grow-from-this-call design.
 
-**W2 — isolated TRF=32.** Independent variable: `EXL3_TEMP_ROWS_FUSED=32`.
-Floor is `MAX_NUM_SEQS × (DFLASH_TOKENS+1) = 32`, so C4 capture still
-fits fused temps. Frozen: `ROW_TILE=0`, `EXL3_FAT_GROUPED=1`, scratch
-policy, geometry. S1 on E2 already lost at TRF=64 (−7.2% / −5.6%); E3's
-cheaper spill (isolated 1.87× at Zipf cap=32) is why this is not a
-re-open of S1. Abort: decode-skip, prefill outside the pre-registered
-band, structured outside 68–70, prose outside 28–31. Rollback: env flip
-to 128.
+**W2 — isolated TRF=32. Probe 2026-09-07; not armed.** Independent
+variable would be `EXL3_TEMP_ROWS_FUSED=32`. Floor is
+`MAX_NUM_SEQS × (DFLASH_TOKENS+1) = 32`, so C4 capture still fits fused
+temps. Host probe: `fused_moe_decode_skips_fat(32, 32, 32) is False`
+(skip is `>`; Zipf-all-to-one C4 unique-per-token does not drop
+experts). Frozen: `ROW_TILE=0`, `EXL3_FAT_GROUPED=1`, scratch policy,
+geometry. S1 on E2 already lost at TRF=64 (−7.2% / −5.6%); E3's cheaper
+spill (isolated 1.87× at Zipf cap=32) is why this is not a re-open of
+S1. Abort: no-fallback skip (hottest > cap with T ≤ cap), prefill
+outside the pre-registered band, structured outside 68–70, prose
+outside 28–31. Rollback: env flip to 128. Do not arm until an owner
+window; do not combine with W1/W4.
 
 **W3 — zero-fill A-pad.** In `fm_mainloop::load_stage`, `cp.async` of
 size 0 into unused A-tile rows instead of cloning `rows-1`. Swizzled

--- a/overlay/exl3.py
+++ b/overlay/exl3.py
@@ -150,6 +150,29 @@ def temp_rows_fused() -> int:
         return int(TEMP_ROWS_FUSED)
     return max(1, int(raw))
 
+
+def fused_moe_decode_skips_fat(
+    tokens: int, hottest_expert_count: int, cap: int
+) -> bool:
+    """True when decode would drop fat experts with no fallback.
+
+    Host-side of the fused-kernel skip
+    (`token_count > max_tokens_per_expert` in `exl3_moe_kernel.cuh`) plus
+    `apply_exl3_fused_moe`'s `if tokens <= cap: return` after one fused
+    launch. Decode has no fat/grouped/row-tile tier.
+
+    Production C4 decode T = MAX_NUM_SEQS × (DFLASH_TOKENS+1) = 32.
+    One expert's count is tokens that routed to it (≤ T under unique
+    per-token top-k). TRF=32 does **not** drop experts (`>` not `>=`)
+    even when every token picks the same expert. No-fallback skip
+    requires tokens ≤ cap **and** hottest > cap (non-unique top-k).
+    Prefill T > cap takes the fat/grouped path instead. Abort a
+    TRF=32 arm if this helper is true for the live decode shape.
+    """
+    if int(tokens) > int(cap):
+        return False
+    return int(hottest_expert_count) > int(cap)
+
 def sorted_fat_fallback_enabled() -> bool:
     """Use the existing expert-sorted buffers for oversized prefill experts."""
     return os.environ.get("EXL3_FAT_SORTED", "0") != "0"

--- a/tests/test_exl3_grouped.py
+++ b/tests/test_exl3_grouped.py
@@ -40,6 +40,8 @@ def _exec_helpers():
         "resolve_exl3_fat_tier",
         "grouped_scratch_bytes_for",
         "grouped_scratch_capacity",
+        "fused_moe_decode_skips_fat",
+        "temp_rows_fused",
     }
     wanted_assign = {
         "EXL3_FAT_MOE_SYMBOLS",
@@ -49,6 +51,7 @@ def _exec_helpers():
         "EXL3_FAT_DIAG_KEYS",
         "_FAT_TIERS",
         "GROUPED_SCRATCH_MIN_ROWS",
+        "TEMP_ROWS_FUSED",
     }
     for node in tree.body:
         if isinstance(node, ast.FunctionDef) and node.name in wanted_fn:
@@ -308,3 +311,34 @@ def test_row_tile_still_short_circuits_grouped() -> None:
     assert "and not use_row_tiles" in src
     assert 'layer._exl3_last_fat_fallback = "none"' in src
     assert "EXL3_MOE_ROW_TILE" in src
+
+
+def test_w2_decode_skip_gate_c4_unique_topk() -> None:
+    """W2 hard gate: fused decode drops count > TRF with no fat fallback.
+
+    C4 decode T = 4 seqs × 8 drafts = 32. Hottest expert count ≤ T when
+    top-k is unique per token. Kernel skip is `token_count > cap`, so
+    TRF=32 does not drop experts even Zipf-all-to-one. Prefill T > cap
+    takes fat/grouped (helper False). No-fallback skip needs hottest >
+    cap while T ≤ cap (non-unique top-k). Production TRF stays 128.
+    """
+    skip = HELPERS["fused_moe_decode_skips_fat"]
+    assert HELPERS["TEMP_ROWS_FUSED"] == 128
+    # Decode early-return in apply_exl3_fused_moe, then kernel skip.
+    apply = OVERLAY.read_text()
+    assert "if tokens <= cap:" in apply
+    assert "Decode never reaches here" in apply
+    kernel = (KIT_ROOT / "tests" / "fixtures" / "exl3-v147" / "quant" / "exl3_moe_kernel.cuh").read_text()
+    assert "if (token_count > max_tokens_per_expert) continue;" in kernel
+    # Production C4 unique-per-token: 4 × 8 drafts → T=32, hottest ≤ T.
+    assert skip(tokens=32, hottest_expert_count=32, cap=128) is False
+    assert skip(tokens=32, hottest_expert_count=32, cap=32) is False
+    # Prefill T > cap takes fat/grouped instead of the decode skip.
+    assert skip(tokens=1792, hottest_expert_count=1792, cap=32) is False
+    assert skip(tokens=40, hottest_expert_count=40, cap=32) is False
+    c4_unique = 4 * 8
+    assert c4_unique == 32
+    assert skip(c4_unique, c4_unique, 32) is False
+    # Non-unique top-k (one expert appears twice in a token) can make
+    # hottest > T; then decode T ≤ cap still skips with no fat fallback.
+    assert skip(tokens=32, hottest_expert_count=33, cap=32) is True


### PR DESCRIPTION
## Summary

Locks the fused-MoE decode-skip hard gate as a host helper + C4 unique-topk fixture. **Does not arm** `EXL3_TEMP_ROWS_FUSED=32`. Production TRF stays 128. No cluster restart, no cubin/Dockerfile change.

Fused `exl3_moe` skips experts with `token_count > max_tokens_per_expert`. Decode `tokens <= cap` returns after one fused launch with **no fat fallback**. Distinguish:

- **Skip with fallback** — prefill `T > cap` takes fat/grouped (`fused_moe_decode_skips_fat` is False).
- **Skip without fallback** — decode `T <= cap` **and** hottest expert count `> cap` (non-unique top-k). Helper True; experts are dropped.

C4 decode `T = MAX_NUM_SEQS * (DFLASH_TOKENS+1) = 4 * 8 = 32`. Hottest count is tokens that routed to one expert, **not** `T * topk` slots. Unique-per-token top-k therefore has hottest <= 32, so TRF=32 does **not** drop experts (`32 > 32` is false) even Zipf-all-to-one.

## Probe receipts

| Case | tokens | hottest | cap | helper | Meaning |
|---|---|---|---|---|---|
| Production C4 @ TRF=128 | 32 | 32 | 128 | False | current production |
| C4 unique Zipf-all-to-one @ TRF=32 | 32 | 32 | 32 | False | no drop |
| Prefill LPTT | 1792 | 1792 | 32 | False | fat/grouped path |
| Extra sequences (prefill) | 40 | 40 | 32 | False | fat/grouped path |
| Non-unique top-k decode | 32 | 33 | 32 | True | no-fallback skip |

Host tests: `pytest tests/test_exl3_grouped.py tests/test_numeric_config.py` -> **22 passed**.

Final review: APPROVED after a P2 wording fix (docs initially claimed extra sequences / T>32 skip; those take fat/grouped).

## What this does **not** do

- Does not set `EXL3_TEMP_ROWS_FUSED=32`. Isolated env window remains owner-gated.
- Does not rebuild cubin or switch the production image.
- Does not combine with W1 (REVERTED, PR #54) or W4.
- A live skewed-routing logit probe is still required before any TRF flip.

## Files

- `overlay/exl3.py` — additive `fused_moe_decode_skips_fat` (not on the serving path)
- `tests/test_exl3_grouped.py` — C4 unique-topk gate
- `docs/11-gb10-kernel-program.md`, `docs/06-improvement-plan.md` — probe receipts

Production stays `IMAGE=glm53-selfbuild:e3-grouped`, `EXL3_FAT_GROUPED=1`, TRF=128.
