### PR TITLE
EXL3: adopt W3 zero-fill A-pad cubin

### DIFF
--- a/Dockerfile.e3-cubin-layer
+++ b/Dockerfile.e3-cubin-layer
@@ -1,0 +1,32 @@
+# W3 cubin-only layer on the adopted grouped image.
+#
+# Rebuilds `exl3_fat_moe_ext` from overlay/exl3_fat_moe.cu inside a copy of
+# the installed exllamav3_ext tree (WITHOUT --use_fast_math). Does **not**
+# COPY overlay/exl3.py: the independent variable is the A-pad cubin, not
+# W1 lazy-scratch Python. Production Python stays the e3-grouped overlay
+# (schema 2).
+#
+# Build (repo root of the experiment worktree):
+#   docker build -f Dockerfile.e3-cubin-layer \
+#     --build-arg BASE=glm53-selfbuild:e3-grouped \
+#     --build-arg GLM53_RECIPE_STAMP=$(git rev-parse --short HEAD) \
+#     -t glm53-selfbuild:e3-w3-zfill .
+ARG BASE=glm53-selfbuild:e3-grouped
+FROM ${BASE}
+
+COPY overlay/exl3_fat_moe.cu /opt/glm53/exl3-fat-kernel/exl3_fat_moe.cu
+COPY overlay/exl3_fat_moe.cuh /opt/glm53/exl3-fat-kernel/exl3_fat_moe.cuh
+COPY overlay/build_exl3_fat_moe_ext.py /opt/glm53/build_exl3_fat_moe_ext.py
+
+ENV MAX_JOBS=2
+# Compile does not need a device. Prefix CUDA_VISIBLE_DEVICES= on this RUN
+# only so the layer can build while production holds GB10 UMA. Do not bake
+# it as ENV: start.sh GPU overlay self-check needs CUDA at runtime.
+RUN CUDA_VISIBLE_DEVICES= python3 /opt/glm53/build_exl3_fat_moe_ext.py \
+        --src /opt/glm53/exl3-fat-kernel --out /tmp/e3build \
+        --install /usr/local/lib/python3.12/dist-packages \
+    && python3 -c "import torch, exl3_fat_moe_ext as m; print('exl3_fat_moe_ext OK tile_gu', m.exl3_fat_moe_tile_rows_gateup(), 'tile_dn', m.exl3_fat_moe_tile_rows_down())" \
+    && rm -rf /tmp/e3build
+
+ARG GLM53_RECIPE_STAMP=unknown
+LABEL glm53.recipe.stamp=${GLM53_RECIPE_STAMP} glm53.e3.w3=1

--- a/docs/06-improvement-plan.md
+++ b/docs/06-improvement-plan.md
@@ -75,9 +75,33 @@ fail-closed before SUH downgrade). Watchdog re-armed after
 E3 follow-ups are **not automatic-next**. Ranked TEST-NEXT queue (cuda-reviewer
 2026-09-07, `docs/11` §8): ~~W1 lazy scratch~~ **REVERTED** → W2 TRF=32
 (decode-skip probe 2026-09-07: C4 T=32 does **not** skip at TRF=32 because
-the kernel uses `>`; not armed) → W3 zero-fill A-pad → W4 fused gather →
-W5 occupancy (ncu gate). Decode is fused `exl3_moe`; do not retune E3
-for prose. Production TRF stays 128.
+the kernel uses `>`; not armed) → ~~W3 zero-fill A-pad~~ **ADOPTED
+2026-09-08** (`e3-w3-zfill` `d8144f02`, 240k −2.5% wash, structured
+69.04 @ 7.0/1.000) → W4 fused gather → W5 occupancy (ncu gate). Decode
+is fused `exl3_moe`; do not retune E3 for prose. Production TRF stays
+128. Do not combine W3 with W4.
+
+**W3 zero-fill A-pad ADOPTED 2026-09-08.** Cubin-only
+`Dockerfile.e3-cubin-layer` on `e3-grouped` (`glm53-selfbuild:e3-w3-zfill`
+`sha256:d8144f02…`). Unused A-tile rows use 4-operand `cp.async.cg`
+src-size 0 instead of cloning `rows-1`. Python overlay identical
+(schema 2). First boot failed: baked `ENV CUDA_VISIBLE_DEVICES=` hid
+the GPU from `start.sh` overlay self-check; rebuilt with RUN prefix
+only. Same-boot A vs B:
+
+| Gate | A `e3-grouped` | B `e3-w3-zfill` |
+|---|---|---|
+| Acceptance | — | 7/7 |
+| Serving (:18000) | — | 6/6 |
+| Pool | 1,396,551 / 1.40× | identical |
+| 60k median tok/s | 1336.9 | 1331.6 (−0.4%) |
+| 240k median tok/s | 1293.7 | 1261.3 (−2.5%) |
+| Structured median | 68.96 @ 7.0/1.000 | 69.04 @ 7.0/1.000 (one 15.6 contended) |
+
+**Verdict: ADOPT.** Expected sign was wash. Production
+`IMAGE=glm53-selfbuild:e3-w3-zfill`, `EXL3_FAT_GROUPED=1`. Rollback:
+`.env.bak-pre-task24-w3-20260908-052000` last-wins
+`IMAGE=glm53-selfbuild:e3-grouped`.
 
 **W1 lazy scratch REVERTED 2026-09-07.** Overlay-only grow-only capacity
 `max(256, this-call rows)` on `glm53-selfbuild:e3-w1-scratch`

--- a/docs/11-gb10-kernel-program.md
+++ b/docs/11-gb10-kernel-program.md
@@ -355,14 +355,14 @@ Live TP2 scratch is **~280 MiB/rank**, not the 336 MiB microbench figure:
 `intermediate_size_per_partition` (1024) × 2 B = 56 MiB.
 
 **Queue:** ~~W1 lazy scratch~~ **REVERTED 2026-09-07** → W2 isolated TRF=32
-(gated) → W3 zero-fill A-pad → W4 fused gather → W5 occupancy (gated).
-Not automatic-next.
+(gated) → ~~W3 zero-fill A-pad~~ **ADOPTED 2026-09-08** → W4 fused gather →
+W5 occupancy (gated). Not automatic-next.
 
 | Window | Path it can move | Rebuild | Expected sign |
 |---|---|---|---|
 | ~~**W1 lazy scratch**~~ **REVERTED** | CUDA-graph capture already requests MNBT×topk (28,672 rows / 280 MiB). Idle MemFree unchanged. | overlay Python | no MemFree win |
 | **W2 TRF=32 vs E3@128** (cheap 2nd, env) | Cold prefill (S1 trend: lose). Mixed TTFT / C4 co-batch (plausible win). **Decode leak.** | env only | unknown, leaning lose on cold |
-| **W3 zero-fill A-pad** | Hygiene; tiny LPDDR save on <64-row tails. Outputs bit-identical. | cubin | wash |
+| ~~**W3 zero-fill A-pad**~~ **ADOPTED** | Same-boot 240k −2.5% (wash). Structured 69.04 @ 7.0/1.000. | cubin | wash |
 | **W4 fuse gather into gate/up A-tile** | Reclaim 224 MiB `h13`. Prefill not obviously faster (8× redundant gather). | cubin | MemFree win; speed unknown |
 | **W5 occupancy sweep** | Cold prefill **only if ncu shows a gap**. | cubin | stop if regs > 96 or <3% |
 
@@ -417,11 +417,23 @@ outside the pre-registered band, structured outside 68–70, prose
 outside 28–31. Rollback: env flip to 128. Do not arm until an owner
 window; do not combine with W1/W4.
 
-**W3 — zero-fill A-pad.** In `fm_mainloop::load_stage`, `cp.async` of
-size 0 into unused A-tile rows instead of cloning `rows-1`. Swizzled
-SMEM must still be fully written so `ldsm4` never reads stale bytes.
-Epilogue already skips `r >= rows_mb`, so outputs are bit-identical.
-Abort: any output delta vs clone, sanitizer non-zero.
+**W3 — zero-fill A-pad. ADOPTED 2026-09-08.** In `fm_mainloop::load_stage`,
+4-operand `cp.async.cg` of src-size 0 into unused A-tile rows instead of
+cloning `rows-1`. Dummy global src is the A buffer base (`a`, 16 B
+aligned); src-size 0 does not read it. Do not use `cp_async_pred`
+(Blackwell miscompile). Swizzled SMEM is still fully written so `ldsm4`
+never reads stale bytes. Epilogue already skips `r >= rows_mb`.
+Vehicle: `Dockerfile.e3-cubin-layer` on `e3-grouped` (cubin only; does
+not COPY `exl3.py`). Compile-time `CUDA_VISIBLE_DEVICES=` is a RUN
+prefix, **not** an image ENV (first boot failed overlay GPU self-check
+when it was baked). Cluster: `glm53-selfbuild:e3-w3-zfill`
+(`sha256:d8144f02…`), cubin `exl3_fat_moe_ext.so` sha
+`09d5c9c76c…` vs grouped `a841128a1e…`, Python overlay identical
+(schema 2). Same-boot A vs B: structured 68.96 → 69.04 @ 7.0/1.000;
+60k 1336.9 → 1331.6; 240k 1293.7 → 1261.3 (−2.5%, wash vs expected
+sign). Acceptance 7/7, serving 6/6, pool 1,396,551 / 1.40×,
+`grouped_ok` both ranks. Production stays `e3-w3-zfill`. Rollback:
+`IMAGE=glm53-selfbuild:e3-grouped`. Do not combine with W4.
 
 **W4 — fuse gather.** Drop `h13`; gate/up A-tile loads from `x` +
 `row_token`/`row_expert` + gate SUH. Input Hadamard is 128-wide while

--- a/overlay/exl3_fat_moe.cu
+++ b/overlay/exl3_fat_moe.cu
@@ -88,6 +88,21 @@ __device__ __forceinline__ int fm_swz(int row, int chunk)
     return chunk ^ ((row >> 1) & 3);
 }
 
+// 16 B cp.async with runtime src-size. src_bytes=16 is a full copy;
+// src_bytes=0 zero-fills dst and does not touch glob_ptr (PTX 4-operand
+// form). Do not use cp_async_pred: it miscompiles on Blackwell. Do not
+// clone rows-1 into unused A-tile rows: ldsm4 still reads those bytes,
+// and the clone re-fetches LPDDR. Epilogue skips r >= rows, so outputs
+// stay bit-identical to the clone.
+__device__ __forceinline__ void cp_async_cg16(void* smem_ptr, const void* glob_ptr, int src_bytes)
+{
+    uint32_t smem = static_cast<uint32_t>(__cvta_generic_to_shared(smem_ptr));
+    asm volatile(
+        "cp.async.cg.shared.global [%0], [%1], 16, %2;\n"
+        :: "r"(smem), "l"(glob_ptr), "r"(src_bytes)
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Gather + input Hadamard: h13[row] = had128(x[token[row]] * suh[expert[row]])
 // ---------------------------------------------------------------------------
@@ -177,10 +192,17 @@ __device__ __forceinline__ void fm_mainloop(
             {
                 int row = c >> 2;
                 int chunk = c & 3;
-                int src_row = row < rows ? row : rows - 1;
-                const half* src = a + (int64_t) (row0 + src_row) * size_k + kt * FM_TILE_K + chunk * 8;
                 half* dst = sa + row * FM_TILE_K + fm_swz(row, chunk) * 8;
-                cp_async(dst, src);
+                if (row < rows)
+                {
+                    const half* src = a + (int64_t) (row0 + row) * size_k + kt * FM_TILE_K + chunk * 8;
+                    cp_async_cg16(dst, src, 16);
+                }
+                else
+                {
+                    // Dummy src is unused at src-size 0; a is 16 B aligned.
+                    cp_async_cg16(dst, a, 0);
+                }
             }
         }
         uint16_t* sb = sh_b + stage * B_STAGE;

--- a/tests/test_exl3_grouped.py
+++ b/tests/test_exl3_grouped.py
@@ -281,6 +281,32 @@ def test_kernel_intake_and_float4_atomic() -> None:
     assert "exl3_fat_moe.cu" not in py_layer
 
 
+def test_w3_zero_fill_a_pad_not_clone() -> None:
+    """W3: unused A-tile rows are cp.async src-size 0, not a clone of rows-1.
+
+    Swizzled SMEM is still fully written so ldsm4 never reads stale bytes.
+    Epilogue already skips r >= rows, so outputs are bit-identical to clone.
+    Cubin-only vehicle: Dockerfile.e3-cubin-layer on e3-grouped, no exl3.py.
+    """
+    src = KERNEL.read_text()
+    load = src[src.index("auto load_stage") : src.index("for (int s = 0; s < FM_STAGES - 1;")]
+    assert "rows - 1" not in load
+    assert "src_row" not in load
+    assert "cp_async_cg16" in load
+    assert "cp_async_cg16(dst, a, 0)" in load
+    assert "cp_async_pred(" not in src
+    helper = src[src.index("void cp_async_cg16") : src.index("__global__ __launch_bounds__(FM_THREADS)\nvoid fm_gather_kernel")]
+    assert "cp.async.cg.shared.global" in helper
+    assert ", %2" in helper
+    cubin_layer = (KIT_ROOT / "Dockerfile.e3-cubin-layer").read_text()
+    assert "BASE=glm53-selfbuild:e3-grouped" in cubin_layer
+    assert "COPY overlay/exl3_fat_moe.cu" in cubin_layer
+    assert "\nCOPY overlay/exl3.py" not in cubin_layer
+    assert "e3-w3-zfill" in cubin_layer
+    assert "RUN CUDA_VISIBLE_DEVICES= python3" in cubin_layer
+    assert "ENV CUDA_VISIBLE_DEVICES=" not in cubin_layer
+
+
 def test_launcher_and_env_grouped_adopted() -> None:
     start = LAUNCHER.read_text()
     env = ENV_EXAMPLE.read_text()


### PR DESCRIPTION
## Summary

Adopts W3 zero-fill A-pad as a cubin-only layer on `e3-grouped`. Unused A-tile rows in `fm_mainloop::load_stage` now use 4-operand `cp.async.cg` src-size 0 instead of cloning `rows-1`. Swizzled SMEM is still fully written so `ldsm4` never reads stale bytes; epilogue already skips `r >= rows`, so outputs stay bit-identical.

Does **not** COPY `overlay/exl3.py`. Independent variable is the cubin. Compile-time `CUDA_VISIBLE_DEVICES=` is a RUN prefix only (first boot failed when it was baked as ENV and hid CUDA from `start.sh` overlay GPU self-check).

## Cluster receipts (same-day A vs B)

| Gate | A `e3-grouped` | B `e3-w3-zfill` `d8144f02` |
|---|---|---|
| Acceptance | — | 7/7 |
| Serving (:18000) | — | 6/6 |
| Pool | 1,396,551 / 1.40x | identical |
| 60k median tok/s | 1336.9 | 1331.6 (−0.4%) |
| 240k median tok/s | 1293.7 | 1261.3 (−2.5%, wash) |
| Structured median | 68.96 @ 7.0/1.000 | 69.04 @ 7.0/1.000 (one 15.6 contended) |
| Health / bind | 200 / loopback | 200 / loopback |

Python overlay identical (schema 2). Cubin `exl3_fat_moe_ext.so` sha `09d5c9c76c…` vs grouped `a841128a1e…`. Both ranks `grouped_ok`. Watchdog timer re-armed.

**Verdict: ADOPT.** Expected sign was wash. Production `IMAGE=glm53-selfbuild:e3-w3-zfill`, `EXL3_FAT_GROUPED=1`.

Rollback: last-wins `IMAGE=glm53-selfbuild:e3-grouped` (`.env.bak-pre-task24-w3-20260908-052000`).

## What this does **not** do

- Does not flip TRF (still 128).
- Does not COPY W1 lazy-scratch Python.
- Does not combine with W4 fused gather.

Host tests: `pytest tests/test_exl3_grouped.py tests/test_numeric_config.py` -> **23 passed**.

CUDA review: APPROVED. Final review: APPROVED (including the ENV-prefix repair).
