### PR TITLE
EXL3: adopt isolated TRF=32 fused temps (task 24 W2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The headline figures, same pair:
 | Context window | **1,000,000 tokens**, with speculation active — on two desk machines |
 | **Prose decode** | **~28–31 tok/s** at the 1M window — the most reliable real-workload figure we track (natural prose acceptance is ~0.3–0.4, so this is what unstructured generation actually costs; it is also the number least inflated by a high-acceptance prompt). E3 did not change this decode path. Task 25 (2026-09-09) adopted **verification-only** adaptive-k (`GLM53_ADAPTIVE_K=ema`): native DFlash2 draft stays eight-row / k=7, the target verify uses a 2/4/7 prefix. Same-day B vs B0: hashmap **+7.1%** (27.72 → 29.70), hard essay **+10.7%** (21.77 → 24.09); structured stayed 7.0/1.000 |
 | Structured decode | **~70 tok/s** at speculative acceptance **1.0000** (7/7 drafted tokens accepted, every uncontended pass) — treat this as the **acceptance/quality gate, not the headline throughput**: near-ceiling structured prompts are the most favorable regime, not the realistic workload. Same-day E3 adopt median **69.62 tok/s** (uncontended B-arm 69.0–69.8; one contended 25.6). Concurrency medians land wherever ambient traffic puts them; the durable invariant is the acceptance profile |
-| Cold prefill | **~1285 tok/s** solo at 240k, **~1330 tok/s** at 60k (grouped fat-expert MoE, 2026-09-07; +19.6% vs the same-day pipelined-E2 control of **1075 tok/s** at 240k) |
+| Cold prefill | **~1408 tok/s** solo at 240k, **~1454 tok/s** at 60k (W2 TRF=32, 2026-09-09; +13.3% / +16.1% vs same-boot E3@128). E3 grouped vs pipelined-E2 was **1075 → 1286 tok/s** at 240k (+19.6%, 2026-09-07) |
 | 500k prompt, drafter on | **854 tok/s** cold (2026-08-30 battery, pre-kernel-stack image — not a current-stack rate); same prompt replayed from cache **111× faster** (5.3 s) |
 | Short request behind a 240k read | **6.7–7.9 s** to first token (mixed-prefill gate v3 with the 512→1792 aging ladder; 256 s without this kit's fairness cap) |
 | Multi-agent concurrency | **4 in-flight generations**; a warm follow-up lands in **~2.6 s behind a running generation** (45.8 s before the mixed-prefill gate); decode keeps **+27% tokens per fixed window** during a co-batched cold read; cached-conversation capacity ≈ **50,176 tokens ≈ 14 sessions** under per-group retention — replays at 86% of the pool cost retention (4×200k: 49.9%), plan concurrency below that |
@@ -260,7 +260,10 @@ prose — the pin stays on `7d74cdd`); sharding the drafter across ranks
 wash here, and the head node's memory gets slightly worse); the row-tiling arms
 of the fat-expert path (`EXL3_MOE_ROW_TILE=1` and a `EXL3_TEMP_ROWS_FUSED`
 ladder — both directions lose prefill to the stock 128-row config, and the
-row-tile path costs −20.9% once it bypasses the tuned fat kernel). We also chased
+row-tile path costs −20.9% once it bypasses the tuned fat kernel). W2
+isolated TRF=32 vs E3@128 was **ADOPTED 2026-09-09** (60k +16.1%, 240k
++13.3%; unique-per-token top-k so decode does not drop experts; launcher
+default still 128, production last-wins 32). We also chased
 the reported long-context decode collapse (acceptance falling to 16% past 100k)
 and could not reproduce it on this stack — structured acceptance stays 0.93–0.98
 per position out to ~195k tokens. If a knob isn't set the way upstream defaults

--- a/docs/02-parameters.md
+++ b/docs/02-parameters.md
@@ -208,3 +208,17 @@ cache is invisible to it). 0.87 demands 105.87 GiB free against boots measured a
   1286 tok/s), structured decode non-inferior, pool 1,396,551 / 1.40×.
   Rollback: `EXL3_FAT_GROUPED=0` and `IMAGE=glm53-selfbuild:ca13bdd-v147`.
   GHCR/old images must leave this 0.
+
+- `EXL3_TEMP_ROWS_FUSED=32` — fused `exl3_moe` temp rows per expert
+  (decode + thin prefill), **adopted 2026-09-09**. Launcher default
+  stays **128**; production `.env` last-wins 32. Not in the JIT
+  shape hash. `start.sh validate` requires a base-10 integer 1..8388608
+  and, on dflash, at least the C-decode floor
+  `MAX_NUM_SEQS × (DFLASH_TOKENS+1)` (C4 k=7 → 32). Unique-per-token
+  top-k (`grouped_topk` / `torch.topk`) keeps hottest ≤ T, so TRF=32
+  does not drop decode experts (kernel skip is `>`). CPU judge:
+  `scripts/probe_w2_unique_topk.py`. Same-boot A vs B: 60k **+16.1%**
+  (1253 → 1454), 240k **+13.3%** (1242 → 1408), structured 66.6 →
+  69.1 @ 7.0/1.000, hashmap prose 27.5 → 30.8. Frozen: `ROW_TILE=0`,
+  `EXL3_FAT_GROUPED=1`, scratch, geometry, `e3-w3-zfill`. Rollback:
+  last-wins `EXL3_TEMP_ROWS_FUSED=128`. Do not combine with W1 or W4.

--- a/docs/06-improvement-plan.md
+++ b/docs/06-improvement-plan.md
@@ -38,6 +38,35 @@ Mainline GLM support (#53906) has merged, so model resolution is no longer the
 mainline blocker described in the historical section above; EXL3 integration
 and overlay compatibility still block a stock-image replacement.
 
+### 2026-09-09: task 24 W2 isolated TRF=32 ADOPTED
+
+Independent variable `EXL3_TEMP_ROWS_FUSED=32` vs production E3@128.
+Env-only; no cubin. Frozen: `IMAGE=e3-w3-zfill`, `EXL3_FAT_GROUPED=1`,
+`EXL3_MOE_ROW_TILE=0`, pin / C4 / k=7 / adaptive-k ema. Unique-per-token
+top-k CPU judge `scripts/probe_w2_unique_topk.py` ARM-OK against the live
+`grouped_topk_router.py` dump (AST fingerprint). Kernel skip is `>`; C4
+T=32 does not drop decode experts.
+
+**Cluster verdict: ADOPT.** Same-boot A (TRF=128) vs B (TRF=32). Expected
+sign was cold-prefill lean-lose; measured was a fat-path-share win.
+
+| Gate | A TRF=128 | B TRF=32 | Adopt |
+|---|---|---|---|
+| Acceptance | (healthy) | 7/7 | 7/7 |
+| Serving (:18000) | — | 6/6 | 6/6 |
+| Pool | 1,396,551 / 1.40× | identical | identical |
+| 60k median tok/s | 1253.1 | **1454.3 (+16.1%)** | — |
+| 240k median tok/s | 1242.4 | **1407.8 (+13.3%)** | — |
+| Structured n=9 | 66.60 @ 7.0/1.000 (one 15.4 contended) | 69.10 @ 7.0/1.000 (15.7 / 25.7 contended; rest 68.7–70.3) | 69.10 |
+| Hashmap prose n=9 | 27.54 | **30.82** | 30.82 |
+| Health / bind | 200 / loopback | 200 / loopback | 200 / loopback |
+| MemFree head/worker GiB | 5.00 / 3.67 post-A | 4.46 / 4.56 idle; 3.77 / 4.04 post-B | ≥2.5 abort |
+
+Both ranks `EXL3_TEMP_ROWS_FUSED=32`, `grouped_ok`, overlay `temp_rows_fused()=32`.
+No CUDA/Xid/IMA. Watchdog re-armed. Rollback:
+`.env.bak-pre-task24-w2-20260909` last-wins `EXL3_TEMP_ROWS_FUSED=128`.
+W5 occupancy stays ncu-gated.
+
 ### 2026-09-09: Task 25 verification-only adaptive-k ADOPTED
 
 Kit [#139](https://github.com/MiaAI-Lab/GLM-5.3-Flash-EXL3-2x-DGX-Sparks/pull/139)
@@ -111,14 +140,13 @@ fail-closed before SUH downgrade). Watchdog re-armed after
 `EXL3_FAT_GROUPED=0`).
 
 E3 follow-ups are **not automatic-next**. Ranked TEST-NEXT queue (cuda-reviewer
-2026-09-07, `docs/11` §8): ~~W1 lazy scratch~~ **REVERTED** → W2 TRF=32
-(decode-skip probe 2026-09-07: C4 T=32 does **not** skip at TRF=32 because
-the kernel uses `>`; not armed) → ~~W3 zero-fill A-pad~~ **ADOPTED
-2026-09-08** (`e3-w3-zfill` `d8144f02`, 240k −2.5% wash, structured
-69.04 @ 7.0/1.000) → ~~W4 fused gather~~ **REVERTED 2026-09-08**
-→ W5 occupancy (ncu gate). Decode
-is fused `exl3_moe`; do not retune E3 for prose. Production TRF stays
-128. Do not re-arm W4 without a gather that does not 8×-reload.
+2026-09-07, `docs/11` §8): ~~W1 lazy scratch~~ **REVERTED** → ~~W2 TRF=32~~
+**ADOPTED 2026-09-09** (unique-topk proof; 60k +16.1%, 240k +13.3%) →
+~~W3 zero-fill A-pad~~ **ADOPTED 2026-09-08** (`e3-w3-zfill` `d8144f02`,
+240k −2.5% wash, structured 69.04 @ 7.0/1.000) → ~~W4 fused gather~~
+**REVERTED 2026-09-08** → W5 occupancy (ncu gate). Decode is fused
+`exl3_moe`; do not retune E3 for prose. Production last-wins TRF=32.
+Do not re-arm W4 without a gather that does not 8×-reload.
 
 **W3 zero-fill A-pad ADOPTED 2026-09-08.** Cubin-only
 `Dockerfile.e3-cubin-layer` on `e3-grouped` (`glm53-selfbuild:e3-w3-zfill`

--- a/docs/11-gb10-kernel-program.md
+++ b/docs/11-gb10-kernel-program.md
@@ -361,7 +361,7 @@ Live TP2 scratch is **~280 MiB/rank**, not the 336 MiB microbench figure:
 | Window | Path it can move | Rebuild | Expected sign |
 |---|---|---|---|
 | ~~**W1 lazy scratch**~~ **REVERTED** | CUDA-graph capture already requests MNBT×topk (28,672 rows / 280 MiB). Idle MemFree unchanged. | overlay Python | no MemFree win |
-| **W2 TRF=32 vs E3@128** (cheap 2nd, env) | Cold prefill (S1 trend: lose). Mixed TTFT / C4 co-batch (plausible win). **Decode leak.** | env only | unknown, leaning lose on cold |
+| ~~**W2 TRF=32 vs E3@128**~~ **ADOPTED** | Same-boot 60k **+16.1%**, 240k **+13.3%**. Structured 69.10 @ 7.0/1.000. Decode unique-topk safe. | env only | win (fat-path share) |
 | ~~**W3 zero-fill A-pad**~~ **ADOPTED** | Same-boot 240k −2.5% (wash). Structured 69.04 @ 7.0/1.000. | cubin | wash |
 | ~~**W4 fuse gather into gate/up A-tile**~~ **REVERTED** | 60k −10.7%, 240k −3.2%, structured −2.2%. No MemFree win. 8× A-tile gather. | cubin+Python | no MemFree win; speed lose |
 | **W5 occupancy sweep** | Cold prefill **only if ncu shows a gap**. | cubin | stop if regs > 96 or <3% |
@@ -382,10 +382,12 @@ Live TP2 scratch is **~280 MiB/rank**, not the 336 MiB microbench figure:
   Zipf-all-to-one unique-per-token. No-fallback skip needs non-unique
   top-k (hottest > T while T ≤ cap). Extra sequences are prefill
   (T > cap) and take the fat path. **Hard gate before any TRF=32 arm:**
-  `fused_moe_decode_skips_fat` on the live decode shape, plus a
-  skewed-routing logit probe vs TRF=128. If any no-fallback skip,
-  abort. Do not ship a decode-fat guard as a ride-along. Production
-  TRF stays 128.
+  `fused_moe_decode_skips_fat` / `w2_trf32_no_fallback_skip` on the
+  live decode shape, plus a unique-per-token router proof (CPU judge
+  `scripts/probe_w2_unique_topk.py`; no CUDA-graph D2H). If any
+  no-fallback skip or uniqueness is not proven, abort. Do not ship a
+  decode-fat guard as a ride-along. Production last-wins TRF=32
+  (2026-09-09). Launcher default stays 128.
 - **Mixed C4 / LPTT=1792:** W2 increases fat-path share during co-batched
   prefills (its actual upside hypothesis). W1 changes MemFree headroom
   for C4. W4's 224 MiB is the only reclaim that could later fund capacity
@@ -404,18 +406,20 @@ non-inferior; pool identical. Production stays `e3-grouped`. A later
 attempt must not grow from capture dummy shapes (or must size capture
 to LPTT, not MNBT). Do not re-run the same grow-from-this-call design.
 
-**W2 — isolated TRF=32. Probe 2026-09-07; not armed.** Independent
-variable would be `EXL3_TEMP_ROWS_FUSED=32`. Floor is
-`MAX_NUM_SEQS × (DFLASH_TOKENS+1) = 32`, so C4 capture still fits fused
-temps. Host probe: `fused_moe_decode_skips_fat(32, 32, 32) is False`
-(skip is `>`; Zipf-all-to-one C4 unique-per-token does not drop
-experts). Frozen: `ROW_TILE=0`, `EXL3_FAT_GROUPED=1`, scratch policy,
-geometry. S1 on E2 already lost at TRF=64 (−7.2% / −5.6%); E3's cheaper
-spill (isolated 1.87× at Zipf cap=32) is why this is not a re-open of
-S1. Abort: no-fallback skip (hottest > cap with T ≤ cap), prefill
-outside the pre-registered band, structured outside 68–70, prose
-outside 28–31. Rollback: env flip to 128. Do not arm until an owner
-window; do not combine with W1/W4.
+**W2 — isolated TRF=32. ADOPTED 2026-09-09.** Independent variable
+`EXL3_TEMP_ROWS_FUSED=32`. Floor is
+`MAX_NUM_SEQS × (DFLASH_TOKENS+1) = 32`; `start.sh validate` refuses
+TRF below that on dflash. Host helpers: `unique_per_token_topk_ids`,
+`fused_moe_decode_skips_unique_topk`, `w2_trf32_no_fallback_skip`.
+Live router is unique-per-token (`torch.topk` / `ops.grouped_topk`);
+CPU judge ARM-OK against the pinned production dump
+(`tests/fixtures/w2-grouped-topk-router.py`, AST fingerprint). Skip is
+`>`; Zipf-all-to-one C4 does **not** drop decode experts. Frozen:
+`ROW_TILE=0`, `EXL3_FAT_GROUPED=1`, scratch, geometry, `e3-w3-zfill`.
+Same-boot A vs B: 60k 1253 → **1454 (+16.1%)**, 240k 1242 → **1408
+(+13.3%)**, structured 66.60 → 69.10 @ 7.0/1.000, hashmap 27.54 →
+30.82. Acceptance 7/7, serving 6/6, pool 1,396,551 / 1.40×. Rollback:
+last-wins `EXL3_TEMP_ROWS_FUSED=128`. Do not combine with W1/W4.
 
 **W3 — zero-fill A-pad. ADOPTED 2026-09-08.** In `fm_mainloop::load_stage`,
 4-operand `cp.async.cg` of src-size 0 into unused A-tile rows instead of

--- a/env.example
+++ b/env.example
@@ -249,9 +249,17 @@ VLLM_EXECUTE_MODEL_TIMEOUT_SECONDS=1800
 EXL3_FAT_SORTED=1     # contiguous expert slices of the existing sort
 EXL3_FAT_BATCHED=1    # E1: persistent scratch + concatenated gate+up trellis
 EXL3_FAT_KERNEL=1     # E2: fused direct/scatter trellis GEMM (SM121; pipelined)
+# Fused exl3_moe temp rows/expert (decode + thin prefill).
+# Floor is C-decode T = MAX_NUM_SEQS × (DFLASH_TOKENS+1) = 32 at C4/k=7.
+# W2 isolated 32 vs E3@128 ADOPTED 2026-09-09 (env-only, no cubin).
+# Unique-per-token top-k keeps hottest ≤ T, so TRF=32 does not drop decode
+# experts (`>` not `>=`). start.sh default stays 128; production last-wins 32.
+# Rollback: last-wins EXL3_TEMP_ROWS_FUSED=128. Do not combine with W1 or W4.
+# Not in the JIT shape hash.
+EXL3_TEMP_ROWS_FUSED=32
 # E3 grouped fat-expert MoE (prefill). ADOPTED 2026-09-07. Needs the additive
 # exl3_fat_moe kernels (layered image glm53-selfbuild:e3-w3-zfill). Does not
-# rewrite E2. Decode never takes this path. 1M / pin / TRF=128 / C4 unchanged.
+# rewrite E2. Decode never takes this path. 1M / pin / C4 unchanged.
 # Rollback: EXL3_FAT_GROUPED=0 and IMAGE=glm53-selfbuild:ca13bdd-v147.
 # GHCR/old images without exl3_fat_moe must leave this 0 (fail-closed).
 # W4 fused-gather (drop h13) was REVERTED 2026-09-08: 60k −10.7% vs

--- a/local/pr-59-body.md
+++ b/local/pr-59-body.md
@@ -1,0 +1,34 @@
+## Summary
+
+Adopts isolated env-only `EXL3_TEMP_ROWS_FUSED=32` vs production E3@128 (task 24 W2). No cubin rebuild. Independent variable is TRF only. Frozen: `IMAGE=e3-w3-zfill`, `EXL3_FAT_GROUPED=1`, `EXL3_MOE_ROW_TILE=0`, pin / C4 / k=7 / adaptive-k ema.
+
+Fused `exl3_moe` skips `token_count > cap`. Decode `tokens <= cap` returns with **no fat fallback**. Unique-per-token top-k (`grouped_topk` / `torch.topk`) keeps hottest ≤ T. C4 T=32 therefore does **not** drop experts (`32 > 32` is false). CPU judge `scripts/probe_w2_unique_topk.py` fail-closes without live evidence and pins the production router AST fingerprint (`tests/fixtures/w2-grouped-topk-router.py`).
+
+`start.sh` still defaults TRF=128 and refuses TRF below `MAX_NUM_SEQS*(DFLASH_TOKENS+1)` on dflash. Production last-wins 32.
+
+## Cluster receipts (same-boot A vs B)
+
+| Gate | A `TRF=128` | B `TRF=32` |
+|---|---|---|
+| Acceptance | (healthy) | 7/7 |
+| Serving (:18000) | — | 6/6 |
+| Pool | 1,396,551 / 1.40× | identical |
+| 60k median tok/s | 1253.1 | **1454.3 (+16.1%)** |
+| 240k median tok/s | 1242.4 | **1407.8 (+13.3%)** |
+| Structured n=9 | 66.60 @ 7.0/1.000 | 69.10 @ 7.0/1.000 |
+| Hashmap prose n=9 | 27.54 | **30.82** |
+| Idle/post MemFree head/worker GiB | 5.00 / 3.67 post-A | 4.46 / 4.56 idle; 3.77 / 4.04 post-B |
+| Health / bind | 200 / loopback | 200 / loopback |
+
+Both ranks `temp_rows_fused()=32`, `grouped_ok`. No CUDA/Xid/IMA. Watchdog re-armed.
+
+**Verdict: ADOPT.** Expected sign was cold-prefill lean-lose (S1 at TRF=64). Measured was a fat-path-share win at the C-decode floor. Rollback: last-wins `EXL3_TEMP_ROWS_FUSED=128` (`.env.bak-pre-task24-w2-20260909`).
+
+## What this does **not** do
+
+- Does not rebuild cubin or switch `IMAGE`.
+- Does not combine with W1 (REVERTED) or W4 (REVERTED).
+- Does not change launcher default (still 128). GHCR/old copies stay fail-closed until they set the env.
+- Does not open W5 occupancy (ncu-gated).
+
+Host tests: `pytest tests/test_exl3_grouped.py tests/test_numeric_config.py tests/test_w2_unique_topk_probe.py` → **44 passed**. Final review: APPROVED after fail-closed unique-topk judge (live evidence + AST fingerprint).

--- a/local/task24-w2-adopt-20260909.txt
+++ b/local/task24-w2-adopt-20260909.txt
@@ -1,0 +1,31 @@
+TASK24 W2 ADOPT 2026-09-09
+independent_variable=EXL3_TEMP_ROWS_FUSED=32
+image=glm53-selfbuild:e3-w3-zfill
+frozen=EXL3_FAT_GROUPED=1 EXL3_MOE_ROW_TILE=0 MAX_NUM_SEQS=4 DFLASH_TOKENS=7 GLM53_ADAPTIVE_K=ema
+unique_topk_judge=ARM-OK AST fingerprint tests/fixtures/w2-grouped-topk-router.py
+rollback=.env.bak-pre-task24-w2-20260909 last-wins EXL3_TEMP_ROWS_FUSED=128
+pool=1,396,551 tokens / 1.40x
+bind=127.0.0.1:8000
+health=200
+unit=active
+watchdog.timer=active (re-armed after watchdog.service inactive)
+acceptance=7/7
+serving=6/6 (tunnel :18000)
+fat_diag=schema=2 configured_tier=grouped effective_tier=grouped grouped_ok
+temp_rows_fused=32 both ranks
+prefill_60k_A_median=1253.1
+prefill_60k_B_median=1454.3  (+16.1%)
+prefill_240k_A_median=1242.4
+prefill_240k_B_median=1407.8  (+13.3%)
+structured_A_median=66.60  accept=1.0000/7.0  (one 15.4 contended)
+structured_B_median=69.10  accept=1.0000/7.0  (15.7/25.7 contended; rest 68.7-70.3)
+prose_A_median=27.54
+prose_B_median=30.82
+MemFree_A_post_head_GiB=5.00
+MemFree_A_post_worker_GiB=3.67
+MemFree_B_idle_head_GiB=4.46
+MemFree_B_idle_worker_GiB=4.56
+MemFree_B_post_head_GiB=3.77
+MemFree_B_post_worker_GiB=4.04
+geometry_unchanged=MAX_MODEL_LEN=1000000 MNBT=3584 MAX_NUM_SEQS=4 DFLASH_TOKENS=7 KV pin 15414698763 IMAGE=e3-w3-zfill
+no_cuda_xid_ima=1

--- a/overlay/exl3.py
+++ b/overlay/exl3.py
@@ -151,6 +151,39 @@ def temp_rows_fused() -> int:
     return max(1, int(raw))
 
 
+def fused_temp_rows_decode_floor(max_num_seqs: int, dflash_tokens: int) -> int:
+    """C-decode fused-temp floor: seqs × (k+1).
+
+    Capture sizes include that product (C4 k=7 → 32). TRF below the floor
+    cannot hold a full decode step in one fused launch.
+    """
+    return int(max_num_seqs) * (int(dflash_tokens) + 1)
+
+
+def unique_per_token_topk_ids(ids) -> bool:
+    """True when each token's top-k expert ids are unique (negative sentinels ignored).
+
+    Native ``torch.topk`` / grouped_topk never repeat an expert in one row.
+    Hottest expert count is then tokens that routed to it, so hottest ≤ T.
+    """
+    rows = ids.tolist() if hasattr(ids, "tolist") else ids
+    for row in rows:
+        seen: set[int] = set()
+        for expert in row:
+            expert_id = int(expert)
+            if expert_id < 0:
+                continue
+            if expert_id in seen:
+                return False
+            seen.add(expert_id)
+    return True
+
+
+def unique_topk_hottest_upper_bound(tokens: int) -> int:
+    """Hottest ≤ T when each token picks distinct experts."""
+    return max(0, int(tokens))
+
+
 def fused_moe_decode_skips_fat(
     tokens: int, hottest_expert_count: int, cap: int
 ) -> bool:
@@ -172,6 +205,35 @@ def fused_moe_decode_skips_fat(
     if int(tokens) > int(cap):
         return False
     return int(hottest_expert_count) > int(cap)
+
+
+def fused_moe_decode_skips_unique_topk(tokens: int, cap: int) -> bool:
+    """Decode-skip helper under unique-per-token top-k (hottest ≤ T)."""
+    return fused_moe_decode_skips_fat(
+        tokens, unique_topk_hottest_upper_bound(tokens), cap
+    )
+
+
+def w2_trf32_no_fallback_skip(
+    tokens: int,
+    *,
+    unique_topk: bool = True,
+    hottest_expert_count: int | None = None,
+    cap: int = 32,
+) -> bool:
+    """True when a TRF=32 decode arm would drop experts with no fat fallback.
+
+    Unique top-k (this image's grouped_topk / torch.topk) makes hottest ≤ T,
+    so C4 T=32 never skips at cap=32. Non-unique routing must pass the live
+    hottest count; missing it fail-closes to skip.
+    """
+    if unique_topk:
+        hottest = unique_topk_hottest_upper_bound(tokens)
+    elif hottest_expert_count is None:
+        return True
+    else:
+        hottest = int(hottest_expert_count)
+    return fused_moe_decode_skips_fat(tokens, hottest, cap)
 
 def sorted_fat_fallback_enabled() -> bool:
     """Use the existing expert-sorted buffers for oversized prefill experts."""

--- a/scripts/probe_w2_unique_topk.py
+++ b/scripts/probe_w2_unique_topk.py
@@ -1,0 +1,362 @@
+#!/usr/bin/env python3
+"""CPU-only W2 unique-topk / TRF=32 decode-skip judge.
+
+Decode cannot D2H hottest-count under CUDA graphs. Native grouped_topk /
+torch.topk is unique per token, so hottest ≤ T. Arming TRF=32 requires
+live evidence: a parseable router source whose selected CUDA path is
+unique top-k, and/or a non-empty unique ids dump of the requested shape.
+
+Exit 0 = ARM-OK for isolated EXL3_TEMP_ROWS_FUSED=32.
+Exit 1 = ABORT (no-fallback skip, or uniqueness not proven).
+No CUDA, no vLLM import. Synthetic Zipf rows are self-test only.
+"""
+from __future__ import annotations
+
+import argparse
+import ast
+import hashlib
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+OVERLAY = ROOT / "overlay" / "exl3.py"
+REVIEWED_ROUTER_FIXTURE = ROOT / "tests/fixtures/w2-grouped-topk-router.py"
+REVIEWED_ROUTER_FUNCTIONS = (
+    "fused_grouped_topk",
+    "grouped_topk",
+    "GroupedTopKRouter._compute_routing",
+)
+
+UNIQUE_CALLS = {"topk", "grouped_topk"}
+NON_UNIQUE_CALLS = {"multinomial"}
+
+
+def load_helpers() -> dict[str, Any]:
+    src = OVERLAY.read_text()
+    tree = ast.parse(src)
+    keep: list[str] = []
+    wanted = {
+        "fused_moe_decode_skips_fat",
+        "fused_moe_decode_skips_unique_topk",
+        "fused_temp_rows_decode_floor",
+        "unique_per_token_topk_ids",
+        "unique_topk_hottest_upper_bound",
+        "w2_trf32_no_fallback_skip",
+        "temp_rows_fused",
+        "TEMP_ROWS_FUSED",
+    }
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef) and node.name in wanted:
+            keep.append(ast.get_source_segment(src, node) or "")
+        elif isinstance(node, ast.Assign):
+            names = [t.id for t in node.targets if isinstance(t, ast.Name)]
+            if any(name in wanted for name in names):
+                keep.append(ast.get_source_segment(src, node) or "")
+    ns: dict[str, Any] = {}
+    exec("from __future__ import annotations\n" + "\n\n".join(keep), ns, ns)
+    return ns
+
+
+def zipf_unique_ids(tokens: int, topk: int) -> list[list[int]]:
+    """Every token picks the same first expert, remaining k-1 unique."""
+    return [[0] + list(range(1, topk)) for _ in range(tokens)]
+
+
+def hottest_from_ids(ids: list[list[int]]) -> int:
+    counts: dict[int, int] = {}
+    for row in ids:
+        seen: set[int] = set()
+        for expert in row:
+            expert_id = int(expert)
+            if expert_id < 0 or expert_id in seen:
+                continue
+            seen.add(expert_id)
+            counts[expert_id] = counts.get(expert_id, 0) + 1
+    return max(counts.values(), default=0)
+
+
+def _call_name(node: ast.Call) -> str | None:
+    func = node.func
+    if isinstance(func, ast.Name):
+        return func.id
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    return None
+
+
+def _call_has_replacement_true(node: ast.Call) -> bool:
+    for kw in node.keywords:
+        if kw.arg != "replacement":
+            continue
+        return isinstance(kw.value, ast.Constant) and kw.value.value is True
+    return False
+
+
+def _walk_functions(tree: ast.AST) -> dict[str, ast.FunctionDef]:
+    found: dict[str, ast.FunctionDef] = {}
+    for node in tree.body if hasattr(tree, "body") else []:
+        if isinstance(node, ast.FunctionDef):
+            found[node.name] = node
+        elif isinstance(node, ast.ClassDef):
+            for item in node.body:
+                if isinstance(item, ast.FunctionDef):
+                    found[f"{node.name}.{item.name}"] = item
+    return found
+
+
+def _calls_in(fn: ast.AST) -> list[ast.Call]:
+    return [node for node in ast.walk(fn) if isinstance(node, ast.Call)]
+
+
+def _assigns_name_from(fn: ast.AST, target: str, source: str) -> bool:
+    for node in ast.walk(fn):
+        if not isinstance(node, ast.Assign):
+            continue
+        names = [t.id for t in node.targets if isinstance(t, ast.Name)]
+        if target not in names:
+            continue
+        value = node.value
+        if isinstance(value, ast.Name) and value.id == source:
+            return True
+        if isinstance(value, ast.Call):
+            for kw in value.keywords:
+                if isinstance(kw.value, ast.Name) and kw.value.id == source:
+                    return True
+            for arg in value.args:
+                if isinstance(arg, ast.Name) and arg.id == source:
+                    return True
+    return False
+
+
+def _function_fingerprint(
+    fns: dict[str, ast.FunctionDef], names: tuple[str, ...]
+) -> str:
+    if any(name not in fns for name in names):
+        return ""
+    payload = "\n".join(
+        ast.dump(fns[name], include_attributes=False) for name in names
+    )
+    return hashlib.sha256(payload.encode()).hexdigest()
+
+
+def reviewed_router_fingerprint() -> str:
+    if not REVIEWED_ROUTER_FIXTURE.is_file():
+        return ""
+    tree = ast.parse(REVIEWED_ROUTER_FIXTURE.read_text())
+    return _function_fingerprint(_walk_functions(tree), REVIEWED_ROUTER_FUNCTIONS)
+
+
+def router_unique_proof(source: str) -> tuple[bool, str]:
+    """Accept only the reviewed production grouped_topk AST.
+
+    Call presence is not enough: discarded ``torch.topk`` results or a
+    post-routing ``topk_ids.zero_()`` would still mention unique APIs.
+    The pin is the normalized AST of fused_grouped_topk, grouped_topk, and
+    GroupedTopKRouter._compute_routing from
+    ``tests/fixtures/w2-grouped-topk-router.py``.
+    """
+    try:
+        tree = ast.parse(source)
+    except SyntaxError as exc:
+        return False, f"router source is not parseable Python: {exc.msg}"
+
+    fns = _walk_functions(tree)
+    expected = reviewed_router_fingerprint()
+    if not expected:
+        return False, "reviewed grouped_topk fixture is missing or unreadable"
+    actual = _function_fingerprint(fns, REVIEWED_ROUTER_FUNCTIONS)
+    if not actual:
+        return False, (
+            "router source missing reviewed fused_grouped_topk / grouped_topk / "
+            "GroupedTopKRouter._compute_routing"
+        )
+    if actual != expected:
+        return False, (
+            "router AST does not match the reviewed production grouped_topk fixture"
+        )
+
+    grouped = fns["grouped_topk"]
+    fused = fns["fused_grouped_topk"]
+    compute = fns["GroupedTopKRouter._compute_routing"]
+    for fn in (grouped, fused, compute):
+        for call in _calls_in(fn):
+            if _call_has_replacement_true(call):
+                return False, "selected router path calls a sampler with replacement=True"
+            if _call_name(call) in NON_UNIQUE_CALLS:
+                return False, f"selected router path calls non-unique {_call_name(call)}()"
+    return True, (
+        "AST unique CUDA path: fingerprint match vs "
+        "tests/fixtures/w2-grouped-topk-router.py "
+        "(grouped_topk -> torch.topk; fused_grouped_topk -> ops.grouped_topk; "
+        "GroupedTopKRouter._compute_routing -> grouped_topk)"
+    )
+
+
+def _normalize_ids(ids: Any, tokens: int, topk: int) -> tuple[list[list[int]] | None, str]:
+    if ids is None:
+        return None, ""
+    if not isinstance(ids, list) or len(ids) == 0:
+        return None, "ids dump is empty"
+    rows: list[list[int]] = []
+    for row in ids:
+        if not isinstance(row, (list, tuple)):
+            return None, "ids dump rows must be sequences"
+        rows.append([int(v) for v in row])
+    if len(rows) != tokens:
+        return None, f"ids dump has {len(rows)} rows, expected tokens={tokens}"
+    for row in rows:
+        live = [v for v in row if v >= 0]
+        if len(live) != topk:
+            return None, f"ids dump row width {len(live)} != topk={topk}"
+    return rows, ""
+
+
+def judge(
+    *,
+    tokens: int,
+    cap: int,
+    ids: list[list[int]] | None,
+    router_source: str | None,
+    helpers: dict[str, Any],
+    topk: int = 8,
+) -> dict[str, Any]:
+    unique_fn = helpers["unique_per_token_topk_ids"]
+    unique_skip = helpers["fused_moe_decode_skips_unique_topk"]
+    skip = helpers["fused_moe_decode_skips_fat"]
+    gate = helpers["w2_trf32_no_fallback_skip"]
+    floor = helpers["fused_temp_rows_decode_floor"]
+    bound = helpers["unique_topk_hottest_upper_bound"]
+
+    report: dict[str, Any] = {
+        "tokens": tokens,
+        "cap": cap,
+        "topk": topk,
+        "floor_c4": floor(4, 7),
+        "unique_topk": None,
+        "hottest": None,
+        "unique_skip": unique_skip(tokens, cap),
+        "w2_gate_unique": gate(tokens, unique_topk=True, cap=cap),
+        "router_proof": None,
+        "evidence": [],
+        "decision": "ABORT",
+        "reason": "",
+    }
+    if report["floor_c4"] != 32:
+        report["reason"] = f"C4 floor is {report['floor_c4']}, expected 32"
+        return report
+    if tokens <= cap and unique_skip(tokens, cap):
+        report["reason"] = "unique-topk decode skip True (hottest bound > cap)"
+        return report
+    if gate(tokens, unique_topk=True, cap=cap):
+        report["reason"] = "w2_trf32_no_fallback_skip unique=True"
+        return report
+    if cap < 32 and tokens == 32:
+        report["reason"] = "cap below C4 floor"
+        return report
+
+    proven = False
+    if router_source is not None:
+        ok, msg = router_unique_proof(router_source)
+        report["router_proof"] = msg
+        if not ok:
+            report["reason"] = msg
+            return report
+        report["evidence"].append("router_ast")
+        proven = True
+    elif router_source == "":
+        report["reason"] = "router source is empty"
+        return report
+
+    rows, id_err = _normalize_ids(ids, tokens, topk)
+    if id_err:
+        report["reason"] = id_err
+        return report
+    if ids is not None and rows is None:
+        report["reason"] = "ids dump is empty"
+        return report
+    if rows is not None:
+        unique = bool(unique_fn(rows))
+        hottest = hottest_from_ids(rows)
+        report["unique_topk"] = unique
+        report["hottest"] = hottest
+        report["evidence"].append("ids_dump")
+        if not unique:
+            report["reason"] = "dumped top-k ids are not unique per token"
+            report["w2_gate_live"] = skip(len(rows), hottest, cap)
+            return report
+        if hottest > bound(len(rows)):
+            report["reason"] = f"hottest {hottest} exceeds unique bound {bound(len(rows))}"
+            return report
+        if skip(len(rows), hottest, cap):
+            report["reason"] = "live hottest > cap with T ≤ cap"
+            return report
+        proven = True
+
+    if not proven:
+        report["reason"] = (
+            "uniqueness not proven: need parseable unique router source "
+            "and/or a non-empty unique ids dump"
+        )
+        return report
+
+    report["decision"] = "ARM-OK"
+    report["reason"] = (
+        "unique-per-token top-k; hottest ≤ T; fused skip is >; "
+        f"C4 T={tokens} cap={cap} does not no-fallback-skip; "
+        f"evidence={','.join(report['evidence'])}"
+    )
+    return report
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--tokens", type=int, default=32)
+    ap.add_argument("--cap", type=int, default=32)
+    ap.add_argument("--topk", type=int, default=8)
+    ap.add_argument("--ids-json", type=Path, default=None)
+    ap.add_argument("--router-source", type=Path, default=None)
+    ap.add_argument(
+        "--synthetic-selftest",
+        action="store_true",
+        help="Build Zipf-unique ids for helper tests. Not live evidence; cannot ARM.",
+    )
+    args = ap.parse_args(argv)
+
+    helpers = load_helpers()
+    ids = None
+    synthetic = False
+    if args.ids_json is not None:
+        ids = json.loads(args.ids_json.read_text() or "null")
+    elif args.synthetic_selftest:
+        ids = zipf_unique_ids(args.tokens, args.topk)
+        synthetic = True
+    router_source = None
+    if args.router_source is not None:
+        router_source = args.router_source.read_text()
+
+    report = judge(
+        tokens=args.tokens,
+        cap=args.cap,
+        ids=ids,
+        router_source=router_source,
+        helpers=helpers,
+        topk=args.topk,
+    )
+    if synthetic:
+        report["synthetic_selftest"] = True
+        if report["decision"] == "ARM-OK":
+            report["decision"] = "SELFTEST-OK"
+            report["reason"] = (
+                "synthetic Zipf rows only; not live evidence — "
+                + report["reason"]
+            )
+    json.dump(report, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+    return 0 if report["decision"] == "ARM-OK" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/start.sh
+++ b/start.sh
@@ -489,6 +489,29 @@ validate_numeric_config() {
             return 2
         fi
     fi
+    # LOCAL: W2 TRF floor — C-decode T = MAX_NUM_SEQS × (DFLASH_TOKENS+1).
+    # Isolated 32 vs 128 is env-only; below the floor capture cannot fit.
+    # Default here as well as the launcher prologue so `validate` and the
+    # numeric-config tests still see production 128 when the env is empty.
+    EXL3_TEMP_ROWS_FUSED="${EXL3_TEMP_ROWS_FUSED:-128}"
+    if ! [[ "${EXL3_TEMP_ROWS_FUSED}" =~ ^[0-9]+$ ]] \
+       || [ "${#EXL3_TEMP_ROWS_FUSED}" -gt 7 ] \
+       || [ "$((10#$EXL3_TEMP_ROWS_FUSED))" -lt 1 ] \
+       || [ "$((10#$EXL3_TEMP_ROWS_FUSED))" -gt 8388608 ]; then
+        echo "EXL3_TEMP_ROWS_FUSED must be a base-10 integer 1..8388608 (got: '${EXL3_TEMP_ROWS_FUSED}')" >&2
+        return 2
+    fi
+    EXL3_TEMP_ROWS_FUSED="$((10#$EXL3_TEMP_ROWS_FUSED))"
+    export EXL3_TEMP_ROWS_FUSED
+    if [ "$SPEC_METHOD" = dflash ]; then
+        _trf_floor=$((MAX_NUM_SEQS * (DFLASH_TOKENS + 1)))
+        if [ "$EXL3_TEMP_ROWS_FUSED" -lt "$_trf_floor" ]; then
+            echo "EXL3_TEMP_ROWS_FUSED=$EXL3_TEMP_ROWS_FUSED is below the C-decode floor MAX_NUM_SEQS*(DFLASH_TOKENS+1)=$_trf_floor" >&2
+            unset _trf_floor
+            return 2
+        fi
+        unset _trf_floor
+    fi
     # LOCAL: W41/W42 strict-bool validation (end)
     # LOCAL: task 25 — verification-only adaptive-k. DFLASH_TOKENS stays 7.
     case "${GLM53_ADAPTIVE_K:-off}" in

--- a/tests/fixtures/w2-grouped-topk-router.py
+++ b/tests/fixtures/w2-grouped-topk-router.py
@@ -1,0 +1,350 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from functools import partial
+
+import torch
+
+from vllm import _custom_ops as ops
+from vllm import envs as envs
+from vllm._aiter_ops import rocm_aiter_ops
+from vllm.distributed.eplb.eplb_state import EplbLayerState
+from vllm.model_executor.custom_op import CustomOp
+from vllm.model_executor.layers.fused_moe.config import (
+    RoutingMethodType,
+    get_routing_method_type,
+)
+from vllm.model_executor.layers.fused_moe.experts.rocm_aiter_moe import (
+    rocm_aiter_grouped_topk,
+)
+from vllm.model_executor.layers.fused_moe.router.base_router import BaseRouter
+from vllm.model_executor.layers.fused_moe.router.fused_topk_bias_router import (
+    fused_topk_bias,
+)
+from vllm.model_executor.layers.fused_moe.router.fused_topk_router import fused_topk
+from vllm.model_executor.utils import maybe_disable_graph_partition
+from vllm.platforms import current_platform
+
+
+def fused_grouped_topk(
+    hidden_states: torch.Tensor,
+    gating_output: torch.Tensor,
+    topk: int,
+    renormalize: bool,
+    e_score_correction_bias: torch.Tensor,
+    num_expert_group: int = 0,
+    topk_group: int = 0,
+    scoring_func: str = "softmax",
+    routed_scaling_factor: float = 1.0,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    assert hidden_states.size(0) == gating_output.size(0), "Number of tokens mismatch"
+
+    if scoring_func == "sigmoid":
+        # Fully fused kernel path for sigmoid
+        topk_values, topk_indices = ops.grouped_topk(
+            gating_output,  # raw logits
+            num_expert_group,
+            topk_group,
+            topk,
+            renormalize,
+            routed_scaling_factor,
+            e_score_correction_bias,
+            1,  # scoring_func=1 for sigmoid
+        )
+    elif scoring_func == "softmax":
+        # Apply softmax in Python, then use fused kernel
+        # TODO: Add support for softmax in kernel
+        scores = torch.softmax(gating_output, dim=-1)
+        topk_values, topk_indices = ops.grouped_topk(
+            scores,  # pre-computed scores
+            num_expert_group,
+            topk_group,
+            topk,
+            renormalize,
+            routed_scaling_factor,
+            e_score_correction_bias,
+            0,  # scoring_func=0 (no activation, scores already computed)
+        )
+    else:
+        raise ValueError(f"Unsupported scoring function: {scoring_func}")
+
+    # Fused kernel outputs float32 values and int32 indices directly
+    return topk_values, topk_indices
+
+
+# This is used by the Deepseek-V2 and Deepseek-V3 model
+@torch.compile(
+    dynamic=True,
+    backend=current_platform.simple_compile_backend,
+    options=maybe_disable_graph_partition(current_platform.simple_compile_backend),
+)
+def grouped_topk(
+    hidden_states: torch.Tensor,
+    gating_output: torch.Tensor,
+    topk: int,
+    renormalize: bool,
+    num_expert_group: int = 0,
+    topk_group: int = 0,
+    scoring_func: str = "softmax",
+    routed_scaling_factor: float = 1.0,
+    e_score_correction_bias: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    if (
+        envs.VLLM_USE_FUSED_MOE_GROUPED_TOPK
+        and current_platform.is_cuda()
+        and num_expert_group <= 32
+        and topk <= 32
+        and e_score_correction_bias is not None
+    ):
+        return fused_grouped_topk(
+            hidden_states=hidden_states,
+            gating_output=gating_output,
+            topk=topk,
+            renormalize=renormalize,
+            e_score_correction_bias=e_score_correction_bias,
+            num_expert_group=num_expert_group,
+            topk_group=topk_group,
+            scoring_func=scoring_func,
+            routed_scaling_factor=routed_scaling_factor,
+        )
+
+    assert hidden_states.size(0) == gating_output.size(0), "Number of tokens mismatch"
+
+    if scoring_func == "softmax":
+        scores = torch.softmax(gating_output, dim=-1)
+    elif scoring_func == "sigmoid":
+        scores = gating_output.sigmoid()
+    else:
+        raise ValueError(f"Unsupported scoring function: {scoring_func}")
+
+    num_token = scores.size(0)
+    if e_score_correction_bias is not None:
+        # Store original scores before applying correction bias. We use biased
+        # scores for expert selection but original scores for routing weights
+        original_scores = scores
+        scores = scores + e_score_correction_bias.unsqueeze(0)
+        group_scores = (
+            scores.view(num_token, num_expert_group, -1).topk(2, dim=-1)[0].sum(dim=-1)
+        )
+    else:
+        group_scores = (
+            scores.view(num_token, num_expert_group, -1).max(dim=-1).values
+        )  # [n, n_group]
+
+    # For batch invariance, use sorted=True to ensure deterministic expert selection
+    use_sorted = envs.VLLM_BATCH_INVARIANT
+    group_idx = torch.topk(group_scores, k=topk_group, dim=-1, sorted=use_sorted)[
+        1
+    ]  # [n, top_k_group]
+    group_mask = torch.zeros_like(group_scores)  # [n, n_group]
+    group_mask.scatter_(1, group_idx, 1)  # [n, n_group]
+    score_mask = (
+        group_mask.unsqueeze(-1)
+        .expand(num_token, num_expert_group, scores.size(-1) // num_expert_group)
+        .reshape(num_token, -1)
+    )  # [n, e]
+    tmp_scores = scores.masked_fill(~score_mask.bool(), float("-inf"))  # [n, e]
+
+    if e_score_correction_bias is not None:
+        topk_ids = torch.topk(tmp_scores, k=topk, dim=-1, sorted=use_sorted)[1]
+        # Use original unbiased scores for the routing weights
+        topk_weights = original_scores.gather(1, topk_ids)
+    else:
+        topk_weights, topk_ids = torch.topk(
+            tmp_scores, k=topk, dim=-1, sorted=use_sorted
+        )
+
+    if renormalize:
+        topk_weights = topk_weights / topk_weights.sum(dim=-1, keepdim=True)
+
+    if routed_scaling_factor != 1.0:
+        topk_weights = topk_weights * routed_scaling_factor
+    return topk_weights.to(torch.float32), topk_ids.to(torch.int32)
+
+
+# --8<-- [start:grouped_topk]
+@CustomOp.register("grouped_topk")
+class GroupedTopk(CustomOp):
+    """GroupedTopk used by the Deepseek-V2 and Deepseek-V3 model."""
+
+    # --8<-- [end:grouped_topk]
+
+    def __init__(
+        self,
+        topk: int,
+        renormalize: bool,
+        num_expert_group: int = 0,
+        topk_group: int = 0,
+        scoring_func: str = "softmax",
+        routed_scaling_factor: float = 1.0,
+        num_fused_shared_experts: int = 0,
+    ) -> None:
+        super().__init__()
+        self.native_impl = grouped_topk
+        self.topk = topk
+        self.renormalize = renormalize
+        self.num_expert_group = num_expert_group
+        self.topk_group = topk_group
+        self.scoring_func = scoring_func
+        self.routed_scaling_factor = routed_scaling_factor
+        self.num_fused_shared_experts = num_fused_shared_experts
+
+    def forward_native(
+        self,
+        hidden_states: torch.Tensor,
+        gating_output: torch.Tensor,
+        e_score_correction_bias: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        return self.native_impl(
+            hidden_states,
+            gating_output,
+            self.topk,
+            self.renormalize,
+            self.num_expert_group,
+            self.topk_group,
+            self.scoring_func,
+            self.routed_scaling_factor,
+            e_score_correction_bias,
+        )
+
+    def forward_cuda(
+        self,
+        hidden_states: torch.Tensor,
+        gating_output: torch.Tensor,
+        e_score_correction_bias: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        return self.forward_native(
+            hidden_states, gating_output, e_score_correction_bias
+        )
+
+    def forward_hip(
+        self,
+        hidden_states: torch.Tensor,
+        gating_output: torch.Tensor,
+        e_score_correction_bias: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if rocm_aiter_ops.is_fused_moe_enabled():
+            if not rocm_aiter_ops.is_fusion_moe_shared_experts_enabled():
+                assert self.num_fused_shared_experts == 0
+            return rocm_aiter_grouped_topk(
+                hidden_states,
+                gating_output,
+                self.topk,
+                self.renormalize,
+                self.num_expert_group,
+                self.topk_group,
+                self.scoring_func,
+                self.routed_scaling_factor,
+                e_score_correction_bias,
+                self.num_fused_shared_experts,
+            )
+        else:
+            return self.forward_native(
+                hidden_states, gating_output, e_score_correction_bias
+            )
+
+
+class GroupedTopKRouter(BaseRouter):
+    """Router using grouped top-k routing (e.g., DeepSeekV2/V3)."""
+
+    def __init__(
+        self,
+        top_k: int,
+        global_num_experts: int,
+        num_expert_group: int,
+        topk_group: int,
+        renormalize: bool = True,
+        scoring_func: str = "softmax",
+        routed_scaling_factor: float = 1.0,
+        e_score_correction_bias: torch.Tensor | None = None,
+        num_fused_shared_experts: int = 0,
+        eplb_state: EplbLayerState | None = None,
+    ):
+        super().__init__(
+            top_k=top_k,
+            global_num_experts=global_num_experts,
+            eplb_state=eplb_state,
+        )
+        self.num_expert_group = num_expert_group
+        self.topk_group = topk_group
+        self.renormalize = renormalize
+        self.scoring_func = scoring_func
+        self.routed_scaling_factor = routed_scaling_factor
+        self.e_score_correction_bias = e_score_correction_bias
+        self.num_fused_shared_experts = num_fused_shared_experts
+
+    @property
+    def routing_method_type(self) -> RoutingMethodType:
+        return get_routing_method_type(
+            scoring_func=self.scoring_func,
+            top_k=self.top_k,
+            renormalize=self.renormalize,
+            num_expert_group=self.num_expert_group,
+            has_e_score_bias=self.e_score_correction_bias is not None,
+            routed_scaling_factor=self.routed_scaling_factor,
+        )
+
+    def _compute_routing(
+        self,
+        hidden_states: torch.Tensor,
+        router_logits: torch.Tensor,
+        indices_type: torch.dtype | None,
+        *,
+        input_ids: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Compute routing using grouped top-k."""
+
+        def valid_grouping() -> bool:
+            # Check if num_experts is greater than num_expert_group
+            # and is divisible by num_expert_group
+            num_experts = router_logits.shape[-1]
+            if num_experts <= self.num_expert_group:
+                return False
+            return num_experts % self.num_expert_group == 0
+
+        if not valid_grouping():
+            if self.e_score_correction_bias is not None:
+                topk_weights, topk_ids = fused_topk_bias(
+                    hidden_states=hidden_states,
+                    gating_output=router_logits,
+                    scoring_func=self.scoring_func,
+                    e_score_correction_bias=self.e_score_correction_bias.data,
+                    topk=self.top_k,
+                    renormalize=self.renormalize,
+                )
+                if self.routed_scaling_factor != 1.0:
+                    topk_weights *= self.routed_scaling_factor
+            else:
+                topk_weights, topk_ids, token_expert_indices = fused_topk(
+                    hidden_states=hidden_states,
+                    gating_output=router_logits,
+                    topk=self.top_k,
+                    renormalize=self.renormalize,
+                    indices_type=indices_type,
+                )
+            return topk_weights, topk_ids
+
+        # Select grouped_topk implementation
+        if rocm_aiter_ops.is_fused_moe_enabled():
+            if not rocm_aiter_ops.is_fusion_moe_shared_experts_enabled():
+                assert self.num_fused_shared_experts == 0
+            grouped_topk_impl = partial(
+                rocm_aiter_grouped_topk,
+                num_fused_shared_experts=self.num_fused_shared_experts,
+            )
+        else:
+            grouped_topk_impl = grouped_topk
+
+        topk_weights, topk_ids = grouped_topk_impl(
+            hidden_states=hidden_states,
+            gating_output=router_logits,
+            topk=self.top_k,
+            renormalize=self.renormalize,
+            num_expert_group=self.num_expert_group,
+            topk_group=self.topk_group,
+            scoring_func=self.scoring_func,
+            routed_scaling_factor=self.routed_scaling_factor,
+            e_score_correction_bias=self.e_score_correction_bias,
+        )
+
+        return topk_weights, topk_ids
+

--- a/tests/test_exl3_grouped.py
+++ b/tests/test_exl3_grouped.py
@@ -41,6 +41,11 @@ def _exec_helpers():
         "grouped_scratch_bytes_for",
         "grouped_scratch_capacity",
         "fused_moe_decode_skips_fat",
+        "fused_moe_decode_skips_unique_topk",
+        "fused_temp_rows_decode_floor",
+        "unique_per_token_topk_ids",
+        "unique_topk_hottest_upper_bound",
+        "w2_trf32_no_fallback_skip",
         "temp_rows_fused",
     }
     wanted_assign = {
@@ -63,7 +68,7 @@ def _exec_helpers():
             if any(name in wanted_assign for name in names):
                 keep.append(ast.get_source_segment(src, node) or "")
     ns: dict = {"os": os}
-    exec("\n\n".join(keep), ns, ns)
+    exec("from __future__ import annotations\n" + "\n\n".join(keep), ns, ns)
     return ns
 
 
@@ -368,3 +373,35 @@ def test_w2_decode_skip_gate_c4_unique_topk() -> None:
     # Non-unique top-k (one expert appears twice in a token) can make
     # hottest > T; then decode T ≤ cap still skips with no fat fallback.
     assert skip(tokens=32, hottest_expert_count=33, cap=32) is True
+
+
+def test_w2_unique_topk_hottest_bound_and_trf32_gate() -> None:
+    """Unique-per-token top-k (torch.topk / grouped_topk) keeps hottest ≤ T.
+
+    C4 floor is 4 × (7+1) = 32. Zipf-all-to-one still unique-per-row, so
+    TRF=32 does not no-fallback-skip. Missing hottest on a non-unique
+    claim fail-closes.
+    """
+    unique = HELPERS["unique_per_token_topk_ids"]
+    bound = HELPERS["unique_topk_hottest_upper_bound"]
+    floor = HELPERS["fused_temp_rows_decode_floor"]
+    unique_skip = HELPERS["fused_moe_decode_skips_unique_topk"]
+    gate = HELPERS["w2_trf32_no_fallback_skip"]
+
+    assert floor(4, 7) == 32
+    assert bound(32) == 32
+    zipf_all_to_one = [[0] + [i + 1 for i in range(7)] for _ in range(32)]
+    assert unique(zipf_all_to_one) is True
+    assert unique([[0, 0, 1, 2, 3, 4, 5, 6]]) is False
+    assert unique([[0, 1, -1, 2]]) is True
+    assert unique_skip(32, 32) is False
+    assert unique_skip(32, 128) is False
+    assert gate(32, unique_topk=True, cap=32) is False
+    assert gate(32, unique_topk=False, hottest_expert_count=32, cap=32) is False
+    assert gate(32, unique_topk=False, hottest_expert_count=33, cap=32) is True
+    assert gate(32, unique_topk=False, hottest_expert_count=None, cap=32) is True
+    env = ENV_EXAMPLE.read_text()
+    assert "EXL3_TEMP_ROWS_FUSED=32" in env
+    start = LAUNCHER.read_text()
+    assert "below the C-decode floor" in start
+    assert "EXL3_TEMP_ROWS_FUSED:-128" in start

--- a/tests/test_numeric_config.py
+++ b/tests/test_numeric_config.py
@@ -75,7 +75,19 @@ def expect_rc(values: tuple[str, str, str, str], expected: int) -> None:
 def test_matrix() -> None:
     expect_rc(("0.87", "1000000", "4", "1024"), 0)
     expect_rc((".87", "01000000", "0004", "01024"), 0)
-    expect_rc(("1.0", "1000000", "4096", "8388608"), 0)
+    # C-decode floor is MAX_NUM_SEQS*(DFLASH_TOKENS+1). Default TRF=128
+    # covers production C4 (32) and C16, but not the numeric max C4096.
+    c4096 = validate(
+        "1.0",
+        "1000000",
+        "4096",
+        "8388608",
+        extra_env={"EXL3_TEMP_ROWS_FUSED": "32768"},
+    )
+    assert c4096.returncode == 0, (c4096.returncode, c4096.stderr)
+    default_c4096 = validate("1.0", "1000000", "4096", "8388608")
+    assert default_c4096.returncode == 2
+    assert "C-decode floor" in default_c4096.stderr
     expect_rc(("0", "1000000", "4", "1024"), 2)
     expect_rc(("8.7", "1000000", "4", "1024"), 2)
     expect_rc(("nope", "1000000", "4", "1024"), 2)
@@ -255,6 +267,62 @@ def test_adaptive_k_defaults_and_refusals() -> None:
     assert mtp_custom.returncode == 0, mtp_custom.stderr
 
 
+def test_trf_floor_allows_32_refuses_31() -> None:
+    """W2: C4 dflash floor is 4×(7+1)=32. Isolated 32 is legal; 31 is not."""
+    allowed_default = validate("0.87", "1000000", "4", "1024")
+    assert allowed_default.returncode == 0, allowed_default.stderr
+    allowed_32 = validate(
+        "0.87",
+        "1000000",
+        "4",
+        "1024",
+        extra_env={"EXL3_TEMP_ROWS_FUSED": "32"},
+    )
+    assert allowed_32.returncode == 0, allowed_32.stderr
+    allowed_128 = validate(
+        "0.87",
+        "1000000",
+        "4",
+        "1024",
+        extra_env={"EXL3_TEMP_ROWS_FUSED": "128"},
+    )
+    assert allowed_128.returncode == 0, allowed_128.stderr
+    refused_31 = validate(
+        "0.87",
+        "1000000",
+        "4",
+        "1024",
+        extra_env={"EXL3_TEMP_ROWS_FUSED": "31"},
+    )
+    assert refused_31.returncode == 2
+    assert "C-decode floor" in refused_31.stderr
+    refused_zero = validate(
+        "0.87",
+        "1000000",
+        "4",
+        "1024",
+        extra_env={"EXL3_TEMP_ROWS_FUSED": "0"},
+    )
+    assert refused_zero.returncode == 2
+    refused_c8 = validate(
+        "0.87",
+        "1000000",
+        "8",
+        "1024",
+        extra_env={"EXL3_TEMP_ROWS_FUSED": "32"},
+    )
+    assert refused_c8.returncode == 2
+    mtp_no_floor = validate(
+        "0.87",
+        "1000000",
+        "4",
+        "1024",
+        spec_method="mtp",
+        extra_env={"EXL3_TEMP_ROWS_FUSED": "1"},
+    )
+    assert mtp_no_floor.returncode == 0, mtp_no_floor.stderr
+
+
 def test_restart_validates_before_stop() -> None:
     source = START.read_text()
     main = source.index("main() {")
@@ -267,5 +335,6 @@ if __name__ == "__main__":
     test_matrix()
     test_decimal_normalization()
     test_adaptive_k_defaults_and_refusals()
+    test_trf_floor_allows_32_refuses_31()
     test_restart_validates_before_stop()
     print("numeric config tests: PASS")

--- a/tests/test_w2_unique_topk_probe.py
+++ b/tests/test_w2_unique_topk_probe.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""CPU tests for the W2 unique-topk / TRF=32 decode-skip probe."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/probe_w2_unique_topk.py"
+SPEC = importlib.util.spec_from_file_location("probe_w2_unique_topk", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+HELPERS = MODULE.load_helpers()
+PINNED = (ROOT / "tests/fixtures/w2-grouped-topk-router.py").read_text()
+
+NATIVE_ROUTER = '''
+import torch
+
+def grouped_topk(hidden_states, gating_output, topk, renormalize,
+                 num_expert_group=0, topk_group=0, scoring_func="softmax",
+                 routed_scaling_factor=1.0, e_score_correction_bias=None):
+    topk_weights, topk_ids = torch.topk(gating_output, k=topk, dim=-1, sorted=True)
+    return topk_weights, topk_ids
+'''
+
+COMMENT_ONLY = '''
+def grouped_topk(hidden_states, gating_output, topk, renormalize):
+    # torch.topk(gating_output, k=topk, dim=-1)
+    return gating_output, gating_output
+'''
+
+UNUSED_UNIQUE = '''
+def grouped_topk(hidden_states, gating_output, topk, renormalize):
+    topk_weights, topk_ids = torch.topk(gating_output, k=topk, dim=-1)
+    return topk_weights, topk_ids
+
+class GroupedTopKRouter:
+    def _compute_routing(self, hidden_states, router_logits, indices_type):
+        ids = torch.multinomial(router_logits.softmax(-1), 8, replacement=True)
+        return router_logits, ids
+'''
+
+REPLACEMENT = '''
+def grouped_topk(hidden_states, gating_output, topk, renormalize):
+    ids = torch.multinomial(gating_output.softmax(-1), topk, replacement=True)
+    return gating_output, ids
+'''
+
+DISCARDED_TOPK = '''
+def fused_grouped_topk(hidden_states, gating_output, topk, renormalize,
+                       e_score_correction_bias, num_expert_group=0, topk_group=0,
+                       scoring_func="softmax", routed_scaling_factor=1.0):
+    ops.grouped_topk(gating_output, num_expert_group, topk_group, topk, renormalize)
+    ids = gating_output.new_zeros(gating_output.size(0), topk)
+    return gating_output, ids
+
+def grouped_topk(hidden_states, gating_output, topk, renormalize,
+                 num_expert_group=0, topk_group=0, scoring_func="softmax",
+                 routed_scaling_factor=1.0, e_score_correction_bias=None):
+    torch.topk(gating_output, k=topk, dim=-1)
+    return gating_output, gating_output.new_zeros(gating_output.size(0), topk)
+'''
+
+
+def _mutate_compute_zero() -> str:
+    needle = "        return topk_weights, topk_ids\n"
+    idx = PINNED.rfind(needle)
+    assert idx != -1
+    return PINNED[:idx] + "        topk_ids.zero_()\n" + PINNED[idx:]
+
+
+def test_c4_zipf_unique_ids_and_pinned_router_arm_ok() -> None:
+    report = MODULE.judge(
+        tokens=32,
+        cap=32,
+        ids=MODULE.zipf_unique_ids(32, 8),
+        router_source=PINNED,
+        helpers=HELPERS,
+    )
+    assert report["decision"] == "ARM-OK"
+    assert report["unique_topk"] is True
+    assert report["hottest"] == 32
+    assert report["unique_skip"] is False
+    assert "router_ast" in report["evidence"]
+    assert "fingerprint match" in report["router_proof"]
+
+
+def test_trf128_pinned_router_arm_ok() -> None:
+    report = MODULE.judge(
+        tokens=32,
+        cap=128,
+        ids=None,
+        router_source=PINNED,
+        helpers=HELPERS,
+    )
+    assert report["decision"] == "ARM-OK"
+
+
+def test_pinned_live_router_dump_is_arm_ok() -> None:
+    report = MODULE.judge(
+        tokens=32,
+        cap=32,
+        ids=None,
+        router_source=PINNED,
+        helpers=HELPERS,
+    )
+    assert report["decision"] == "ARM-OK", report
+    assert "fingerprint match" in report["router_proof"]
+
+
+def test_simplified_native_router_does_not_match_fixture() -> None:
+    report = MODULE.judge(
+        tokens=32,
+        cap=32,
+        ids=None,
+        router_source=NATIVE_ROUTER,
+        helpers=HELPERS,
+    )
+    assert report["decision"] == "ABORT"
+    assert "does not match" in report["reason"] or "missing reviewed" in report["reason"]
+
+
+def test_non_unique_ids_abort_even_with_pinned_router() -> None:
+    ids = [[0, 0, 1, 2, 3, 4, 5, 6] for _ in range(32)]
+    report = MODULE.judge(
+        tokens=32,
+        cap=32,
+        ids=ids,
+        router_source=PINNED,
+        helpers=HELPERS,
+    )
+    assert report["decision"] == "ABORT"
+    assert report["unique_topk"] is False
+
+
+def test_replacement_true_router_aborts() -> None:
+    report = MODULE.judge(
+        tokens=32,
+        cap=32,
+        ids=MODULE.zipf_unique_ids(32, 8),
+        router_source=REPLACEMENT,
+        helpers=HELPERS,
+    )
+    assert report["decision"] == "ABORT"
+
+
+def test_missing_evidence_aborts() -> None:
+    report = MODULE.judge(
+        tokens=32,
+        cap=32,
+        ids=None,
+        router_source=None,
+        helpers=HELPERS,
+    )
+    assert report["decision"] == "ABORT"
+    assert "not proven" in report["reason"]
+
+
+def test_empty_ids_abort() -> None:
+    report = MODULE.judge(
+        tokens=32,
+        cap=32,
+        ids=[],
+        router_source=PINNED,
+        helpers=HELPERS,
+    )
+    assert report["decision"] == "ABORT"
+    assert "empty" in report["reason"]
+
+
+def test_wrong_shape_ids_abort() -> None:
+    report = MODULE.judge(
+        tokens=32,
+        cap=32,
+        ids=[[0, 1, 2, 3, 4, 5, 6, 7]],
+        router_source=PINNED,
+        helpers=HELPERS,
+        topk=8,
+    )
+    assert report["decision"] == "ABORT"
+    assert "rows" in report["reason"]
+
+
+def test_comment_only_topk_aborts() -> None:
+    report = MODULE.judge(
+        tokens=32,
+        cap=32,
+        ids=None,
+        router_source=COMMENT_ONLY,
+        helpers=HELPERS,
+    )
+    assert report["decision"] == "ABORT"
+
+
+def test_unused_unique_path_aborts() -> None:
+    report = MODULE.judge(
+        tokens=32,
+        cap=32,
+        ids=None,
+        router_source=UNUSED_UNIQUE,
+        helpers=HELPERS,
+    )
+    assert report["decision"] == "ABORT"
+
+
+def test_discarded_unique_call_aborts() -> None:
+    report = MODULE.judge(
+        tokens=32,
+        cap=32,
+        ids=None,
+        router_source=DISCARDED_TOPK,
+        helpers=HELPERS,
+    )
+    assert report["decision"] == "ABORT"
+    assert "does not match" in report["reason"] or "missing reviewed" in report["reason"]
+
+
+def test_post_routing_id_mutation_aborts() -> None:
+    report = MODULE.judge(
+        tokens=32,
+        cap=32,
+        ids=None,
+        router_source=_mutate_compute_zero(),
+        helpers=HELPERS,
+    )
+    assert report["decision"] == "ABORT"
+    assert "does not match" in report["reason"]
+
+
+def test_cli_without_evidence_exits_nonzero() -> None:
+    rc = MODULE.main([])
+    assert rc == 1
+
+
+def test_cli_synthetic_cannot_arm() -> None:
+    rc = MODULE.main(["--synthetic-selftest"])
+    assert rc == 1
+
+
+def test_cli_pinned_router_exits_zero() -> None:
+    rc = MODULE.main(
+        ["--router-source", str(ROOT / "tests/fixtures/w2-grouped-topk-router.py")]
+    )
+    assert rc == 0
+
+
+def test_cli_empty_ids_exits_nonzero(tmp_path: Path) -> None:
+    ids_path = tmp_path / "ids.json"
+    ids_path.write_text("[]")
+    rc = MODULE.main(
+        [
+            "--router-source",
+            str(ROOT / "tests/fixtures/w2-grouped-topk-router.py"),
+            "--ids-json",
+            str(ids_path),
+        ]
+    )
+    assert rc == 1
+
+
+def test_cli_unique_ids_without_router_can_arm(tmp_path: Path) -> None:
+    ids_path = tmp_path / "ids.json"
+    ids_path.write_text(json.dumps(MODULE.zipf_unique_ids(32, 8)))
+    rc = MODULE.main(["--ids-json", str(ids_path)])
+    assert rc == 0


### PR DESCRIPTION
## Summary

Adopts isolated env-only `EXL3_TEMP_ROWS_FUSED=32` vs production E3@128 (task 24 W2). No cubin rebuild. Independent variable is TRF only. Frozen: `IMAGE=e3-w3-zfill`, `EXL3_FAT_GROUPED=1`, `EXL3_MOE_ROW_TILE=0`, pin / C4 / k=7 / adaptive-k ema.

Fused `exl3_moe` skips `token_count > cap`. Decode `tokens <= cap` returns with **no fat fallback**. Unique-per-token top-k (`grouped_topk` / `torch.topk`) keeps hottest ≤ T. C4 T=32 therefore does **not** drop experts (`32 > 32` is false). CPU judge `scripts/probe_w2_unique_topk.py` fail-closes without live evidence and pins the production router AST fingerprint (`tests/fixtures/w2-grouped-topk-router.py`).

`start.sh` still defaults TRF=128 and refuses TRF below `MAX_NUM_SEQS*(DFLASH_TOKENS+1)` on dflash. Production last-wins 32.

## Cluster receipts (same-boot A vs B)

| Gate | A `TRF=128` | B `TRF=32` |
|---|---|---|
| Acceptance | (healthy) | 7/7 |
| Serving (:18000) | — | 6/6 |
| Pool | 1,396,551 / 1.40× | identical |
| 60k median tok/s | 1253.1 | **1454.3 (+16.1%)** |
| 240k median tok/s | 1242.4 | **1407.8 (+13.3%)** |
| Structured n=9 | 66.60 @ 7.0/1.000 | 69.10 @ 7.0/1.000 |
| Hashmap prose n=9 | 27.54 | **30.82** |
| Idle/post MemFree head/worker GiB | 5.00 / 3.67 post-A | 4.46 / 4.56 idle; 3.77 / 4.04 post-B |
| Health / bind | 200 / loopback | 200 / loopback |

Both ranks `temp_rows_fused()=32`, `grouped_ok`. No CUDA/Xid/IMA. Watchdog re-armed.

**Verdict: ADOPT.** Expected sign was cold-prefill lean-lose (S1 at TRF=64). Measured was a fat-path-share win at the C-decode floor. Rollback: last-wins `EXL3_TEMP_ROWS_FUSED=128` (`.env.bak-pre-task24-w2-20260909`).

## What this does **not** do

- Does not rebuild cubin or switch `IMAGE`.
- Does not combine with W1 (REVERTED) or W4 (REVERTED).
- Does not change launcher default (still 128). GHCR/old copies stay fail-closed until they set the env.
- Does not open W5 occupancy (ncu-gated).

Host tests: `pytest tests/test_exl3_grouped.py tests/test_numeric_config.py tests/test_w2_unique_topk_probe.py` → **44 passed**. Final review: APPROVED after fail-closed unique-topk judge (live evidence + AST fingerprint).
