### PR TITLE
docs: align README standing numbers to W2 TRF=32

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The headline figures, same pair:
 | | |
 |---|---|
 | Context window | **1,000,000 tokens**, with speculation active — on two desk machines |
-| **Prose decode** | **~29–31 tok/s** at the 1M window — the most reliable real-workload figure we track (natural prose acceptance is ~0.3–0.4, so this is what unstructured generation actually costs; it is also the number least inflated by a high-acceptance prompt). Task 25 (2026-09-09) adopted **verification-only** adaptive-k (`GLM53_ADAPTIVE_K=ema`): native DFlash2 draft stays eight-row / k=7, the target verify uses a 2/4/7 prefix (hashmap **27.72 → 29.70**, hard essay **21.77 → 24.09** vs extra-graphs-off). W2 TRF=32 (2026-09-09) then moved hashmap **27.54 → 30.82** vs same-boot E3@128. E3 itself did not change the fused decode path |
+| **Prose decode** | **~29–31 tok/s** at the 1M window — the most reliable real-workload figure we track (natural prose acceptance is ~0.3–0.4, so this is what unstructured generation actually costs; it is also the number least inflated by a high-acceptance prompt). Task 25 (2026-09-09, PR #58) adopted **verification-only** adaptive-k (`GLM53_ADAPTIVE_K=ema`): native DFlash2 draft stays eight-row / k=7; the target verify uses a 2/4/7 prefix. Isolated B vs extra-graphs-off: hashmap **27.72 → 29.70 (+7.1%)**, hard essay **21.77 → 24.09 (+10.7%)**; structured stayed 7.0/1.000 (never trimmed). That knob stays on. W2 TRF=32 (same day, PR #59) then moved hashmap **27.54 → 30.82** vs same-boot E3@128 with adaptive-k frozen on. E3 itself did not change the fused decode path |
 | Structured decode | **~70 tok/s** at speculative acceptance **1.0000** (7/7 drafted tokens accepted, every uncontended pass) — treat this as the **acceptance/quality gate, not the headline throughput**: near-ceiling structured prompts are the most favorable regime, not the realistic workload. Standing median **69.10 tok/s** (W2 TRF=32, 2026-09-09; uncontended 68.7–70.3; two contended 15.7 / 25.7). Same-day A at TRF=128 was 66.60 with one 15.4 contended. The durable invariant is the 7.0/1.000 acceptance profile, not the contended tail |
 | Cold prefill | **~1408 tok/s** solo at 240k, **~1454 tok/s** at 60k (W2 TRF=32, 2026-09-09; +13.3% / +16.1% vs same-boot E3@128 1242 / 1253). E3 grouped vs pipelined-E2 was **1075 → 1286 tok/s** at 240k (+19.6%, 2026-09-07) |
 | 500k prompt, drafter on | **854 tok/s** cold (2026-08-30 battery, pre-kernel-stack image — not a current-stack rate); same prompt replayed from cache **111× faster** (5.3 s) |
@@ -63,23 +63,27 @@ JSON tokenize denser (more tokens per kB), so the same document can cost 20–50
 more prompt tokens and proportionally longer TTFT. Read the rows above as
 per-token rates, not per-document promises. The standing 240k receipt is the
 2026-09-09 W2 TRF=32 adopt: median **1407.8 tok/s** vs same-boot E3@128
-**1242.4** (+13.3%); 60k **1454.3** vs **1253.1** (+16.1%). The 2026-09-07
-E3 grouped adopt (240k **1075.0 → 1285.7 / 1284.2**, +19.6%) is the
-previous stack, not production. The older pipelined-E2 240k set (906–1072,
-full-set median 1001; `docs/06` 2026-09-02 S2b) is the pre-E3 control class.
+**1242.4** (+13.3%); 60k **1454.3** vs **1253.1** (+16.1%), with
+Task 25 adaptive-k already on (decode-lane, not a prefill variable).
+The 2026-09-07 E3 grouped adopt (240k **1075.0 → 1285.7 / 1284.2**,
++19.6%) is the previous kernel stack, not production. The older
+pipelined-E2 240k set (906–1072, full-set median 1001; `docs/06`
+2026-09-02 S2b) is the pre-E3 control class.
 
-No other public recipe serves this model on this hardware with all five of: EXL3
+No other public recipe serves this model on this hardware with all six of: EXL3
 (the only quantization GB10 can actually run — it lacks the instruction NVFP4
 compiles to), a 1M window that *coexists* with speculative decoding, prefix caching
 that survives the hybrid-KDA architecture and the drafter, perfect structured
-acceptance, and a hand-tuned MoE kernel stack (packed-expert fat GEMM, dynamic
-ticket scheduling, a 3-stage `cp.async` pipeline measured **+41%** over the
-base recipe's kernels at production shapes, grouped fat-expert dispatch
-measured **+19.6%** end-to-end 240k prefill vs that pipelined E2, and W2
+acceptance, verification-only adaptive-k on the target (hashmap **+7.1%**,
+hard essay **+10.7%**; native draft stays eight-row / k=7), and a hand-tuned
+MoE kernel stack (packed-expert fat GEMM, dynamic ticket scheduling, a
+3-stage `cp.async` pipeline measured **+41%** over the base recipe's kernels
+at production shapes, grouped fat-expert dispatch measured **+19.6%**
+end-to-end 240k prefill vs that pipelined E2, and W2
 `EXL3_TEMP_ROWS_FUSED=32` measured **+13.3% / +16.1%** 240k/60k vs E3@128).
 Each of those is a specific fix in this tree, and removing any one of them
 has a measured cost (`docs/10-selfbuild-production.md`, "load-bearing set";
-kernel receipts `docs/06`, 2026-09-02 S2b, 2026-09-07 E3, 2026-09-09 W2).
+receipts `docs/06`, 2026-09-02 S2b, 2026-09-07 E3, 2026-09-09 Task 25 / W2).
 
 Metric provenance, honestly: the cache/latency rows were re-measured on
 2026-08-31 on the self-built image with all of this repo's then-fixes active
@@ -89,14 +93,20 @@ drifts by a few percent, so every A/B here runs its control arm the same
 day). The fat-GEMM pipeline rows are from the 2026-09-02 wave (isolated
 kernel **+41%** at production shapes, bit-exact ×56; that day's end-to-end
 240k was **parity under ambient bursts**, +0.3%). The **standing prefill
-and decode numbers** are the 2026-09-09 W2 TRF=32 adopt on
-`glm53-selfbuild:e3-w3-zfill` / last-wins `EXL3_TEMP_ROWS_FUSED=32`:
-same-boot A vs B, 240k **1242.4 → 1407.8 tok/s (+13.3%)**, 60k
-**1253.1 → 1454.3 (+16.1%)**, hashmap prose **27.54 → 30.82**, structured
+and decode numbers** are the 2026-09-09 stack on
+`glm53-selfbuild:e3-w3-zfill`: last-wins `EXL3_TEMP_ROWS_FUSED=32` plus
+`GLM53_ADAPTIVE_K=ema` / extra target graphs. Isolated decode receipt
+is Task 25 (PR #58): hashmap **27.72 → 29.70 (+7.1%)**, hard essay
+**21.77 → 24.09 (+10.7%)** vs extra-graphs-off; structured stayed
+**69.54** at 7.0/1.000; verify tokens/step ~4 on trimmed prose. Isolated
+prefill receipt is W2 (PR #59): same-boot A vs B, 240k
+**1242.4 → 1407.8 tok/s (+13.3%)**, 60k **1253.1 → 1454.3 (+16.1%)**,
+hashmap **27.54 → 30.82** with adaptive-k already on, structured
 **66.60 → 69.10** at 7.0/1.000, pool 1,396,551 / 1.40×. The 2026-09-07
 E3 grouped-MoE adopt (240k **1075.0 → 1285.7 / 1284.2**, +19.6%; 60k
 **1108.8 → 1330.3 / 1328.2**; structured **69.62**) is the previous
-stack. Isolated GPU microbench PARITY OK, 1.87× at Zipf-1.0 cap=32. The
+kernel stack. Isolated GPU microbench PARITY OK, 1.87× at Zipf-1.0
+cap=32. The
 500k/111× replay row is from the 2026-08-30 cutover battery
 (pre-kernel-stack image) and is not a current-stack rate. Every bench
 and probe ships in `tests/` and `local/` — reproduce any row in minutes.

--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ The headline figures, same pair:
 | | |
 |---|---|
 | Context window | **1,000,000 tokens**, with speculation active — on two desk machines |
-| **Prose decode** | **~28–31 tok/s** at the 1M window — the most reliable real-workload figure we track (natural prose acceptance is ~0.3–0.4, so this is what unstructured generation actually costs; it is also the number least inflated by a high-acceptance prompt). E3 did not change this decode path. Task 25 (2026-09-09) adopted **verification-only** adaptive-k (`GLM53_ADAPTIVE_K=ema`): native DFlash2 draft stays eight-row / k=7, the target verify uses a 2/4/7 prefix. Same-day B vs B0: hashmap **+7.1%** (27.72 → 29.70), hard essay **+10.7%** (21.77 → 24.09); structured stayed 7.0/1.000 |
-| Structured decode | **~70 tok/s** at speculative acceptance **1.0000** (7/7 drafted tokens accepted, every uncontended pass) — treat this as the **acceptance/quality gate, not the headline throughput**: near-ceiling structured prompts are the most favorable regime, not the realistic workload. Same-day E3 adopt median **69.62 tok/s** (uncontended B-arm 69.0–69.8; one contended 25.6). Concurrency medians land wherever ambient traffic puts them; the durable invariant is the acceptance profile |
-| Cold prefill | **~1408 tok/s** solo at 240k, **~1454 tok/s** at 60k (W2 TRF=32, 2026-09-09; +13.3% / +16.1% vs same-boot E3@128). E3 grouped vs pipelined-E2 was **1075 → 1286 tok/s** at 240k (+19.6%, 2026-09-07) |
+| **Prose decode** | **~29–31 tok/s** at the 1M window — the most reliable real-workload figure we track (natural prose acceptance is ~0.3–0.4, so this is what unstructured generation actually costs; it is also the number least inflated by a high-acceptance prompt). Task 25 (2026-09-09) adopted **verification-only** adaptive-k (`GLM53_ADAPTIVE_K=ema`): native DFlash2 draft stays eight-row / k=7, the target verify uses a 2/4/7 prefix (hashmap **27.72 → 29.70**, hard essay **21.77 → 24.09** vs extra-graphs-off). W2 TRF=32 (2026-09-09) then moved hashmap **27.54 → 30.82** vs same-boot E3@128. E3 itself did not change the fused decode path |
+| Structured decode | **~70 tok/s** at speculative acceptance **1.0000** (7/7 drafted tokens accepted, every uncontended pass) — treat this as the **acceptance/quality gate, not the headline throughput**: near-ceiling structured prompts are the most favorable regime, not the realistic workload. Standing median **69.10 tok/s** (W2 TRF=32, 2026-09-09; uncontended 68.7–70.3; two contended 15.7 / 25.7). Same-day A at TRF=128 was 66.60 with one 15.4 contended. The durable invariant is the 7.0/1.000 acceptance profile, not the contended tail |
+| Cold prefill | **~1408 tok/s** solo at 240k, **~1454 tok/s** at 60k (W2 TRF=32, 2026-09-09; +13.3% / +16.1% vs same-boot E3@128 1242 / 1253). E3 grouped vs pipelined-E2 was **1075 → 1286 tok/s** at 240k (+19.6%, 2026-09-07) |
 | 500k prompt, drafter on | **854 tok/s** cold (2026-08-30 battery, pre-kernel-stack image — not a current-stack rate); same prompt replayed from cache **111× faster** (5.3 s) |
 | Short request behind a 240k read | **6.7–7.9 s** to first token (mixed-prefill gate v3 with the 512→1792 aging ladder; 256 s without this kit's fairness cap) |
 | Multi-agent concurrency | **4 in-flight generations**; a warm follow-up lands in **~2.6 s behind a running generation** (45.8 s before the mixed-prefill gate); decode keeps **+27% tokens per fixed window** during a co-batched cold read; cached-conversation capacity ≈ **50,176 tokens ≈ 14 sessions** under per-group retention — replays at 86% of the pool cost retention (4×200k: 49.9%), plan concurrency below that |
@@ -62,9 +62,11 @@ essentially content-independent** — but **tokens per document is not**: code a
 JSON tokenize denser (more tokens per kB), so the same document can cost 20–50%
 more prompt tokens and proportionally longer TTFT. Read the rows above as
 per-token rates, not per-document promises. The standing 240k receipt is the
-2026-09-07 E3 adopt: median **1285.7 tok/s** (B2 1284.2) vs same-day E2
-**1075.0**. The older pipelined-E2 240k set (906–1072, full-set median 1001;
-`docs/06` 2026-09-02 S2b) is the pre-E3 control class, not production.
+2026-09-09 W2 TRF=32 adopt: median **1407.8 tok/s** vs same-boot E3@128
+**1242.4** (+13.3%); 60k **1454.3** vs **1253.1** (+16.1%). The 2026-09-07
+E3 grouped adopt (240k **1075.0 → 1285.7 / 1284.2**, +19.6%) is the
+previous stack, not production. The older pipelined-E2 240k set (906–1072,
+full-set median 1001; `docs/06` 2026-09-02 S2b) is the pre-E3 control class.
 
 No other public recipe serves this model on this hardware with all five of: EXL3
 (the only quantization GB10 can actually run — it lacks the instruction NVFP4
@@ -72,11 +74,12 @@ compiles to), a 1M window that *coexists* with speculative decoding, prefix cach
 that survives the hybrid-KDA architecture and the drafter, perfect structured
 acceptance, and a hand-tuned MoE kernel stack (packed-expert fat GEMM, dynamic
 ticket scheduling, a 3-stage `cp.async` pipeline measured **+41%** over the
-base recipe's kernels at production shapes, and grouped fat-expert dispatch
-measured **+19.6%** end-to-end 240k prefill vs that pipelined E2). Each of
-those is a specific fix in this tree, and removing any one of them has a
-measured cost (`docs/10-selfbuild-production.md`, "load-bearing set"; kernel
-receipts `docs/06`, 2026-09-02 S2b and 2026-09-07 E3 entries).
+base recipe's kernels at production shapes, grouped fat-expert dispatch
+measured **+19.6%** end-to-end 240k prefill vs that pipelined E2, and W2
+`EXL3_TEMP_ROWS_FUSED=32` measured **+13.3% / +16.1%** 240k/60k vs E3@128).
+Each of those is a specific fix in this tree, and removing any one of them
+has a measured cost (`docs/10-selfbuild-production.md`, "load-bearing set";
+kernel receipts `docs/06`, 2026-09-02 S2b, 2026-09-07 E3, 2026-09-09 W2).
 
 Metric provenance, honestly: the cache/latency rows were re-measured on
 2026-08-31 on the self-built image with all of this repo's then-fixes active
@@ -86,15 +89,19 @@ drifts by a few percent, so every A/B here runs its control arm the same
 day). The fat-GEMM pipeline rows are from the 2026-09-02 wave (isolated
 kernel **+41%** at production shapes, bit-exact ×56; that day's end-to-end
 240k was **parity under ambient bursts**, +0.3%). The **standing prefill
-numbers** are the 2026-09-07 E3 grouped-MoE adopt on
-`glm53-selfbuild:e3-grouped`: same-day A-B-B-A, 240k **1075.0 → 1285.7 /
-1284.2 tok/s (+19.6% / +19.5%)**, 60k **1108.8 → 1330.3 / 1328.2**,
-structured **69.79 → 69.18 / 69.62** at 7.0/1.000, pool 1,396,551 / 1.40×.
-Isolated GPU microbench PARITY OK, 1.87× at Zipf-1.0 cap=32. The 500k/111×
-replay row is from the 2026-08-30 cutover battery (pre-kernel-stack image)
-and is not a current-stack rate. Every bench and probe ships in `tests/`
-and `local/` — reproduce any row in minutes. The offline regression suite
-runs with `pip install -r requirements-dev.txt && pytest tests/ -q`.
+and decode numbers** are the 2026-09-09 W2 TRF=32 adopt on
+`glm53-selfbuild:e3-w3-zfill` / last-wins `EXL3_TEMP_ROWS_FUSED=32`:
+same-boot A vs B, 240k **1242.4 → 1407.8 tok/s (+13.3%)**, 60k
+**1253.1 → 1454.3 (+16.1%)**, hashmap prose **27.54 → 30.82**, structured
+**66.60 → 69.10** at 7.0/1.000, pool 1,396,551 / 1.40×. The 2026-09-07
+E3 grouped-MoE adopt (240k **1075.0 → 1285.7 / 1284.2**, +19.6%; 60k
+**1108.8 → 1330.3 / 1328.2**; structured **69.62**) is the previous
+stack. Isolated GPU microbench PARITY OK, 1.87× at Zipf-1.0 cap=32. The
+500k/111× replay row is from the 2026-08-30 cutover battery
+(pre-kernel-stack image) and is not a current-stack rate. Every bench
+and probe ships in `tests/` and `local/` — reproduce any row in minutes.
+The offline regression suite runs with
+`pip install -r requirements-dev.txt && pytest tests/ -q`.
 
 ## The serving image: preview vLLM, pinned and completed
 `download.sh` validates the selected snapshot's
@@ -235,9 +242,12 @@ clients. **Tokenize** is mounted at the root (`/v1/tokenize` is 404) and validat
 > fat-expert dispatch** (`overlay/exl3_fat_moe.cu`, `EXL3_FAT_GROUPED=1`) —
 > three launches instead of a host loop over fat experts, 240k cold
 > prefill **1075 → 1286 tok/s (+19.6%)** vs the pipelined-E2 control
-> (2026-09-07; isolated Zipf-1.0 microbench 1.87×, PARITY OK). Decode
-> stays on fused `exl3_moe` and was non-inferior (structured 69.62 at
-> 7.0/1.000). `docs/11-gb10-kernel-program.md` is the full program
+> (2026-09-07; isolated Zipf-1.0 microbench 1.87×, PARITY OK), and
+> (5) **W2 fused-temp floor** (`EXL3_TEMP_ROWS_FUSED=32`, 2026-09-09)
+> — 240k **1242 → 1408 tok/s (+13.3%)**, 60k **1253 → 1454
+> (+16.1%)** vs same-boot E3@128; decode stays fused `exl3_moe`
+> (structured **69.10** at 7.0/1.000, hashmap **30.82**).
+> `docs/11-gb10-kernel-program.md` is the full program
 > ledger, with the rejected arms too. If you update `exllamav3` or
 > rebuild, the JIT-cache shape guard wipes Triton/TileLang caches on
 > **both** nodes by design; and if you touch the `.cu`, the validation

--- a/local/pr-60-body.md
+++ b/local/pr-60-body.md
@@ -1,0 +1,24 @@
+## Summary
+
+Follow-up to merged [#59](https://github.com/Reederey87/glm53-flash-exl3-2x-dgx-spark/pull/59). Aligns README standing numbers with the W2 TRF=32 cluster receipts. No runtime, overlay, or env change.
+
+#59 adopted `EXL3_TEMP_ROWS_FUSED=32` and updated the cold-prefill table row, but left prose, structured, provenance, and the kernel callout on the 2026-09-07 E3 figures (240k 1286, structured 69.62, prose band 28–31). Those are no longer production.
+
+## What changed
+
+Standing claims now match the same-boot A/B on `e3-w3-zfill`:
+
+| Claim | Before (E3 / task 25) | After (W2 TRF=32, 2026-09-09) |
+|---|---|---|
+| Cold prefill 240k / 60k | ~1408 / ~1454 (already in #59 table) | same, now also the standing receipt |
+| Hashmap prose | ~28–31; task 25 29.70 | **30.82** vs same-boot 27.54; band **~29–31** |
+| Structured | E3 adopt **69.62** | **69.10** @ 7.0/1.000 (uncontended 68.7–70.3) |
+| Provenance / kernel callout | E3 1075 → 1286 as standing | W2 1242 → 1408 standing; E3 kept as previous stack |
+
+## What this does **not** do
+
+- Does not change `EXL3_TEMP_ROWS_FUSED`, image, or overlay.
+- Does not re-run cluster benches.
+- Does not reopen W5.
+
+Rollback of the numbers is reverting this README commit; production stays last-wins TRF=32.

--- a/local/pr-60-body.md
+++ b/local/pr-60-body.md
@@ -1,19 +1,20 @@
 ## Summary
 
-Follow-up to merged [#59](https://github.com/Reederey87/glm53-flash-exl3-2x-dgx-spark/pull/59). Aligns README standing numbers with the W2 TRF=32 cluster receipts. No runtime, overlay, or env change.
+Follow-up to merged [#59](https://github.com/Reederey87/glm53-flash-exl3-2x-dgx-spark/pull/59). Aligns README standing numbers with the 2026-09-09 production stack: Task 25 verification-only adaptive-k (PR #58) plus W2 `EXL3_TEMP_ROWS_FUSED=32` (PR #59). No runtime, overlay, or env change.
 
-#59 adopted `EXL3_TEMP_ROWS_FUSED=32` and updated the cold-prefill table row, but left prose, structured, provenance, and the kernel callout on the 2026-09-07 E3 figures (240k 1286, structured 69.62, prose band 28–31). Those are no longer production.
+#59 adopted TRF=32 and updated the cold-prefill table row, but left prose, structured, provenance, and the kernel callout on the 2026-09-07 E3 figures (240k 1286, structured 69.62, prose band 28–31). Those are no longer production. Adaptive-k decode impact (hashmap +7.1%, hard essay +10.7%) was in the Task 25 docs, not the standing README provenance.
 
 ## What changed
 
-Standing claims now match the same-boot A/B on `e3-w3-zfill`:
+Standing claims now match the two isolated 2026-09-09 receipts on `e3-w3-zfill`:
 
-| Claim | Before (E3 / task 25) | After (W2 TRF=32, 2026-09-09) |
+| Claim | Before (E3 as standing) | After (Task 25 + W2) |
 |---|---|---|
-| Cold prefill 240k / 60k | ~1408 / ~1454 (already in #59 table) | same, now also the standing receipt |
-| Hashmap prose | ~28–31; task 25 29.70 | **30.82** vs same-boot 27.54; band **~29–31** |
+| Adaptive-k prose | mentioned only as a prior hop | isolated **+7.1% / +10.7%** (hashmap 27.72 → 29.70, essay 21.77 → 24.09); knob stays on |
+| Cold prefill 240k / 60k | ~1408 / ~1454 (already in #59 table) | same, now also the standing prefill receipt |
+| Hashmap prose | ~28–31 | standing W2 **30.82** vs same-boot 27.54 (adaptive-k frozen on); band **~29–31** |
 | Structured | E3 adopt **69.62** | **69.10** @ 7.0/1.000 (uncontended 68.7–70.3) |
-| Provenance / kernel callout | E3 1075 → 1286 as standing | W2 1242 → 1408 standing; E3 kept as previous stack |
+| Provenance / kernel callout | E3 1075 → 1286 as standing | W2 1242 → 1408 standing; Task 25 is the decode-lane receipt; E3 kept as previous kernel stack |
 
 ## What this does **not** do
 


### PR DESCRIPTION
## Summary

Follow-up to merged [#59](https://github.com/Reederey87/glm53-flash-exl3-2x-dgx-spark/pull/59). Aligns README standing numbers with the 2026-09-09 production stack: Task 25 verification-only adaptive-k (PR #58) plus W2 `EXL3_TEMP_ROWS_FUSED=32` (PR #59). No runtime, overlay, or env change.

#59 adopted TRF=32 and updated the cold-prefill table row, but left prose, structured, provenance, and the kernel callout on the 2026-09-07 E3 figures (240k 1286, structured 69.62, prose band 28–31). Those are no longer production. Adaptive-k decode impact (hashmap +7.1%, hard essay +10.7%) was in the Task 25 docs, not the standing README provenance.

## What changed

Standing claims now match the two isolated 2026-09-09 receipts on `e3-w3-zfill`:

| Claim | Before (E3 as standing) | After (Task 25 + W2) |
|---|---|---|
| Adaptive-k prose | mentioned only as a prior hop | isolated **+7.1% / +10.7%** (hashmap 27.72 → 29.70, essay 21.77 → 24.09); knob stays on |
| Cold prefill 240k / 60k | ~1408 / ~1454 (already in #59 table) | same, now also the standing prefill receipt |
| Hashmap prose | ~28–31 | standing W2 **30.82** vs same-boot 27.54 (adaptive-k frozen on); band **~29–31** |
| Structured | E3 adopt **69.62** | **69.10** @ 7.0/1.000 (uncontended 68.7–70.3) |
| Provenance / kernel callout | E3 1075 → 1286 as standing | W2 1242 → 1408 standing; Task 25 is the decode-lane receipt; E3 kept as previous kernel stack |

## What this does **not** do

- Does not change `EXL3_TEMP_ROWS_FUSED`, image, or overlay.
- Does not re-run cluster benches.
- Does not reopen W5.

Rollback of the numbers is reverting this README commit; production stays last-wins TRF=32.
