### PR TITLE
KDA: Task 30 fused_recurrent warps=2 measured and reverted

### DIFF
--- a/docs/02-parameters.md
+++ b/docs/02-parameters.md
@@ -181,6 +181,23 @@ cache is invisible to it). 0.87 demands 105.87 GiB free against boots measured a
   both knobs to `off`/`0` through the guarded unit (stock
   `1 2 4 8 16 24 32`, no image rebuild).
 
+- `GLM53_KDA_REC_WARPS` / `GLM53_KDA_REC_STAGES` / `GLM53_KDA_REC_BV_CAP`
+  — Task 30 fused `fused_recurrent_kda` launch. **REVERTED 2026-09-09
+  at warps=2** (hashmap −5.7%; structured −0.5% at 7.0/1.000). Live
+  path on `e3-w3-zfill` is FLA `ops/kda.py` `fused_recurrent_kda_fwd`
+  (`num_warps=1`, `num_stages=3`, `BV=min(next_power_of_2(V), 8)`).
+  Overlay `overlay/patch_kda_recurrent.py` is default-off: empty knobs
+  leave the file byte-identical. Armed values: warps `1|2|4|8`, stages
+  `1..5`, BV cap `8|16|32`. Fail-closed on drifted anchors. **Does not**
+  drop in FlashInfer `fused_kda_decode` (hard-dispatches
+  H∈{12,24,48,96}; GLM TP2 is 32 local heads; no
+  `num_accepted_tokens` rollback). Draft T=8 shares this kernel;
+  query 3/5 already have FULL graphs from Task 25. These knobs **are**
+  in the JIT shape hash. Production leaves all three unset. Do not
+  chain STAGES or BV_CAP. Occupancy at T∈{3,5,8} remains unmeasured;
+  nsys/ncu still gates any later arm. Rollback: unset all three
+  through the guarded unit.
+
 ## Added 2026-09-02
 
 - `EXL3_FAT_SORTED=1` / `EXL3_FAT_BATCHED=1` / `EXL3_FAT_KERNEL=1` — the

--- a/docs/06-improvement-plan.md
+++ b/docs/06-improvement-plan.md
@@ -38,6 +38,46 @@ Mainline GLM support (#53906) has merged, so model resolution is no longer the
 mainline blocker described in the historical section above; EXL3 integration
 and overlay compatibility still block a stock-image replacement.
 
+### 2026-09-09: task 30 fused_recurrent_kda warps=2 REVERTED
+
+Independent variable `GLM53_KDA_REC_WARPS=2` vs stock FLA
+`fused_recurrent_kda_fwd` (`num_warps=1`, `num_stages=3`,
+`BV=min(next_power_of_2(V), 8)`). Stages and BV-cap stayed empty
+(stock). Frozen: `IMAGE=e3-w3-zfill`, `EXL3_FAT_GROUPED=1`, last-wins
+TRF=32, `GLM53_ADAPTIVE_K=ema`, k=7, C4, pin, MNBT 3584, LPTT 1792.
+Live path is FLA `ops/kda.py` (GLM `kernels.py` absent on this
+image). Overlay `overlay/patch_kda_recurrent.py` is default-off and
+fail-closed; it does **not** drop in FlashInfer `fused_kda_decode`.
+Knobs are in the JIT shape hash; caches wiped both directions.
+nsys/ncu occupancy at T∈{3,5,8} was **not** attached (nsys 2025.3
+cannot safely attach to this CUDA-graph server; ncu replay already
+fail-closed on the TP2 graph stack, PR #40). Overlay e2e A/B was the
+allowed overlay-only path.
+
+**Cluster verdict: REVERT.** A (incumbent live boot, knobs unset)
+vs B (`GLM53_KDA_REC_WARPS=2`). Stages/BV not chained: B already
+missed the ≥5% prose bar. Return-A restored unset knobs and ran a
+restoration smoke (structured n=3 + acceptance 7/7 + serving 6/6).
+Occupancy share at T∈{3,5,8} remains unmeasured. Overlay stays
+in-tree default-off. Do not re-arm STAGES or BV_CAP. Do not attach
+ncu to the live graph process.
+
+| Gate | A stock warps=1 | B warps=2 | Return-A restoration |
+|---|---|---|---|
+| Acceptance | standing healthy (not re-run) | skipped (B already failed adopt) | **7/7** |
+| Serving (:18000) | standing healthy (not re-run) | skipped (B already failed adopt) | **6/6** |
+| Pool | 1,396,551 / 1.40× | identical | identical |
+| Structured | n=9 69.56 @ 7.0/1.000 | n=9 69.19 (−0.53%) @ 7.0/1.000 | n=3 69.80 @ 7.0/1.000 |
+| Hashmap n=9 | 31.87 | **30.05 (−5.7%)** | skipped (B already failed adopt) |
+| Health / bind | 200 / loopback | 200 / loopback | 200 / loopback |
+| Idle MemFree head/worker GiB | 5.07 / 4.06 | 5.61 / 3.87 post-benches | 4.21 / 4.17 |
+
+Watchdog re-armed. Rollback last-wins:
+`.env.bak-pre-task30-kda-20260909-163715` (no `GLM53_KDA_REC_*`).
+B overlay line: `kda.py:patched kernels.py:missing warps=2`. Return-A
+both ranks: `knobs unset, leaving fused_recurrent_kda_fwd as-is`.
+Tasks 29/31 stay parked behind a decode-step nsys/ncu share.
+
 ### 2026-09-09: task 28 cfontes DFlash2 TR3-v3 REVERTED
 
 Independent variable `DFLASH_MODEL` / `DFLASH_REVISION` only.

--- a/docs/11-gb10-kernel-program.md
+++ b/docs/11-gb10-kernel-program.md
@@ -477,6 +477,12 @@ layer time; table-build share (persist tables only if ≥2% of layer time).
 - **C1** superseded (above). **C3** sub-16 fused GEMM stays parked until
   ncu decode-tail occupancy data. **S3** Trellis parked behind ≥ ~80
   TFLOP/s vs 73.5.
+- **Task 30 fused_recurrent_kda warps=2 REVERTED 2026-09-09.** Overlay
+  `patch_kda_recurrent.py` default-off. Hashmap 31.87 → 30.05 (−5.7%);
+  structured 69.56 → 69.19 @ 7.0/1.000. Occupancy share at T∈{3,5,8}
+  still unmeasured (nsys attach unsafe on this graph stack; ncu replay
+  fail-closed, PR #40). Do not chain STAGES/BV. Do not attach ncu to
+  the live process. Re-open only with a decode-step nsys/ncu share.
 - Still parked: merge down into gateup; replace `float4` atomics unless
   parity fails; dual-issue K16 / more stages / larger MB; cluster /
   DSMEM / multicast; CUDA-graphing prefill fat as a reason to change

--- a/env.example
+++ b/env.example
@@ -214,6 +214,16 @@ GLM53_ADAPTIVE_K_CAPTURE=1
 # GLM53_ADAPTIVE_K_MIN_STEPS=4
 # GLM53_ADAPTIVE_K_SATURATE=max
 # GLM53_ADAPTIVE_K_HIST=200
+# Task 30 — fused_recurrent_kda Triton launch (FLA kda.py on this image).
+# Empty = stock num_warps=1 / num_stages=3 / BV-cap=8. Overlay is default-off
+# and fail-closed on drifted anchors. Does NOT port FlashInfer fused_kda_decode
+# (H∈{12,24,48,96}; no num_accepted_tokens rollback; GLM TP2 is 32 heads).
+# Shape-hashed (prod-start). warps=2 A/B REVERTED 2026-09-09 (hashmap −5.7%).
+# Do not arm STAGES/BV. nsys/ncu occupancy at T∈{3,5,8} still unmeasured.
+# Rollback: unset all three through the guarded unit (JIT wipe).
+# GLM53_KDA_REC_WARPS=2
+# GLM53_KDA_REC_STAGES=3
+# GLM53_KDA_REC_BV_CAP=8
 # Compatibility lane (tasks 27 + 13 + 17). Production already uses the V2 GPU
 # model runner; W28 patches that path. Unset or 1 is a no-op. 0 is refused
 # before stop/restart. SPEC_METHOD=mtp also refuses MAX_NUM_SEQS > 12 (MTP

--- a/local/pr-62-body.md
+++ b/local/pr-62-body.md
@@ -1,0 +1,26 @@
+Task 30 A/B'd `GLM53_KDA_REC_WARPS=2` against stock FLA
+`fused_recurrent_kda_fwd` (`num_warps=1`, `num_stages=3`, BV-cap=8) on
+the current production stack (`e3-w3-zfill`, TRF=32, adaptive-k ema,
+k=7, C4, DFlash `7d74cdd`). Independent variable was warps only;
+stages and BV stayed stock. Live path is FLA `ops/kda.py` (GLM
+`kernels.py` is absent on this image). The overlay is default-off,
+fail-closed on drifted unique-launch anchors, and refuses a FlashInfer
+`fused_kda_decode` drop-in. Knobs are in the JIT shape hash; caches
+were wiped both directions through the guarded unit.
+
+Cluster A vs B: hashmap 31.87 → 30.05 tok/s (−5.7%). Structured stayed
+7.0/1.000 (69.56 → 69.19, −0.5%). Stages/BV were not chained because B
+already missed the ≥5% prose bar. nsys/ncu occupancy at T∈{3,5,8} was
+not attached (nsys 2025.3 cannot safely attach to this CUDA-graph
+server; ncu replay already fail-closed on the TP2 graph stack, PR #40).
+
+Verdict: REVERT. Occupancy share remains unmeasured. Overlay stays
+in-tree default-off. Production last-wins restored unset knobs
+(`.env.bak-pre-task30-kda-20260909-163715`). Return-A restoration
+smoke: structured 69.80 @ 7.0/1.000, acceptance 7/7, serving 6/6,
+watchdog re-armed. Do not chain STAGES or BV_CAP. Do not attach ncu to
+the live graph process.
+
+This PR records the window: default-off overlay, six-way launcher
+wiring, JIT hash, docs/02 / docs/06 / docs/11, tests, and cluster
+receipts under `local/task30/`.

--- a/local/prod-start.sh
+++ b/local/prod-start.sh
@@ -95,7 +95,9 @@ log "starting pair"
 # start.sh still wipes even when .env carries no DFLASH_REVISION= line.
 # GLM53_ADAPTIVE_K (policy) is NOT hashed: it trims spec_token_ids only.
 # GLM53_ADAPTIVE_K_CAPTURE changes extra FULL graphs (task 25 B0/B).
-shape_hash="$( { grep -E '^(DFLASH_TOKENS|DFLASH_DRAFT_TP|DFLASH_MODEL|DFLASH_REVISION|MTP_TOKENS|SPEC_METHOD|MAX_NUM_BATCHED_TOKENS|MAX_NUM_SEQS|MAX_MODEL_LEN|IMAGE|EXTRA_ARGS|GLM53_ADAPTIVE_K_CAPTURE)=' .env 2>/dev/null; grep -E '^DFLASH_REVISION=' start.sh 2>/dev/null; printf 'GLM53_ADAPTIVE_K_CAPTURE=%s\n' "${GLM53_ADAPTIVE_K_CAPTURE:-}"; } | sort | md5sum | cut -d' ' -f1)"
+# GLM53_KDA_REC_* change the captured fused_recurrent_kda Triton specialization
+# (task 30). Unset = stock warps=1 / stages=3 / BV-cap=8.
+shape_hash="$( { grep -E '^(DFLASH_TOKENS|DFLASH_DRAFT_TP|DFLASH_MODEL|DFLASH_REVISION|MTP_TOKENS|SPEC_METHOD|MAX_NUM_BATCHED_TOKENS|MAX_NUM_SEQS|MAX_MODEL_LEN|IMAGE|EXTRA_ARGS|GLM53_ADAPTIVE_K_CAPTURE|GLM53_KDA_REC_WARPS|GLM53_KDA_REC_STAGES|GLM53_KDA_REC_BV_CAP)=' .env 2>/dev/null; grep -E '^DFLASH_REVISION=' start.sh 2>/dev/null; printf 'GLM53_ADAPTIVE_K_CAPTURE=%s\n' "${GLM53_ADAPTIVE_K_CAPTURE:-}"; printf 'GLM53_KDA_REC_WARPS=%s\n' "${GLM53_KDA_REC_WARPS:-}"; printf 'GLM53_KDA_REC_STAGES=%s\n' "${GLM53_KDA_REC_STAGES:-}"; printf 'GLM53_KDA_REC_BV_CAP=%s\n' "${GLM53_KDA_REC_BV_CAP:-}"; } | sort | md5sum | cut -d' ' -f1)"
 stamp="$HOME/.cache/vllm-glm53-flash/.config-shape"
 if [ -n "$shape_hash" ] && [ "$(cat "$stamp" 2>/dev/null)" != "$shape_hash" ]; then
     echo "[prod-start] config shape changed — wiping Triton/TileLang JIT caches on both nodes"

--- a/local/task30/task30-a-prose.json
+++ b/local/task30/task30-a-prose.json
@@ -1,0 +1,344 @@
+{
+  "phase": "a-hashmap",
+  "health_code": 200,
+  "health_body": "",
+  "runs": [
+    {
+      "http": 200,
+      "ttft_s": 0.3746533840021584,
+      "wall_s": 6.378495468001347,
+      "decode_s": 6.003842083999189,
+      "tok_s": 33.145442071228686,
+      "completion_tokens": 200,
+      "prompt_tokens": 40,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "# How a Hash Map Works: A Complete Guide\n\nA hash map (also called a hash table or dictionary) is a data structure that stores key-value pairs and provides near-constant-time lookup, insertion, and deletion. Here's a thorough breakdown of how it works.\n\n---\n\n## 1. The Core Concept\n\nA hash map stores data as **key-value pairs**. Instead of searching through data linearly (like an array) or following",
+      "text_len": 863,
+      "usage": {
+        "prompt_tokens": 40,
+        "total_tokens": 240,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 58,
+        "draft_tokens": 249,
+        "accepted": 148,
+        "accept_ratio": 0.5944,
+        "accepted_per_step": 2.552,
+        "pos": [
+          0.8793,
+          0.7414,
+          0.5172,
+          0.3103,
+          0.0345,
+          0.0345,
+          0.0345
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.37481022102292627,
+      "wall_s": 7.2002778370224405,
+      "decode_s": 6.825467615999514,
+      "tok_s": 29.15551156283065,
+      "completion_tokens": 200,
+      "prompt_tokens": 40,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "# How a Hash Map Works: A Complete Guide\n\nA hash map (also called a hash table or dictionary) is a data structure that stores key-value pairs and provides near-constant-time lookup, insertion, and deletion. Let's build up an understanding from the ground up.\n\n---\n\n## 1. The Core Concept\n\nA hash map stores data as **key-value pairs**. You provide a key (e.g., a username) and a value (e.g., the user",
+      "text_len": 839,
+      "usage": {
+        "prompt_tokens": 40,
+        "total_tokens": 240,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 67,
+        "draft_tokens": 269,
+        "accepted": 132,
+        "accept_ratio": 0.4907,
+        "accepted_per_step": 1.97,
+        "pos": [
+          0.7761,
+          0.5821,
+          0.3582,
+          0.209,
+          0.0149,
+          0.0149,
+          0.0149
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.3804795960022602,
+      "wall_s": 6.625355467986083,
+      "decode_s": 6.244875871983822,
+      "tok_s": 31.866125777257967,
+      "completion_tokens": 200,
+      "prompt_tokens": 40,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "# How a Hash Map Works: A Complete Guide\n\nA hash map (also called a hash table or dictionary) is a data structure that stores key-value pairs and provides near-constant-time lookup, insertion, and deletion. Here's a thorough breakdown of how it works.\n\n---\n\n## 1. The Core Concept\n\nA hash map stores data as **key-value pairs**. Instead of searching through data linearly (like an array) or following",
+      "text_len": 865,
+      "usage": {
+        "prompt_tokens": 40,
+        "total_tokens": 240,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 61,
+        "draft_tokens": 253,
+        "accepted": 138,
+        "accept_ratio": 0.5455,
+        "accepted_per_step": 2.262,
+        "pos": [
+          0.8525,
+          0.6393,
+          0.459,
+          0.2623,
+          0.0164,
+          0.0164,
+          0.0164
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.3852208580065053,
+      "wall_s": 6.505960723006865,
+      "decode_s": 6.12073986500036,
+      "tok_s": 32.512409347425894,
+      "completion_tokens": 200,
+      "prompt_tokens": 40,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "# How a Hash Map Works: A Complete Guide\n\nA hash map (also called a hash table or dictionary) is a data structure that stores key-value pairs and provides near-constant-time lookup, insertion, and deletion. Here's a thorough breakdown of how it works.\n\n---\n\n## 1. The Core Concept\n\nA hash map stores data as **key-value pairs**. Instead of searching through data linearly (like an array) or following",
+      "text_len": 856,
+      "usage": {
+        "prompt_tokens": 40,
+        "total_tokens": 240,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 60,
+        "draft_tokens": 246,
+        "accepted": 142,
+        "accept_ratio": 0.5772,
+        "accepted_per_step": 2.367,
+        "pos": [
+          0.85,
+          0.6667,
+          0.5,
+          0.3,
+          0.0167,
+          0.0167,
+          0.0167
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.3794175229850225,
+      "wall_s": 7.721581268997397,
+      "decode_s": 7.342163746012375,
+      "tok_s": 27.103726760122928,
+      "completion_tokens": 200,
+      "prompt_tokens": 40,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "# How a Hash Map Works: A Complete Guide\n\nA hash map (also called a hash table or dictionary) is a data structure that stores key-value pairs and provides near-constant-time lookup, insertion, and deletion. Let's build up an understanding from the ground up.\n\n---\n\n## 1. The Core Idea\n\nA hash map lets you associate values with keys and retrieve them quickly. Instead of searching through data (like ",
+      "text_len": 883,
+      "usage": {
+        "prompt_tokens": 40,
+        "total_tokens": 240,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 73,
+        "draft_tokens": 276,
+        "accepted": 128,
+        "accept_ratio": 0.4638,
+        "accepted_per_step": 1.753,
+        "pos": [
+          0.7671,
+          0.4795,
+          0.274,
+          0.1918,
+          0.0137,
+          0.0137,
+          0.0137
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.3780590139795095,
+      "wall_s": 8.104086082981667,
+      "decode_s": 7.726027069002157,
+      "tok_s": 25.757093292931152,
+      "completion_tokens": 200,
+      "prompt_tokens": 40,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "# How a Hash Map Works: A Complete Guide\n\nA hash map (also called a hash table or dictionary) is a data structure that stores key-value pairs and provides near-constant-time lookup, insertion, and deletion. Let's build up the full picture step by step.\n\n---\n\n## 1. The Core Idea\n\nA hash map stores data in an **array of \"buckets.\"** The magic is in how it decides *which bucket* a key-value pair belo",
+      "text_len": 822,
+      "usage": {
+        "prompt_tokens": 40,
+        "total_tokens": 240,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 78,
+        "draft_tokens": 277,
+        "accepted": 121,
+        "accept_ratio": 0.4368,
+        "accepted_per_step": 1.551,
+        "pos": [
+          0.7051,
+          0.4615,
+          0.2179,
+          0.1282,
+          0.0128,
+          0.0128,
+          0.0128
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.37804529201821424,
+      "wall_s": 6.572512450016802,
+      "decode_s": 6.194467157998588,
+      "tok_s": 32.12544274176057,
+      "completion_tokens": 200,
+      "prompt_tokens": 40,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "# How a Hash Map Works: A Complete Guide\n\nA hash map (also called a hash table or dictionary) is a data structure that stores key-value pairs and provides near-constant-time lookup, insertion, and deletion. Here's a thorough breakdown of how it works.\n\n---\n\n## 1. The Core Concept\n\nA hash map stores data as **key-value pairs**. Instead of searching through data linearly (like an array) or following",
+      "text_len": 873,
+      "usage": {
+        "prompt_tokens": 40,
+        "total_tokens": 240,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 61,
+        "draft_tokens": 246,
+        "accepted": 138,
+        "accept_ratio": 0.561,
+        "accepted_per_step": 2.262,
+        "pos": [
+          0.8361,
+          0.6557,
+          0.459,
+          0.2623,
+          0.0164,
+          0.0164,
+          0.0164
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.37323058300535195,
+      "wall_s": 6.258165616018232,
+      "decode_s": 5.88493503301288,
+      "tok_s": 33.81515664721264,
+      "completion_tokens": 200,
+      "prompt_tokens": 40,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "# How a Hash Map Works: A Complete Guide\n\nA hash map (also called a hash table or dictionary) is a data structure that stores key-value pairs and provides near-constant-time lookup, insertion, and deletion. Here's a thorough breakdown of how it works.\n\n---\n\n## 1. The Core Concept\n\nA hash map stores data as **key-value pairs**. Instead of searching through data linearly (like an array) or following",
+      "text_len": 863,
+      "usage": {
+        "prompt_tokens": 40,
+        "total_tokens": 240,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 57,
+        "draft_tokens": 242,
+        "accepted": 146,
+        "accept_ratio": 0.6033,
+        "accepted_per_step": 2.561,
+        "pos": [
+          0.8772,
+          0.7544,
+          0.5614,
+          0.3158,
+          0.0175,
+          0.0175,
+          0.0175
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.37710936201619916,
+      "wall_s": 7.231037436024053,
+      "decode_s": 6.853928074007854,
+      "tok_s": 29.03444533575827,
+      "completion_tokens": 200,
+      "prompt_tokens": 40,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "# How a Hash Map Works: A Complete Guide\n\nA hash map (also called a hash table or dictionary) is a data structure that stores key-value pairs and provides near-constant-time lookup, insertion, and deletion. Let's build up the full picture step by step.\n\n---\n\n## 1. The Core Idea\n\nA hash map lets you associate values with keys and retrieve them later without searching through all the data. Instead o",
+      "text_len": 848,
+      "usage": {
+        "prompt_tokens": 40,
+        "total_tokens": 240,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 68,
+        "draft_tokens": 262,
+        "accepted": 132,
+        "accept_ratio": 0.5038,
+        "accepted_per_step": 1.941,
+        "pos": [
+          0.7794,
+          0.5441,
+          0.3382,
+          0.2353,
+          0.0147,
+          0.0147,
+          0.0147
+        ]
+      }
+    }
+  ],
+  "ts": 1788971694.8277342,
+  "prompt": "hashmap-prose",
+  "thinking": false,
+  "temperature": 0,
+  "tok_s_median": 31.866125777257967,
+  "tok_s_min": 25.757093292931152,
+  "tok_s_max": 33.81515664721264,
+  "ttft_median_s": 0.37804529201821424,
+  "completion_tokens_median": 200.0,
+  "accept_ratio_median": 0.5455,
+  "accepted_per_step_median": 2.262,
+  "any_nan": false,
+  "health_code_after": 200,
+  "short_after": {
+    "http": 200,
+    "ttft_s": 0.37291374200140126,
+    "wall_s": 0.49304492797818966,
+    "decode_s": 0.1201311859767884,
+    "tok_s": 58.269632011728675,
+    "completion_tokens": 8,
+    "prompt_tokens": 40,
+    "finish_reason": "length",
+    "nan": false,
+    "text_head": "# How a Hash Map Works: A",
+    "text_len": 25,
+    "usage": {
+      "prompt_tokens": 40,
+      "total_tokens": 48,
+      "completion_tokens": 8
+    }
+  }
+}

--- a/local/task30/task30-a-structured.json
+++ b/local/task30/task30-a-structured.json
@@ -1,0 +1,349 @@
+{
+  "phase": "a-structured",
+  "health_code": 200,
+  "health_body": "",
+  "runs": [
+    {
+      "http": 200,
+      "ttft_s": 0.3534080940007698,
+      "wall_s": 3.2288875919766724,
+      "decode_s": 2.8754794979759026,
+      "tok_s": 69.20584902103437,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.35150535599677823,
+      "wall_s": 3.2120824309822638,
+      "decode_s": 2.8605770749854855,
+      "tok_s": 69.56638286035684,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.3574152409855742,
+      "wall_s": 3.2201615379890427,
+      "decode_s": 2.8627462970034685,
+      "tok_s": 69.51366951668051,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.3517455859982874,
+      "wall_s": 3.2293711910024285,
+      "decode_s": 2.877625605004141,
+      "tok_s": 69.15423592768373,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.37169283800176345,
+      "wall_s": 3.224325826013228,
+      "decode_s": 2.8526329880114645,
+      "tok_s": 69.7601131433036,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.35398810598417185,
+      "wall_s": 3.218685997009743,
+      "decode_s": 2.864697891025571,
+      "tok_s": 69.46631287837384,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.360578952007927,
+      "wall_s": 3.210106946004089,
+      "decode_s": 2.849527993996162,
+      "tok_s": 69.83612739347878,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.3598178490065038,
+      "wall_s": 3.2043017240066547,
+      "decode_s": 2.844483875000151,
+      "tok_s": 69.95996769360819,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.3585010329843499,
+      "wall_s": 3.2192591940111015,
+      "decode_s": 2.8607581610267516,
+      "tok_s": 69.56197930711386,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    }
+  ],
+  "ts": 1788971664.4728513,
+  "prompt": "structured-count-1-200",
+  "thinking": false,
+  "temperature": 0,
+  "warmup": {
+    "tok_s": 86.75711519005753,
+    "ttft_s": 0.36114442598773167,
+    "completion_tokens": 32
+  },
+  "tok_s_median": 69.56197930711386,
+  "tok_s_min": 69.15423592768373,
+  "tok_s_max": 69.95996769360819,
+  "ttft_median_s": 0.3574152409855742,
+  "completion_tokens_median": 200.0,
+  "accept_ratio_median": 1.0,
+  "accepted_per_step_median": 7.0,
+  "any_nan": false,
+  "health_code_after": 200,
+  "short_after": {
+    "http": 200,
+    "ttft_s": 0.38413549700635485,
+    "wall_s": 0.5015875920071267,
+    "decode_s": 0.1174520950007718,
+    "tok_s": 59.5987666286753,
+    "completion_tokens": 8,
+    "prompt_tokens": 40,
+    "finish_reason": "length",
+    "nan": false,
+    "text_head": "# How a Hash Map Works: A",
+    "text_len": 25,
+    "usage": {
+      "prompt_tokens": 40,
+      "total_tokens": 48,
+      "completion_tokens": 8
+    }
+  }
+}

--- a/local/task30/task30-b-prose.json
+++ b/local/task30/task30-b-prose.json
@@ -1,0 +1,344 @@
+{
+  "phase": "b-hashmap",
+  "health_code": 200,
+  "health_body": "",
+  "runs": [
+    {
+      "http": 200,
+      "ttft_s": 0.37840165101806633,
+      "wall_s": 7.001593587017851,
+      "decode_s": 6.623191935999785,
+      "tok_s": 30.04593584527617,
+      "completion_tokens": 200,
+      "prompt_tokens": 40,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "# How a Hash Map Works: A Complete Guide\n\nA hash map (also called a hash table or dictionary) is a data structure that stores key-value pairs and provides near-constant-time lookup, insertion, and deletion. Let's build up an understanding from the ground up.\n\n---\n\n## 1. The Core Concept\n\nA hash map stores data as **key-value pairs**. You provide a key (e.g., a username) and a value (e.g., the user",
+      "text_len": 827,
+      "usage": {
+        "prompt_tokens": 40,
+        "total_tokens": 240,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 64,
+        "draft_tokens": 266,
+        "accepted": 138,
+        "accept_ratio": 0.5188,
+        "accepted_per_step": 2.156,
+        "pos": [
+          0.7969,
+          0.5938,
+          0.4219,
+          0.25,
+          0.0312,
+          0.0312,
+          0.0312
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.380624905024888,
+      "wall_s": 6.940525795012945,
+      "decode_s": 6.559900889988057,
+      "tok_s": 30.335824174374423,
+      "completion_tokens": 200,
+      "prompt_tokens": 40,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "# How a Hash Map Works: A Complete Guide\n\nA hash map (also called a hash table or dictionary) is a data structure that stores key-value pairs and provides near-constant-time lookup, insertion, and deletion. Here's a thorough breakdown of how it works under the hood.\n\n---\n\n## 1. The Core Idea\n\nA hash map lets you associate values with keys and retrieve them efficiently. Instead of searching through",
+      "text_len": 898,
+      "usage": {
+        "prompt_tokens": 40,
+        "total_tokens": 240,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 64,
+        "draft_tokens": 264,
+        "accepted": 138,
+        "accept_ratio": 0.5227,
+        "accepted_per_step": 2.156,
+        "pos": [
+          0.8125,
+          0.6094,
+          0.4219,
+          0.2656,
+          0.0156,
+          0.0156,
+          0.0156
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.3708736489934381,
+      "wall_s": 8.105460749997292,
+      "decode_s": 7.734587101003854,
+      "tok_s": 25.72858737012248,
+      "completion_tokens": 200,
+      "prompt_tokens": 40,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "# How a Hash Map Works: A Complete Guide\n\nA hash map (also called a hash table or dictionary) is a data structure that stores key-value pairs and provides near-constant-time lookup, insertion, and deletion. Let's build up an understanding from the ground up.\n\n---\n\n## 1. The Core Idea\n\nA hash map lets you associate values with keys and retrieve them efficiently. Instead of searching through data li",
+      "text_len": 878,
+      "usage": {
+        "prompt_tokens": 40,
+        "total_tokens": 240,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 77,
+        "draft_tokens": 281,
+        "accepted": 125,
+        "accept_ratio": 0.4448,
+        "accepted_per_step": 1.623,
+        "pos": [
+          0.7403,
+          0.4675,
+          0.2208,
+          0.1558,
+          0.013,
+          0.013,
+          0.013
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.3766520170029253,
+      "wall_s": 6.577977541979635,
+      "decode_s": 6.20132552497671,
+      "tok_s": 32.0899135513044,
+      "completion_tokens": 200,
+      "prompt_tokens": 40,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "# How a Hash Map Works: A Complete Guide\n\nA hash map (also called a hash table or dictionary) is a data structure that stores key-value pairs and provides near-constant-time lookup, insertion, and deletion. Let's build up an understanding from the ground up.\n\n---\n\n## 1. The Core Concept\n\nA hash map stores data as **key-value pairs**. You provide a key (e.g., a username) and a value (e.g., the user",
+      "text_len": 845,
+      "usage": {
+        "prompt_tokens": 40,
+        "total_tokens": 240,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 60,
+        "draft_tokens": 256,
+        "accepted": 142,
+        "accept_ratio": 0.5547,
+        "accepted_per_step": 2.367,
+        "pos": [
+          0.8667,
+          0.6833,
+          0.4167,
+          0.2833,
+          0.05,
+          0.0333,
+          0.0333
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.3745959480002057,
+      "wall_s": 6.602078336989507,
+      "decode_s": 6.227482388989301,
+      "tok_s": 31.95512850455399,
+      "completion_tokens": 200,
+      "prompt_tokens": 40,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "# How a Hash Map Works: A Complete Guide\n\nA hash map (also called a hash table or dictionary) is a data structure that stores key-value pairs and provides near-constant-time lookup, insertion, and deletion. Here's a thorough breakdown of how it works.\n\n---\n\n## 1. The Core Concept\n\nA hash map stores data as **key-value pairs**. Instead of searching through data linearly (like an array) or following",
+      "text_len": 856,
+      "usage": {
+        "prompt_tokens": 40,
+        "total_tokens": 240,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 60,
+        "draft_tokens": 255,
+        "accepted": 140,
+        "accept_ratio": 0.549,
+        "accepted_per_step": 2.333,
+        "pos": [
+          0.85,
+          0.6833,
+          0.4833,
+          0.2333,
+          0.0333,
+          0.0333,
+          0.0167
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.37687901000026613,
+      "wall_s": 7.025742491008714,
+      "decode_s": 6.648863481008448,
+      "tok_s": 29.929927207622143,
+      "completion_tokens": 200,
+      "prompt_tokens": 40,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "# How a Hash Map Works: A Complete Guide\n\nA hash map (also called a hash table or dictionary) is a data structure that stores key-value pairs and provides near-constant-time lookup, insertion, and deletion. Let's build up an understanding from the ground up.\n\n---\n\n## 1. The Core Concept\n\nA hash map stores data as **key-value pairs**. You provide a key (e.g., a username) and a value (e.g., the user",
+      "text_len": 839,
+      "usage": {
+        "prompt_tokens": 40,
+        "total_tokens": 240,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 65,
+        "draft_tokens": 265,
+        "accepted": 136,
+        "accept_ratio": 0.5132,
+        "accepted_per_step": 2.092,
+        "pos": [
+          0.8308,
+          0.6462,
+          0.3385,
+          0.2308,
+          0.0154,
+          0.0154,
+          0.0154
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.38793830398935825,
+      "wall_s": 6.300596907007275,
+      "decode_s": 5.912658603017917,
+      "tok_s": 33.65660244588233,
+      "completion_tokens": 200,
+      "prompt_tokens": 40,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "# How a Hash Map Works: A Complete Guide\n\nA hash map (also called a hash table or dictionary) is a data structure that stores key-value pairs and provides near-constant-time lookup, insertion, and deletion. Here's a thorough breakdown of how it works.\n\n---\n\n## 1. The Core Concept\n\nA hash map stores data as **key-value pairs**. Instead of searching through data linearly (like an array) or following",
+      "text_len": 852,
+      "usage": {
+        "prompt_tokens": 40,
+        "total_tokens": 240,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 57,
+        "draft_tokens": 244,
+        "accepted": 145,
+        "accept_ratio": 0.5943,
+        "accepted_per_step": 2.544,
+        "pos": [
+          0.8772,
+          0.7193,
+          0.5439,
+          0.3509,
+          0.0175,
+          0.0175,
+          0.0175
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.3814917119743768,
+      "wall_s": 11.57918045198312,
+      "decode_s": 11.197688740008743,
+      "tok_s": 17.771524519071836,
+      "completion_tokens": 200,
+      "prompt_tokens": 40,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "# How a Hash Map Works: A Complete Guide\n\nA hash map (also called a hash table or dictionary) is a data structure that stores key-value pairs and provides near-constant-time lookup, insertion, and deletion. Here's a thorough breakdown of how it works.\n\n---\n\n## 1. The Core Concept\n\nA hash map stores data as **key-value pairs**. Instead of searching through data linearly (like an array or linked lis",
+      "text_len": 864,
+      "usage": {
+        "prompt_tokens": 40,
+        "total_tokens": 240,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 61,
+        "draft_tokens": 246,
+        "accepted": 142,
+        "accept_ratio": 0.5772,
+        "accepted_per_step": 2.328,
+        "pos": [
+          0.8525,
+          0.6885,
+          0.5082,
+          0.2295,
+          0.0164,
+          0.0164,
+          0.0164
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.38781211400055327,
+      "wall_s": 8.193122574011795,
+      "decode_s": 7.805310460011242,
+      "tok_s": 25.495462482822674,
+      "completion_tokens": 200,
+      "prompt_tokens": 40,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "# How a Hash Map Works: A Complete Guide\n\nA hash map (also called a hash table or dictionary) is a data structure that stores key-value pairs and provides near-constant-time lookup, insertion, and deletion. Let's build up the full picture step by step.\n\n---\n\n## 1. The Core Idea\n\nA hash map lets you associate values with keys and retrieve them quickly. Instead of searching through data (like a list",
+      "text_len": 834,
+      "usage": {
+        "prompt_tokens": 40,
+        "total_tokens": 240,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 79,
+        "draft_tokens": 269,
+        "accepted": 120,
+        "accept_ratio": 0.4461,
+        "accepted_per_step": 1.519,
+        "pos": [
+          0.7468,
+          0.3797,
+          0.2152,
+          0.1392,
+          0.0127,
+          0.0127,
+          0.0127
+        ]
+      }
+    }
+  ],
+  "ts": 1788972620.934073,
+  "prompt": "hashmap-prose",
+  "thinking": false,
+  "temperature": 0,
+  "tok_s_median": 30.04593584527617,
+  "tok_s_min": 17.771524519071836,
+  "tok_s_max": 33.65660244588233,
+  "ttft_median_s": 0.37840165101806633,
+  "completion_tokens_median": 200.0,
+  "accept_ratio_median": 0.5227,
+  "accepted_per_step_median": 2.156,
+  "any_nan": false,
+  "health_code_after": 200,
+  "short_after": {
+    "http": 200,
+    "ttft_s": 0.37700139899970964,
+    "wall_s": 0.4942779279954266,
+    "decode_s": 0.11727652899571694,
+    "tok_s": 59.68798752779976,
+    "completion_tokens": 8,
+    "prompt_tokens": 40,
+    "finish_reason": "length",
+    "nan": false,
+    "text_head": "# How a Hash Map Works: A",
+    "text_len": 25,
+    "usage": {
+      "prompt_tokens": 40,
+      "total_tokens": 48,
+      "completion_tokens": 8
+    }
+  }
+}

--- a/local/task30/task30-b-structured.json
+++ b/local/task30/task30-b-structured.json
@@ -1,0 +1,349 @@
+{
+  "phase": "b-structured",
+  "health_code": 200,
+  "health_body": "",
+  "runs": [
+    {
+      "http": 200,
+      "ttft_s": 0.3568412240128964,
+      "wall_s": 3.23690887002158,
+      "decode_s": 2.8800676460086834,
+      "tok_s": 69.09559929114249,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.38159128700499423,
+      "wall_s": 3.2562728430202696,
+      "decode_s": 2.8746815560152754,
+      "tok_s": 69.22505888820702,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.3560154139995575,
+      "wall_s": 3.2139221459801774,
+      "decode_s": 2.85790673198062,
+      "tok_s": 69.63138361834737,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.35415496199857444,
+      "wall_s": 3.2541207489848603,
+      "decode_s": 2.899965786986286,
+      "tok_s": 68.62149922354966,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.3696091140154749,
+      "wall_s": 3.253829647001112,
+      "decode_s": 2.884220532985637,
+      "tok_s": 68.99611098531452,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.3729907870001625,
+      "wall_s": 3.235425363003742,
+      "decode_s": 2.8624345760035794,
+      "tok_s": 69.52123960081425,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.3608620199956931,
+      "wall_s": 3.232498430996202,
+      "decode_s": 2.871636411000509,
+      "tok_s": 69.29846662957803,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.35514192600385286,
+      "wall_s": 3.2414678490022197,
+      "decode_s": 2.886325922998367,
+      "tok_s": 68.94578273865733,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.35666580201359466,
+      "wall_s": 3.232700421998743,
+      "decode_s": 2.8760346199851483,
+      "tok_s": 69.19249115333237,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    }
+  ],
+  "ts": 1788972590.3736477,
+  "prompt": "structured-count-1-200",
+  "thinking": false,
+  "temperature": 0,
+  "warmup": {
+    "tok_s": 83.49316686165953,
+    "ttft_s": 0.3693434949964285,
+    "completion_tokens": 32
+  },
+  "tok_s_median": 69.19249115333237,
+  "tok_s_min": 68.62149922354966,
+  "tok_s_max": 69.63138361834737,
+  "ttft_median_s": 0.3568412240128964,
+  "completion_tokens_median": 200.0,
+  "accept_ratio_median": 1.0,
+  "accepted_per_step_median": 7.0,
+  "any_nan": false,
+  "health_code_after": 200,
+  "short_after": {
+    "http": 200,
+    "ttft_s": 0.4011675179935992,
+    "wall_s": 0.5213664690090809,
+    "decode_s": 0.12019895101548173,
+    "tok_s": 58.23678111049733,
+    "completion_tokens": 8,
+    "prompt_tokens": 40,
+    "finish_reason": "length",
+    "nan": false,
+    "text_head": "# How a Hash Map Works: A",
+    "text_len": 25,
+    "usage": {
+      "prompt_tokens": 40,
+      "total_tokens": 48,
+      "completion_tokens": 8
+    }
+  }
+}

--- a/local/task30/task30-return-a-acceptance.txt
+++ b/local/task30/task30-return-a-acceptance.txt
@@ -1,0 +1,33 @@
+
+== 1. served model id ==
+  PASS  /v1/models advertises GLM-5.3-Flash-EXL3
+
+== 2. basic completion, thinking OFF, temp 0 ==
+  PASS  basic completion
+
+== 3. thinking ON (reasoning parser glm45) ==
+    reasoning field: reasoning
+    reasoning chars: 157 | content chars: 547
+    finish_reason: stop
+  PASS  thinking returns reasoning + content
+
+== 4. tool call (parser glm47, auto tool choice) ==
+    finish_reason: tool_calls | tool_calls: 1
+    name: get_weather | args: {"city": "Oslo"}
+  PASS  tool call emitted and parsed
+
+== 5. production sampling: temp 1.0, thinking ON ==
+    finish_reason: stop | content chars: 374
+  PASS  temp 1.0 + thinking (the real production path)
+
+== 6. vision (LANGUAGE_MODEL_ONLY=0, limit-mm image:4) ==
+    content: Colorful
+  PASS  vision tower accepts an image
+
+== 7. long-context needle (~32k tokens) ==
+    prompt_tokens: 36040 | answer: CORMORANT-8815
+  PASS  needle retrieved at ~32k
+
+== RESULT ==
+  passed: 7   failed: 0
+  ACCEPTANCE PASSED

--- a/local/task30/task30-return-a-serving.txt
+++ b/local/task30/task30-return-a-serving.txt
@@ -1,0 +1,26 @@
+
+== 1. tunnel reaches the API ==
+  PASS  tunnel -> GLM-5.3-Flash-EXL3
+
+== 2. non-streaming chat completion ==
+  PASS  non-streaming
+
+== 3. STREAMING (SSE) — the path most clients use ==
+    SSE chunks: 11 | [DONE]: 1 | text: 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30
+  PASS  streaming works (11 chunks, terminated)
+
+== 4. concurrency — 4 simultaneous (MAX_NUM_SEQS=4) ==
+    4/4 completed with pairwise-distinct content in 2s
+  PASS  4-way concurrency, no cross-talk
+
+== 5. tool call through the tunnel ==
+    finish: tool_calls | calls: 1 | get_weather {"city": "Bergen"}
+  PASS  tool call over tunnel
+
+== 6. sustained: 5 sequential requests, all must succeed ==
+    5/5 succeeded
+  PASS  sustained sequential
+
+== RESULT ==
+  passed: 6   failed: 0
+  SERVING TEST PASSED

--- a/local/task30/task30-return-a-structured.json
+++ b/local/task30/task30-return-a-structured.json
@@ -1,0 +1,145 @@
+{
+  "phase": "return-a-structured",
+  "health_code": 200,
+  "health_body": "",
+  "runs": [
+    {
+      "http": 200,
+      "ttft_s": 0.3642152749816887,
+      "wall_s": 3.242910706991097,
+      "decode_s": 2.8786954320094083,
+      "tok_s": 69.12853572046437,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.3535790060122963,
+      "wall_s": 3.1971038480114657,
+      "decode_s": 2.8435248419991694,
+      "tok_s": 69.98356302739069,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.3568262790213339,
+      "wall_s": 3.207904644019436,
+      "decode_s": 2.851078364998102,
+      "tok_s": 69.7981516197758,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    }
+  ],
+  "ts": 1788973380.2662103,
+  "prompt": "structured-count-1-200",
+  "thinking": false,
+  "temperature": 0,
+  "warmup": {
+    "tok_s": 83.70414562213354,
+    "ttft_s": 0.3746501349960454,
+    "completion_tokens": 32
+  },
+  "tok_s_median": 69.7981516197758,
+  "tok_s_min": 69.12853572046437,
+  "tok_s_max": 69.98356302739069,
+  "ttft_median_s": 0.3568262790213339,
+  "completion_tokens_median": 200.0,
+  "accept_ratio_median": 1.0,
+  "accepted_per_step_median": 7.0,
+  "any_nan": false,
+  "health_code_after": 200,
+  "short_after": {
+    "http": 200,
+    "ttft_s": 0.3936299310007598,
+    "wall_s": 0.5232299140188843,
+    "decode_s": 0.12959998301812448,
+    "tok_s": 54.01235275641243,
+    "completion_tokens": 8,
+    "prompt_tokens": 40,
+    "finish_reason": "length",
+    "nan": false,
+    "text_head": "# How a Hash Map Works: A",
+    "text_len": 25,
+    "usage": {
+      "prompt_tokens": 40,
+      "total_tokens": 48,
+      "completion_tokens": 8
+    }
+  }
+}

--- a/local/task30/task30-revert-20260909.txt
+++ b/local/task30/task30-revert-20260909.txt
@@ -1,0 +1,59 @@
+TASK30 KDA fused_recurrent warps=2 REVERT 2026-09-09
+independent_variable=GLM53_KDA_REC_WARPS
+control=unset (stock FLA fused_recurrent_kda_fwd num_warps=1 num_stages=3 BV-cap=8)
+candidate=GLM53_KDA_REC_WARPS=2 (stages/BV remain stock / empty)
+frozen=IMAGE=glm53-selfbuild:e3-w3-zfill EXL3_FAT_GROUPED=1 EXL3_TEMP_ROWS_FUSED=32
+       GLM53_ADAPTIVE_K=ema GLM53_ADAPTIVE_K_CAPTURE=1 DFLASH_TOKENS=7 DFLASH_DRAFT_TP=1
+       DFLASH_REVISION=7d74cdd881ed7e32c31175984a67823127b66cfe
+       MAX_NUM_SEQS=4 MNBT=3584 LPTT=1792 KV pin 15414698763
+live_path=FLA vllm/third_party/flash_linear_attention/ops/kda.py fused_recurrent_kda_fwd
+          (GLM kernels.py absent on e3-w3-zfill)
+overlay=overlay/patch_kda_recurrent.py default-off; fail-closed unique launch rewrite
+        refuses FlashInfer fused_kda_decode drop-in
+sequence=A (incumbent live boot, knobs unset) -> B (warps=2, JIT wipe, health 200 @ 540s)
+         -> return-A restoration (.env.bak-pre-task30-kda-20260909-163715, JIT wipe)
+         stages/BV not chained: B already missed the prose bar
+rollback=.env.bak-pre-task30-kda-20260909-163715 (no GLM53_KDA_REC_* last-wins; applied)
+nsys_ncu=not attached. nsys 2025.3 cannot safely attach to the live CUDA-graph
+         server; ncu replay already fail-closed on this TP2 graph stack (PR #40).
+         e2e overlay A/B was the allowed overlay-only path.
+
+pool=1,396,551 tokens / 1.40x  A, B, return-A
+bind=127.0.0.1:8000
+health=200
+unit=active
+watchdog.timer=active (re-armed after restore-A smoke)
+
+A control (stock warps=1, standing production boot)
+  structured n=9  median=69.56  accept=1.000/7.0  (range 69.15-69.96)
+  hashmap n=9     median=31.87  accept_ratio=0.5455  accepted_per_step=2.262
+                  range 25.76-33.82
+  idle MemFree head/worker GiB=5.07 / 4.06
+  running=0 waiting=0 preemptions=0
+
+B candidate (GLM53_KDA_REC_WARPS=2)
+  both ranks: kda-recurrent kda.py:patched kernels.py:missing warps=2 stages= bv_cap=
+  adaptive-k graphs query lenses [3,5,8] policy ema on
+  structured n=9  median=69.19  (-0.53%) accept=1.000/7.0  (range 68.62-69.63)
+  hashmap n=9     median=30.05  (-5.71%) accept_ratio=0.5227  accepted_per_step=2.156
+                  range 17.77-33.66 (17.77 contended dip)
+  idle MemFree head/worker GiB=5.61 / 3.87 post-benches (abort floor 2.5)
+  running=0 waiting=0 preemptions=0
+
+return-A (knobs unset, stock launch)
+  both ranks: kda-recurrent knobs unset, leaving fused_recurrent_kda_fwd as-is
+  structured n=3  median=69.80  accept=1.000/7.0
+  acceptance=7/7  serving=6/6 (Mac tunnel :18000)
+  pool identical
+  idle MemFree head/worker GiB=4.21 / 4.17
+  running=0 waiting=0 preemptions=0
+  no CUDA/Xid/IMA in dmesg
+
+Verdict: REVERT / KEEP stock warps=1 stages=3 BV-cap=8.
+  Structured non-inferior (>= -3% at 7.0/1.000). Hashmap -5.7% missed the
+  >=5% prose/agentic adopt bar (sign was unknown; wash was the park rule).
+  Occupancy share at T in {3,5,8} remains unmeasured. Overlay stays in-tree
+  default-off. Do not chain STAGES or BV_CAP. Do not attach ncu to the live
+  graph process. Tasks 29/31 stay parked behind a decode-step nsys/ncu share.
+no_cuda_xid_ima=1
+geometry_unchanged=MAX_MODEL_LEN=1000000 MNBT=3584 MAX_NUM_SEQS=4 DFLASH_TOKENS=7 IMAGE=e3-w3-zfill

--- a/overlay/patch_kda_recurrent.py
+++ b/overlay/patch_kda_recurrent.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Task 30: env-gated fused_recurrent_kda launch (warps / stages / BV cap).
+
+LIVE path on ``glm53-selfbuild:e3-w3-zfill`` is FLA
+``vllm/third_party/flash_linear_attention/ops/kda.py``
+``fused_recurrent_kda_fwd``: ``num_warps=1``, ``num_stages=3``,
+``BV = min(next_power_of_2(V), 8)``. GLM TP2 local heads are 32, head_dim
+128. CUDA graphs capture this kernel at query T∈{3,5,8} (adaptive-k).
+
+This overlay **does not** port FlashInfer ``fused_kda_decode`` (H∈{12,24,48,96}
+only; no ``num_accepted_tokens`` rollback). It only rewrites the Triton
+launch constants. Default OFF: unset knobs leave the file byte-identical.
+When armed, fail-closed on drifted anchors. Not a replacement for the
+nsys/ncu occupancy oracle; an e2e A/B still needs structured 7.0/1.000
+and a predeclared decode share.
+
+Knobs (container runtime, hashed by local/prod-start.sh):
+  GLM53_KDA_REC_WARPS     unset = stock 1; allowed 1|2|4|8
+  GLM53_KDA_REC_STAGES    unset = stock 3; allowed 1..5
+  GLM53_KDA_REC_BV_CAP    unset = stock 8; allowed 8|16|32
+
+Install after patch_adaptive_k.py. Idempotent. JIT-shape: yes (Triton
+specialization). Rollback: unset all three through the guarded unit.
+"""
+from __future__ import annotations
+
+import ast
+import os
+import sys
+from pathlib import Path
+
+MARK = "# [glm53-kda-recurrent]"
+FLA = Path(
+    os.environ.get(
+        "GLM53_FLA_KDA_PY",
+        "/usr/local/lib/python3.12/dist-packages/vllm/third_party/"
+        "flash_linear_attention/ops/kda.py",
+    )
+)
+GLM = Path(
+    os.environ.get(
+        "GLM53_GLM_KDA_KERNELS_PY",
+        "/usr/local/lib/python3.12/dist-packages/vllm/models/glm5next/"
+        "nvidia/ops/third_party/kda/kernels.py",
+    )
+)
+
+LAUNCH_OLD = """    BK, BV = next_power_of_2(K), min(next_power_of_2(V), 8)
+    NK, NV = cdiv(K, BK), cdiv(V, BV)
+    assert NK == 1, "NK > 1 is not supported yet"
+    num_stages = 3
+    num_warps = 1
+"""
+
+LAUNCH_NEW = """    BK, BV = next_power_of_2(K), min(next_power_of_2(V), _glm53_kda_bv_cap())  # [glm53-kda-recurrent]
+    NK, NV = cdiv(K, BK), cdiv(V, BV)
+    assert NK == 1, "NK > 1 is not supported yet"
+    num_stages = _glm53_kda_num_stages()
+    num_warps = _glm53_kda_num_warps()
+"""
+
+HELPER = '''
+def _glm53_kda_rec_int(name: str, default: int, allowed: set[int]) -> int:  # [glm53-kda-recurrent]
+    raw = os.environ.get(name, "").strip()
+    if raw == "":
+        return default
+    try:
+        value = int(raw, 10)
+    except ValueError as exc:
+        raise SystemExit(f"{name} must be an int in {sorted(allowed)} (got {raw!r})") from exc
+    if value not in allowed:
+        raise SystemExit(f"{name} must be one of {sorted(allowed)} (got {value})")
+    return value
+
+
+def _glm53_kda_num_warps() -> int:  # [glm53-kda-recurrent]
+    return _glm53_kda_rec_int("GLM53_KDA_REC_WARPS", 1, {1, 2, 4, 8})
+
+
+def _glm53_kda_num_stages() -> int:  # [glm53-kda-recurrent]
+    return _glm53_kda_rec_int("GLM53_KDA_REC_STAGES", 3, {1, 2, 3, 4, 5})
+
+
+def _glm53_kda_bv_cap() -> int:  # [glm53-kda-recurrent]
+    return _glm53_kda_rec_int("GLM53_KDA_REC_BV_CAP", 8, {8, 16, 32})
+
+'''
+
+INSERT_AFTER = (
+    "NUM_WARPS_AUTOTUNE = [2, 4, 8, 16] if is_amd else [4, 8, 16, 32]\n"
+)
+
+
+def knobs_armed() -> bool:
+    return any(
+        os.environ.get(k, "").strip()
+        for k in ("GLM53_KDA_REC_WARPS", "GLM53_KDA_REC_STAGES", "GLM53_KDA_REC_BV_CAP")
+    )
+
+
+def _need_os_import(text: str) -> bool:
+    head = text.split("def fused_recurrent_kda_fwd", 1)[0]
+    return "import os\n" not in head and "\nimport os\n" not in ("\n" + head)
+
+
+def validate(path: Path, text: str) -> None:
+    ast.parse(text, filename=str(path))
+    if text.count(MARK) < 5:
+        raise SystemExit(f"{path}: kda-recurrent marker incomplete ({text.count(MARK)})")
+    if text.count("def _glm53_kda_num_warps()") != 1:
+        raise SystemExit(f"{path}: helper missing or duplicated")
+    if LAUNCH_OLD in text:
+        raise SystemExit(f"{path}: stock launch block still present")
+    if LAUNCH_NEW not in text:
+        raise SystemExit(f"{path}: patched launch block missing")
+    if "num_warps = _glm53_kda_num_warps()" not in text:
+        raise SystemExit(f"{path}: launch does not call warps helper")
+
+
+def patch_one(path: Path) -> str:
+    if not path.is_file():
+        return "missing"
+    text = path.read_text()
+    if MARK in text:
+        validate(path, text)
+        return "already"
+    if not knobs_armed():
+        return "skip"
+    if text.count(LAUNCH_OLD) != 1:
+        raise SystemExit(
+            f"{path}: launch anchor found {text.count(LAUNCH_OLD)} times (expected 1)"
+        )
+    if text.count(INSERT_AFTER) != 1:
+        raise SystemExit(
+            f"{path}: helper insert point found {text.count(INSERT_AFTER)} times (expected 1)"
+        )
+    if _need_os_import(text):
+        # Keep a top-level os import ahead of the helpers.
+        if "import torch\n" not in text:
+            raise SystemExit(f"{path}: cannot insert import os (no import torch)")
+        text = text.replace("import torch\n", "import os\nimport torch\n", 1)
+    text = text.replace(INSERT_AFTER, INSERT_AFTER + HELPER, 1)
+    text = text.replace(LAUNCH_OLD, LAUNCH_NEW, 1)
+    validate(path, text)
+    tmp = path.with_suffix(path.suffix + ".glm53-kda-recurrent.tmp")
+    tmp.write_text(text)
+    os.replace(tmp, path)
+    return "patched"
+
+
+def main() -> int:
+    if not knobs_armed():
+        print("kda-recurrent: knobs unset, leaving fused_recurrent_kda_fwd as-is")
+        return 0
+    statuses = []
+    found = 0
+    for path in (FLA, GLM):
+        status = patch_one(path)
+        statuses.append(f"{path.name}:{status}")
+        if status in ("patched", "already"):
+            found += 1
+        elif status == "missing":
+            continue
+        elif status == "skip":
+            continue
+    if found == 0:
+        print(
+            "kda-recurrent FATAL: armed knobs but no fused_recurrent_kda_fwd "
+            f"target (tried {FLA} and {GLM})",
+            file=sys.stderr,
+        )
+        return 1
+    warps = os.environ.get("GLM53_KDA_REC_WARPS", "1")
+    stages = os.environ.get("GLM53_KDA_REC_STAGES", "3")
+    bv = os.environ.get("GLM53_KDA_REC_BV_CAP", "8")
+    print(
+        "kda-recurrent: "
+        + " ".join(statuses)
+        + f" warps={warps} stages={stages} bv_cap={bv}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except SystemExit:
+        raise
+    except Exception as exc:  # pragma: no cover — fail closed
+        print(f"kda-recurrent FATAL: {exc}", file=sys.stderr)
+        sys.exit(1)

--- a/start.sh
+++ b/start.sh
@@ -230,6 +230,8 @@ FGAPC_PATCH_HOST="${FGAPC_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_fine_grained_apc
 ALIGN_FLOOR_PATCH_HOST="${ALIGN_FLOOR_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_align_floor.py}"
 # LOCAL: task 25 — verification-only adaptive-k (kit #139 split, default off)
 ADAPTIVE_K_PATCH_HOST="${ADAPTIVE_K_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_adaptive_k.py}"
+# LOCAL: task 30 — fused_recurrent_kda launch (warps/stages/BV cap), default off
+KDA_REC_PATCH_HOST="${KDA_REC_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_kda_recurrent.py}"
 # LOCAL: W41 (kit PR #94) block-level KV capacity boot log, log-only; W42 (kit PR #95) per-request APC no-store
 KV_CAPACITY_LOG_PATCH_HOST="${KV_CAPACITY_LOG_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_kv_capacity_log.py}"
 APC_NO_STORE_PATCH_HOST="${APC_NO_STORE_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_apc_no_store.py}"
@@ -321,6 +323,10 @@ GLM53_ADAPTIVE_K_MARGIN="${GLM53_ADAPTIVE_K_MARGIN:-1.0}"
 GLM53_ADAPTIVE_K_MIN_STEPS="${GLM53_ADAPTIVE_K_MIN_STEPS:-4}"
 GLM53_ADAPTIVE_K_SATURATE="${GLM53_ADAPTIVE_K_SATURATE:-max}"
 GLM53_ADAPTIVE_K_HIST="${GLM53_ADAPTIVE_K_HIST:-200}"
+# LOCAL: task 30 fused_recurrent_kda launch. Empty = stock warps=1 / stages=3 / BV-cap=8.
+GLM53_KDA_REC_WARPS="${GLM53_KDA_REC_WARPS:-}"
+GLM53_KDA_REC_STAGES="${GLM53_KDA_REC_STAGES:-}"
+GLM53_KDA_REC_BV_CAP="${GLM53_KDA_REC_BV_CAP:-}"
 if [ "${ENFORCE_EAGER}" != "1" ]; then
     case " ${EXTRA_ARGS:-} " in
         *" --cudagraph-capture-sizes "*|*" cudagraph-capture-sizes "*) ;;
@@ -574,6 +580,19 @@ validate_numeric_config() {
     GLM53_ADAPTIVE_K_HIST="$((10#$_ak_hist))"
     export GLM53_ADAPTIVE_K_HIST
     unset _ak_hist
+    # LOCAL: task 30 — fused_recurrent_kda launch. Empty = stock (1 / 3 / 8).
+    case "${GLM53_KDA_REC_WARPS:-}" in
+        ""|1|2|4|8) ;;
+        *) echo "GLM53_KDA_REC_WARPS must be empty (stock 1) or one of: 1 2 4 8 (got: '${GLM53_KDA_REC_WARPS}')" >&2; return 2 ;;
+    esac
+    case "${GLM53_KDA_REC_STAGES:-}" in
+        ""|1|2|3|4|5) ;;
+        *) echo "GLM53_KDA_REC_STAGES must be empty (stock 3) or one of: 1 2 3 4 5 (got: '${GLM53_KDA_REC_STAGES}')" >&2; return 2 ;;
+    esac
+    case "${GLM53_KDA_REC_BV_CAP:-}" in
+        ""|8|16|32) ;;
+        *) echo "GLM53_KDA_REC_BV_CAP must be empty (stock 8) or one of: 8 16 32 (got: '${GLM53_KDA_REC_BV_CAP}')" >&2; return 2 ;;
+    esac
     # Capture list is a configuration-shape change (prod-start hashes EXTRA_ARGS).
     # Extra 3/5 multiples are the independent B0/B variable; stock stays 1 2 4 8 16 24 32.
     if [ "$SPEC_METHOD" = dflash ]; then
@@ -782,6 +801,7 @@ preflight() {
     [ -f "$FGAPC_PATCH_HOST" ] || die "$FGAPC_PATCH_HOST missing"  # LOCAL: W18
     [ -f "$ALIGN_FLOOR_PATCH_HOST" ] || die "$ALIGN_FLOOR_PATCH_HOST missing"  # LOCAL: align-floor
     [ -f "$ADAPTIVE_K_PATCH_HOST" ] || die "$ADAPTIVE_K_PATCH_HOST missing"  # LOCAL: task 25
+    [ -f "$KDA_REC_PATCH_HOST" ] || die "$KDA_REC_PATCH_HOST missing"  # LOCAL: task 30
     [ -f "$KV_CAPACITY_LOG_PATCH_HOST" ] || die "$KV_CAPACITY_LOG_PATCH_HOST missing"  # LOCAL: W41
     [ -f "$APC_NO_STORE_PATCH_HOST" ] || die "$APC_NO_STORE_PATCH_HOST missing"  # LOCAL: W42
     [ -f "$INDEXER_WORKSPACE_PATCH_HOST" ] || die "$INDEXER_WORKSPACE_PATCH_HOST missing"  # LOCAL: W28
@@ -1311,6 +1331,9 @@ fi
 if [ -f /opt/glm53/patch_adaptive_k.py ]; then  # LOCAL: task 25 (after align-floor)
     python3 -S /opt/glm53/patch_adaptive_k.py
 fi
+if [ -f /opt/glm53/patch_kda_recurrent.py ]; then  # LOCAL: task 30 (after adaptive-k)
+    python3 -S /opt/glm53/patch_kda_recurrent.py
+fi
 if [ -f /opt/glm53/patch_kv_capacity_log.py ]; then  # LOCAL: W41 (after patch_hybrid_prefix_hit.py)
     python3 -S /opt/glm53/patch_kv_capacity_log.py
 fi
@@ -1450,6 +1473,9 @@ fi
 if [ -f /opt/glm53/patch_adaptive_k.py ]; then  # LOCAL: task 25 (after align-floor)
     python3 -S /opt/glm53/patch_adaptive_k.py
 fi
+if [ -f /opt/glm53/patch_kda_recurrent.py ]; then  # LOCAL: task 30 (after adaptive-k)
+    python3 -S /opt/glm53/patch_kda_recurrent.py
+fi
 if [ -f /opt/glm53/patch_kv_capacity_log.py ]; then  # LOCAL: W41 (after patch_hybrid_prefix_hit.py)
     python3 -S /opt/glm53/patch_kv_capacity_log.py
 fi
@@ -1512,6 +1538,8 @@ launch_cluster() {
     scp -q -o BatchMode=yes "$ALIGN_FLOOR_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_align_floor.py"
     [ -f "$ADAPTIVE_K_PATCH_HOST" ] || die "missing $ADAPTIVE_K_PATCH_HOST"
     scp -q -o BatchMode=yes "$ADAPTIVE_K_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_adaptive_k.py"
+    [ -f "$KDA_REC_PATCH_HOST" ] || die "missing $KDA_REC_PATCH_HOST"
+    scp -q -o BatchMode=yes "$KDA_REC_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_kda_recurrent.py"
     [ -f "$KV_CAPACITY_LOG_PATCH_HOST" ] || die "missing $KV_CAPACITY_LOG_PATCH_HOST"  # LOCAL: W41
     scp -q -o BatchMode=yes "$KV_CAPACITY_LOG_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_kv_capacity_log.py"
     [ -f "$APC_NO_STORE_PATCH_HOST" ] || die "missing $APC_NO_STORE_PATCH_HOST"  # LOCAL: W42
@@ -1565,6 +1593,9 @@ launch_cluster() {
         -e "GLM53_ADAPTIVE_K_MIN_STEPS=$GLM53_ADAPTIVE_K_MIN_STEPS"
         -e "GLM53_ADAPTIVE_K_SATURATE=$GLM53_ADAPTIVE_K_SATURATE"
         -e "GLM53_ADAPTIVE_K_HIST=$GLM53_ADAPTIVE_K_HIST"
+        -e "GLM53_KDA_REC_WARPS=$GLM53_KDA_REC_WARPS"
+        -e "GLM53_KDA_REC_STAGES=$GLM53_KDA_REC_STAGES"
+        -e "GLM53_KDA_REC_BV_CAP=$GLM53_KDA_REC_BV_CAP"
         -e "GLM53_KV_CAPACITY_LOG=$GLM53_KV_CAPACITY_LOG"  # LOCAL: W41
         -e "GLM53_APC_NO_STORE=$GLM53_APC_NO_STORE"  # LOCAL: W42
         -e "GLM53_INDEXER_WORKSPACE=$GLM53_INDEXER_WORKSPACE"  # LOCAL: W28
@@ -1673,6 +1704,7 @@ launch_cluster() {
         -v '/tmp/patch_fine_grained_apc.py:/opt/glm53/patch_fine_grained_apc.py:ro' \
         -v '/tmp/patch_align_floor.py:/opt/glm53/patch_align_floor.py:ro' \
         -v '/tmp/patch_adaptive_k.py:/opt/glm53/patch_adaptive_k.py:ro' \
+        -v '/tmp/patch_kda_recurrent.py:/opt/glm53/patch_kda_recurrent.py:ro' \
         -v '/tmp/patch_kv_capacity_log.py:/opt/glm53/patch_kv_capacity_log.py:ro' \
         -v '/tmp/patch_apc_no_store.py:/opt/glm53/patch_apc_no_store.py:ro' \
         -v '/tmp/patch_w28_correctness.py:/opt/glm53/patch_w28_correctness.py:ro' \
@@ -1714,6 +1746,7 @@ launch_cluster() {
         -v "$FGAPC_PATCH_HOST:/opt/glm53/patch_fine_grained_apc.py:ro" \
         -v "$ALIGN_FLOOR_PATCH_HOST:/opt/glm53/patch_align_floor.py:ro" \
         -v "$ADAPTIVE_K_PATCH_HOST:/opt/glm53/patch_adaptive_k.py:ro" \
+        -v "$KDA_REC_PATCH_HOST:/opt/glm53/patch_kda_recurrent.py:ro" \
         -v "$KV_CAPACITY_LOG_PATCH_HOST:/opt/glm53/patch_kv_capacity_log.py:ro" \
         -v "$APC_NO_STORE_PATCH_HOST:/opt/glm53/patch_apc_no_store.py:ro" \
         -v "$W28_CORRECTNESS_PATCH_HOST:/opt/glm53/patch_w28_correctness.py:ro" \

--- a/tests/fixtures/kda-recurrent-fla.py
+++ b/tests/fixtures/kda-recurrent-fla.py
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Songlin Yang, Yu Zhang
+#
+# This file contains code copied from the flash-linear-attention project.
+# The original source code was licensed under the MIT license and included
+# the following copyright notice:
+# Copyright (c) 2023-2025, Songlin Yang, Yu Zhang
+# ruff: noqa: E501
+
+
+import torch
+import torch.nn as nn
+
+from vllm.model_executor.custom_op import CustomOp
+from vllm.triton_utils import tl, triton
+from vllm.utils.math_utils import RCP_LN2, cdiv, next_power_of_2
+
+from .chunk_delta_h import chunk_gated_delta_rule_fwd_h
+from .cumsum import chunk_local_cumsum
+from .fused_recurrent import fused_recurrent_gated_delta_rule_fwd_kernel
+from .index import prepare_chunk_indices
+from .l2norm import l2norm_fwd
+from .op import exp2, log
+from .solve_tril import solve_tril
+from .utils import FLA_CHUNK_SIZE, is_amd
+
+BT_LIST_AUTOTUNE = [32, 64, 128]
+NUM_WARPS_AUTOTUNE = [2, 4, 8, 16] if is_amd else [4, 8, 16, 32]
+
+
+def fused_recurrent_kda_fwd(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+    beta: torch.Tensor,
+    scale: float,
+    initial_state: torch.Tensor,
+    inplace_final_state: bool = True,
+    cu_seqlens: torch.Tensor | None = None,
+    ssm_state_indices: torch.Tensor | None = None,
+    num_accepted_tokens: torch.Tensor | None = None,
+    use_qk_l2norm_in_kernel: bool = False,
+    out: torch.Tensor | None = None,
+    sigmoid_beta: bool = False,
+    a_log: torch.Tensor | None = None,
+    g_bias: torch.Tensor | None = None,
+    compute_gate: bool = False,
+    lower_bound: float | None = -5.0,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    B, T, H, K, V = *k.shape, v.shape[-1]
+    HV = v.shape[2]
+    N = B if cu_seqlens is None else len(cu_seqlens) - 1
+    BK, BV = next_power_of_2(K), min(next_power_of_2(V), 8)
+    NK, NV = cdiv(K, BK), cdiv(V, BV)
+    assert NK == 1, "NK > 1 is not supported yet"
+    num_stages = 3
+    num_warps = 1
+
+    if compute_gate:
+        a_log = a_log
+    grid = (NK, NV, N * HV)
+    fused_recurrent_gated_delta_rule_fwd_kernel[grid](
+        q=q, k=k, v=v, g=g, beta=beta, o=o, h0=initial_state, ht=final_state,
+        num_warps=num_warps, num_stages=num_stages,
+    )
+    return o, final_state

--- a/tests/test_kda_recurrent_patch.py
+++ b/tests/test_kda_recurrent_patch.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""Apply overlay/patch_kda_recurrent.py against the live FLA launch fixture.
+
+Hard gates:
+  * default-off leaves the stock warps=1 / stages=3 / BV-cap=8 block
+  * armed knobs rewrite only that unique launch
+  * helpers refuse illegal values
+  * installer is idempotent
+  * FlashInfer fused_kda_decode is not imported
+"""
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+PATCH = HERE.parent / "overlay" / "patch_kda_recurrent.py"
+FIXTURE = HERE / "fixtures" / "kda-recurrent-fla.py"
+STOCK = (
+    "    BK, BV = next_power_of_2(K), min(next_power_of_2(V), 8)\n"
+    "    NK, NV = cdiv(K, BK), cdiv(V, BV)\n"
+    "    assert NK == 1, \"NK > 1 is not supported yet\"\n"
+    "    num_stages = 3\n"
+    "    num_warps = 1\n"
+)
+
+
+def _helpers(text: str) -> dict:
+    start = text.index("def _glm53_kda_rec_int")
+    end = text.index("def fused_recurrent_kda_fwd")
+    ns: dict = {"os": os}
+    exec(compile("import os\n" + text[start:end], "<kda-helpers>", "exec"), ns)
+    return ns
+
+
+def _run(tmp: Path, env: dict[str, str] | None = None, glm_present: bool = False) -> subprocess.CompletedProcess[str]:
+    fla = tmp / "kda.py"
+    shutil.copy2(FIXTURE, fla)
+    glm = tmp / "kernels.py"
+    if glm_present:
+        shutil.copy2(FIXTURE, glm)
+    full_env = {**os.environ, "GLM53_FLA_KDA_PY": str(fla), "PYTHONPATH": ""}
+    if glm_present:
+        full_env["GLM53_GLM_KDA_KERNELS_PY"] = str(glm)
+    else:
+        full_env["GLM53_GLM_KDA_KERNELS_PY"] = str(tmp / "missing-kernels.py")
+    if env:
+        full_env.update(env)
+    return subprocess.run(
+        [sys.executable, "-S", str(PATCH)],
+        cwd=tmp,
+        env=full_env,
+        text=True,
+        capture_output=True,
+        check=False,
+    ), fla, glm
+
+
+def test_default_off_leaves_stock() -> None:
+    with tempfile.TemporaryDirectory() as raw:
+        tmp = Path(raw)
+        result, fla, _ = _run(tmp)
+        assert result.returncode == 0, result.stderr
+        assert "knobs unset" in result.stdout
+        text = fla.read_text()
+        assert STOCK in text
+        assert "[glm53-kda-recurrent]" not in text
+        assert "fused_kda_decode" not in text
+
+
+def test_armed_rewrites_launch_and_is_idempotent() -> None:
+    with tempfile.TemporaryDirectory() as raw:
+        tmp = Path(raw)
+        result, fla, _ = _run(
+            tmp,
+            env={"GLM53_KDA_REC_WARPS": "2", "GLM53_KDA_REC_STAGES": "3", "GLM53_KDA_REC_BV_CAP": "8"},
+        )
+        assert result.returncode == 0, result.stderr
+        text = fla.read_text()
+        assert STOCK not in text
+        assert "num_warps = _glm53_kda_num_warps()" in text
+        assert "min(next_power_of_2(V), _glm53_kda_bv_cap())" in text
+        assert "fused_kda_decode" not in text
+        helpers = _helpers(text)
+        os.environ["GLM53_KDA_REC_WARPS"] = "2"
+        os.environ["GLM53_KDA_REC_STAGES"] = "3"
+        os.environ["GLM53_KDA_REC_BV_CAP"] = "8"
+        try:
+            assert helpers["_glm53_kda_num_warps"]() == 2
+            assert helpers["_glm53_kda_num_stages"]() == 3
+            assert helpers["_glm53_kda_bv_cap"]() == 8
+        finally:
+            os.environ.pop("GLM53_KDA_REC_WARPS", None)
+            os.environ.pop("GLM53_KDA_REC_STAGES", None)
+            os.environ.pop("GLM53_KDA_REC_BV_CAP", None)
+        again, fla2, _ = _run(
+            tmp,
+            env={"GLM53_KDA_REC_WARPS": "2"},
+        )
+        # Second apply uses the already-patched file via GLM53_FLA_KDA_PY on a
+        # fresh copy; re-copy then apply twice on the same file.
+        patched = fla.read_text()
+        fla.write_text(patched)
+        result2 = subprocess.run(
+            [sys.executable, "-S", str(PATCH)],
+            cwd=tmp,
+            env={
+                **os.environ,
+                "GLM53_FLA_KDA_PY": str(fla),
+                "GLM53_GLM_KDA_KERNELS_PY": str(tmp / "missing-kernels.py"),
+                "GLM53_KDA_REC_WARPS": "2",
+            },
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        assert result2.returncode == 0, result2.stderr
+        assert "already" in result2.stdout
+        assert fla.read_text() == patched
+        del again, fla2
+
+
+def test_helpers_refuse_illegal_values() -> None:
+    with tempfile.TemporaryDirectory() as raw:
+        tmp = Path(raw)
+        result, fla, _ = _run(tmp, env={"GLM53_KDA_REC_WARPS": "3"})
+        assert result.returncode == 0, result.stderr
+        helpers = _helpers(fla.read_text())
+        os.environ["GLM53_KDA_REC_WARPS"] = "3"
+        try:
+            raised = False
+            try:
+                helpers["_glm53_kda_num_warps"]()
+            except SystemExit as exc:
+                raised = True
+                assert "GLM53_KDA_REC_WARPS" in str(exc)
+            assert raised
+        finally:
+            os.environ.pop("GLM53_KDA_REC_WARPS", None)
+
+
+def test_armed_missing_targets_fail_closed() -> None:
+    with tempfile.TemporaryDirectory() as raw:
+        tmp = Path(raw)
+        env = {
+            **os.environ,
+            "GLM53_FLA_KDA_PY": str(tmp / "no-fla.py"),
+            "GLM53_GLM_KDA_KERNELS_PY": str(tmp / "no-glm.py"),
+            "GLM53_KDA_REC_WARPS": "2",
+        }
+        result = subprocess.run(
+            [sys.executable, "-S", str(PATCH)],
+            cwd=tmp,
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        assert result.returncode == 1, (result.returncode, result.stdout, result.stderr)
+        assert "no fused_recurrent_kda_fwd" in (result.stderr + result.stdout)
+
+
+def test_drifted_anchor_fails_closed() -> None:
+    with tempfile.TemporaryDirectory() as raw:
+        tmp = Path(raw)
+        fla = tmp / "kda.py"
+        text = FIXTURE.read_text().replace("num_warps = 1", "num_warps = 4", 1)
+        fla.write_text(text)
+        result = subprocess.run(
+            [sys.executable, "-S", str(PATCH)],
+            cwd=tmp,
+            env={
+                **os.environ,
+                "GLM53_FLA_KDA_PY": str(fla),
+                "GLM53_GLM_KDA_KERNELS_PY": str(tmp / "missing-kernels.py"),
+                "GLM53_KDA_REC_WARPS": "2",
+            },
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        assert result.returncode == 1, (result.returncode, result.stdout, result.stderr)
+        assert "launch anchor found 0 times" in (result.stderr + result.stdout)
+
+
+if __name__ == "__main__":
+    test_default_off_leaves_stock()
+    test_armed_rewrites_launch_and_is_idempotent()
+    test_helpers_refuse_illegal_values()
+    test_armed_missing_targets_fail_closed()
+    test_drifted_anchor_fails_closed()
+    print("kda-recurrent overlay OK")

--- a/tests/test_kda_recurrent_wiring.py
+++ b/tests/test_kda_recurrent_wiring.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Static wiring guards for the Task 30 fused_recurrent_kda overlay."""
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+START = (ROOT / "start.sh").read_text(encoding="utf-8")
+PROD_START = (ROOT / "local" / "prod-start.sh").read_text(encoding="utf-8")
+OVERLAY = (ROOT / "overlay" / "patch_kda_recurrent.py").read_text(encoding="utf-8")
+ENV_EXAMPLE = (ROOT / "env.example").read_text(encoding="utf-8")
+DOCS_02 = (ROOT / "docs" / "02-parameters.md").read_text(encoding="utf-8")
+
+
+def _count(s: str) -> int:
+    return START.count(s)
+
+
+def test_overlay_wired_six_ways() -> None:
+    host_var = "KDA_REC_PATCH_HOST"
+    fname = "patch_kda_recurrent.py"
+    assert (ROOT / "overlay" / fname).is_file()
+    assert f'{host_var}="${{{host_var}:-$SCRIPT_DIR/overlay/{fname}}}"' in START
+    assert f'[ -f "${host_var}" ] || die "${host_var} missing"' in START
+    assert f'scp -q -o BatchMode=yes "${host_var}" "${{WORKER_SSH}}:/tmp/{fname}"' in START
+    assert f"-v '/tmp/{fname}:/opt/glm53/{fname}:ro'" in START
+    assert f'-v "${host_var}:/opt/glm53/{fname}:ro"' in START
+    assert _count(f"python3 -S /opt/glm53/{fname}") == 2
+    assert START.index("python3 -S /opt/glm53/patch_adaptive_k.py") < START.index(
+        "python3 -S /opt/glm53/patch_kda_recurrent.py"
+    )
+    assert START.index("python3 -S /opt/glm53/patch_kda_recurrent.py") < START.index(
+        "python3 -S /opt/glm53/patch_kv_capacity_log.py"
+    )
+
+
+def test_env_defaults_off_and_reach_both_ranks() -> None:
+    assert 'GLM53_KDA_REC_WARPS="${GLM53_KDA_REC_WARPS:-}"' in START
+    assert 'GLM53_KDA_REC_STAGES="${GLM53_KDA_REC_STAGES:-}"' in START
+    assert 'GLM53_KDA_REC_BV_CAP="${GLM53_KDA_REC_BV_CAP:-}"' in START
+    for knob in (
+        "GLM53_KDA_REC_WARPS",
+        "GLM53_KDA_REC_STAGES",
+        "GLM53_KDA_REC_BV_CAP",
+    ):
+        assert f'-e "{knob}=${knob}"' in START
+    assert '"${nccl_common[@]}"' in START and 'for e in "${nccl_common[@]}"' in START
+
+
+def test_overlay_refuses_flashinfer_decode() -> None:
+    assert "import" not in OVERLAY.lower().split("fused_kda_decode", 1)[0][-40:]
+    assert "Does not" in OVERLAY or "does not" in OVERLAY
+    assert "fused_kda_decode" in OVERLAY  # named only as a refused drop-in
+    assert "from vllm" not in OVERLAY
+    assert "num_warps = 1" in OVERLAY
+    assert "num_stages = 3" in OVERLAY
+    assert "min(next_power_of_2(V), 8)" in OVERLAY
+
+
+def test_prod_start_hashes_kda_recurrent() -> None:
+    hash_line = [ln for ln in PROD_START.splitlines() if "shape_hash=" in ln][0]
+    assert "GLM53_KDA_REC_WARPS" in hash_line
+    assert "GLM53_KDA_REC_STAGES" in hash_line
+    assert "GLM53_KDA_REC_BV_CAP" in hash_line
+    assert "printf 'GLM53_KDA_REC_WARPS=%s" in PROD_START
+
+
+def test_docs_and_env_example_name_the_knobs() -> None:
+    assert "GLM53_KDA_REC_WARPS" in ENV_EXAMPLE
+    assert "GLM53_KDA_REC_STAGES" in ENV_EXAMPLE
+    assert "GLM53_KDA_REC_BV_CAP" in ENV_EXAMPLE
+    assert "Task 30" in ENV_EXAMPLE or "task 30" in ENV_EXAMPLE.lower()
+    assert "GLM53_KDA_REC_WARPS" in DOCS_02
+    assert "fused_recurrent_kda" in DOCS_02
+
+
+if __name__ == "__main__":
+    test_overlay_wired_six_ways()
+    test_env_defaults_off_and_reach_both_ranks()
+    test_overlay_refuses_flashinfer_decode()
+    test_prod_start_hashes_kda_recurrent()
+    test_docs_and_env_example_name_the_knobs()
+    print("kda-recurrent wiring guards OK")

--- a/tests/test_numeric_config.py
+++ b/tests/test_numeric_config.py
@@ -267,6 +267,48 @@ def test_adaptive_k_defaults_and_refusals() -> None:
     assert mtp_custom.returncode == 0, mtp_custom.stderr
 
 
+def test_kda_recurrent_defaults_and_refusals() -> None:
+    ok = validate("0.87", "1000000", "4", "1024")
+    assert ok.returncode == 0, ok.stderr
+    for extra in (
+        {"GLM53_KDA_REC_WARPS": "1"},
+        {"GLM53_KDA_REC_WARPS": "2"},
+        {"GLM53_KDA_REC_STAGES": "3"},
+        {"GLM53_KDA_REC_STAGES": "4"},
+        {"GLM53_KDA_REC_BV_CAP": "8"},
+        {"GLM53_KDA_REC_BV_CAP": "16"},
+        {"GLM53_KDA_REC_BV_CAP": "32"},
+    ):
+        result = validate("0.87", "1000000", "4", "1024", extra_env=extra)
+        assert result.returncode == 0, (extra, result.stderr)
+    refused_warps = validate(
+        "0.87",
+        "1000000",
+        "4",
+        "1024",
+        extra_env={"GLM53_KDA_REC_WARPS": "3"},
+    )
+    assert refused_warps.returncode == 2
+    assert "GLM53_KDA_REC_WARPS must be empty" in refused_warps.stderr
+    refused_stages = validate(
+        "0.87",
+        "1000000",
+        "4",
+        "1024",
+        extra_env={"GLM53_KDA_REC_STAGES": "6"},
+    )
+    assert refused_stages.returncode == 2
+    refused_bv = validate(
+        "0.87",
+        "1000000",
+        "4",
+        "1024",
+        extra_env={"GLM53_KDA_REC_BV_CAP": "64"},
+    )
+    assert refused_bv.returncode == 2
+    assert "GLM53_KDA_REC_BV_CAP must be empty" in refused_bv.stderr
+
+
 def test_trf_floor_allows_32_refuses_31() -> None:
     """W2: C4 dflash floor is 4×(7+1)=32. Isolated 32 is legal; 31 is not."""
     allowed_default = validate("0.87", "1000000", "4", "1024")
@@ -335,6 +377,7 @@ if __name__ == "__main__":
     test_matrix()
     test_decimal_normalization()
     test_adaptive_k_defaults_and_refusals()
+    test_kda_recurrent_defaults_and_refusals()
     test_trf_floor_allows_32_refuses_31()
     test_restart_validates_before_stop()
     print("numeric config tests: PASS")


### PR DESCRIPTION
Task 30 A/B'd `GLM53_KDA_REC_WARPS=2` against stock FLA
`fused_recurrent_kda_fwd` (`num_warps=1`, `num_stages=3`, BV-cap=8) on
the current production stack (`e3-w3-zfill`, TRF=32, adaptive-k ema,
k=7, C4, DFlash `7d74cdd`). Independent variable was warps only;
stages and BV stayed stock. Live path is FLA `ops/kda.py` (GLM
`kernels.py` is absent on this image). The overlay is default-off,
fail-closed on drifted unique-launch anchors, and refuses a FlashInfer
`fused_kda_decode` drop-in. Knobs are in the JIT shape hash; caches
were wiped both directions through the guarded unit.

Cluster A vs B: hashmap 31.87 → 30.05 tok/s (−5.7%). Structured stayed
7.0/1.000 (69.56 → 69.19, −0.5%). Stages/BV were not chained because B
already missed the ≥5% prose bar. nsys/ncu occupancy at T∈{3,5,8} was
not attached (nsys 2025.3 cannot safely attach to this CUDA-graph
server; ncu replay already fail-closed on the TP2 graph stack, PR #40).

Verdict: REVERT. Occupancy share remains unmeasured. Overlay stays
in-tree default-off. Production last-wins restored unset knobs
(`.env.bak-pre-task30-kda-20260909-163715`). Return-A restoration
smoke: structured 69.80 @ 7.0/1.000, acceptance 7/7, serving 6/6,
watchdog re-armed. Do not chain STAGES or BV_CAP. Do not attach ncu to
the live graph process.

This PR records the window: default-off overlay, six-way launcher
wiring, JIT hash, docs/02 / docs/06 / docs/11, tests, and cluster
receipts under `local/task30/`.
