### PR TITLE
Adaptive-k: Task 32 SATURATE=n measured and reverted

### DIFF
--- a/docs/02-parameters.md
+++ b/docs/02-parameters.md
@@ -180,6 +180,17 @@ cache is invisible to it). 0.87 demands 105.87 GiB free against boots measured a
   (6.00/5.74 → 4.90/4.57 GiB), still above the 2.5 GiB abort. Rollback
   both knobs to `off`/`0` through the guarded unit (stock
   `1 2 4 8 16 24 32`, no image rebuild).
+- `GLM53_ADAPTIVE_K_SATURATE` — leftover Task 25 policy knob.
+  **REVERTED 2026-09-09 at `n`.** Production last-wins stay unset
+  (launcher default `max`). `max` treats a fully-accepted prefix as
+  k=7 so the EMA can climb; `n` records the accepted count and never
+  climbs after a low-accept stretch. Policy-only: not in the JIT
+  shape hash, no cubin, no extra graphs. Isolated A vs B on
+  `e3-w3-zfill` / TRF=32 / ema / extra graphs / k=7: hashmap
+  29.09 → 28.90 (−0.7%), essay 24.95 → 25.21 (+1.1%), structured
+  70.51 → 70.23 @ 7.0/1.000 (−0.4%). Wash vs the ≥5% prose/agentic
+  bar. Do not chain ALPHA/MARGIN/MIN_STEPS. Rollback: unset through
+  the guarded unit (oneshot restart; `start` is a no-op).
 
 - `GLM53_KDA_REC_WARPS` / `GLM53_KDA_REC_STAGES` / `GLM53_KDA_REC_BV_CAP`
   — Task 30 fused `fused_recurrent_kda` launch. **REVERTED 2026-09-09

--- a/docs/06-improvement-plan.md
+++ b/docs/06-improvement-plan.md
@@ -38,6 +38,43 @@ Mainline GLM support (#53906) has merged, so model resolution is no longer the
 mainline blocker described in the historical section above; EXL3 integration
 and overlay compatibility still block a stock-image replacement.
 
+### 2026-09-09: task 32 adaptive-k SATURATE=n REVERTED
+
+Independent variable `GLM53_ADAPTIVE_K_SATURATE=n` vs production
+`max` (launcher default; last-wins unset). Frozen:
+`IMAGE=e3-w3-zfill`, `EXL3_FAT_GROUPED=1`, last-wins TRF=32,
+`GLM53_ADAPTIVE_K=ema`, extra graphs, k=7, C4, pin, MNBT 3584,
+LPTT 1792. Policy-only: not in the JIT shape hash, no cubin, no
+extra graphs. `max` treats a fully-accepted prefix as k=7 so the
+EMA can climb; `n` records the accepted count and never climbs
+after a low-accept stretch. Guarded oneshot restart required
+(`Type=oneshot` start is a no-op on an already-active unit).
+
+**Cluster verdict: REVERT.** A (incumbent live boot, saturate=max)
+vs B (`SATURATE=n`). B2 skipped: B already missed the ≥5%
+prose/agentic bar. Return-A restored unset last-wins and ran a
+restoration smoke (structured n=3 + acceptance 7/7 + serving 6/6).
+Keep `max`. Do not chain ALPHA/MARGIN/MIN_STEPS.
+
+| Gate | A saturate=max | B saturate=n | Return-A restoration |
+|---|---|---|---|
+| Acceptance | standing healthy (not re-run) | skipped (B already failed adopt) | **7/7** |
+| Serving (:18000) | standing healthy (not re-run) | skipped (B already failed adopt) | **6/6** |
+| Pool | 1,396,551 / 1.40× | identical | identical |
+| Structured | n=9 70.51 @ 7.0/1.000 | n=9 70.23 (−0.40%) @ 7.0/1.000 | n=3 69.64 @ 7.0/1.000 |
+| Hashmap n=9 | 29.09 | **28.90 (−0.65%)** | skipped (B already failed adopt) |
+| Essay n=9 | 24.95 | 25.21 (+1.05%) | skipped (B already failed adopt) |
+| Health / bind | 200 / loopback | 200 / loopback | 200 / loopback |
+| Idle MemFree head/worker GiB | 4.50 / 3.76 | 5.20 / 4.54 | 4.74 / 4.07 |
+
+Watchdog re-armed. Rollback last-wins:
+`.env.bak-pre-task32-saturate-n-20260909-140038` (no
+`GLM53_ADAPTIVE_K_SATURATE`). B overlay line:
+`saturate=n graphs=True`. Return-A both ranks: `saturate=max`.
+Hashmap accept_ratio rose 0.500 → 0.634 while accepted_per_step
+fell 1.985 → 1.689 (shorter verified prefix, no climb). Tasks
+29/31 stay parked behind a decode-step nsys/ncu share.
+
 ### 2026-09-09: task 30 fused_recurrent_kda warps=2 REVERTED
 
 Independent variable `GLM53_KDA_REC_WARPS=2` vs stock FLA

--- a/env.example
+++ b/env.example
@@ -212,7 +212,7 @@ GLM53_ADAPTIVE_K_CAPTURE=1
 # GLM53_ADAPTIVE_K_ALPHA=0.25
 # GLM53_ADAPTIVE_K_MARGIN=1.0
 # GLM53_ADAPTIVE_K_MIN_STEPS=4
-# GLM53_ADAPTIVE_K_SATURATE=max
+# GLM53_ADAPTIVE_K_SATURATE=max   # Task 32 REVERTED n (hashmap -0.7%, essay +1.1%). Keep max.
 # GLM53_ADAPTIVE_K_HIST=200
 # Task 30 — fused_recurrent_kda Triton launch (FLA kda.py on this image).
 # Empty = stock num_warps=1 / num_stages=3 / BV-cap=8. Overlay is default-off

--- a/local/pr-63-body.md
+++ b/local/pr-63-body.md
@@ -1,0 +1,24 @@
+Task 32 A/B'd leftover Task 25 policy knob
+`GLM53_ADAPTIVE_K_SATURATE=n` against production `max` (launcher
+default; last-wins unset) on the current stack (`e3-w3-zfill`,
+TRF=32, adaptive-k ema, extra graphs, k=7, C4, DFlash `7d74cdd`).
+Independent variable was saturate only. Policy-only: not in the JIT
+shape hash, no cubin, no extra graphs. Guarded oneshot restart
+required (`Type=oneshot` start is a no-op on an already-active unit).
+
+Cluster A vs B: hashmap 29.09 → 28.90 tok/s (−0.7%). Hard essay
+24.95 → 25.21 (+1.1%). Structured stayed 7.0/1.000 (70.51 → 70.23,
+−0.4%). B2 skipped because B already missed the ≥5% prose/agentic
+bar. saturate=n raised accept_ratio by verifying a shorter prefix,
+but accepted_per_step fell (hashmap 1.985 → 1.689) because the
+ratchet never climbs after a low-accept stretch.
+
+Verdict: REVERT. Production last-wins restored unset
+(`.env.bak-pre-task32-saturate-n-20260909-140038`). Return-A
+restoration smoke: structured 69.64 @ 7.0/1.000, acceptance 7/7,
+serving 6/6, watchdog re-armed. Keep `max`. Do not chain
+ALPHA/MARGIN/MIN_STEPS.
+
+This PR records the window: `--essay` bench payload (Task 25/28
+hard-essay), docs/02 / docs/06 / env.example, wiring/tests, and
+cluster receipts under `local/task32/`.

--- a/local/task32/task32-a-essay.json
+++ b/local/task32/task32-a-essay.json
@@ -1,0 +1,344 @@
+{
+  "phase": "a-essay",
+  "health_code": 200,
+  "health_body": "",
+  "runs": [
+    {
+      "http": 200,
+      "ttft_s": 0.49625595799999994,
+      "wall_s": 8.288142416000001,
+      "decode_s": 7.7918864580000005,
+      "tok_s": 25.539386523745467,
+      "completion_tokens": 200,
+      "prompt_tokens": 61,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "# Speculative Decoding and the Hidden Cost of Failed Drafts: A Technical Analysis\n\n## 1. Introduction\n\nAutoregressive large language models generate text one token at a time, and each token requires a full forward pass through the network. For large models\u2014those with tens or hundreds of billions of parameters\u2014a single forward pass can take tens of milliseconds even on state-of-the-art accelerators",
+      "text_len": 963,
+      "usage": {
+        "prompt_tokens": 61,
+        "total_tokens": 261,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 79,
+        "draft_tokens": 281,
+        "accepted": 122,
+        "accept_ratio": 0.4342,
+        "accepted_per_step": 1.544,
+        "pos": [
+          0.7342,
+          0.443,
+          0.1772,
+          0.1139,
+          0.0253,
+          0.0253,
+          0.0253
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.5067565839999997,
+      "wall_s": 9.343780292,
+      "decode_s": 8.837023708,
+      "tok_s": 22.518893982353905,
+      "completion_tokens": 200,
+      "prompt_tokens": 61,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "# Speculative Decoding and the Hidden Cost of Failed Drafts: A Technical Analysis\n\n## 1. Introduction\n\nAutoregressive large language models generate text one token at a time, and each token requires a full forward pass through the network. For large models\u2014those with tens or hundreds of billions of parameters\u2014this sequential dependency is the dominant bottleneck in inference: memory bandwidth, not",
+      "text_len": 1031,
+      "usage": {
+        "prompt_tokens": 61,
+        "total_tokens": 261,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 90,
+        "draft_tokens": 285,
+        "accepted": 111,
+        "accept_ratio": 0.3895,
+        "accepted_per_step": 1.233,
+        "pos": [
+          0.6556,
+          0.3222,
+          0.1111,
+          0.0778,
+          0.0222,
+          0.0222,
+          0.0222
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.45456375000000193,
+      "wall_s": 8.431592375000001,
+      "decode_s": 7.977028624999999,
+      "tok_s": 24.9466323057102,
+      "completion_tokens": 200,
+      "prompt_tokens": 61,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "# Speculative Decoding and the Hidden Cost of Failed Drafts: A Technical Analysis\n\n## 1. Introduction\n\nAutoregressive large language models generate text one token at a time, and each token requires a full forward pass through the network. For large models\u2014those with tens or hundreds of billions of parameters\u2014this sequential dependency is the dominant bottleneck in inference: memory bandwidth, not",
+      "text_len": 1051,
+      "usage": {
+        "prompt_tokens": 61,
+        "total_tokens": 261,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 81,
+        "draft_tokens": 277,
+        "accepted": 120,
+        "accept_ratio": 0.4332,
+        "accepted_per_step": 1.481,
+        "pos": [
+          0.7037,
+          0.4198,
+          0.1728,
+          0.1111,
+          0.0247,
+          0.0247,
+          0.0247
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.4400556669999993,
+      "wall_s": 8.197637624999999,
+      "decode_s": 7.757581957999999,
+      "tok_s": 25.65232324677942,
+      "completion_tokens": 200,
+      "prompt_tokens": 61,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "# Speculative Decoding and the Hidden Cost of Failed Drafts: A Technical Analysis\n\n## 1. Introduction\n\nAutoregressive large language models generate text one token at a time, and each token requires a full forward pass through the network. For large models\u2014those with tens or hundreds of billions of parameters\u2014this sequential dependency is the dominant bottleneck in inference: memory bandwidth, not",
+      "text_len": 1052,
+      "usage": {
+        "prompt_tokens": 61,
+        "total_tokens": 261,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 79,
+        "draft_tokens": 271,
+        "accepted": 120,
+        "accept_ratio": 0.4428,
+        "accepted_per_step": 1.519,
+        "pos": [
+          0.6962,
+          0.4304,
+          0.1899,
+          0.1266,
+          0.0253,
+          0.0253,
+          0.0253
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.46397779200000144,
+      "wall_s": 8.110845625000003,
+      "decode_s": 7.646867833000002,
+      "tok_s": 26.023726883472076,
+      "completion_tokens": 200,
+      "prompt_tokens": 61,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "# Speculative Decoding and the Hidden Cost of Failed Drafts: A Technical Analysis\n\n## 1. Introduction\n\nAutoregressive large language models generate text one token at a time, and each token requires a full forward pass through the network. For large models\u2014those with tens or hundreds of billions of parameters\u2014this sequential dependency is the dominant bottleneck in inference: memory bandwidth, not",
+      "text_len": 985,
+      "usage": {
+        "prompt_tokens": 61,
+        "total_tokens": 261,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 77,
+        "draft_tokens": 266,
+        "accepted": 123,
+        "accept_ratio": 0.4624,
+        "accepted_per_step": 1.597,
+        "pos": [
+          0.7662,
+          0.4026,
+          0.1818,
+          0.1429,
+          0.039,
+          0.039,
+          0.026
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.7062099589999988,
+      "wall_s": 8.331676999999999,
+      "decode_s": 7.625467041,
+      "tok_s": 26.09676219568359,
+      "completion_tokens": 200,
+      "prompt_tokens": 61,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "# Speculative Decoding and the Hidden Cost of Failed Drafts: A Technical Analysis\n\n## 1. Introduction: The Latency Problem in Autoregressive Inference\n\nLarge language models generate text one token at a time. Each token requires a full forward pass through the network, and because the next token depends on all previously generated tokens, this process is inherently sequential. For a model with bil",
+      "text_len": 1048,
+      "usage": {
+        "prompt_tokens": 61,
+        "total_tokens": 261,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 77,
+        "draft_tokens": 281,
+        "accepted": 124,
+        "accept_ratio": 0.4413,
+        "accepted_per_step": 1.61,
+        "pos": [
+          0.7143,
+          0.5065,
+          0.2208,
+          0.0909,
+          0.026,
+          0.026,
+          0.026
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.43753195899999753,
+      "wall_s": 8.848795916999997,
+      "decode_s": 8.411263958,
+      "tok_s": 23.658751050218797,
+      "completion_tokens": 200,
+      "prompt_tokens": 61,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "# Speculative Decoding and the Hidden Cost of Failed Drafts: A Technical Analysis\n\n## 1. Introduction: The Latency Problem in Autoregressive Inference\n\nLarge language models generate text one token at a time. Each token requires a full forward pass through the network, and because the next token depends on all previously generated tokens, this process is inherently sequential. For a model with bil",
+      "text_len": 1073,
+      "usage": {
+        "prompt_tokens": 61,
+        "total_tokens": 261,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 85,
+        "draft_tokens": 287,
+        "accepted": 115,
+        "accept_ratio": 0.4007,
+        "accepted_per_step": 1.353,
+        "pos": [
+          0.6824,
+          0.4471,
+          0.1176,
+          0.0353,
+          0.0235,
+          0.0235,
+          0.0235
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.496951291000002,
+      "wall_s": 8.887715499999999,
+      "decode_s": 8.390764208999997,
+      "tok_s": 23.71655251455536,
+      "completion_tokens": 200,
+      "prompt_tokens": 61,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "# Speculative Decoding and the Hidden Cost of Failed Drafts: A Technical Analysis\n\n## 1. Introduction: The Latency Problem in Autoregressive Inference\n\nLarge language models generate text autoregressively: each token is produced conditioned on all previously generated tokens. This sequential dependency is the fundamental bottleneck of inference. Even though a single forward pass through a transfor",
+      "text_len": 1024,
+      "usage": {
+        "prompt_tokens": 61,
+        "total_tokens": 261,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 85,
+        "draft_tokens": 295,
+        "accepted": 114,
+        "accept_ratio": 0.3864,
+        "accepted_per_step": 1.341,
+        "pos": [
+          0.6706,
+          0.4,
+          0.1294,
+          0.0706,
+          0.0235,
+          0.0235,
+          0.0235
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.5236360840000032,
+      "wall_s": 8.991910208999997,
+      "decode_s": 8.468274124999994,
+      "tok_s": 23.499475461300108,
+      "completion_tokens": 200,
+      "prompt_tokens": 61,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "# Speculative Decoding and the Hidden Cost of Failed Drafts: A Technical Analysis\n\n## 1. Introduction: The Latency Problem in Autoregressive Inference\n\nLarge language models generate text autoregressively: each token is produced conditioned on all previously generated tokens. This sequential dependency is the fundamental bottleneck of inference. Even though a single forward pass through a transfor",
+      "text_len": 1066,
+      "usage": {
+        "prompt_tokens": 61,
+        "total_tokens": 261,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 87,
+        "draft_tokens": 289,
+        "accepted": 112,
+        "accept_ratio": 0.3875,
+        "accepted_per_step": 1.287,
+        "pos": [
+          0.7241,
+          0.3678,
+          0.092,
+          0.0345,
+          0.023,
+          0.023,
+          0.023
+        ]
+      }
+    }
+  ],
+  "ts": 1788976736.3345752,
+  "prompt": "hard-essay",
+  "thinking": false,
+  "temperature": 0,
+  "tok_s_median": 24.9466323057102,
+  "tok_s_min": 22.518893982353905,
+  "tok_s_max": 26.09676219568359,
+  "ttft_median_s": 0.49625595799999994,
+  "completion_tokens_median": 200.0,
+  "accept_ratio_median": 0.4332,
+  "accepted_per_step_median": 1.481,
+  "any_nan": false,
+  "health_code_after": 200,
+  "short_after": {
+    "http": 200,
+    "ttft_s": 0.38536570899999845,
+    "wall_s": 0.5045020000000022,
+    "decode_s": 0.11913629100000378,
+    "tok_s": 58.75623574683702,
+    "completion_tokens": 8,
+    "prompt_tokens": 40,
+    "finish_reason": "length",
+    "nan": false,
+    "text_head": "# How a Hash Map Works: A",
+    "text_len": 25,
+    "usage": {
+      "prompt_tokens": 40,
+      "total_tokens": 48,
+      "completion_tokens": 8
+    }
+  }
+}

--- a/local/task32/task32-a-prose.json
+++ b/local/task32/task32-a-prose.json
@@ -1,0 +1,344 @@
+{
+  "phase": "a-prose",
+  "health_code": 200,
+  "health_body": "",
+  "runs": [
+    {
+      "http": 200,
+      "ttft_s": 0.49030112499999995,
+      "wall_s": 7.305815792000001,
+      "decode_s": 6.815514667,
+      "tok_s": 29.19808843835916,
+      "completion_tokens": 200,
+      "prompt_tokens": 40,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "# How a Hash Map Works: A Complete Guide\n\nA hash map (also called a hash table or dictionary) is a data structure that stores key-value pairs and provides near-constant-time lookup, insertion, and deletion. Let's build up an understanding from the ground up.\n\n---\n\n## 1. The Core Idea\n\nA hash map lets you associate values with keys and retrieve them quickly. Instead of searching through data (like ",
+      "text_len": 890,
+      "usage": {
+        "prompt_tokens": 40,
+        "total_tokens": 240,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 67,
+        "draft_tokens": 266,
+        "accepted": 133,
+        "accept_ratio": 0.5,
+        "accepted_per_step": 1.985,
+        "pos": [
+          0.8209,
+          0.5821,
+          0.3284,
+          0.209,
+          0.0149,
+          0.0149,
+          0.0149
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.4552201250000003,
+      "wall_s": 6.598596000000001,
+      "decode_s": 6.143375875,
+      "tok_s": 32.39261345049964,
+      "completion_tokens": 200,
+      "prompt_tokens": 40,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "# How a Hash Map Works: A Complete Guide\n\nA hash map (also called a hash table or dictionary) is a data structure that stores key-value pairs and provides near-constant-time lookup, insertion, and deletion. Here's a thorough breakdown of how it works.\n\n---\n\n## 1. The Core Concept\n\nA hash map stores data as **key-value pairs**. Instead of searching through data linearly (like an array) or following",
+      "text_len": 873,
+      "usage": {
+        "prompt_tokens": 40,
+        "total_tokens": 240,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 61,
+        "draft_tokens": 253,
+        "accepted": 138,
+        "accept_ratio": 0.5455,
+        "accepted_per_step": 2.262,
+        "pos": [
+          0.8197,
+          0.6721,
+          0.459,
+          0.2623,
+          0.0164,
+          0.0164,
+          0.0164
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.4925712079999993,
+      "wall_s": 7.831851666,
+      "decode_s": 7.339280458000001,
+      "tok_s": 27.114374650049648,
+      "completion_tokens": 200,
+      "prompt_tokens": 40,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "# How a Hash Map Works: A Complete Guide\n\nA hash map (also called a hash table or dictionary) is a data structure that stores key-value pairs and provides near-constant-time lookup, insertion, and deletion. Let's build up the full picture step by step.\n\n---\n\n## 1. The Core Idea\n\nA hash map lets you associate values with keys and retrieve them instantly. Instead of searching through data (like a li",
+      "text_len": 816,
+      "usage": {
+        "prompt_tokens": 40,
+        "total_tokens": 240,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 72,
+        "draft_tokens": 277,
+        "accepted": 130,
+        "accept_ratio": 0.4693,
+        "accepted_per_step": 1.806,
+        "pos": [
+          0.7639,
+          0.5417,
+          0.2917,
+          0.1667,
+          0.0139,
+          0.0139,
+          0.0139
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.4609368329999981,
+      "wall_s": 7.301168291,
+      "decode_s": 6.840231458000002,
+      "tok_s": 29.092582790785432,
+      "completion_tokens": 200,
+      "prompt_tokens": 40,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "# How a Hash Map Works: A Complete Guide\n\nA hash map (also called a hash table or dictionary) is a data structure that stores key-value pairs and provides near-constant-time lookup, insertion, and deletion. Let's build up the full picture step by step.\n\n---\n\n## 1. The Core Idea\n\nA hash map lets you associate values with keys and retrieve them quickly. Instead of searching through data (like a list",
+      "text_len": 845,
+      "usage": {
+        "prompt_tokens": 40,
+        "total_tokens": 240,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 67,
+        "draft_tokens": 272,
+        "accepted": 136,
+        "accept_ratio": 0.5,
+        "accepted_per_step": 2.03,
+        "pos": [
+          0.791,
+          0.597,
+          0.3731,
+          0.2239,
+          0.0149,
+          0.0149,
+          0.0149
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.4501046659999979,
+      "wall_s": 7.623865083000002,
+      "decode_s": 7.173760417000004,
+      "tok_s": 27.73998411327205,
+      "completion_tokens": 200,
+      "prompt_tokens": 40,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "# How a Hash Map Works: A Complete Guide\n\nA hash map (also called a hash table or dictionary) is a data structure that stores key-value pairs and provides near-constant-time lookup, insertion, and deletion. Let's build up an understanding from the ground up.\n\n---\n\n## 1. The Core Concept\n\nA hash map stores data as **key-value pairs**. You provide a key (e.g., a username) and a value (e.g., the user",
+      "text_len": 889,
+      "usage": {
+        "prompt_tokens": 40,
+        "total_tokens": 240,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 72,
+        "draft_tokens": 275,
+        "accepted": 127,
+        "accept_ratio": 0.4618,
+        "accepted_per_step": 1.764,
+        "pos": [
+          0.7639,
+          0.5139,
+          0.2778,
+          0.1667,
+          0.0139,
+          0.0139,
+          0.0139
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.49534024999999815,
+      "wall_s": 6.412965624999998,
+      "decode_s": 5.917625375,
+      "tok_s": 33.62835383948244,
+      "completion_tokens": 200,
+      "prompt_tokens": 40,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "# How a Hash Map Works: A Complete Guide\n\nA hash map (also called a hash table or dictionary) is a data structure that stores key-value pairs and provides near-constant-time lookup, insertion, and deletion. Here's a thorough breakdown of how it works.\n\n---\n\n## 1. The Core Concept\n\nA hash map stores data as **key-value pairs**. Instead of searching through data linearly (like an array) or following",
+      "text_len": 874,
+      "usage": {
+        "prompt_tokens": 40,
+        "total_tokens": 240,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 59,
+        "draft_tokens": 243,
+        "accepted": 143,
+        "accept_ratio": 0.5885,
+        "accepted_per_step": 2.424,
+        "pos": [
+          0.8983,
+          0.7119,
+          0.4746,
+          0.2881,
+          0.0169,
+          0.0169,
+          0.0169
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.3844124159999964,
+      "wall_s": 6.939742040999995,
+      "decode_s": 6.555329624999999,
+      "tok_s": 30.356978425779776,
+      "completion_tokens": 200,
+      "prompt_tokens": 40,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "# How a Hash Map Works: A Complete Guide\n\nA hash map (also called a hash table or dictionary) is a data structure that stores key-value pairs and provides near-constant-time lookup, insertion, and deletion. Here's a thorough breakdown of how it works.\n\n---\n\n## 1. The Core Concept\n\nA hash map stores data as **key-value pairs**. Instead of searching through data linearly (like an array) or following",
+      "text_len": 856,
+      "usage": {
+        "prompt_tokens": 40,
+        "total_tokens": 240,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 65,
+        "draft_tokens": 258,
+        "accepted": 135,
+        "accept_ratio": 0.5233,
+        "accepted_per_step": 2.077,
+        "pos": [
+          0.8,
+          0.6,
+          0.4,
+          0.2308,
+          0.0154,
+          0.0154,
+          0.0154
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.5098814169999955,
+      "wall_s": 7.481777375,
+      "decode_s": 6.971895958000005,
+      "tok_s": 28.54316834313262,
+      "completion_tokens": 200,
+      "prompt_tokens": 40,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "# How a Hash Map Works: A Complete Guide\n\nA hash map (also called a hash table or dictionary) is a data structure that stores key-value pairs and provides near-constant-time lookup, insertion, and deletion. Let's build up the full picture step by step.\n\n---\n\n## 1. The Core Idea\n\nA hash map stores data in an **array of \"buckets.\"** The magic is in how it decides *which bucket* a key belongs to: it ",
+      "text_len": 794,
+      "usage": {
+        "prompt_tokens": 40,
+        "total_tokens": 240,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 71,
+        "draft_tokens": 268,
+        "accepted": 129,
+        "accept_ratio": 0.4813,
+        "accepted_per_step": 1.817,
+        "pos": [
+          0.7465,
+          0.5211,
+          0.2958,
+          0.2113,
+          0.0141,
+          0.0141,
+          0.0141
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.3818795829999999,
+      "wall_s": 7.645274749999999,
+      "decode_s": 7.263395166999999,
+      "tok_s": 27.397655700205142,
+      "completion_tokens": 200,
+      "prompt_tokens": 40,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "# How a Hash Map Works: A Complete Guide\n\nA hash map (also called a hash table or dictionary) is a data structure that stores key-value pairs and provides near-constant-time lookup, insertion, and deletion. Let's build up an understanding from the ground up.\n\n---\n\n## 1. The Core Concept\n\nA hash map stores data as **key-value pairs**. You provide a key (e.g., a username) and a value (e.g., the user",
+      "text_len": 864,
+      "usage": {
+        "prompt_tokens": 40,
+        "total_tokens": 240,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 72,
+        "draft_tokens": 275,
+        "accepted": 129,
+        "accept_ratio": 0.4691,
+        "accepted_per_step": 1.792,
+        "pos": [
+          0.75,
+          0.5278,
+          0.2778,
+          0.1944,
+          0.0139,
+          0.0139,
+          0.0139
+        ]
+      }
+    }
+  ],
+  "ts": 1788976653.883873,
+  "prompt": "hashmap-prose",
+  "thinking": false,
+  "temperature": 0,
+  "tok_s_median": 29.092582790785432,
+  "tok_s_min": 27.114374650049648,
+  "tok_s_max": 33.62835383948244,
+  "ttft_median_s": 0.4609368329999981,
+  "completion_tokens_median": 200.0,
+  "accept_ratio_median": 0.5,
+  "accepted_per_step_median": 1.985,
+  "any_nan": false,
+  "health_code_after": 200,
+  "short_after": {
+    "http": 200,
+    "ttft_s": 0.46339500000000555,
+    "wall_s": 0.5265712500000035,
+    "decode_s": 0.06317624999999794,
+    "tok_s": 110.80113175442082,
+    "completion_tokens": 8,
+    "prompt_tokens": 40,
+    "finish_reason": "length",
+    "nan": false,
+    "text_head": "# How a Hash Map Works: A",
+    "text_len": 25,
+    "usage": {
+      "prompt_tokens": 40,
+      "total_tokens": 48,
+      "completion_tokens": 8
+    }
+  }
+}

--- a/local/task32/task32-a-structured.json
+++ b/local/task32/task32-a-structured.json
@@ -1,0 +1,349 @@
+{
+  "phase": "a-structured",
+  "health_code": 200,
+  "health_body": "",
+  "runs": [
+    {
+      "http": 200,
+      "ttft_s": 0.4888214579999999,
+      "wall_s": 3.2057899999999995,
+      "decode_s": 2.716968542,
+      "tok_s": 73.24339495425781,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.378648042,
+      "wall_s": 3.254062125,
+      "decode_s": 2.875414083,
+      "tok_s": 69.20742343738462,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.38143766600000006,
+      "wall_s": 3.368219916000001,
+      "decode_s": 2.986782250000001,
+      "tok_s": 66.62688584010432,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.4826418749999988,
+      "wall_s": 3.234129790999999,
+      "decode_s": 2.7514879160000003,
+      "tok_s": 72.32450444096371,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.36316729200000175,
+      "wall_s": 3.2125455830000007,
+      "decode_s": 2.849378290999999,
+      "tok_s": 69.83979650176961,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.5098490829999989,
+      "wall_s": 3.212667666999998,
+      "decode_s": 2.702818583999999,
+      "tok_s": 73.62684316958213,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.3797934999999981,
+      "wall_s": 3.212859625,
+      "decode_s": 2.833066125000002,
+      "tok_s": 70.24191855034795,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.3813381249999992,
+      "wall_s": 3.2035110829999986,
+      "decode_s": 2.8221729579999995,
+      "tok_s": 70.51304188706638,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.47863024999999837,
+      "wall_s": 3.2158679170000006,
+      "decode_s": 2.7372376670000023,
+      "tok_s": 72.70103082356854,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    }
+  ],
+  "ts": 1788976584.8876789,
+  "prompt": "structured-count-1-200",
+  "thinking": false,
+  "temperature": 0,
+  "warmup": {
+    "tok_s": 70.67398947685271,
+    "ttft_s": 0.398187042,
+    "completion_tokens": 32
+  },
+  "tok_s_median": 70.51304188706638,
+  "tok_s_min": 66.62688584010432,
+  "tok_s_max": 73.62684316958213,
+  "ttft_median_s": 0.38143766600000006,
+  "completion_tokens_median": 200.0,
+  "accept_ratio_median": 1.0,
+  "accepted_per_step_median": 7.0,
+  "any_nan": false,
+  "health_code_after": 200,
+  "short_after": {
+    "http": 200,
+    "ttft_s": 0.40040879200000035,
+    "wall_s": 0.5149525829999995,
+    "decode_s": 0.11454379099999912,
+    "tok_s": 61.11199864163789,
+    "completion_tokens": 8,
+    "prompt_tokens": 40,
+    "finish_reason": "length",
+    "nan": false,
+    "text_head": "# How a Hash Map Works: A",
+    "text_len": 25,
+    "usage": {
+      "prompt_tokens": 40,
+      "total_tokens": 48,
+      "completion_tokens": 8
+    }
+  }
+}

--- a/local/task32/task32-b-essay.json
+++ b/local/task32/task32-b-essay.json
@@ -1,0 +1,344 @@
+{
+  "phase": "b-essay",
+  "health_code": 200,
+  "health_body": "",
+  "runs": [
+    {
+      "http": 200,
+      "ttft_s": 0.493162791,
+      "wall_s": 8.404986291,
+      "decode_s": 7.911823500000001,
+      "tok_s": 25.15222944495665,
+      "completion_tokens": 200,
+      "prompt_tokens": 61,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "# Speculative Decoding and the Hidden Cost of Failed Drafts: A Technical Analysis\n\n## 1. Introduction\n\nAutoregressive large language models generate text one token at a time, and each token requires a full forward pass through the network. For large models\u2014those with tens or hundreds of billions of parameters\u2014this sequential dependency is the dominant bottleneck in inference: memory bandwidth, not",
+      "text_len": 1003,
+      "usage": {
+        "prompt_tokens": 61,
+        "total_tokens": 261,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 86,
+        "draft_tokens": 217,
+        "accepted": 114,
+        "accept_ratio": 0.5253,
+        "accepted_per_step": 1.326,
+        "pos": [
+          0.7093,
+          0.4186,
+          0.0698,
+          0.0581,
+          0.0233,
+          0.0233,
+          0.0233
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.4797607500000005,
+      "wall_s": 8.4464915,
+      "decode_s": 7.96673075,
+      "tok_s": 24.978878569480962,
+      "completion_tokens": 200,
+      "prompt_tokens": 61,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "# Speculative Decoding and the Hidden Cost of Failed Drafts: A Technical Analysis\n\n## 1. Introduction\n\nAutoregressive large language models generate text one token at a time, and each token requires a full forward pass through the network. For large models\u2014those with tens or hundreds of billions of parameters\u2014this sequential dependency is the dominant bottleneck in inference: memory bandwidth, not",
+      "text_len": 978,
+      "usage": {
+        "prompt_tokens": 61,
+        "total_tokens": 261,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 86,
+        "draft_tokens": 217,
+        "accepted": 113,
+        "accept_ratio": 0.5207,
+        "accepted_per_step": 1.314,
+        "pos": [
+          0.7326,
+          0.3837,
+          0.0698,
+          0.0581,
+          0.0233,
+          0.0233,
+          0.0233
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.4412006670000004,
+      "wall_s": 8.156235583,
+      "decode_s": 7.7150349160000005,
+      "tok_s": 25.79379123577255,
+      "completion_tokens": 200,
+      "prompt_tokens": 61,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "# Speculative Decoding and the Hidden Cost of Failed Drafts: A Technical Analysis\n\n## 1. Introduction: The Latency Problem in Autoregressive Inference\n\nLarge language models generate text one token at a time. Each token requires a full forward pass through the network, and because the next token depends on all previously generated tokens, this process is inherently sequential. For a model with bil",
+      "text_len": 1056,
+      "usage": {
+        "prompt_tokens": 61,
+        "total_tokens": 261,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 81,
+        "draft_tokens": 211,
+        "accepted": 118,
+        "accept_ratio": 0.5592,
+        "accepted_per_step": 1.457,
+        "pos": [
+          0.7778,
+          0.4938,
+          0.0741,
+          0.037,
+          0.0247,
+          0.0247,
+          0.0247
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.4469961669999982,
+      "wall_s": 8.340057625,
+      "decode_s": 7.893061458000002,
+      "tok_s": 25.212017042931272,
+      "completion_tokens": 200,
+      "prompt_tokens": 61,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "# Speculative Decoding and the Hidden Cost of Failed Drafts: A Technical Analysis\n\n## 1. Introduction\n\nAutoregressive large language models generate text one token at a time, and each token requires a full forward pass through the network. For large models\u2014those with tens or hundreds of billions of parameters\u2014this sequential dependency is the dominant bottleneck in inference: memory bandwidth, not",
+      "text_len": 1034,
+      "usage": {
+        "prompt_tokens": 61,
+        "total_tokens": 261,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 85,
+        "draft_tokens": 215,
+        "accepted": 115,
+        "accept_ratio": 0.5349,
+        "accepted_per_step": 1.353,
+        "pos": [
+          0.7176,
+          0.4353,
+          0.0706,
+          0.0588,
+          0.0235,
+          0.0235,
+          0.0235
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.4552775419999975,
+      "wall_s": 8.336282417,
+      "decode_s": 7.881004875000002,
+      "tok_s": 25.250587095976126,
+      "completion_tokens": 200,
+      "prompt_tokens": 61,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "# Speculative Decoding and the Hidden Cost of Failed Drafts: A Technical Analysis\n\n## 1. Introduction\n\nAutoregressive large language models generate text one token at a time, and each token requires a full forward pass through the network. For large models\u2014those with tens or hundreds of billions of parameters\u2014this sequential dependency is the dominant bottleneck in inference: memory bandwidth, not",
+      "text_len": 1059,
+      "usage": {
+        "prompt_tokens": 61,
+        "total_tokens": 261,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 84,
+        "draft_tokens": 211,
+        "accepted": 117,
+        "accept_ratio": 0.5545,
+        "accepted_per_step": 1.393,
+        "pos": [
+          0.7262,
+          0.4405,
+          0.0714,
+          0.0595,
+          0.0357,
+          0.0357,
+          0.0238
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.45108450000000033,
+      "wall_s": 8.316094833000001,
+      "decode_s": 7.865010333000001,
+      "tok_s": 25.30193751494973,
+      "completion_tokens": 200,
+      "prompt_tokens": 61,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "# Speculative Decoding and the Hidden Cost of Failed Drafts: A Technical Analysis\n\n## 1. Introduction\n\nAutoregressive large language models generate text one token at a time, and each token requires a full forward pass through the network. For large models\u2014those with tens or hundreds of billions of parameters\u2014this sequential dependency is the dominant bottleneck in inference: memory bandwidth, not",
+      "text_len": 1057,
+      "usage": {
+        "prompt_tokens": 61,
+        "total_tokens": 261,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 84,
+        "draft_tokens": 213,
+        "accepted": 115,
+        "accept_ratio": 0.5399,
+        "accepted_per_step": 1.369,
+        "pos": [
+          0.7381,
+          0.4286,
+          0.0714,
+          0.0595,
+          0.0238,
+          0.0238,
+          0.0238
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.4851363329999998,
+      "wall_s": 8.874982291999999,
+      "decode_s": 8.389845958999999,
+      "tok_s": 23.71914823853562,
+      "completion_tokens": 200,
+      "prompt_tokens": 61,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "# Speculative Decoding and the Hidden Cost of Failed Drafts: A Technical Analysis\n\n## 1. Introduction\n\nAutoregressive large language models generate text one token at a time, and each token requires a full forward pass through the network. For large models\u2014those with tens or hundreds of billions of parameters\u2014this sequential dependency is the dominant bottleneck in inference: memory bandwidth, not",
+      "text_len": 1058,
+      "usage": {
+        "prompt_tokens": 61,
+        "total_tokens": 261,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 89,
+        "draft_tokens": 223,
+        "accepted": 110,
+        "accept_ratio": 0.4933,
+        "accepted_per_step": 1.236,
+        "pos": [
+          0.6854,
+          0.3596,
+          0.0674,
+          0.0562,
+          0.0225,
+          0.0225,
+          0.0225
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.4830657500000015,
+      "wall_s": 8.345932209000004,
+      "decode_s": 7.862866459000003,
+      "tok_s": 25.30883629242112,
+      "completion_tokens": 200,
+      "prompt_tokens": 61,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "# Speculative Decoding and the Hidden Cost of Failed Drafts: A Technical Analysis\n\n## 1. Introduction\n\nAutoregressive large language models generate text one token at a time, and each token requires a full forward pass through the network. For large models\u2014those with tens or hundreds of billions of parameters\u2014this sequential dependency is the dominant bottleneck in inference: memory bandwidth, not",
+      "text_len": 1084,
+      "usage": {
+        "prompt_tokens": 61,
+        "total_tokens": 261,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 85,
+        "draft_tokens": 215,
+        "accepted": 115,
+        "accept_ratio": 0.5349,
+        "accepted_per_step": 1.353,
+        "pos": [
+          0.7647,
+          0.3882,
+          0.0706,
+          0.0588,
+          0.0235,
+          0.0235,
+          0.0235
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.45868375000000583,
+      "wall_s": 8.507541916999998,
+      "decode_s": 8.048858166999992,
+      "tok_s": 24.724003811608004,
+      "completion_tokens": 200,
+      "prompt_tokens": 61,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "# Speculative Decoding and the Hidden Cost of Failed Drafts: A Technical Analysis\n\n## 1. Introduction\n\nAutoregressive large language models generate text one token at a time, and each token requires a full forward pass through the network. For large models\u2014those with tens or hundreds of billions of parameters\u2014this sequential dependency is the dominant bottleneck in inference: memory bandwidth, not",
+      "text_len": 1044,
+      "usage": {
+        "prompt_tokens": 61,
+        "total_tokens": 261,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 87,
+        "draft_tokens": 219,
+        "accepted": 113,
+        "accept_ratio": 0.516,
+        "accepted_per_step": 1.299,
+        "pos": [
+          0.7011,
+          0.4023,
+          0.069,
+          0.0575,
+          0.023,
+          0.023,
+          0.023
+        ]
+      }
+    }
+  ],
+  "ts": 1788977618.537812,
+  "prompt": "hard-essay",
+  "thinking": false,
+  "temperature": 0,
+  "tok_s_median": 25.212017042931272,
+  "tok_s_min": 23.71914823853562,
+  "tok_s_max": 25.79379123577255,
+  "ttft_median_s": 0.45868375000000583,
+  "completion_tokens_median": 200.0,
+  "accept_ratio_median": 0.5349,
+  "accepted_per_step_median": 1.353,
+  "any_nan": false,
+  "health_code_after": 200,
+  "short_after": {
+    "http": 200,
+    "ttft_s": 0.3822626670000062,
+    "wall_s": 0.5002434590000036,
+    "decode_s": 0.11798079199999734,
+    "tok_s": 59.331691891000006,
+    "completion_tokens": 8,
+    "prompt_tokens": 40,
+    "finish_reason": "length",
+    "nan": false,
+    "text_head": "# How a Hash Map Works: A",
+    "text_len": 25,
+    "usage": {
+      "prompt_tokens": 40,
+      "total_tokens": 48,
+      "completion_tokens": 8
+    }
+  }
+}

--- a/local/task32/task32-b-prose.json
+++ b/local/task32/task32-b-prose.json
@@ -1,0 +1,344 @@
+{
+  "phase": "b-prose",
+  "health_code": 200,
+  "health_body": "",
+  "runs": [
+    {
+      "http": 200,
+      "ttft_s": 0.39378062500000005,
+      "wall_s": 7.080490334,
+      "decode_s": 6.6867097090000005,
+      "tok_s": 29.760526276795783,
+      "completion_tokens": 200,
+      "prompt_tokens": 40,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "# How a Hash Map Works: A Complete Guide\n\nA hash map (also called a hash table or dictionary) is a data structure that stores key-value pairs and provides near-constant-time lookup, insertion, and deletion. Here's a thorough breakdown of how it works.\n\n---\n\n## 1. The Core Concept\n\nA hash map stores data as **key-value pairs**. Instead of searching through data linearly (like an array) or following",
+      "text_len": 865,
+      "usage": {
+        "prompt_tokens": 40,
+        "total_tokens": 240,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 72,
+        "draft_tokens": 200,
+        "accepted": 127,
+        "accept_ratio": 0.635,
+        "accepted_per_step": 1.764,
+        "pos": [
+          0.8194,
+          0.625,
+          0.1667,
+          0.1111,
+          0.0139,
+          0.0139,
+          0.0139
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.45813866599999997,
+      "wall_s": 7.283398874999999,
+      "decode_s": 6.825260208999999,
+      "tok_s": 29.15639754475477,
+      "completion_tokens": 200,
+      "prompt_tokens": 40,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "# How a Hash Map Works: A Complete Guide\n\nA hash map (also called a hash table or dictionary) is a data structure that stores key-value pairs and provides near-constant-time lookup, insertion, and deletion. Let's build up an understanding from the ground up.\n\n---\n\n## 1. The Core Concept\n\nA hash map stores data as **key-value pairs**. You provide a key (e.g., a username) and a value (e.g., the user",
+      "text_len": 829,
+      "usage": {
+        "prompt_tokens": 40,
+        "total_tokens": 240,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 74,
+        "draft_tokens": 188,
+        "accepted": 125,
+        "accept_ratio": 0.6649,
+        "accepted_per_step": 1.689,
+        "pos": [
+          0.8514,
+          0.6486,
+          0.0946,
+          0.0541,
+          0.0135,
+          0.0135,
+          0.0135
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.4723563749999986,
+      "wall_s": 7.816302584000001,
+      "decode_s": 7.343946209000002,
+      "tok_s": 27.097148363658437,
+      "completion_tokens": 200,
+      "prompt_tokens": 40,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "# How a Hash Map Works: A Complete Guide\n\nA hash map (also called a hash table or dictionary) is a data structure that stores key-value pairs and provides near-constant-time lookup, insertion, and deletion. Let's build up an understanding from the ground up.\n\n---\n\n## 1. The Core Concept\n\nA hash map stores data as **key-value pairs**. You provide a key (e.g., a username), and the map retrieves the ",
+      "text_len": 857,
+      "usage": {
+        "prompt_tokens": 40,
+        "total_tokens": 240,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 80,
+        "draft_tokens": 202,
+        "accepted": 119,
+        "accept_ratio": 0.5891,
+        "accepted_per_step": 1.488,
+        "pos": [
+          0.75,
+          0.575,
+          0.075,
+          0.05,
+          0.0125,
+          0.0125,
+          0.0125
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.4679707079999993,
+      "wall_s": 6.951955082999998,
+      "decode_s": 6.483984374999999,
+      "tok_s": 30.691005482257975,
+      "completion_tokens": 200,
+      "prompt_tokens": 40,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "# How a Hash Map Works: A Complete Guide\n\nA hash map (also called a hash table or dictionary) is a data structure that stores key-value pairs and provides near-constant-time lookup, insertion, and deletion. Here's a thorough breakdown of how it works.\n\n---\n\n## 1. The Core Concept\n\nA hash map stores data as **key-value pairs**. Instead of searching through data linearly (like an array or linked lis",
+      "text_len": 864,
+      "usage": {
+        "prompt_tokens": 40,
+        "total_tokens": 240,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 70,
+        "draft_tokens": 196,
+        "accepted": 131,
+        "accept_ratio": 0.6684,
+        "accepted_per_step": 1.871,
+        "pos": [
+          0.8429,
+          0.7,
+          0.1714,
+          0.1143,
+          0.0143,
+          0.0143,
+          0.0143
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.37849129199999965,
+      "wall_s": 7.263506709000001,
+      "decode_s": 6.885015417000002,
+      "tok_s": 28.903348496307363,
+      "completion_tokens": 200,
+      "prompt_tokens": 40,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "# How a Hash Map Works: A Complete Guide\n\nA hash map (also called a hash table or dictionary) is a data structure that stores key-value pairs and provides near-constant-time lookup, insertion, and deletion. Here's a thorough breakdown of how it works.\n\n---\n\n## 1. The Core Concept\n\nA hash map stores data as **key-value pairs**. Instead of searching through data linearly (like an array) or following",
+      "text_len": 854,
+      "usage": {
+        "prompt_tokens": 40,
+        "total_tokens": 240,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 73,
+        "draft_tokens": 202,
+        "accepted": 128,
+        "accept_ratio": 0.6337,
+        "accepted_per_step": 1.753,
+        "pos": [
+          0.7945,
+          0.6438,
+          0.1644,
+          0.1096,
+          0.0137,
+          0.0137,
+          0.0137
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.3785277499999964,
+      "wall_s": 7.3581857920000004,
+      "decode_s": 6.979658042000004,
+      "tok_s": 28.5114254598893,
+      "completion_tokens": 200,
+      "prompt_tokens": 40,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "# How a Hash Map Works: A Complete Guide\n\nA hash map (also called a hash table or dictionary) is a data structure that stores key-value pairs and provides near-constant-time lookup, insertion, and deletion. Let's build up an understanding from the ground up.\n\n---\n\n## 1. The Core Concept\n\nA hash map stores data as **key-value pairs**. You provide a key (e.g., a username) and a value (e.g., the user",
+      "text_len": 866,
+      "usage": {
+        "prompt_tokens": 40,
+        "total_tokens": 240,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 76,
+        "draft_tokens": 192,
+        "accepted": 123,
+        "accept_ratio": 0.6406,
+        "accepted_per_step": 1.618,
+        "pos": [
+          0.8421,
+          0.6184,
+          0.0921,
+          0.0526,
+          0.0132,
+          0.0,
+          0.0
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.3842931670000027,
+      "wall_s": 7.808746959000004,
+      "decode_s": 7.424453792000001,
+      "tok_s": 26.803318543705736,
+      "completion_tokens": 200,
+      "prompt_tokens": 40,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "# How a Hash Map Works: A Complete Guide\n\nA hash map (also called a hash table or dictionary) is a data structure that stores key-value pairs and provides near-constant-time lookup, insertion, and deletion. Let's build up an understanding from the ground up.\n\n---\n\n## 1. The Core Idea\n\nA hash map lets you associate values with keys and retrieve them quickly. The naive alternatives are slow:\n\n- **Un",
+      "text_len": 854,
+      "usage": {
+        "prompt_tokens": 40,
+        "total_tokens": 240,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 81,
+        "draft_tokens": 202,
+        "accepted": 118,
+        "accept_ratio": 0.5842,
+        "accepted_per_step": 1.457,
+        "pos": [
+          0.7778,
+          0.5062,
+          0.0864,
+          0.0494,
+          0.0123,
+          0.0123,
+          0.0123
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.5073937910000055,
+      "wall_s": 7.321546750000003,
+      "decode_s": 6.814152958999998,
+      "tok_s": 29.203923245832744,
+      "completion_tokens": 200,
+      "prompt_tokens": 40,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "# How a Hash Map Works: A Complete Guide\n\nA hash map (also called a hash table or dictionary) is a data structure that stores key-value pairs and provides near-constant-time lookup, insertion, and deletion. Here's a thorough breakdown of how it works under the hood.\n\n---\n\n## 1. The Core Concept\n\nA hash map stores data as **key-value pairs**. Instead of searching through data linearly (like an arra",
+      "text_len": 860,
+      "usage": {
+        "prompt_tokens": 40,
+        "total_tokens": 240,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 72,
+        "draft_tokens": 204,
+        "accepted": 127,
+        "accept_ratio": 0.6225,
+        "accepted_per_step": 1.764,
+        "pos": [
+          0.7778,
+          0.6528,
+          0.1667,
+          0.125,
+          0.0139,
+          0.0139,
+          0.0139
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.4883688339999992,
+      "wall_s": 7.558342375000002,
+      "decode_s": 7.069973541000003,
+      "tok_s": 28.147205763354627,
+      "completion_tokens": 200,
+      "prompt_tokens": 40,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "# How a Hash Map Works: A Complete Guide\n\nA hash map (also called a hash table or dictionary) is a data structure that stores key-value pairs and provides near-constant-time lookup, insertion, and deletion. Let's build up an understanding from the ground up.\n\n---\n\n## 1. The Core Concept\n\nA hash map stores data as **key-value pairs**. You provide a key (e.g., a username) and a value (e.g., the user",
+      "text_len": 819,
+      "usage": {
+        "prompt_tokens": 40,
+        "total_tokens": 240,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 77,
+        "draft_tokens": 194,
+        "accepted": 123,
+        "accept_ratio": 0.634,
+        "accepted_per_step": 1.597,
+        "pos": [
+          0.8312,
+          0.5844,
+          0.0909,
+          0.0519,
+          0.013,
+          0.013,
+          0.013
+        ]
+      }
+    }
+  ],
+  "ts": 1788977541.1753411,
+  "prompt": "hashmap-prose",
+  "thinking": false,
+  "temperature": 0,
+  "tok_s_median": 28.903348496307363,
+  "tok_s_min": 26.803318543705736,
+  "tok_s_max": 30.691005482257975,
+  "ttft_median_s": 0.45813866599999997,
+  "completion_tokens_median": 200.0,
+  "accept_ratio_median": 0.634,
+  "accepted_per_step_median": 1.689,
+  "any_nan": false,
+  "health_code_after": 200,
+  "short_after": {
+    "http": 200,
+    "ttft_s": 0.4118589579999963,
+    "wall_s": 0.7578758329999999,
+    "decode_s": 0.34601687500000367,
+    "tok_s": 20.230227210739148,
+    "completion_tokens": 8,
+    "prompt_tokens": 40,
+    "finish_reason": "length",
+    "nan": false,
+    "text_head": "# How a Hash Map Works: A",
+    "text_len": 25,
+    "usage": {
+      "prompt_tokens": 40,
+      "total_tokens": 48,
+      "completion_tokens": 8
+    }
+  }
+}

--- a/local/task32/task32-b-structured.json
+++ b/local/task32/task32-b-structured.json
@@ -1,0 +1,349 @@
+{
+  "phase": "b-structured",
+  "health_code": 200,
+  "health_body": "",
+  "runs": [
+    {
+      "http": 200,
+      "ttft_s": 0.492447667,
+      "wall_s": 3.250087292,
+      "decode_s": 2.7576396249999995,
+      "tok_s": 72.16316381441612,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.37277329100000056,
+      "wall_s": 3.284052333,
+      "decode_s": 2.9112790419999994,
+      "tok_s": 68.35483549639075,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.44941283299999935,
+      "wall_s": 3.3147992079999993,
+      "decode_s": 2.865386375,
+      "tok_s": 69.44962178093697,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.3762465000000006,
+      "wall_s": 3.2023582500000014,
+      "decode_s": 2.826111750000001,
+      "tok_s": 70.4147668612184,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.4712286250000002,
+      "wall_s": 3.185043500000001,
+      "decode_s": 2.7138148750000006,
+      "tok_s": 73.32850955797048,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.3838785840000014,
+      "wall_s": 3.2174904170000005,
+      "decode_s": 2.833611832999999,
+      "tok_s": 70.22839108817347,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.371761124999999,
+      "wall_s": 3.4196072089999987,
+      "decode_s": 3.0478460839999997,
+      "tok_s": 65.29201098594585,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.49231679200000045,
+      "wall_s": 3.217007542000001,
+      "decode_s": 2.7246907500000006,
+      "tok_s": 73.03581149530454,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.38356741600000177,
+      "wall_s": 3.2350179160000003,
+      "decode_s": 2.8514504999999986,
+      "tok_s": 69.78904245400722,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    }
+  ],
+  "ts": 1788977498.6155672,
+  "prompt": "structured-count-1-200",
+  "thinking": false,
+  "temperature": 0,
+  "warmup": {
+    "tok_s": 59.44123323301826,
+    "ttft_s": 0.387837125,
+    "completion_tokens": 32
+  },
+  "tok_s_median": 70.22839108817347,
+  "tok_s_min": 65.29201098594585,
+  "tok_s_max": 73.32850955797048,
+  "ttft_median_s": 0.3838785840000014,
+  "completion_tokens_median": 200.0,
+  "accept_ratio_median": 1.0,
+  "accepted_per_step_median": 7.0,
+  "any_nan": false,
+  "health_code_after": 200,
+  "short_after": {
+    "http": 200,
+    "ttft_s": 0.40033116600000085,
+    "wall_s": 0.5344845410000012,
+    "decode_s": 0.13415337500000035,
+    "tok_s": 52.17908233766002,
+    "completion_tokens": 8,
+    "prompt_tokens": 40,
+    "finish_reason": "length",
+    "nan": false,
+    "text_head": "# How a Hash Map Works: A",
+    "text_len": 25,
+    "usage": {
+      "prompt_tokens": 40,
+      "total_tokens": 48,
+      "completion_tokens": 8
+    }
+  }
+}

--- a/local/task32/task32-return-a-structured.json
+++ b/local/task32/task32-return-a-structured.json
@@ -1,0 +1,145 @@
+{
+  "phase": "return-a-structured",
+  "health_code": 200,
+  "health_body": "",
+  "runs": [
+    {
+      "http": 200,
+      "ttft_s": 0.4152543329999999,
+      "wall_s": 3.260483875,
+      "decode_s": 2.845229542,
+      "tok_s": 69.94163284981104,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.36610600000000026,
+      "wall_s": 3.223834667,
+      "decode_s": 2.857728667,
+      "tok_s": 69.63572234760383,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    },
+    {
+      "http": 200,
+      "ttft_s": 0.3684311659999997,
+      "wall_s": 3.2902007499999995,
+      "decode_s": 2.9217695839999998,
+      "tok_s": 68.10940913676102,
+      "completion_tokens": 200,
+      "prompt_tokens": 34,
+      "finish_reason": "length",
+      "nan": false,
+      "text_head": "1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100 ",
+      "text_len": 292,
+      "usage": {
+        "prompt_tokens": 34,
+        "total_tokens": 234,
+        "completion_tokens": 200
+      },
+      "spec": {
+        "drafts": 25,
+        "draft_tokens": 175,
+        "accepted": 175,
+        "accept_ratio": 1.0,
+        "accepted_per_step": 7.0,
+        "pos": [
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0,
+          1.0
+        ]
+      }
+    }
+  ],
+  "ts": 1788978344.906707,
+  "prompt": "structured-count-1-200",
+  "thinking": false,
+  "temperature": 0,
+  "warmup": {
+    "tok_s": 86.46716777625939,
+    "ttft_s": 0.412128917,
+    "completion_tokens": 32
+  },
+  "tok_s_median": 69.63572234760383,
+  "tok_s_min": 68.10940913676102,
+  "tok_s_max": 69.94163284981104,
+  "ttft_median_s": 0.3684311659999997,
+  "completion_tokens_median": 200.0,
+  "accept_ratio_median": 1.0,
+  "accepted_per_step_median": 7.0,
+  "any_nan": false,
+  "health_code_after": 200,
+  "short_after": {
+    "http": 200,
+    "ttft_s": 0.49737370899999966,
+    "wall_s": 0.5239221250000003,
+    "decode_s": 0.026548416000000685,
+    "tok_s": 263.6692147659514,
+    "completion_tokens": 8,
+    "prompt_tokens": 40,
+    "finish_reason": "length",
+    "nan": false,
+    "text_head": "# How a Hash Map Works: A",
+    "text_len": 25,
+    "usage": {
+      "prompt_tokens": 40,
+      "total_tokens": 48,
+      "completion_tokens": 8
+    }
+  }
+}

--- a/local/task32/task32-revert-20260909.txt
+++ b/local/task32/task32-revert-20260909.txt
@@ -1,0 +1,62 @@
+TASK32 adaptive-k SATURATE=n REVERT 2026-09-09
+independent_variable=GLM53_ADAPTIVE_K_SATURATE
+control=max (launcher default; production last-wins unset)
+candidate=n (last-wins GLM53_ADAPTIVE_K_SATURATE=n)
+frozen=IMAGE=glm53-selfbuild:e3-w3-zfill EXL3_FAT_GROUPED=1 EXL3_TEMP_ROWS_FUSED=32
+       GLM53_ADAPTIVE_K=ema GLM53_ADAPTIVE_K_CAPTURE=1 DFLASH_TOKENS=7 DFLASH_DRAFT_TP=1
+       DFLASH_REVISION=7d74cdd881ed7e32c31175984a67823127b66cfe
+       MAX_NUM_SEQS=4 MNBT=3584 LPTT=1792 KV pin 15414698763
+policy_only=1  not in JIT shape hash  no cubin  no extra graphs
+sequence=A (incumbent live boot, saturate=max) -> B (SATURATE=n, guarded restart, no JIT wipe)
+         -> return-A restoration (.env.bak-pre-task32-saturate-n-20260909-140038, guarded restart)
+         B2 skipped: B already missed the >=5% prose/agentic adopt bar.
+rollback=.env.bak-pre-task32-saturate-n-20260909-140038 (SATURATE unset; applied)
+
+pool=1,396,551 tokens / 1.40x  A, B, return-A
+bind=127.0.0.1:8000
+health=200
+unit=active (oneshot Type=oneshot; restart required, start is a no-op)
+watchdog.timer=active (re-armed after restore-A smoke)
+
+A control (saturate=max, standing production boot after Task 30 return-A)
+  structured n=9  median=70.51  accept=1.000/7.0  (range 66.63-73.63)
+  hashmap n=9     median=29.09  accept_ratio=0.500  accepted_per_step=1.985
+                  range 27.11-33.63
+  essay n=9       median=24.95  accept_ratio=0.433  accepted_per_step=1.481
+                  range 22.52-26.10
+  idle MemFree head/worker GiB=4.50 / 3.76
+  running=0 waiting=0 preemptions=0
+
+B candidate (GLM53_ADAPTIVE_K_SATURATE=n)
+  both ranks: GLM53_ADAPTIVE_K_SATURATE=n
+  EngineCore: enabled set=[2, 4, 7] alpha=0.25 margin=1.0 min_steps=4 saturate=n graphs=True
+  query lenses [3,5,8]
+  structured n=9  median=70.23  (-0.40%) accept=1.000/7.0  (range 65.29-73.33)
+  hashmap n=9     median=28.90  (-0.65%) accept_ratio=0.634  accepted_per_step=1.689
+                  range 26.80-30.69
+  essay n=9       median=25.21  (+1.05%) accept_ratio=0.535  accepted_per_step=1.353
+                  range 23.72-25.79
+  idle MemFree head/worker GiB=5.20 / 4.54
+  running=0 waiting=0 preemptions=0
+  pool identical
+
+return-A (SATURATE unset, launcher default max)
+  EngineCore: saturate=max graphs=True
+  structured n=3  median=69.64  accept=1.000/7.0
+  acceptance=7/7  serving=6/6 (Mac tunnel :18000)
+  pool identical
+  idle MemFree head/worker GiB=4.74 / 4.07
+  running=0 waiting=0 preemptions=0
+  dmesg CUDA/Xid/IMA: not scraped this window (health 200, unit active;
+  metrics preemptions=0). no_cuda_xid_ima is unverified, not a receipt.
+
+Verdict: REVERT / KEEP saturate=max (unset last-wins).
+  Structured non-inferior (>= -3% at 7.0/1.000). Hashmap -0.65% and essay +1.05%
+  missed the >=5% prose/agentic adopt bar. Wash. saturate=n raised accept_ratio
+  (hashmap 0.500 -> 0.634, essay 0.433 -> 0.535) by verifying a shorter prefix,
+  but accepted_per_step fell (1.985 -> 1.689 hashmap; 1.481 -> 1.353 essay)
+  because the ratchet never climbs after a low-accept stretch. Throughput is
+  wash. Do not chain ALPHA/MARGIN/MIN_STEPS. Do not leave SATURATE=n last-wins.
+  Tasks 29/31 stay parked behind a decode-step nsys/ncu share.
+no_cuda_xid_ima=unverified (dmesg not scraped)
+geometry_unchanged=MAX_MODEL_LEN=1000000 MNBT=3584 MAX_NUM_SEQS=4 DFLASH_TOKENS=7 IMAGE=e3-w3-zfill

--- a/overlay/patch_adaptive_k.py
+++ b/overlay/patch_adaptive_k.py
@@ -22,6 +22,7 @@ Knobs (read at container runtime):
   GLM53_ADAPTIVE_K_MARGIN     n = largest set value <= ceil(ema + margin)
   GLM53_ADAPTIVE_K_MIN_STEPS  full-k steps before trimming, default 4
   GLM53_ADAPTIVE_K_SATURATE   "max" (default) or "n"
+                              Task 32 REVERTED n (hashmap −0.7%). Keep max.
   GLM53_ADAPTIVE_K_HIST       histogram every N steps, default 200
   GLM53_ADAPTIVE_K_FILE       optional JSON override; only when graphs existed
                               at boot

--- a/tests/bench_decode.py
+++ b/tests/bench_decode.py
@@ -28,6 +28,13 @@ BENCH_PROMPT = (
 STRUCTURED_PROMPT = (
     "Count from 1 to 200. Output only the numbers, separated by spaces. No other text."
 )
+# Low-accept technical essay used by Task 25 / Task 28 (label: hard-essay).
+ESSAY_PROMPT = (
+    "Write a detailed technical essay titled \"Speculative Decoding and the Hidden "
+    "Cost of Failed Drafts: A Technical Analysis\". Cover draft generation, "
+    "verification cost, rejection sampling, and when longer drafts stop paying. "
+    "Use numbered sections. Be thorough."
+)
 NAN_RE = re.compile(r"\bnan\b|locklock", re.I)
 SPEC_RE = re.compile(
     r"^(vllm:spec_decode_[a-zA-Z0-9_]+)\{([^}]*)\}\s+(\S+)$"
@@ -260,7 +267,14 @@ def main() -> int:
         action="store_true",
         help="Warmed count-1-to-200 decode (temp 0, thinking off). Reports median tok/s + DFlash2 accept.",
     )
+    ap.add_argument(
+        "--essay",
+        action="store_true",
+        help="Low-accept technical essay (temp 0, thinking off). Same payload as Task 25/28 hard-essay.",
+    )
     args = ap.parse_args()
+    if args.structured and args.essay:
+        ap.error("--structured and --essay are mutually exclusive")
     h_code, h_body = health()
     rec: dict = {
         "phase": args.phase,
@@ -273,8 +287,15 @@ def main() -> int:
         Path(args.out).write_text(json.dumps(rec, indent=2))
         print(json.dumps(rec, indent=2))
         return 2
-    prompt = STRUCTURED_PROMPT if args.structured else BENCH_PROMPT
-    rec["prompt"] = "structured-count-1-200" if args.structured else "hashmap-prose"
+    if args.structured:
+        prompt = STRUCTURED_PROMPT
+        rec["prompt"] = "structured-count-1-200"
+    elif args.essay:
+        prompt = ESSAY_PROMPT
+        rec["prompt"] = "hard-essay"
+    else:
+        prompt = BENCH_PROMPT
+        rec["prompt"] = "hashmap-prose"
     rec["thinking"] = False
     rec["temperature"] = 0
     if args.structured:

--- a/tests/test_adaptive_k_wiring.py
+++ b/tests/test_adaptive_k_wiring.py
@@ -84,8 +84,9 @@ def test_prod_start_hashes_extra_args_not_policy_knobs() -> None:
     assert "EXTRA_ARGS" in hash_line
     assert "DFLASH_TOKENS" in hash_line
     assert "GLM53_ADAPTIVE_K_CAPTURE" in hash_line
-    # Policy-only EMA must not itself force a JIT wipe.
+    # Policy-only EMA / SATURATE must not themselves force a JIT wipe.
     assert "GLM53_ADAPTIVE_K=" not in hash_line or "GLM53_ADAPTIVE_K_CAPTURE" in hash_line
+    assert "GLM53_ADAPTIVE_K_SATURATE" not in hash_line
     assert "printf 'GLM53_ADAPTIVE_K_CAPTURE=%s" in PROD_START
 
 
@@ -94,8 +95,11 @@ def test_docs_and_env_example_name_the_knobs() -> None:
     assert "GLM53_ADAPTIVE_K_CAPTURE=1" in ENV_EXAMPLE
     assert "verification-only" in ENV_EXAMPLE
     assert "Rollback: GLM53_ADAPTIVE_K=off" in ENV_EXAMPLE
+    assert "Task 32 REVERTED n" in ENV_EXAMPLE
     assert "GLM53_ADAPTIVE_K" in DOCS_02
     assert "B0" in DOCS_02
+    assert "GLM53_ADAPTIVE_K_SATURATE" in DOCS_02
+    assert "REVERTED 2026-09-09 at `n`" in DOCS_02
 
 
 if __name__ == "__main__":

--- a/tests/test_bench_decode.py
+++ b/tests/test_bench_decode.py
@@ -41,3 +41,10 @@ def test_aggregate_any_nan_semantics(monkeypatch) -> None:
     bad_runs = clean_runs + [{"nan": module.contains_nan("value NaN")}]
     assert not any(run["nan"] for run in clean_runs)
     assert any(run["nan"] for run in bad_runs)
+
+
+def test_essay_prompt_is_distinct(monkeypatch) -> None:
+    module = _module(monkeypatch)
+    assert "Failed Drafts" in module.ESSAY_PROMPT
+    assert module.ESSAY_PROMPT != module.BENCH_PROMPT
+    assert module.ESSAY_PROMPT != module.STRUCTURED_PROMPT


### PR DESCRIPTION
Task 32 A/B'd leftover Task 25 policy knob
`GLM53_ADAPTIVE_K_SATURATE=n` against production `max` (launcher
default; last-wins unset) on the current stack (`e3-w3-zfill`,
TRF=32, adaptive-k ema, extra graphs, k=7, C4, DFlash `7d74cdd`).
Independent variable was saturate only. Policy-only: not in the JIT
shape hash, no cubin, no extra graphs. Guarded oneshot restart
required (`Type=oneshot` start is a no-op on an already-active unit).

Cluster A vs B: hashmap 29.09 → 28.90 tok/s (−0.7%). Hard essay
24.95 → 25.21 (+1.1%). Structured stayed 7.0/1.000 (70.51 → 70.23,
−0.4%). B2 skipped because B already missed the ≥5% prose/agentic
bar. saturate=n raised accept_ratio by verifying a shorter prefix,
but accepted_per_step fell (hashmap 1.985 → 1.689) because the
ratchet never climbs after a low-accept stretch.

Verdict: REVERT. Production last-wins restored unset
(`.env.bak-pre-task32-saturate-n-20260909-140038`). Return-A
restoration smoke: structured 69.64 @ 7.0/1.000, acceptance 7/7,
serving 6/6, watchdog re-armed. Keep `max`. Do not chain
ALPHA/MARGIN/MIN_STEPS.

This PR records the window: `--essay` bench payload (Task 25/28
hard-essay), docs/02 / docs/06 / env.example, wiring/tests, and
cluster receipts under `local/task32/`.
