### PR TITLE
Task 24: E3 prefill share oracle — W4 successor STOP

### DIFF
--- a/docs/11-gb10-kernel-program.md
+++ b/docs/11-gb10-kernel-program.md
@@ -356,7 +356,9 @@ Live TP2 scratch is **~280 MiB/rank**, not the 336 MiB microbench figure:
 
 **Queue:** ~~W1 lazy scratch~~ **REVERTED 2026-09-07** → W2 isolated TRF=32
 (gated) → ~~W3 zero-fill A-pad~~ **ADOPTED 2026-09-08** → ~~W4 fused gather~~
-**REVERTED 2026-09-08** → W5 occupancy (gated). Not automatic-next.
+**REVERTED 2026-09-08** → ~~W4 successor persistent A-cache~~ **STOP by
+measurement 2026-09-09** (gather 8.6% of E3 / 2.1% of prefill kernel time,
+below both pre-registered floors) → W5 occupancy (gated). Not automatic-next.
 
 | Window | Path it can move | Rebuild | Expected sign |
 |---|---|---|---|
@@ -460,14 +462,42 @@ restored `e3-w3-zfill`. Overlay stays in-tree. Do not re-run this
 gather-as-reload. A later attempt needs a persistent SUH-scaled
 A-cache across K, not per-stage `x[row_token]` re-Hadamard.
 
+**W4 successor — persistent SUH-scaled A-cache: STOP by measurement
+(2026-09-09).** The ncu-first gate was answered with the in-process
+torch-profiler prefill-share oracle instead (`scripts/probe_prefill_profile.py`
++ `scripts/audit_prefill_kernel_share.py` driven by the guarded window in
+`scripts/run_decode_profile_window.py --probe …`; ncu is not installed here and
+`nsys --gpu-metrics` fails `ERR_NVGPUCTRPERM`, see
+`docs/14-profiling-privilege-runbook.md`). Pre-registered before the window:
+proceed only if the min-across-ranks `fm_gather_kernel` share is ≥10% of E3
+layer time **and** ≥3% of total prefill kernel time. Two independent guarded 60k
+windows (`e3-w3-zfill`, TRF=32, adaptive-k ema, pin `7d74cdd`, JIT stamp
+`078835f1d75f` unchanged) measured gather at **8.68 / 8.62%** and **8.64 /
+8.69%** of E3 layer time (head/worker) and **2.10 / 2.09%** and **2.11 /
+2.09%** of total prefill kernel time; gateup 55.4%, down 35.9% of E3. Capture
+validity: 1428 grouped launches per rank (34 chunks × 42 layers) against
+1428/1428/1428 gather/gateup/down and 1470 fused `exl3_moe`, with 96.8% of CUDA
+time in 1792-token context steps and 1.7% in the final 896-token context step.
+The fused kernel also runs during prefill here (launch ratio 1.03), which is why
+the decode guard pairs a time ceiling with that ratio. Ceiling if the gather
+became free: **2.09%** of prefill kernel time, below the ≥3% end-to-end bar, and
+W4 already measured −10.7% at this shape. No kernel window opened and the
+persistent A-cache stays unbuilt; re-open only with a measured counter that
+contradicts the gather share. The 240k share is **unmeasured and deferred**: the
+60k window already stopped the gate, and equal chunk sizes do not imply equal
+per-expert routing — `build_grouped_fat_tables()` derives live rows and rounded
+segment counts from those counts — so the 240k share could differ.
+
 **W5 — occupancy.** `__launch_bounds__(256, 2)` is already on gateup/down.
 SMEM 32,768 B is not the limiter. Open only on ncu at production shapes
 (TP2 inter=1024, E3@128 fat histogram) showing achieved occupancy ≪
 theoretical from registers or the 512 grid-Y cap.
 
 Measure before coding: live `grouped_scratch_bytes` (expect ≈280 MiB/rank);
-E3@128 fat-row / segment-mod-64 histograms; gather vs gateup share of
-layer time; table-build share (persist tables only if ≥2% of layer time).
+E3@128 fat-row / segment-mod-64 histograms; table-build share (persist tables
+only if ≥2% of layer time). Gather-vs-gateup share of layer time is now
+measured (8.6% vs 55.4%, above), so it is no longer an open pre-coding
+measurement.
 
 ### Do-not-bundle / parked
 

--- a/docs/14-profiling-privilege-runbook.md
+++ b/docs/14-profiling-privilege-runbook.md
@@ -1,0 +1,92 @@
+# 14 — Enabling GPU performance counters on the Spark pair (owner runbook)
+
+**Status: prepared, not executed.** This change needs root on both nodes and a
+reboot, so it is the owner's call. Nothing in this document has been run.
+
+## Why
+
+The counter lane for tasks 1, 29, W5 and #55061 is blocked by one driver
+setting, not by tooling:
+
+```
+$ cat /proc/driver/nvidia/params | grep -i restrict
+RmProfilingAdminOnly: 1
+$ nsys profile --gpu-metrics-devices=help
+GPU Metrics: None of the installed GPUs are supported:
+  Blackwell GB20B | NVIDIA GB10 PCI[000f:01:00.0] - Insufficient privilege,
+  see https://developer.nvidia.com/ERR_NVGPUCTRPERM
+```
+
+`ncu` is not installed on either node; `nsys` 2025.3.2 is, and it reports the
+GB10 as *supported but privilege-denied*. `dcgmi`/`nv-hostengine` are not
+installed. `perf_event_paranoid=4` is a second, unrelated restriction on host
+perf events.
+
+Consequence today: PR #64's in-process torch profiler is the only counter path
+that works. It gives kernel durations and launch geometry, which is enough for
+share questions, but it cannot produce DRAM/L2 byte counters. Task 29 was parked
+(`GAP_CANDIDATE_UNMEASURED`) and W5 (occupancy) was gated on exactly that
+missing measurement.
+
+## What the change is
+
+One module option, in a dedicated drop-in so no existing file is edited:
+
+```
+# /etc/modprobe.d/99-nvidia-profiling.conf
+options nvidia NVreg_RestrictProfilingToAdminUsers=0
+```
+
+`NVreg_RestrictProfilingToAdminUsers=1` is the upstream default that makes the
+profiling APIs root-only. Setting it to 0 lets local users collect GPU
+performance counters. It has no effect on clocks, power limits or ECC.
+
+The `scripts/enable-gpu-profiling.sh` helper in this repo writes the drop-in,
+rebuilds the initramfs, and reports the state. It never reboots on its own.
+
+## Steps (owner, both nodes)
+
+1. Stop the vLLM unit and the watchdog on that node so nothing is mid-flight:
+   `systemctl --user stop vllm-glm53exl3-watchdog.timer vllm-glm53exl3.service`
+   (as `nvidia`), and let the peer idle.
+2. Write the drop-in and rebuild initramfs:
+   `sudo bash scripts/enable-gpu-profiling.sh`
+3. Reboot the node: `sudo systemctl reboot`. Repeat on the other node.
+   Both nodes must be rebooted; the option is read at module load.
+4. Verify on both nodes:
+   - `cat /proc/driver/nvidia/params | grep RmProfilingAdminOnly` -> `0`
+   - `nsys profile --gpu-metrics-devices=help` -> lists `NVIDIA GB10` with no
+     privilege error
+   - bring production back with `local/prod-start.sh` and confirm `/health`
+     200, pool line unchanged, and the watchdog timers re-armed.
+5. Capture one proof-of-capability receipt before any A/B claims a counter:
+   a short `nsys profile --gpu-metrics-device=0` of a throwaway workload, or an
+   `ncu --metrics dram__bytes_read.sum` run if `ncu` is installed first
+   (`sudo apt-get install -y nsight-compute`).
+
+## Rollback
+
+`sudo bash scripts/enable-gpu-profiling.sh --revert` (removes the drop-in and
+rebuilds initramfs), then reboot. Counters go back to root-only.
+
+## Risk
+
+- The profiling APIs become available to every local user. These are
+  single-tenant boxes; treat it as a local trust change, not a network one.
+- A reboot is required, so this belongs in a maintenance slot. It does not
+  change weights, the KV pin, the image, or any serving knob.
+- Profiling while production serves still perturbs it. Keep the existing
+  contract: `ncu` replay stays off the live CUDA-graph server; use
+  `nsys --gpu-metrics` or a stopped window.
+
+## What it unblocks
+
+- Task 29: a measured DRAM-byte counter for the fused `exl3_moe` decode path,
+  replacing the advisory 218 GB/s weight-streaming model.
+- Task 24 W5: the achieved-occupancy measurement the cubin sweep is gated on.
+- Task 1: the exact-workload traffic measurement that gates selective
+  quantization.
+- #55061: the `index_select` overflow-path probe.
+
+Until this is run, those stay parked and the software-only oracles in
+`scripts/audit_*_kernel_share.py` remain the only counter path.

--- a/scripts/audit_prefill_kernel_share.py
+++ b/scripts/audit_prefill_kernel_share.py
@@ -1,0 +1,395 @@
+#!/usr/bin/env python3
+"""Prefill kernel-share oracle for the E3 W4-successor gate (task 24).
+
+Why this exists
+---------------
+``docs/11`` §8 ranks the W4 successor (a persistent SUH-scaled A-cache consumed
+read-only by every gate/up K-slab) TEST-NEXT behind an ncu measurement of the
+gather-vs-gateup share of E3 layer time. ncu is not usable on this cluster: it
+is not installed and the driver enforces ``RmProfilingAdminOnly: 1``, so both
+ncu and ``nsys --gpu-metrics`` fail closed (``ERR_NVGPUCTRPERM``). The counter
+path that *is* safe and available here is the per-rank chrome trace written by
+vLLM's in-process torch profiler. Kineto records every grouped ``fm_*`` kernel
+with its duration and launch geometry, including launches that happen inside a
+captured CUDA graph, so the *share* question can be answered without hardware
+counters.
+
+What it reports
+---------------
+Per rank (two ranks have independent GPU clock domains, so they are summarised
+separately and never summed):
+
+* total kernel time and family shares;
+* the three grouped fat-MoE kernels -- ``fm_gather_kernel`` (gather + input
+  Hadamard into ``h13``), ``fm_gateup_kernel``, ``fm_down_kernel`` -- as shares
+  of total kernel time and of E3 layer time (their sum);
+* the launch geometry the trace carries (registers, SMEM, block, grid volume)
+  and the derived occupancy, which is context for W5, not a measurement;
+* the decode share, so a capture that is not prefill-dominated fails closed.
+
+Pre-registered gate (2026-09-09, before the cluster window)
+-----------------------------------------------------------
+Let ``g`` = ``fm_gather_kernel`` time / (gather + gateup + down) time and
+``t`` = ``fm_gather_kernel`` time / total kernel time, on a rank. Take the
+minimum of each across ranks (conservative). All three grouped kernels must be
+present with positive time on every audited rank; otherwise the capture is
+``INCONCLUSIVE_NO_GROUPED_CAPTURE`` (a lone gather kernel would otherwise read
+as a 100% share on no evidence).
+
+* ``g >= --gather-share-floor`` (default 0.10) **and**
+  ``t >= --gather-total-floor`` (default 0.03)
+      -> ``PROCEED_W4_SUCCESSOR``: removing the gather can plausibly clear the
+      standing >=3% end-to-end bar, so the kernel work is worth opening.
+* otherwise
+      -> ``STOP_GATHER_SHARE_BELOW_FLOOR``: the ceiling is too small. W4
+      already measured a -10.7% regression at 60k for the fused-gather rewrite,
+      so a low gather share does not justify another attempt.
+
+Rationale for the floors: the successor can at best remove the gather kernel;
+a 10% share of E3 layer time means even a partial recovery can move
+end-to-end, and the 3% total-time floor matches the W5 stop bar.
+
+Prefill-vs-decode guard (calibrated 2026-09-09 on this deployment)
+-----------------------------------------------------------------
+The fused ``exl3_moe`` kernel is *not* decode-only here: with
+``EXL3_FAT_GROUPED=1``/``EXL3_TEMP_ROWS_FUSED=32`` a prefill chunk runs one
+fused launch per layer beside the grouped triple. Measured on the first 60k
+capture, on both ranks: 1470 fused launches against 1428 grouped launches per
+rank (ratio 1.03) and a fused share of 12.7% of kernel time, while the profiler's
+own step table attributes 96.8% of CUDA time to 1792-token context steps and
+1.7% to a final 896-token context step -- i.e. essentially the whole window is
+prefill. A decode-dominated capture instead measures 50.7% fused (PR #64). The
+guard therefore uses both a time ceiling (``--decode-share-max``, default 0.30:
+2.3x above the measured prefill value and 1.7x below the measured decode value)
+and a structural launch ratio (``--fused-call-ratio-max``, default 2.0: 1.9x
+above the measured prefill ratio, and unreachable for a capture that runs the
+fused path every step).
+
+Both guards are calibrated heuristics on this pinned window (one cold prefill,
+``max_tokens=1``), not general phase identification: the launch ratio
+approximates ``1 + fused-only steps / grouped steps`` rather than decode *time*,
+and a mixed workload with enough concurrent decode can land between the two
+measured regimes. They stop a window whose capture is not the prefill it claims
+to be; they do not certify a share under arbitrary concurrent traffic.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import audit_decode_kernel_share as base  # noqa: E402
+
+# First match wins. Restricted to names the base auditor already classifies as
+# grouped_fat_moe, so a generic "down"/"gather" token cannot match.
+ROLES: tuple[tuple[str, re.Pattern[str]], ...] = (
+    ("gather", re.compile(r"fm_gather", re.I)),
+    ("gateup", re.compile(r"fm_gateup", re.I)),
+    ("down", re.compile(r"fm_down", re.I)),
+)
+
+VERDICT_PROCEED = "PROCEED_W4_SUCCESSOR"
+VERDICT_STOP = "STOP_GATHER_SHARE_BELOW_FLOOR"
+VERDICT_NO_GROUPED = "INCONCLUSIVE_NO_GROUPED_CAPTURE"
+VERDICT_DECODE = "INCONCLUSIVE_DECODE_DOMINATED"
+
+
+def role_of(name: str) -> str | None:
+    if base.classify(name) != "grouped_fat_moe":
+        return None
+    for role, pattern in ROLES:
+        if pattern.search(name):
+            return role
+    return None
+
+
+def summarize_rank(report: dict[str, Any], top: int) -> dict[str, Any]:
+    """Reduce one rank's ``audit_decode_kernel_share.audit`` report to shares."""
+    totals = report["totals"]
+    total_us = float(totals["kernel_us"])
+    grouped: dict[str, dict[str, Any]] = {}
+    e3_us = 0.0
+    for row in report["kernels"]:
+        role = role_of(str(row["name"]))
+        if role is None:
+            continue
+        e3_us += float(row["total_us"])
+        grouped[role] = {
+            "name": row["name"],
+            "count": row["count"],
+            "total_us": row["total_us"],
+            "share_of_total": row["share"],
+            "share_of_e3": None,  # filled below once the E3 total is known
+            "regs": row["regs"],
+            "smem": row["smem"],
+            "block": row["block"],
+            "grid_volume": row["grid_volume"],
+            "derived_occupancy_pct": row["derived_occupancy_pct"],
+        }
+    for row in grouped.values():
+        row["share_of_e3"] = (
+            round(float(row["total_us"]) / e3_us, 6) if e3_us else None
+        )
+    families = {
+        fam: {"total_us": body["total_us"], "count": body["count"], "share": body["share"]}
+        for fam, body in report["families"].items()
+    }
+    return {
+        "kernel_us": round(total_us, 3),
+        "kernel_count": totals["kernel_count"],
+        "memcpy_us": totals["memcpy_us"],
+        "distinct_kernels": totals["distinct_kernels"],
+        "e3_us": round(e3_us, 3),
+        "e3_share_of_total": round(e3_us / total_us, 6) if total_us else 0.0,
+        "grouped": grouped,
+        "families": families,
+        "kernels": report["kernels"][:top],
+    }
+
+
+def decide(
+    ranks: dict[str, dict[str, Any]],
+    gather_share_floor: float,
+    gather_total_floor: float,
+    decode_share_max: float,
+    fused_call_ratio_max: float = 2.0,
+) -> dict[str, Any]:
+    if not ranks:
+        return {"verdict": VERDICT_NO_GROUPED, "reason": "no ranks in the audit"}
+    missing = sorted(r for r, body in ranks.items() if not body["grouped"])
+    if missing:
+        return {
+            "verdict": VERDICT_NO_GROUPED,
+            "reason": f"rank(s) {missing} captured no grouped fm_* kernels",
+            "gather_share_floor": gather_share_floor,
+            "gather_total_floor": gather_total_floor,
+            "decode_share_max": decode_share_max,
+            "fused_call_ratio_max": fused_call_ratio_max,
+        }
+    # A gather-vs-E3 share is only meaningful when the whole E3 layer ran: a
+    # trace with one lone fm_gather_kernel would otherwise read as a 100%
+    # gather share and pass the gate on no evidence.
+    incomplete: dict[str, list[str]] = {}
+    for rank, body in ranks.items():
+        absent = [
+            role
+            for role in ("gather", "gateup", "down")
+            if role not in body["grouped"] or float(body["grouped"][role]["total_us"]) <= 0
+        ]
+        if absent:
+            incomplete[rank] = absent
+    if incomplete:
+        return {
+            "verdict": VERDICT_NO_GROUPED,
+            "reason": (
+                "an E3 layer share needs all three grouped kernels with positive "
+                f"time; missing roles by rank: {incomplete}"
+            ),
+            "gather_share_floor": gather_share_floor,
+            "gather_total_floor": gather_total_floor,
+            "decode_share_max": decode_share_max,
+            "fused_call_ratio_max": fused_call_ratio_max,
+        }
+    decode_share = {
+        r: float(body["families"].get("fused_moe", {}).get("share", 0.0))
+        for r, body in ranks.items()
+    }
+    fused_ratio = {
+        r: (
+            float(body["families"].get("fused_moe", {}).get("count", 0))
+            / max(1.0, float(body["grouped"]["gather"]["count"]))
+        )
+        for r, body in ranks.items()
+    }
+    worst_decode = max(decode_share.values())
+    worst_ratio = max(fused_ratio.values())
+    if worst_decode > decode_share_max or worst_ratio > fused_call_ratio_max:
+        return {
+            "verdict": VERDICT_DECODE,
+            "reason": (
+                f"fused exl3_moe share {worst_decode:.4f} vs max {decode_share_max:.4f} "
+                f"and fused/gather launch ratio {worst_ratio:.2f} vs max "
+                f"{fused_call_ratio_max:.2f}; this capture is not prefill-dominated"
+            ),
+            "decode_share_by_rank": decode_share,
+            "decode_share_max": decode_share_max,
+            "fused_call_ratio_by_rank": fused_ratio,
+            "fused_call_ratio_max": fused_call_ratio_max,
+        }
+    share_of_e3 = {
+        r: float(body["grouped"]["gather"]["share_of_e3"]) for r, body in ranks.items()
+    }
+    share_of_total = {
+        r: float(body["grouped"]["gather"]["share_of_total"]) for r, body in ranks.items()
+    }
+    min_e3 = min(share_of_e3.values())
+    min_total = min(share_of_total.values())
+    proceed = min_e3 >= gather_share_floor and min_total >= gather_total_floor
+    reason = (
+        f"min gather share of E3 layer time {min_e3:.4f} vs floor "
+        f"{gather_share_floor:.4f}; min gather share of total kernel time "
+        f"{min_total:.4f} vs floor {gather_total_floor:.4f}"
+    )
+    if not proceed:
+        reason += (
+            "; the successor can at best remove the gather, so this ceiling "
+            "does not justify opening the kernel window"
+        )
+    return {
+        "verdict": VERDICT_PROCEED if proceed else VERDICT_STOP,
+        "reason": reason,
+        "gather_share_of_e3_by_rank": share_of_e3,
+        "gather_share_of_total_by_rank": share_of_total,
+        "min_gather_share_of_e3": round(min_e3, 6),
+        "min_gather_share_of_total": round(min_total, 6),
+        "gather_share_floor": gather_share_floor,
+        "gather_total_floor": gather_total_floor,
+        "decode_share_by_rank": decode_share,
+        "decode_share_max": decode_share_max,
+        "fused_call_ratio_by_rank": fused_ratio,
+        "fused_call_ratio_max": fused_call_ratio_max,
+        "e2e_ceiling_if_gather_free": round(min_total, 6),
+    }
+
+
+def audit_prefill(
+    traces: list[Path],
+    gather_share_floor: float = 0.10,
+    gather_total_floor: float = 0.03,
+    decode_share_max: float = 0.30,
+    fused_call_ratio_max: float = 2.0,
+    top: int = 15,
+) -> dict[str, Any]:
+    ranks: dict[str, dict[str, Any]] = {}
+    for path in traces:
+        report = base.audit([path], moe_share_floor=0.05, occ_floor=50.0)
+        ranks[base.rank_of(path)] = summarize_rank(report, top)
+    return {
+        "schema": 1,
+        "source": "vllm torch profiler (in-process, CUDA-graph aware)",
+        "gate": {
+            "name": "w4_successor_gather_share",
+            "preregistered": "2026-09-09, before the cluster window",
+            "gather_share_floor": gather_share_floor,
+            "gather_total_floor": gather_total_floor,
+            "decode_share_max": decode_share_max,
+            "fused_call_ratio_max": fused_call_ratio_max,
+        },
+        "traces": [str(p) for p in traces],
+        "ranks": ranks,
+        "decision": decide(
+            ranks, gather_share_floor, gather_total_floor, decode_share_max, fused_call_ratio_max
+        ),
+    }
+
+
+def render(report: dict[str, Any], top: int) -> str:
+    lines: list[str] = []
+    for rank, body in sorted(report["ranks"].items()):
+        lines.append(
+            f"[{rank}] kernel_us={body['kernel_us']:.0f} kernels={body['kernel_count']} "
+            f"e3_us={body['e3_us']:.0f} e3_share={body['e3_share_of_total']*100:.2f}% "
+            f"memcpy_us={body['memcpy_us']:.0f}"
+        )
+        lines.append("  families:")
+        for fam, row in sorted(
+            body["families"].items(), key=lambda kv: kv[1]["total_us"], reverse=True
+        ):
+            lines.append(
+                f"    {fam:16s} {row['share']*100:6.2f}%  {row['total_us']:12.0f} us  "
+                f"n={row['count']}"
+            )
+        lines.append("  E3 grouped breakdown:")
+        for role in ("gather", "gateup", "down"):
+            row = body["grouped"].get(role)
+            if row is None:
+                lines.append(f"    {role:7s} missing")
+                continue
+            der = ",".join(str(v) for v in row["derived_occupancy_pct"]) or "-"
+            lines.append(
+                f"    {role:7s} {row['share_of_total']*100:6.2f}% of total  "
+                f"{row['share_of_e3']*100:6.2f}% of E3  {row['total_us']:11.0f} us  "
+                f"n={row['count']:<6d} derived%={der:<6s} regs={row['regs']} "
+                f"smem={row['smem']} block={row['block']} grid={row['grid_volume']}"
+            )
+        lines.append(f"  top {top} kernels:")
+        for row in body["kernels"][:top]:
+            der = ",".join(str(v) for v in row["derived_occupancy_pct"]) or "-"
+            lines.append(
+                f"    {row['share']*100:6.2f}%  {row['total_us']:11.0f} us  "
+                f"n={row['count']:<6d} derived%={der:<6s} {row['name'][:78]}"
+            )
+    dec = report["decision"]
+    lines.append(f"decision: {dec['verdict']}")
+    lines.append(f"  {dec['reason']}")
+    if "gather_share_of_e3_by_rank" in dec:
+        lines.append(
+            "  gather share of E3 by rank: "
+            + ", ".join(f"{r}={v*100:.2f}%" for r, v in sorted(dec["gather_share_of_e3_by_rank"].items()))
+        )
+        lines.append(
+            "  gather share of total by rank: "
+            + ", ".join(f"{r}={v*100:.2f}%" for r, v in sorted(dec["gather_share_of_total_by_rank"].items()))
+        )
+        lines.append(
+            f"  ceiling if the gather became free: "
+            f"{dec['e2e_ceiling_if_gather_free']*100:.2f}% of prefill kernel time"
+        )
+    if "fused_call_ratio_by_rank" in dec:
+        lines.append(
+            "  fused/gather launch ratio by rank: "
+            + ", ".join(
+                f"{r}={v:.2f}" for r, v in sorted(dec["fused_call_ratio_by_rank"].items())
+            )
+            + f" (max {dec['fused_call_ratio_max']:.2f})"
+        )
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    src = ap.add_mutually_exclusive_group(required=True)
+    src.add_argument("--trace-dir", type=Path)
+    src.add_argument("--trace", type=Path, action="append", default=[])
+    ap.add_argument("--json-out", type=Path)
+    ap.add_argument("--gather-share-floor", type=float, default=0.10)
+    ap.add_argument("--gather-total-floor", type=float, default=0.03)
+    ap.add_argument("--decode-share-max", type=float, default=0.30,
+                    help="fused exl3_moe share of kernel time; measured prefill 0.128, "
+                         "measured decode 0.507 (PR #64)")
+    ap.add_argument("--fused-call-ratio-max", type=float, default=2.0,
+                    help="fused exl3_moe launches / fm_gather launches; measured prefill 1.03")
+    ap.add_argument("--top", type=int, default=15)
+    args = ap.parse_args(argv)
+
+    try:
+        traces = base.find_traces(args.trace_dir) if args.trace_dir else list(args.trace)
+        for path in traces:
+            if not path.is_file():
+                raise FileNotFoundError(path)
+        report = audit_prefill(
+            traces,
+            args.gather_share_floor,
+            args.gather_total_floor,
+            args.decode_share_max,
+            args.fused_call_ratio_max,
+            args.top,
+        )
+    except (FileNotFoundError, ValueError, json.JSONDecodeError) as exc:
+        print(f"prefill-share audit FAILED: {exc}", file=sys.stderr)
+        return 2
+
+    print(render(report, args.top))
+    if args.json_out:
+        args.json_out.write_text(json.dumps(report, indent=1) + "\n")
+        print(f"wrote {args.json_out}")
+    verdict = report["decision"]["verdict"]
+    return 0 if verdict in (VERDICT_PROCEED, VERDICT_STOP) else 3
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/enable-gpu-profiling.sh
+++ b/scripts/enable-gpu-profiling.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# Prepare (or revert) GPU performance-counter access on a DGX Spark node.
+#
+#   sudo bash scripts/enable-gpu-profiling.sh          # write the drop-in
+#   sudo bash scripts/enable-gpu-profiling.sh --check  # report only
+#   sudo bash scripts/enable-gpu-profiling.sh --revert # remove it
+#
+# The change is one module option, NVreg_RestrictProfilingToAdminUsers=0, in a
+# dedicated drop-in. It is read when the nvidia module loads, so a reboot is
+# required and this script NEVER reboots on its own. See
+# docs/14-profiling-privilege-runbook.md for the full procedure and rollback.
+#
+# It refuses to touch a drop-in it does not own (identified by a managed-by
+# marker); use --force only after inspecting the file. GLM53_PROFILING_DROPIN
+# redirects the target path for tests; the real path always needs root.
+set -euo pipefail
+
+SYSTEM_DROPIN=/etc/modprobe.d/99-nvidia-profiling.conf
+DROPIN="${GLM53_PROFILING_DROPIN:-$SYSTEM_DROPIN}"
+PARAMS=/proc/driver/nvidia/params
+OPTION='options nvidia NVreg_RestrictProfilingToAdminUsers=0'
+MARKER='managed by glm53 enable-gpu-profiling.sh'
+
+say() { printf '%s\n' "$*"; }
+die() { printf 'error: %s\n' "$*" >&2; exit 2; }
+
+is_system() { [ "$DROPIN" = "$SYSTEM_DROPIN" ]; }
+
+require_root() {
+    if is_system && [ "$(id -u)" -ne 0 ]; then
+        die "run this with sudo (it writes $DROPIN)"
+    fi
+}
+
+is_managed() {
+    [ -f "$DROPIN" ] && grep -qF "$MARKER" "$DROPIN"
+}
+
+show_state() {
+    local live="unknown"
+    if [ -r "$PARAMS" ]; then
+        live="$(awk -F': *' '/RmProfilingAdminOnly/ {print $2}' "$PARAMS")"
+        say "live driver  RmProfilingAdminOnly=${live:-unknown}"
+    else
+        say "live driver  $PARAMS not readable"
+    fi
+    if [ -f "$DROPIN" ]; then
+        if is_managed; then
+            say "drop-in      $DROPIN present and managed:"
+        else
+            say "drop-in      $DROPIN present but NOT managed by this script:"
+        fi
+        sed 's/^/  /' "$DROPIN"
+    else
+        say "drop-in      $DROPIN absent"
+    fi
+    if [ "$live" = "0" ]; then
+        say "state        counters enabled"
+    elif [ "$live" = "1" ]; then
+        say "state        counters root-only (default); reboot after writing the drop-in"
+    fi
+    if command -v nsys >/dev/null 2>&1; then
+        say "nsys         $(nsys --version 2>/dev/null | head -1)"
+    else
+        say "nsys         not found"
+    fi
+    if command -v ncu >/dev/null 2>&1; then
+        say "ncu          $(ncu --version 2>/dev/null | awk '/Version/ {print $NF; exit}')"
+    else
+        say "ncu          not installed (nsys --gpu-metrics is enough for byte counters)"
+    fi
+}
+
+report_conflicts() {
+    local hits
+    hits="$(grep -rls 'NVreg_RestrictProfilingToAdminUsers' /etc/modprobe.d 2>/dev/null || true)"
+    if [ -n "$hits" ]; then
+        say "existing references:"
+        printf '%s\n' "$hits" | sed 's/^/  /'
+    fi
+}
+
+rebuild_initramfs() {
+    if ! is_system; then
+        say "skip initramfs rebuild (non-system drop-in: $DROPIN)"
+        return 0
+    fi
+    if command -v update-initramfs >/dev/null 2>&1; then
+        update-initramfs -u -k all
+        say "initramfs rebuilt"
+    else
+        say "note: update-initramfs not found; rebuild your initramfs if your distro needs it"
+    fi
+}
+
+apply() {
+    require_root
+    if ! awk '{print $1}' /proc/modules 2>/dev/null | grep -qx nvidia; then
+        say "note: the nvidia module is not loaded right now"
+    fi
+    if [ -f "$DROPIN" ] && ! is_managed; then
+        if [ "$FORCE" -ne 1 ]; then
+            die "$DROPIN exists and is not managed by this script; inspect it and use --force to replace it (a backup is then kept)"
+        fi
+        cp -p "$DROPIN" "$DROPIN.bak-$(date +%Y%m%d-%H%M%S)"
+        say "backed up the existing drop-in"
+    fi
+    if is_managed && grep -qF "$OPTION" "$DROPIN"; then
+        say "already present: $OPTION"
+    else
+        printf '# Enable GPU performance counters for local users (docs/14).\n# %s\n# Revert: sudo bash scripts/enable-gpu-profiling.sh --revert\n%s\n' \
+            "$MARKER" "$OPTION" > "$DROPIN"
+        say "wrote $DROPIN"
+    fi
+    rebuild_initramfs
+    report_conflicts
+    show_state
+    say
+    say "Next: reboot this node (the option is read at module load), then run"
+    say "  nsys profile --gpu-metrics-devices=help   # expect NVIDIA GB10, no privilege error"
+}
+
+revert() {
+    require_root
+    if [ ! -f "$DROPIN" ]; then
+        say "nothing to remove"
+    elif ! is_managed; then
+        if [ "$FORCE" -ne 1 ]; then
+            die "$DROPIN is not managed by this script; refusing to delete it (use --force only if you are sure)"
+        fi
+        rm -f "$DROPIN"
+        say "removed unmanaged $DROPIN (--force)"
+    else
+        rm -f "$DROPIN"
+        say "removed $DROPIN"
+    fi
+    rebuild_initramfs
+    show_state
+    say
+    say "Next: reboot this node to return the profiling APIs to root-only."
+}
+
+usage() {
+    say "usage: sudo bash scripts/enable-gpu-profiling.sh [--check|--revert|--force]"
+    say "  (no argument)  write the module drop-in and rebuild the initramfs"
+    say "  --check        report the live driver flag, drop-in and tool state"
+    say "  --revert       remove the drop-in and rebuild the initramfs"
+    say "  --force        replace/delete a drop-in this script does not own"
+    say "See docs/14-profiling-privilege-runbook.md. This script never reboots."
+}
+
+MODE=apply
+FORCE=0
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --apply)  MODE=apply ;;
+        --check)  MODE=check ;;
+        --revert) MODE=revert ;;
+        --force)  FORCE=1 ;;
+        -h|--help) MODE=help ;;
+        *) die "unknown argument: $1 (use --check, --revert, --force, or no argument)" ;;
+    esac
+    shift
+done
+
+case "$MODE" in
+    apply)  apply ;;
+    check)  show_state ;;
+    revert) revert ;;
+    help)   usage ;;
+esac

--- a/scripts/probe_prefill_profile.py
+++ b/scripts/probe_prefill_profile.py
@@ -1,0 +1,424 @@
+#!/usr/bin/env python3
+"""Capture one prefill window with the in-process torch profiler (task 24 W4 gate).
+
+Runs on the head node against the loopback API while the boot carries
+``GLM53_PROFILE_TORCH_DIR``. The window is one cold, unbatched long-context
+prefill:
+
+  warmup (unprofiled, nonce A) -> reset prefix cache -> POST /start_profile
+  -> one nonce-B request with ``max_tokens=1`` -> POST /stop_profile
+
+Both prompts carry a random leading nonce, so neither can hit the APC and the
+profiled request is a genuine cold prefill. ``max_tokens=1`` keeps the decode
+tail to a single verify step, which is what makes the capture
+prefill-dominated.
+
+The probe fails closed. It refuses to run unless the profiler routes are
+mounted (GET /start_profile -> 405), the trace directory is empty, and no
+request is in flight. After the capture it re-reads the trace and requires a
+trace-derived floor of ``fm_gather_kernel`` launches
+(``0.5 * prompt_tokens / max_batched_tokens * moe_layers``), so an APC hit, a
+partial capture, or a capture that never entered the grouped path cannot pass
+as a measurement. Prefill-vs-decode is guarded by both the fused ``exl3_moe``
+time share (``--decode-share-max``) and the fused/gather launch ratio
+(``--fused-call-ratio-max``), because on this deployment the fused kernel also
+runs during prefill and the time share alone cannot separate the paths.
+
+The receipt records the observed prompt/completion tokens, the APC
+``cached_tokens`` when the server reports it, the ``/reset_prefix_cache``
+status, and the per-role kernel counts read back from the trace.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+import uuid
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import audit_decode_kernel_share as base  # noqa: E402
+import audit_prefill_kernel_share as prefill  # noqa: E402
+
+MODEL = os.environ.get("SERVED_MODEL_NAME", "GLM-5.3-Flash-EXL3")
+API_KEY = os.environ.get("VLLM_API_KEY", "")
+BASE = os.environ.get("GLM53_BASE", "http://127.0.0.1:8000")
+
+PROMPT_SEED = (
+    "Explain in thorough, well-organised prose how a modern operating system "
+    "schedules threads on a multicore CPU. Cover run queues, priority, "
+    "preemption, affinity, load balancing, and the interaction with memory "
+    "locality. Then do the same for GPU thread-block scheduling. "
+)
+
+
+def headers(json_content: bool = False) -> dict[str, str]:
+    out = {"Content-Type": "application/json"} if json_content else {}
+    if API_KEY:
+        out["Authorization"] = f"Bearer {API_KEY}"
+    return out
+
+
+def request(method: str, url: str, body: dict | None = None, timeout: float = 60.0):
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(
+        url, data=data, headers=headers(body is not None), method=method
+    )
+    return urllib.request.urlopen(req, timeout=timeout)
+
+
+def metrics() -> dict[str, float]:
+    with request("GET", BASE + "/metrics") as resp:
+        raw = resp.read().decode("utf-8", "replace")
+    out: dict[str, float] = {}
+    for line in raw.splitlines():
+        if not line or line.startswith("#"):
+            continue
+        name, _, value = line.partition(" ")
+        try:
+            out[name.split("{")[0]] = out.get(name.split("{")[0], 0.0) + float(value)
+        except ValueError:
+            continue
+    return out
+
+
+def profile_mounted() -> int:
+    """GET is not a defined method on the profiler routes: 405 == mounted."""
+    try:
+        request("GET", BASE + "/start_profile", timeout=15.0)
+        return 200
+    except urllib.error.HTTPError as exc:
+        return exc.code
+    except Exception as exc:  # noqa: BLE001
+        print(f"probe FAILED: server unreachable: {exc!r}", file=sys.stderr)
+        return 0
+
+
+def make_prompt(nonce: str, repeats: int) -> str:
+    """Leading nonce: a shared suffix could still hit the APC prefix."""
+    return f"[run {nonce}] " + PROMPT_SEED * repeats
+
+
+def run_request(prompt: str, max_tokens: int, timeout: float = 3600.0) -> dict:
+    """One streamed completion; returns tokens, TTFT, wall time and completion.
+
+    vLLM sends the ``usage`` block in a final chunk whose ``choices`` is an
+    empty list (OpenAI ``stream_options.include_usage`` semantics), so the
+    delta lookup must tolerate an empty choices array.
+    """
+    body = {
+        "model": MODEL,
+        "messages": [{"role": "user", "content": prompt}],
+        "temperature": 0,
+        "max_tokens": max_tokens,
+        "stream": True,
+        "stream_options": {"include_usage": True},
+        "chat_template_kwargs": {"enable_thinking": False},
+    }
+    started = time.monotonic()
+    first: float | None = None
+    tokens = 0
+    usage: dict = {}
+    completed = False
+    with request("POST", BASE + "/v1/chat/completions", body, timeout=timeout) as resp:
+        for raw in resp:
+            line = raw.decode("utf-8", "replace").strip()
+            if not line.startswith("data: "):
+                continue
+            payload = line[6:]
+            if payload == "[DONE]":
+                completed = True
+                break
+            try:
+                chunk = json.loads(payload)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(chunk.get("usage"), dict):
+                usage = chunk["usage"]
+            choices = chunk.get("choices") or []
+            if not choices:
+                continue
+            choice = choices[0] or {}
+            if choice.get("finish_reason") is not None:
+                completed = True
+            delta = choice.get("delta") or {}
+            if delta.get("content"):
+                tokens += 1
+                if first is None:
+                    first = time.monotonic()
+    return {
+        "tokens": tokens,
+        "completed": completed,
+        "first_token_s": round(first - started, 3) if first else None,
+        "wall_s": round(time.monotonic() - started, 3),
+        "usage": usage,
+    }
+
+
+def count_grouped(trace_dir: Path) -> dict:
+    """Per-role kernel counts read back from the trace(s) in the window."""
+    traces = base.find_traces(trace_dir)
+    per_trace: list[dict] = []
+    for path in traces:
+        row = {
+            "file": path.name,
+            "gather_calls": 0,
+            "gateup_calls": 0,
+            "down_calls": 0,
+            "fused_moe_calls": 0,
+            "kernel_count": 0,
+            "kernel_us": 0.0,
+            "fused_moe_us": 0.0,
+        }
+        for event in base.iter_trace_events(path):
+            if event.get("cat") != "kernel" or not isinstance(event.get("dur"), (int, float)):
+                continue
+            name = str(event.get("name", ""))
+            dur = float(event["dur"])
+            row["kernel_count"] += 1
+            row["kernel_us"] += dur
+            role = prefill.role_of(name)
+            if role:
+                row[f"{role}_calls"] += 1
+            elif base.classify(name) == "fused_moe":
+                row["fused_moe_calls"] += 1
+                row["fused_moe_us"] += dur
+        row["kernel_us"] = round(row["kernel_us"], 3)
+        row["fused_moe_us"] = round(row["fused_moe_us"], 3)
+        row["fused_moe_share"] = (
+            round(row["fused_moe_us"] / row["kernel_us"], 6) if row["kernel_us"] else 0.0
+        )
+        per_trace.append(row)
+    head = max(per_trace, key=lambda r: r["kernel_count"])
+    return {"traces": per_trace, "head": head}
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--base", default=os.environ.get("GLM53_BASE", "http://127.0.0.1:8000"))
+    ap.add_argument("--prompt-repeats", type=int, default=1100,
+                    help="~60k tokens at 54.4 tokens/repeat (measured 2026-09-09: "
+                         "10 repeats = 544 prompt_tokens); 4412 is ~240k")
+    ap.add_argument("--max-tokens", type=int, default=1)
+    ap.add_argument("--trace-dir", type=Path, required=True)
+    ap.add_argument("--out", type=Path, required=True)
+    ap.add_argument("--warmup", action="store_true", help="one unprofiled prefill first (JIT warm)")
+    ap.add_argument("--moe-layers", type=int, default=42)
+    ap.add_argument("--max-batched-tokens", type=int, default=3584,
+                    help="largest possible prefill chunk, for the conservative gather floor")
+    ap.add_argument("--min-gather-calls", type=int, default=100)
+    ap.add_argument("--decode-share-max", type=float, default=0.30,
+                    help="fused exl3_moe share of kernel time; measured prefill 0.128, "
+                         "measured decode 0.507 (PR #64). The fused kernel also runs "
+                         "during prefill here, so this alone cannot separate the paths")
+    ap.add_argument("--fused-call-ratio-max", type=float, default=2.0,
+                    help="fused exl3_moe launches / fm_gather launches; measured prefill 1.03")
+    ap.add_argument("--cold-cached-fraction-max", type=float, default=0.05,
+                    help="fail closed when the server reports more APC hits than this")
+    args = ap.parse_args(argv)
+
+    global BASE
+    BASE = args.base.rstrip("/")
+
+    if args.moe_layers <= 0 or args.max_batched_tokens <= 0:
+        print("probe FAILED: --moe-layers and --max-batched-tokens must be positive", file=sys.stderr)
+        return 2
+    if not args.trace_dir.is_dir():
+        print(f"probe FAILED: trace dir {args.trace_dir} does not exist", file=sys.stderr)
+        return 2
+    try:
+        stale = base.find_traces(args.trace_dir)
+    except FileNotFoundError:
+        stale = []
+    if stale:
+        print(
+            f"probe FAILED: trace dir already holds {[p.name for p in stale]}; "
+            "clear it first so the capture describes this run only",
+            file=sys.stderr,
+        )
+        return 2
+    code = profile_mounted()
+    if code != 405:
+        print(
+            f"probe FAILED: GET /start_profile returned {code}, expected 405 "
+            "(profiler not armed on this boot)",
+            file=sys.stderr,
+        )
+        return 2
+    running = metrics().get("vllm:num_requests_running", 0.0)
+    if running > 0:
+        print(f"probe FAILED: {running} requests already running", file=sys.stderr)
+        return 2
+
+    receipt: dict = {
+        "schema": 1,
+        "mode": "prefill",
+        "prompt_repeats": args.prompt_repeats,
+        "max_tokens": args.max_tokens,
+        "moe_layers": args.moe_layers,
+        "max_batched_tokens": args.max_batched_tokens,
+        "min_gather_calls": args.min_gather_calls,
+        "decode_share_max": args.decode_share_max,
+        "fused_call_ratio_max": args.fused_call_ratio_max,
+        "profile_dir": os.environ.get("GLM53_PROFILE_TORCH_DIR"),
+        "max_iters_failsafe": os.environ.get("GLM53_PROFILE_MAX_ITERS"),
+    }
+
+    if args.warmup:
+        warm = run_request(make_prompt(uuid.uuid4().hex[:8], args.prompt_repeats), args.max_tokens)
+        receipt["warmup"] = warm
+        print(f"warmup complete prompt_tokens={warm['usage'].get('prompt_tokens')} "
+              f"wall={warm['wall_s']}s", flush=True)
+        if not warm["completed"] or not warm["tokens"]:
+            args.out.write_text(json.dumps(receipt, indent=1) + "\n")
+            print(f"probe FAILED: warmup did not complete a generation: {warm}", file=sys.stderr)
+            return 4
+
+    reset: dict = {"status": None}
+    try:
+        with request("POST", BASE + "/reset_prefix_cache", {}, timeout=120.0) as resp:
+            reset = {"status": resp.status, "body": resp.read().decode("utf-8", "replace")[:200]}
+    except urllib.error.HTTPError as exc:
+        reset = {"status": exc.code, "body": exc.read().decode("utf-8", "replace")[:200]}
+    except Exception as exc:  # noqa: BLE001
+        reset = {"status": None, "error": repr(exc)}
+    receipt["reset_prefix_cache"] = reset
+    print(f"reset_prefix_cache -> {reset['status']}", flush=True)
+
+    prompt = make_prompt(uuid.uuid4().hex[:8], args.prompt_repeats)
+    started_profiler = False
+    stop_error: str | None = None
+    result: dict | None = None
+    try:
+        with request("POST", BASE + "/start_profile", timeout=60.0) as resp:
+            if resp.status != 200:
+                raise RuntimeError(f"/start_profile returned {resp.status}")
+        started_profiler = True
+        print("profiler started; issuing cold prefill", flush=True)
+        result = run_request(prompt, args.max_tokens)
+    finally:
+        if started_profiler:
+            try:
+                with request("POST", BASE + "/stop_profile", timeout=120.0) as resp:
+                    print(f"profiler stopped ({resp.status})", flush=True)
+            except Exception as exc:  # noqa: BLE001
+                stop_error = repr(exc)
+                print(f"ERROR: /stop_profile failed: {exc!r}", file=sys.stderr)
+    receipt["request"] = result
+    receipt["stop_profile_error"] = stop_error
+    if result is None:
+        args.out.write_text(json.dumps(receipt, indent=1) + "\n")
+        print("probe FAILED: the profiled request did not complete", file=sys.stderr)
+        return 4
+    if stop_error:
+        args.out.write_text(json.dumps(receipt, indent=1) + "\n")
+        print(f"probe FAILED: /stop_profile failed: {stop_error}", file=sys.stderr)
+        return 4
+
+    # Kineto flushes on stop; poll until the trace parses.
+    captured = None
+    deadline = time.monotonic() + 240.0
+    while True:
+        try:
+            captured = count_grouped(args.trace_dir)
+            break
+        except (base.TruncatedTrace, FileNotFoundError, ValueError, OSError) as exc:
+            if time.monotonic() >= deadline:
+                captured = {"error": repr(exc)}
+                break
+            time.sleep(10)
+    receipt["captured"] = captured
+
+    usage = result["usage"]
+    prompt_tokens = usage.get("prompt_tokens")
+    cached_tokens = (usage.get("prompt_tokens_details") or {}).get("cached_tokens")
+    receipt["prompt_tokens"] = prompt_tokens
+    receipt["cached_tokens"] = cached_tokens
+    # The floor is derived from the *reported* prompt size. Without a completed
+    # generation and a positive prompt_tokens count there is no cold-prefill
+    # evidence at all, so refuse rather than fall back to the fixed minimum.
+    if not result.get("completed") or not result.get("tokens"):
+        args.out.write_text(json.dumps(receipt, indent=1) + "\n")
+        print(f"probe FAILED: the profiled request did not complete a generation: {result}",
+              file=sys.stderr)
+        return 3
+    if not isinstance(prompt_tokens, int) or prompt_tokens <= 0:
+        args.out.write_text(json.dumps(receipt, indent=1) + "\n")
+        print(
+            "probe FAILED: the server reported no prompt_tokens; the capture floor "
+            "cannot be established and the prefill is unverified",
+            file=sys.stderr,
+        )
+        return 3
+    gather_floor = max(
+        args.min_gather_calls,
+        int(0.5 * prompt_tokens / args.max_batched_tokens * args.moe_layers),
+    )
+    receipt["gather_floor"] = gather_floor
+
+    head = captured.get("head") if isinstance(captured, dict) else None
+    # The fused kernel also runs during prefill on this deployment (one launch
+    # per layer per chunk beside the grouped triple: measured 1470 fused vs 1428
+    # grouped per rank), so the time share alone cannot separate prefill from
+    # decode. The launch ratio can: a capture that runs the fused path every
+    # step cannot stay near 1. Recorded on both outcomes.
+    fused_ratio = (
+        float(head["fused_moe_calls"]) / max(1.0, float(head["gather_calls"]))
+        if head is not None
+        else None
+    )
+    if fused_ratio is not None:
+        receipt["fused_call_ratio"] = round(fused_ratio, 4)
+    print(
+        f"prompt_tokens={prompt_tokens} cached={cached_tokens} "
+        f"ttft={result['first_token_s']}s wall={result['wall_s']}s "
+        f"gather={head['gather_calls'] if head else 'n/a'} "
+        f"gateup={head['gateup_calls'] if head else 'n/a'} "
+        f"down={head['down_calls'] if head else 'n/a'} "
+        f"floor={gather_floor}"
+    )
+    args.out.write_text(json.dumps(receipt, indent=1) + "\n")
+
+    if head is None or "error" in captured:
+        print(f"probe FAILED: could not read the captured trace: {captured}", file=sys.stderr)
+        return 3
+    if isinstance(cached_tokens, int) and isinstance(prompt_tokens, int) and prompt_tokens:
+        if cached_tokens / prompt_tokens > args.cold_cached_fraction_max:
+            print(
+                f"probe FAILED: {cached_tokens}/{prompt_tokens} prompt tokens came from the "
+                "prefix cache; the prefill was not cold",
+                file=sys.stderr,
+            )
+            return 3
+    for role in ("gather", "gateup", "down"):
+        calls = int(head[f"{role}_calls"])
+        if calls < gather_floor:
+            print(
+                f"probe FAILED: only {calls} {role} launches captured, need >= {gather_floor} "
+                "(APC hit, partial capture, or the grouped path was never entered)",
+                file=sys.stderr,
+            )
+            return 3
+    assert fused_ratio is not None  # head is present past this point
+    if (
+        float(head["fused_moe_share"]) > args.decode_share_max
+        or fused_ratio > args.fused_call_ratio_max
+    ):
+        print(
+            f"probe FAILED: fused exl3_moe share {head['fused_moe_share']:.4f} vs max "
+            f"{args.decode_share_max} and fused/gather launch ratio {fused_ratio:.2f} vs max "
+            f"{args.fused_call_ratio_max}; capture is not prefill-dominated",
+            file=sys.stderr,
+        )
+        args.out.write_text(json.dumps(receipt, indent=1) + "\n")
+        return 3
+    print(f"wrote {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/run_decode_profile_window.py
+++ b/scripts/run_decode_profile_window.py
@@ -1,12 +1,17 @@
 #!/usr/bin/env python3
-"""Guarded decode-profile window for the task 29/31 oracle (runs on spark1).
+"""Guarded profile window for the task 29/31 and task 24 oracles (runs on spark1).
 
 Adds ONLY the two profiler knobs to ``.env`` (hash-neutral: ProfilerConfig
 .compute_hash is a constant), restarts the pair through the validated
-``local/prod-start.sh``, captures one C4 decode window with the in-process
-torch profiler, copies the per-rank traces into ``local/``, then restores the
-exact pre-window ``.env`` and reboots production. Any failure on the arm side
+``local/prod-start.sh``, captures one window with the in-process torch
+profiler, copies the per-rank traces into ``local/``, then restores the exact
+pre-window ``.env`` and reboots production. Any failure on the arm side
 triggers the same restore unless ``--keep-armed`` is passed.
+
+The default probe is the C4 decode oracle (``scripts/probe_decode_profile.py``).
+``--probe``/``--probe-args``/``--tag`` select another capture in the same guarded
+window; the task 24 W4-successor gate uses ``scripts/probe_prefill_profile.py``
+with ``--probe-args '--prompt-repeats 4412'`` for the 240k shape.
 
 Phases run in order and can be bounded with --from/--to for a stepwise window:
 
@@ -26,6 +31,7 @@ import hashlib
 import json
 import os
 import re
+import shlex
 import shutil
 import signal
 import subprocess
@@ -39,6 +45,12 @@ STAMP = Path.home() / ".cache" / "vllm-glm53-flash" / ".config-shape"
 TRACE_HOST_DIR = Path.home() / ".cache" / "vllm-glm53-flash" / "profiler"
 PROBE = ROOT / "scripts" / "probe_decode_profile.py"
 BASE = "http://127.0.0.1:8000"
+# Set by main(): the probe to run, its extra argv, and the tag used for
+# receipts/trace dirs. The guarded window machinery is shared by the decode
+# oracle (default) and the prefill share oracle (task 24 W4 gate).
+_PROBE: Path = PROBE
+_PROBE_ARG: list[str] = []
+_TAG: str = "task29"
 WORKER = os.environ.get("WORKER_SSH", "nvidia@192.168.177.11")
 ARM_KEYS = ("GLM53_PROFILE_TORCH_DIR", "GLM53_PROFILE_MAX_ITERS")
 SELECTED = (
@@ -235,7 +247,7 @@ def arm_env() -> None:
     if not text.endswith("\n"):
         text += "\n"
     text += (
-        "\n# task 29/31 decode-profile oracle window (removed by restore)\n"
+        f"\n# {_TAG} profile window, {_PROBE.name} (removed by restore)\n"
         "GLM53_PROFILE_TORCH_DIR=/root/.cache/vllm/profiler\n"
         "GLM53_PROFILE_MAX_ITERS=2000\n"
     )
@@ -249,10 +261,10 @@ def restore_env(backup: Path) -> None:
 def phase_preflight(state: dict) -> None:
     if not ENV_FILE.is_file():
         raise RuntimeError(f"missing {ENV_FILE}")
-    if not PROBE.is_file():
-        raise RuntimeError(f"missing {PROBE}")
+    if not _PROBE.is_file():
+        raise RuntimeError(f"missing {_PROBE}")
     stamp_before = STAMP.read_text().strip() if STAMP.is_file() else ""
-    backup = ROOT / f".env.bak-pre-task29-profile-{time.strftime('%Y%m%d-%H%M%S')}"
+    backup = ROOT / f".env.bak-pre-{_TAG}-profile-{time.strftime('%Y%m%d-%H%M%S')}"
     shutil.copy2(ENV_FILE, backup)
     # Persist the recovery coordinates before anything else can fail: an
     # interrupted window must still know which file to restore from.
@@ -267,7 +279,7 @@ def phase_preflight(state: dict) -> None:
     state.update(
         {
             "start_sha256": sha256(ROOT / "start.sh"),
-            "probe_sha256": sha256(PROBE),
+            "probe_sha256": sha256(_PROBE),
             "auditor_sha256": sha256(ROOT / "scripts" / "audit_decode_kernel_share.py"),
             "jit_stamp_before": stamp_before,
             "image_before": image_id(),
@@ -322,6 +334,12 @@ def phase_arm(state: dict) -> None:
     log("armed boot healthy and /start_profile mounted (405 on GET)")
 
 
+def probe_argv(probe: Path, probe_args: list[str], receipt: Path, trace_dir: Path) -> list[str]:
+    """Exact probe command line. Decode is the default; --probe swaps the capture."""
+    return [sys.executable, str(probe), *probe_args, "--warmup", "--out", str(receipt),
+            "--trace-dir", str(trace_dir)]
+
+
 def phase_profile(state: dict) -> None:
     TRACE_HOST_DIR.mkdir(parents=True, exist_ok=True)
     for old in TRACE_HOST_DIR.glob("*"):
@@ -331,21 +349,23 @@ def phase_profile(state: dict) -> None:
                timeout=60, check=False)
     if proc.returncode != 0:
         raise RuntimeError(f"worker trace-dir reset failed: {proc.stderr.strip()}")
-    receipt = ROOT / "local" / f"task29-profile-probe-{time.strftime('%Y%m%d-%H%M%S')}.json"
+    receipt = ROOT / "local" / f"{_TAG}-profile-probe-{time.strftime('%Y%m%d-%H%M%S')}.json"
     proc = subprocess.run(
-        [sys.executable, str(PROBE), "--warmup", "--out", str(receipt),
-         "--trace-dir", str(TRACE_HOST_DIR)],
+        probe_argv(_PROBE, _PROBE_ARG, receipt, TRACE_HOST_DIR),
         check=False, capture_output=True, text=True, timeout=3600,
         env={**os.environ, "GLM53_PROFILE_MAX_ITERS": "2000",
              "GLM53_PROFILE_TORCH_DIR": "/root/.cache/vllm/profiler"},
     )
     state["probe_stdout_tail"] = proc.stdout.strip().splitlines()[-12:]
     state["probe_stderr_tail"] = proc.stderr.strip().splitlines()[-12:]
+    # Record the receipt path even when the probe fails closed: the receipt is
+    # the diagnostic artifact a resumed or audited window needs.
+    state["probe_receipt"] = str(receipt)
     log("probe stdout:\n" + "\n".join(state["probe_stdout_tail"]))
     if proc.returncode != 0:
         log("probe stderr:\n" + "\n".join(state["probe_stderr_tail"]))
         raise RuntimeError(f"probe exited {proc.returncode}")
-    outdir = ROOT / "local" / f"task29-traces-{time.strftime('%Y%m%d-%H%M%S')}"
+    outdir = ROOT / "local" / f"{_TAG}-traces-{time.strftime('%Y%m%d-%H%M%S')}"
     (outdir / "head").mkdir(parents=True)
     (outdir / "worker").mkdir(parents=True)
     for trace in TRACE_HOST_DIR.glob("*"):
@@ -442,12 +462,19 @@ def _on_signal(signum: int, _frame: object) -> None:
 
 
 def main(argv: list[str] | None = None) -> int:
-    global _ACTIVE, _KEEP_ARMED, _RECEIPT, _RESTORE_DONE
+    global _ACTIVE, _KEEP_ARMED, _RECEIPT, _RESTORE_DONE, _PROBE, _PROBE_ARG, _TAG
     ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("--from", dest="first", choices=PHASES, default=PHASES[0])
     ap.add_argument("--to", dest="last", choices=PHASES, default=PHASES[-1])
     ap.add_argument("--keep-armed", action="store_true",
                     help="on failure leave the profiler boot running (debug only)")
+    ap.add_argument("--probe", type=Path,
+                    help=f"probe script to run (default: {PROBE.relative_to(ROOT)})")
+    ap.add_argument("--probe-args", default=None, metavar="SHELL",
+                    help="shell-quoted extra probe argv (shlex.split), e.g. "
+                         "--probe-args '--prompt-repeats 3300'")
+    ap.add_argument("--tag", default=None,
+                    help="receipt/trace filename tag (default: task29)")
     ap.add_argument("--receipt", type=Path)
     ap.add_argument("--state", type=Path,
                     help="resume/checkpoint file (loaded if present, written at exit)")
@@ -458,7 +485,7 @@ def main(argv: list[str] | None = None) -> int:
         print("--from must not come after --to", file=sys.stderr)
         return 2
     receipt = args.receipt or args.state or (
-        ROOT / "local" / f"task29-profile-window-{time.strftime('%Y%m%d-%H%M%S')}.json"
+        ROOT / "local" / f"{(args.tag or 'task29')}-profile-window-{time.strftime('%Y%m%d-%H%M%S')}.json"
     )
     state: dict = {}
     if receipt.is_file():
@@ -466,7 +493,36 @@ def main(argv: list[str] | None = None) -> int:
             state = json.loads(receipt.read_text())
         except json.JSONDecodeError:
             state = {}
+    # A resumed window must run the probe the checkpoint was taken with; the
+    # selection is part of the window's identity, not a per-invocation default.
+    # Resolve to absolute paths so a resume from another cwd cannot silently
+    # select a different file.
+    stored = state.get("probe_selection") or {}
+    stored_probe = Path(stored["probe"]).resolve() if stored.get("probe") else None
+    requested_probe = args.probe.resolve() if args.probe is not None else None
+    conflicts: list[str] = []
+    if stored:
+        if requested_probe is not None and requested_probe != stored_probe:
+            conflicts.append("--probe")
+        if args.probe_args is not None and shlex.split(args.probe_args) != list(stored.get("probe_args", [])):
+            conflicts.append("--probe-args")
+        if args.tag is not None and args.tag != stored.get("tag"):
+            conflicts.append("--tag")
+    if conflicts:
+        print(
+            f"{', '.join(conflicts)} conflicts with the probe selection recorded in "
+            f"{receipt}; resume with the same selection or use a fresh receipt",
+            file=sys.stderr,
+        )
+        return 2
+    _PROBE = requested_probe or stored_probe or PROBE
+    _PROBE_ARG = (
+        shlex.split(args.probe_args) if args.probe_args is not None
+        else list(stored.get("probe_args", []))
+    )
+    _TAG = args.tag or stored.get("tag") or "task29"
     state.update({"schema": 2, "started": state.get("started") or time.strftime("%Y-%m-%dT%H:%M:%S%z")})
+    state["probe_selection"] = {"probe": str(_PROBE), "probe_args": list(_PROBE_ARG), "tag": _TAG}
     state.setdefault("phases", [])
     if args.first != PHASES[0] and "backup" not in state:
         print(f"--from {args.first} needs a prior preflight state (no backup in {receipt})", file=sys.stderr)

--- a/tests/test_decode_profile_oracle.py
+++ b/tests/test_decode_profile_oracle.py
@@ -551,7 +551,8 @@ def test_probe_gates_and_labels_are_truthful() -> None:
     assert "--trace-dir is required outside --dry-run" in src
     assert "the trace holds only" in src
     runner = (ROOT / "scripts" / "run_decode_profile_window.py").read_text()
-    assert '"--trace-dir", str(TRACE_HOST_DIR)' in runner
+    assert '"--trace-dir", str(trace_dir)' in runner
+    assert "probe_argv(_PROBE, _PROBE_ARG, receipt, TRACE_HOST_DIR)" in runner
 
 
 def test_launcher_argv_in_both_inner_scripts() -> None:

--- a/tests/test_prefill_profile_oracle.py
+++ b/tests/test_prefill_profile_oracle.py
@@ -1,0 +1,592 @@
+#!/usr/bin/env python3
+"""CPU-only tests for the task 24 prefill kernel-share oracle (W4 gate).
+
+Covers the per-role classification and the pre-registered gather-share gate
+(proceed, both stop floors, two inconclusive paths, min-across-ranks), the
+prefill probe's fail-closed preflight/stale-trace handling and trace-derived
+role counts, and the shared guarded-window runner's probe/tag wiring.
+"""
+from __future__ import annotations
+
+import gzip
+import http.server
+import json
+import os
+import subprocess
+import sys
+import threading
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import audit_prefill_kernel_share as pf  # noqa: E402
+
+
+def kernel(name: str, dur: float, ts: float = 0.0, **args) -> dict:
+    return {"ph": "X", "cat": "kernel", "name": name, "ts": ts, "dur": dur, "args": args}
+
+
+def write_trace(path: Path, kernels: list[dict], gz: bool = False) -> Path:
+    if gz:
+        path = path.with_suffix(path.suffix + ".gz")
+        with gzip.open(path, "wt", encoding="utf-8") as fh:
+            json.dump({"traceEvents": kernels}, fh)
+    else:
+        path.write_text(json.dumps({"traceEvents": kernels}))
+    return path
+
+
+def prefill_trace(
+    path: Path,
+    gather: float,
+    gateup: float,
+    down: float,
+    gemm: float,
+    fused: float = 0.0,
+    gz: bool = False,
+    gather_calls: int = 1,
+    gateup_calls: int = 1,
+    down_calls: int = 1,
+    fused_calls: int = 1,
+) -> Path:
+    events = [
+        kernel("fm_gather_kernel", gather / gather_calls, float(i),
+               **{"registers per thread": 96})
+        for i in range(gather_calls)
+    ]
+    events += [
+        kernel("fm_gateup_kernel", gateup / gateup_calls, 10.0),
+        kernel("fm_down_kernel", down / down_calls, 20.0),
+        kernel("cutlass::gemm", gemm, 30.0),
+    ]
+    events += [
+        kernel("fm_gateup_kernel", gateup / gateup_calls, 11.0 + i) for i in range(1, gateup_calls)
+    ]
+    events += [
+        kernel("fm_down_kernel", down / down_calls, 21.0 + i) for i in range(1, down_calls)
+    ]
+    if fused:
+        events += [
+            kernel("exl3_moe_kernel<4,256,1>", fused / fused_calls, 40.0 + i)
+            for i in range(fused_calls)
+        ]
+    return write_trace(path, events, gz=gz)
+
+
+def test_role_classification() -> None:
+    assert pf.role_of("fm_gather_kernel") == "gather"
+    assert pf.role_of("void fm_gateup_kernel<...>") == "gateup"
+    assert pf.role_of("fm_down_kernel") == "down"
+    # A generic "gather"/"down" outside the grouped family must not match.
+    assert pf.role_of("tensor_gather_kernel") is None
+    assert pf.role_of("cutlass::gemm") is None
+
+
+def test_proceed_when_gather_share_clears_both_floors(tmp_path: Path) -> None:
+    trace = prefill_trace(tmp_path / "rank0.pt.trace.json", gather=300, gateup=1000, down=1200, gemm=5000)
+    report = pf.audit_prefill([trace])
+    rank = report["ranks"]["rank0"]
+    assert rank["grouped"]["gather"]["share_of_e3"] == round(300 / 2500, 6)
+    assert rank["grouped"]["gather"]["share_of_total"] == round(300 / 7500, 6)
+    assert report["decision"]["verdict"] == pf.VERDICT_PROCEED
+    assert report["decision"]["e2e_ceiling_if_gather_free"] == round(300 / 7500, 6)
+
+
+def test_stop_below_e3_floor(tmp_path: Path) -> None:
+    trace = prefill_trace(tmp_path / "rank0.pt.trace.json", gather=100, gateup=1000, down=1200, gemm=5000)
+    report = pf.audit_prefill([trace])
+    assert report["decision"]["verdict"] == pf.VERDICT_STOP
+    assert report["decision"]["min_gather_share_of_e3"] < 0.10
+
+
+def test_stop_below_total_floor_even_with_high_e3_share(tmp_path: Path) -> None:
+    """A gather-dominated E3 block that is a rounding error of the whole prefill."""
+    trace = prefill_trace(tmp_path / "rank0.pt.trace.json", gather=800, gateup=100, down=100, gemm=100000)
+    report = pf.audit_prefill([trace])
+    decision = report["decision"]
+    assert decision["min_gather_share_of_e3"] > 0.10
+    assert decision["min_gather_share_of_total"] < 0.03
+    assert decision["verdict"] == pf.VERDICT_STOP
+
+
+def test_min_across_ranks_is_conservative(tmp_path: Path) -> None:
+    good = prefill_trace(tmp_path / "rank0.pt.trace.json", gather=300, gateup=1000, down=1200, gemm=5000)
+    bad = prefill_trace(tmp_path / "rank1.pt.trace.json", gather=100, gateup=1000, down=1200, gemm=5000)
+    report = pf.audit_prefill([good, bad])
+    assert report["decision"]["verdict"] == pf.VERDICT_STOP
+    assert report["decision"]["gather_share_of_e3_by_rank"]["rank0"] == round(300 / 2500, 6)
+
+
+def test_inconclusive_without_grouped_capture(tmp_path: Path) -> None:
+    trace = write_trace(
+        tmp_path / "rank0.pt.trace.json",
+        [kernel("cutlass::gemm", 1000.0), kernel("ncclAllReduce", 500.0)],
+    )
+    report = pf.audit_prefill([trace])
+    assert report["decision"]["verdict"] == pf.VERDICT_NO_GROUPED
+
+
+def test_inconclusive_when_decode_dominates(tmp_path: Path) -> None:
+    trace = prefill_trace(
+        tmp_path / "rank0.pt.trace.json", gather=300, gateup=1000, down=1200, gemm=5000, fused=50000
+    )
+    report = pf.audit_prefill([trace])
+    assert report["decision"]["verdict"] == pf.VERDICT_DECODE
+
+
+def test_inconclusive_when_fused_launches_outnumber_gather(tmp_path: Path) -> None:
+    """The structural guard catches what the time ceiling alone would pass."""
+    trace = prefill_trace(
+        tmp_path / "rank0.pt.trace.json", gather=300, gateup=1000, down=1200, gemm=5000,
+        fused=300, fused_calls=3,
+    )
+    report = pf.audit_prefill([trace])
+    decision = report["decision"]
+    assert decision["fused_call_ratio_by_rank"]["rank0"] > 2.0
+    assert decision["verdict"] == pf.VERDICT_DECODE
+
+
+def test_measured_60k_prefill_shape_decides_not_inconclusive(tmp_path: Path) -> None:
+    """Exact both-rank replay of the 2026-09-09 60k capture.
+
+    Real per-rank kernel times and launch counts from the first cluster window.
+    The fused ``exl3_moe`` kernel runs during prefill here (1470 launches beside
+    1428 grouped per rank, 12.7% of kernel time), so the capture must decide,
+    not read as decode-dominated.
+    """
+    # (gather, gateup, down, fused, kernel_total) in us, all over 1428 grouped
+    # and 1470 fused launches.
+    ranks = {
+        "rank0": (818056.0, 5224835.0, 3384937.0, 4986065.0, 38974354.0),
+        "rank1": (816751.0, 5245374.0, 3407585.0, 4945779.0, 38994804.0),
+    }
+    traces = []
+    for rank, (gather, gateup, down, fused, total) in ranks.items():
+        gemm = total - (gather + gateup + down + fused)
+        traces.append(
+            prefill_trace(
+                tmp_path / f"{rank}.pt.trace.json",
+                gather=gather, gateup=gateup, down=down, gemm=gemm, fused=fused,
+                gather_calls=1428, gateup_calls=1428, down_calls=1428, fused_calls=1470,
+            )
+        )
+    decision = pf.audit_prefill(traces)["decision"]
+    assert decision["verdict"] == pf.VERDICT_STOP
+    for rank, (gather, gateup, down, fused, total) in ranks.items():
+        assert abs(decision["fused_call_ratio_by_rank"][rank] - 1470 / 1428) < 1e-9
+        assert decision["decode_share_by_rank"][rank] < 0.30
+        assert abs(decision["gather_share_of_e3_by_rank"][rank]
+                   - gather / (gather + gateup + down)) < 1e-6
+        assert abs(decision["gather_share_of_total_by_rank"][rank] - gather / total) < 1e-6
+    assert decision["min_gather_share_of_e3"] < 0.10
+    assert decision["min_gather_share_of_total"] < 0.03
+
+
+def test_audit_cli_exit_codes(tmp_path: Path) -> None:
+    proceed = prefill_trace(tmp_path / "r0.pt.trace.json", 300, 1000, 1200, 5000)
+    assert pf.main(["--trace", str(proceed), "--json-out", str(tmp_path / "out.json")]) == 0
+    assert json.loads((tmp_path / "out.json").read_text())["decision"]["verdict"] == pf.VERDICT_PROCEED
+    stop = prefill_trace(tmp_path / "r1.pt.trace.json", 100, 1000, 1200, 5000)
+    assert pf.main(["--trace", str(stop)]) == 0
+    empty = write_trace(tmp_path / "r2.pt.trace.json", [kernel("cutlass::gemm", 1.0)])
+    assert pf.main(["--trace", str(empty)]) == 3
+
+
+def test_probe_count_grouped_and_roles(tmp_path: Path) -> None:
+    import probe_prefill_profile as probe
+
+    prefill_trace(tmp_path / "head.pt.trace.json", 300, 1000, 1200, 5000, fused=10, gz=True)
+    captured = probe.count_grouped(tmp_path)
+    head = captured["head"]
+    assert head["gather_calls"] == 1
+    assert head["gateup_calls"] == 1
+    assert head["down_calls"] == 1
+    assert head["fused_moe_calls"] == 1
+    assert head["fused_moe_share"] == round(10 / 7510, 6)
+
+
+def test_probe_prompt_nonce_leads() -> None:
+    """A shared suffix could still hit the APC prefix; the nonce must lead."""
+    import probe_prefill_profile as probe
+
+    prompt = probe.make_prompt("abcd1234", 2)
+    assert prompt.startswith("[run abcd1234] ")
+    assert prompt.count(probe.PROMPT_SEED) == 2
+
+
+def test_probe_refuses_stale_traces(tmp_path: Path) -> None:
+    import probe_prefill_profile as probe
+
+    write_trace(tmp_path / "old.pt.trace.json", [kernel("fm_gather_kernel", 1.0)], gz=True)
+    rc = probe.main(["--out", str(tmp_path / "r.json"), "--trace-dir", str(tmp_path)])
+    assert rc == 2
+
+
+def test_probe_refuses_missing_trace_dir(tmp_path: Path) -> None:
+    import probe_prefill_profile as probe
+
+    rc = probe.main(["--out", str(tmp_path / "r.json"), "--trace-dir", str(tmp_path / "nope")])
+    assert rc == 2
+
+
+class _Handler(http.server.BaseHTTPRequestHandler):
+    armed = False
+
+    def do_GET(self) -> None:  # noqa: N802
+        code = 405 if self.armed and self.path == "/start_profile" else 404
+        self.send_response(code)
+        self.end_headers()
+
+    def log_message(self, *_args) -> None:  # noqa: ANN002
+        return
+
+
+def _serve(armed: bool) -> tuple[str, http.server.ThreadingHTTPServer]:
+    _Handler.armed = armed
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    return f"http://127.0.0.1:{server.server_address[1]}", server
+
+
+def test_probe_refuses_unarmed_boot(tmp_path: Path) -> None:
+    import probe_prefill_profile as probe
+
+    base, server = _serve(armed=False)
+    try:
+        rc = probe.main(["--base", base, "--out", str(tmp_path / "r.json"),
+                         "--trace-dir", str(tmp_path)])
+        assert rc == 2
+    finally:
+        server.shutdown()
+
+
+def test_runner_probe_argv_and_tag_wiring(tmp_path: Path) -> None:
+    import run_decode_profile_window as win
+
+    argv = win.probe_argv(
+        Path("/x/probe_prefill_profile.py"),
+        ["--prompt-repeats", "3300"],
+        tmp_path / "r.json",
+        tmp_path / "traces",
+    )
+    assert argv[1] == "/x/probe_prefill_profile.py"
+    assert argv[2:4] == ["--prompt-repeats", "3300"]
+    assert argv[4:6] == ["--warmup", "--out"]
+    assert argv[-2] == "--trace-dir"
+
+    # --probe/--tag are applied before any phase runs; a missing probe fails
+    # closed in preflight with the tag preserved in the receipt.
+    state = tmp_path / "state.json"
+    rc = win.main(["--from", "preflight", "--to", "preflight", "--tag", "task24",
+                   "--probe", str(tmp_path / "missing.py"), "--receipt", str(state)])
+    assert rc == 1
+    assert win._TAG == "task24"
+    assert win._PROBE == tmp_path / "missing.py"
+    assert json.loads(state.read_text())["schema"] == 2
+
+
+def test_runner_resume_keeps_probe_selection(tmp_path: Path) -> None:
+    """A resumed window must not silently fall back to the decode probe."""
+    import run_decode_profile_window as win
+
+    state = tmp_path / "state.json"
+    rc = win.main(["--from", "preflight", "--to", "preflight", "--tag", "task24",
+                   "--probe", str(tmp_path / "missing.py"),
+                   "--probe-args", "--prompt-repeats 3300",
+                   "--receipt", str(state)])
+    assert rc == 1
+    recorded = json.loads(state.read_text())["probe_selection"]
+    assert recorded == {"probe": str(tmp_path / "missing.py"),
+                        "probe_args": ["--prompt-repeats", "3300"], "tag": "task24"}
+
+    rc = win.main(["--from", "preflight", "--to", "preflight", "--state", str(state)])
+    assert rc == 1
+    assert win._TAG == "task24"
+    assert win._PROBE == tmp_path / "missing.py"
+    assert win._PROBE_ARG == ["--prompt-repeats", "3300"]
+
+    conflict = win.main(["--from", "preflight", "--to", "preflight",
+                         "--state", str(state), "--tag", "other"])
+    assert conflict == 2
+
+
+def test_runner_records_absolute_probe_across_cwd(tmp_path: Path) -> None:
+    """A relative --probe must be frozen absolute or a resume can select another file."""
+    import run_decode_profile_window as win
+
+    workdir = tmp_path / "work"
+    workdir.mkdir()
+    (workdir / "probe.py").write_text("# probe\n")
+    state = tmp_path / "state.json"
+    original = os.getcwd()
+    try:
+        os.chdir(workdir)
+        rc = win.main(["--from", "preflight", "--to", "preflight", "--probe", "probe.py",
+                       "--receipt", str(state)])
+        assert rc == 1
+        assert json.loads(state.read_text())["probe_selection"]["probe"] == str(
+            (workdir / "probe.py").resolve()
+        )
+
+        os.chdir(tmp_path)
+        rc = win.main(["--from", "preflight", "--to", "preflight", "--state", str(state)])
+        assert rc == 1
+        assert win._PROBE == (workdir / "probe.py").resolve()
+
+        # A relative override that resolves elsewhere must be rejected, not
+        # silently swapped in after the window was armed.
+        (tmp_path / "probe.py").write_text("# other\n")
+        rc = win.main(["--from", "preflight", "--to", "preflight", "--state", str(state),
+                       "--probe", "probe.py"])
+        assert rc == 2
+    finally:
+        os.chdir(original)
+
+
+def test_inconclusive_when_a_grouped_role_is_missing(tmp_path: Path) -> None:
+    """A lone gather kernel would otherwise read as a 100% share on no evidence."""
+    for omit in ("gather", "gateup", "down"):
+        events = [
+            kernel("fm_gather_kernel", 300.0),
+            kernel("fm_gateup_kernel", 1000.0),
+            kernel("fm_down_kernel", 1200.0),
+            kernel("cutlass::gemm", 5000.0),
+        ]
+        trace = write_trace(
+            tmp_path / f"omit_{omit}.pt.trace.json",
+            [event for event in events if omit not in event["name"]],
+        )
+        report = pf.audit_prefill([trace])
+        assert report["decision"]["verdict"] == pf.VERDICT_NO_GROUPED, omit
+
+
+def test_inconclusive_when_a_grouped_role_has_zero_time(tmp_path: Path) -> None:
+    trace = write_trace(
+        tmp_path / "zero.pt.trace.json",
+        [
+            kernel("fm_gather_kernel", 0.0),
+            kernel("fm_gateup_kernel", 1000.0),
+            kernel("fm_down_kernel", 1200.0),
+            kernel("cutlass::gemm", 5000.0),
+        ],
+    )
+    report = pf.audit_prefill([trace])
+    assert report["decision"]["verdict"] == pf.VERDICT_NO_GROUPED
+
+
+def _grouped_trace_kernels(
+    per_role: int = 120, fused_calls: int = 0, fused_dur: float = 0.5
+) -> list[dict]:
+    events: list[dict] = []
+    for _ in range(per_role):
+        events.append(kernel("fm_gather_kernel", 1.0))
+        events.append(kernel("fm_gateup_kernel", 3.0))
+        events.append(kernel("fm_down_kernel", 3.0))
+    for _ in range(fused_calls):
+        events.append(kernel("exl3_moe_kernel<4,256,1>", fused_dur))
+    return events
+
+
+class _StreamHandler(http.server.BaseHTTPRequestHandler):
+    """Minimal vLLM-compatible streaming server for the prefill probe."""
+
+    mode = "ok"  # ok | no_usage | incomplete | cached | fused_heavy
+    trace_dir: Path | None = None
+
+    def _send(self, code: int, body: bytes = b"", ctype: str = "application/json") -> None:
+        self.send_response(code)
+        self.send_header("Content-Type", ctype)
+        self.end_headers()
+        if body:
+            self.wfile.write(body)
+
+    def do_GET(self) -> None:  # noqa: N802
+        if self.path == "/start_profile":
+            self._send(405)
+        elif self.path == "/metrics":
+            self._send(200, b"", "text/plain")
+        else:
+            self._send(404)
+
+    def do_POST(self) -> None:  # noqa: N802
+        length = int(self.headers.get("Content-Length") or 0)
+        if length:
+            self.rfile.read(length)
+        if self.path == "/reset_prefix_cache":
+            self._send(200, b'{"success": true}')
+        elif self.path == "/start_profile":
+            self._send(200)
+        elif self.path == "/stop_profile":
+            if self.trace_dir is not None:
+                kernels = (
+                    _grouped_trace_kernels(fused_calls=360)
+                    if self.mode == "fused_heavy"
+                    else _grouped_trace_kernels()
+                )
+                write_trace(self.trace_dir / "head.pt.trace.json", kernels)
+            self._send(200)
+        elif self.path == "/v1/chat/completions":
+            chunks = [b'data: {"choices":[{"delta":{"content":"x"},"finish_reason":null}]}\n\n']
+            if self.mode in ("ok", "cached", "fused_heavy"):
+                cached = 5000 if self.mode == "cached" else 0
+                usage = (
+                    'data: {"choices":[],"usage":{"prompt_tokens":10000,'
+                    f'"completion_tokens":1,"prompt_tokens_details":{{"cached_tokens":{cached}}}}}}}\n\n'
+                )
+                chunks.append(usage.encode())
+                chunks.append(b"data: [DONE]\n\n")
+            elif self.mode == "no_usage":
+                chunks.append(b"data: [DONE]\n\n")
+            # "incomplete": no usage, no [DONE], no finish_reason
+            self.send_response(200)
+            self.send_header("Content-Type", "text/event-stream")
+            self.end_headers()
+            for chunk in chunks:
+                self.wfile.write(chunk)
+            self.wfile.flush()
+        else:
+            self._send(404)
+
+    def log_message(self, *_args) -> None:  # noqa: ANN002
+        return
+
+
+def _serve_stream(trace_dir: Path, mode: str) -> tuple[str, http.server.ThreadingHTTPServer]:
+    _StreamHandler.mode = mode
+    _StreamHandler.trace_dir = trace_dir
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), _StreamHandler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    return f"http://127.0.0.1:{server.server_address[1]}", server
+
+
+def test_probe_accepts_usage_only_final_chunk(tmp_path: Path) -> None:
+    """vLLM sends usage in a chunk whose choices array is empty."""
+    import probe_prefill_profile as probe
+
+    traces = tmp_path / "traces"
+    traces.mkdir()
+    base, server = _serve_stream(traces, "ok")
+    try:
+        rc = probe.main(["--base", base, "--warmup", "--min-gather-calls", "1",
+                         "--trace-dir", str(traces), "--out", str(tmp_path / "r.json")])
+        assert rc == 0
+        receipt = json.loads((tmp_path / "r.json").read_text())
+        assert receipt["prompt_tokens"] == 10000
+        assert receipt["cached_tokens"] == 0
+        assert receipt["gather_floor"] == int(0.5 * 10000 / 3584 * 42)
+        assert receipt["captured"]["head"]["gather_calls"] == 120
+        # The ratio is recorded on success too, not only on the guard failure path.
+        assert receipt["fused_call_ratio"] == 0.0
+    finally:
+        server.shutdown()
+
+
+def test_probe_fails_without_reported_usage(tmp_path: Path) -> None:
+    import probe_prefill_profile as probe
+
+    traces = tmp_path / "traces"
+    traces.mkdir()
+    base, server = _serve_stream(traces, "no_usage")
+    try:
+        rc = probe.main(["--base", base, "--min-gather-calls", "1",
+                         "--trace-dir", str(traces), "--out", str(tmp_path / "r.json")])
+        assert rc == 3
+        assert json.loads((tmp_path / "r.json").read_text())["prompt_tokens"] is None
+    finally:
+        server.shutdown()
+
+
+def test_probe_fails_on_incomplete_stream(tmp_path: Path) -> None:
+    import probe_prefill_profile as probe
+
+    traces = tmp_path / "traces"
+    traces.mkdir()
+    base, server = _serve_stream(traces, "incomplete")
+    try:
+        rc = probe.main(["--base", base, "--min-gather-calls", "1",
+                         "--trace-dir", str(traces), "--out", str(tmp_path / "r.json")])
+        assert rc == 3
+        assert json.loads((tmp_path / "r.json").read_text())["request"]["completed"] is False
+    finally:
+        server.shutdown()
+
+
+def test_probe_fails_when_prefill_was_cached(tmp_path: Path) -> None:
+    import probe_prefill_profile as probe
+
+    traces = tmp_path / "traces"
+    traces.mkdir()
+    base, server = _serve_stream(traces, "cached")
+    try:
+        rc = probe.main(["--base", base, "--min-gather-calls", "1",
+                         "--trace-dir", str(traces), "--out", str(tmp_path / "r.json")])
+        assert rc == 3
+    finally:
+        server.shutdown()
+
+
+def test_probe_fails_when_fused_launches_outnumber_grouped(tmp_path: Path) -> None:
+    """A decode-heavy capture fails on launches even when its fused time share is low."""
+    import probe_prefill_profile as probe
+
+    traces = tmp_path / "traces"
+    traces.mkdir()
+    base, server = _serve_stream(traces, "fused_heavy")
+    try:
+        out = tmp_path / "r.json"
+        rc = probe.main(["--base", base, "--warmup", "--min-gather-calls", "1",
+                         "--trace-dir", str(traces), "--out", str(out)])
+    finally:
+        server.shutdown()
+    assert rc == 3
+    receipt = json.loads(out.read_text())
+    assert receipt["fused_call_ratio"] == 3.0
+    assert receipt["captured"]["head"]["fused_moe_share"] < 0.30
+
+
+def _run_profiling_helper(dropin: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    env = {**os.environ, "GLM53_PROFILING_DROPIN": str(dropin)}
+    return subprocess.run(
+        ["bash", str(ROOT / "scripts" / "enable-gpu-profiling.sh"), *args],
+        env=env, capture_output=True, text=True, check=False,
+    )
+
+
+def test_profiling_helper_refuses_foreign_dropin(tmp_path: Path) -> None:
+    """The runbook claims no existing file is edited; an unowned file must stop it."""
+    dropin = tmp_path / "99-nvidia-profiling.conf"
+    dropin.write_text("options nvidia NVreg_SomeOther=1\n")
+    refused = _run_profiling_helper(dropin)
+    assert refused.returncode == 2
+    assert dropin.read_text() == "options nvidia NVreg_SomeOther=1\n"
+
+    forced = _run_profiling_helper(dropin, "--force")
+    assert forced.returncode == 0
+    body = dropin.read_text()
+    assert "managed by glm53" in body
+    assert "NVreg_RestrictProfilingToAdminUsers=0" in body
+    assert list(tmp_path.glob("*.bak-*")), "a forced replace must keep a backup"
+
+    assert _run_profiling_helper(dropin, "--revert").returncode == 0
+    assert not dropin.exists()
+
+
+def test_profiling_helper_revert_refuses_foreign_dropin(tmp_path: Path) -> None:
+    dropin = tmp_path / "d.conf"
+    dropin.write_text("options nvidia NVreg_SomeOther=1\n")
+    assert _run_profiling_helper(dropin, "--revert").returncode == 2
+    assert dropin.exists()
+
+
+def test_profiling_helper_apply_is_idempotent(tmp_path: Path) -> None:
+    dropin = tmp_path / "d.conf"
+    for _ in range(2):
+        proc = _run_profiling_helper(dropin)
+        assert proc.returncode == 0, proc.stderr
+    assert dropin.read_text().count("NVreg_RestrictProfilingToAdminUsers=0") == 1
+    check = _run_profiling_helper(dropin, "--check")
+    assert check.returncode == 0
+    assert "managed" in check.stdout
+
+


### PR DESCRIPTION
## Why

`docs/11` §8 parked the W4 successor (a persistent SUH-scaled A-cache consumed
read-only by every gate/up K-slab) behind an **ncu-first** measurement of the
gather-vs-gateup share of E3 layer time. That gate cannot be satisfied on this
cluster: `ncu` is not installed and the driver enforces
`RmProfilingAdminOnly: 1`, so both ncu and `nsys --gpu-metrics` fail closed
(`ERR_NVGPUCTRPERM`), and nsys attach is unsafe on the CUDA-graph server.

This PR answers the same question from a path that is available without root:
the per-rank chrome traces vLLM's in-process torch profiler already writes.
Kineto records every grouped `fm_*` kernel with duration and launch geometry,
including launches inside captured CUDA graphs.

## What

- **`scripts/probe_prefill_profile.py`** — captures one cold, unbatched
  long-context prefill: nonce-led warmup, `/reset_prefix_cache`, then one
  `max_tokens=1` request bracketed by `/start_profile`.. `/stop_profile`.
  Fails closed on an unarmed boot, a non-empty trace dir, a request in flight,
  a warm prefix cache, a missing or incomplete generation, a missing
  `prompt_tokens`, or fewer than `0.5 × prompt_tokens / max_batched_tokens ×
  moe_layers` `fm_gather_kernel` launches in the captured trace.
- **`scripts/audit_prefill_kernel_share.py`** — per-rank shares of
  gather/gateup/down in E3 layer time and total kernel time, launch geometry and
  derived occupancy, and the pre-registered min-across-ranks decision. All three
  grouped roles must be present with positive time. A prefill-vs-decode guard
  pairs a fused `exl3_moe` time ceiling with a fused/gather launch ratio, both
  calibrated on measured values.
- **`scripts/run_decode_profile_window.py`** — `--probe/--probe-args/--tag`
  generalization of the guarded 7-phase window. The probe selection is resolved
  to an absolute path, persisted in the receipt and restored on resume; a
  conflicting override is refused.
- **`docs/14-profiling-privilege-runbook.md`** + **`scripts/enable-gpu-profiling.sh`**
  — the prepared, **not applied** root fix (`NVreg_RestrictProfilingToAdminUsers=0`)
  that would unblock real hardware counters for task 1, task 29, W5 and #55061.
  The helper refuses to touch an unowned drop-in, keeps a backup on `--force`,
  and never reboots.
- **Tests** — 28 new prefill-oracle tests plus the decode-oracle argv update;
  341 passed, 1 skipped, 4 subtests passed.

## Verdict: STOP

Two independent guarded 60k windows on `e3-w3-zfill` (TRF=32, adaptive-k ema,
pin `7d74cdd`, JIT stamp `078835f1d75f` unchanged), head/worker:

| metric | rank0 | rank1 | pre-registered floor |
|---|---|---|---|
| gather share of E3 layer time | 8.68 / 8.64% | 8.62 / 8.69% | ≥ 10% |
| gather share of total kernel time | 2.10 / 2.11% | 2.09 / 2.09% | ≥ 3% |

Gateup is 55.4% and down 35.9% of E3 layer time; gather is a 0.57 ms memory-bound
permutation. Ceiling if the gather became free is **2.1%** of prefill kernel
time, below the ≥3% end-to-end bar, and W4 itself measured −10.7% at this shape.
**No kernel window was opened and no cubin was built.** The 240k share is
unmeasured and deferred.

Capture validity: 1428 grouped launches per rank (34 chunks × 42 layers) against
1428/1428/1428 gather/gateup/down and 1470 fused `exl3_moe`; the profiler's own
step table attributes 96.8% of CUDA time to 1792-token context steps and 1.7% to
the final 896-token context step.

## Window integrity

All 7 phases passed (`preflight/disarm/arm/profile/restore/gates/rearm`);
`.env` sha256 matched the pre-window backup, `/start_profile` 404 after restore,
image sha identical before/armed/restored, acceptance 7/7 rc 0, MemFree
4.14/3.43 GiB, watchdog + metrics-alert inactive during the window and active
after. The first window failed closed at the profile phase on a miscalibrated
guard, restored the exact `.env` (diff identical) and rebooted production; its
traces are preserved and audit to the same shares.

## Limitations

- The guards are calibrated heuristics on this pinned one-cold-prefill window,
  not general phase identification; a mixed workload can land between the two
  measured regimes.
- The share comes from the profiler's kernel durations, not hardware counters.
  The runbook exists so the owner can make counters available if a future
  question needs them.
