### PR TITLE
Task 39 close-out, task 37 CLOSED, ISA fact fix, FlashKDA prefill arm gated and reverted

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,9 @@ proportionally longer TTFT. Read the rows as per-token rates, not per-document
 promises.
 
 No other public recipe serves this model on this hardware with all six of: EXL3
-(the only quantization GB10 can actually run — it lacks the instruction NVFP4
-compiles to), a 1M window that *coexists* with speculative decoding, prefix
+(the quantization this stack is built and tuned around — see `docs/01` for why
+the NVFP4 route is target-gated rather than silicon-absent on GB10), a 1M window
+that *coexists* with speculative decoding, prefix
 caching that survives the hybrid-KDA architecture and the drafter, perfect
 structured acceptance, verification-only adaptive-k on the target, and a
 hand-tuned MoE kernel stack (fat-expert GEMM, dynamic ticket scheduling, grouped

--- a/docs/01-architecture.md
+++ b/docs/01-architecture.md
@@ -28,16 +28,24 @@ upstream's asymmetric interface pins hang `ncclCommInitRank`.
 - CUDA graphs FULL_AND_PIECEWISE; capture sizes `1 2 4 8 16 24 32` are **token batches**
   (1–4 seqs × 8 spec tokens), not sequence counts.
 
-## Why EXL3 — GB10 has no NVFP4 hardware
+## Why EXL3 — the NVFP4 route is target-gated, not silicon-absent
 
-The quantization choice is dictated by silicon, not preference. **GB10 (sm_121)
-lacks the `cvt.e2m1x2` microscaling instruction** that datacenter Blackwell
-(SM100/SM103) and even workstation SM120 carry — NVFP4 kernels *can never compile*
-for this chip; it is a hardware limitation, and any "just use the NVFP4
-checkpoint" advice you'll find for other Blackwell platforms does not transfer.
-(sm_120 cubins do run on sm_121 via forward compatibility, but not the FP4
-microscaling paths.) The predecessor NVFP4 deployment of this same model ran
-through Marlin-style emulation and was deposed for exactly this reason.
+The quantization choice is structural, but **not** because GB10 cannot express
+FP4. `cvt.rn.satfinite.e2m1x2.f32` is rejected on the family target `.target
+sm_121`, yet it **assembles and lowers to real SASS on `sm_121a`**
+(`F2FP.SATFINITE.E2M1.F32.PACK_AB_MERGE_C`, confirmed on this node's own ptxas
+13.0.88). The FP4 conversion alphabet is therefore **target-gated, not
+silicon-absent**. An earlier version of this section claimed the instruction is
+absent from the chip; that was wrong in its strong form. The likely origin of
+the observation is that nvcc 13.0 full `-c` compiles emit intermediate PTX
+carrying `.target sm_121`, so an FP4 intrinsic that only assembles under the
+`a` suffix fails in the default build. Treat "NVFP4 can never compile on GB10"
+as a toolchain claim about the default target, not a hardware fact.
+
+The predecessor NVFP4 deployment of this same model ran through Marlin-style
+emulation and was deposed on memory and throughput grounds, not on an ISA
+impossibility. That decision stands; only its stated reason is corrected here.
+The reasons EXL3 remains the right fit are the ones below.
 
 EXL3 is the right fit for what GB10 actually has:
 

--- a/docs/06-improvement-plan.md
+++ b/docs/06-improvement-plan.md
@@ -3147,6 +3147,25 @@ Restored `IMAGE=glm53-selfbuild:b5ab8091-s2b`, clean pair restart
 re-armed (active/active), serving spot-check OK, 6/6 converge probes
 69.7–71.1 on the fresh boot. **M0′ is CLOSED as ADOPT s2b.**
 
+## 2026-09-10: PR #69 follow-up commits — task 37 CLOSED `NOT_REACHABLE`, task 34 arm wired and boot-validated
+
+**Ledger note.** These commits extend PR #69's branch (the PR is still open),
+so they carry the same number rather than inventing a new one. Both close work
+that the earlier commits in that PR left open.
+
+**Task 37 CLOSED `NOT_REACHABLE`.** The three modules that had forced `ABORT`
+are reached through one dead edge, and the audit already knew how to model it —
+it was simply missing a namespace. Detail in the task 37 section below.
+
+**Task 34 track A wired.** The FlashKDA prefill overlay is now mounted and
+executed by `start.sh` (nine sites) and boot-validated without touching
+production. The default is the stock `triton` spelling, so no `.env` change is
+required to deploy the wiring and mounting the overlay cannot alter production
+by itself. Detail in `docs/15` §4.
+
+**Validation.** `compileall` clean; `pytest tests/ -q` → **517 passed, 1
+skipped, 18 subtests** (508 before). Receipts regenerated for both revisions.
+
 ## 2026-09-10: PR #69 — task 39 CLOSED by audit, task 37 NARROWED, 38.1 landed, 34 first arm prepared
 
 **Ledger note.** PRs #64–#67 did not add entries here; this one does, because
@@ -3154,11 +3173,12 @@ task 34 creates an arm that will need a window record and task 36 replaces a
 standing gate. Detail lives in `docs/15` (task 34) and `docs/11` §9 (task 36).
 
 **Review correction.** Three independent review passes of this change found
-fourteen fail-open defects, thirteen of them in the two audits — the code whose entire job is
-to refuse to certify a tree it could not read. All ten are fixed with regression
-tests; the net effect is that **task 37's verdict changed from `NOT_REACHABLE`
-to `ABORT`**, because the original verdict rested on evidence the audit could
-not actually establish. See the task 37 section below.
+fourteen fail-open defects, thirteen of them in the two audits — the code whose
+entire job is to refuse to certify a tree it could not read. All fourteen are
+fixed with regression tests. The verdict travelled `NOT_REACHABLE` -> `ABORT` -> `NOT_REACHABLE`: the
+original pass certified a conclusion it had not established, the audit was
+made fail-closed (which produced the `ABORT`), and call-graph evidence then
+closed the question properly. See the task 37 section below.
 
 Pass 1: the verdict ignored a `calls_exl3_mgemm` hit in the C++ bridge; closure
 modules holding call sites were reported as advisory and then certified anyway;
@@ -3185,7 +3205,7 @@ import could shadow a module-level one, and it ignored the imported symbol
 name; and the overlay's completeness check was still textual, so a
 commented-out import counted as present.
 
-### Task 37 — `v_indices[128]` scratch: **ABORT (narrowed, NOT closed)**
+### Task 37 — `v_indices[128]` scratch: **CLOSED `NOT_REACHABLE`**
 
 The TODO's premise ("unenforced, reachable from the serving path") is **not
 established**, and neither is its negation. What is established, on the
@@ -3204,16 +3224,42 @@ Worst-case slots at production shapes (`top_k=8`, `MAX_NUM_SEQS=4`, draft 7) is
 32 ≤ 128, so *if* the entry were reached it would not overflow — but the entry
 is not the open question.
 
-**Why it is not closed.** Two (v1.4.7) / three (v1.4.9) modules inside the
-serving import closure still contain `exl3_mgemm` call sites:
+**Why it was briefly open, and how it closed.** Two (v1.4.7) / three (v1.4.9)
+modules inside the serving import closure held `exl3_mgemm` call sites:
 `exllamav3.modules.attn`, `exllamav3.modules.dsv4` (and
-`gated_delta_net` on v1.4.9). They enter the closure through **function-local**
-imports — `modules/block_sparse_mlp_routing.py` does `from .attn import
-get_for_device` inside a function body — and all their `ext.exl3_mgemm(...)`
-sites are inside functions, not at module level. Importing a module does not
-execute its call sites, so static import-closure analysis cannot discharge
-them; that needs a call graph. The earlier `NOT_REACHABLE` verdict came from
-reporting exactly these as "advisory context" and then certifying anyway.
+`exllamav3.modules.gated_delta_net` on v1.4.9). The audit refused to certify
+them away and returned `ABORT`. The call-graph work then showed they are
+**not reachable at all**, through one dead edge:
+
+    exllamav3.modules.quant.exl3:3   from ...model.config import Config
+      -> exllamav3.model.config:245  from exllamav3.architecture.architectures
+                                     import get_architectures   (function-local,
+                                     inside Config)
+      -> architecture/architectures.py:1,8,24  imports every architecture
+      -> architecture/{arcee,deepseek_v4,glm5_next}.py
+      -> modules.{attn,dsv4,gated_delta_net}
+
+`overlay/exl3_namespace.py::inject_config_stub` installs
+**`exllamav3.model.config`** as a synthetic `types.ModuleType` *before*
+`exllamav3.modules.quant.exl3` is imported, so that first import binds the stub
+and the real `model/config.py` body never executes. With the namespace stubbed,
+the closure is 79 modules on the deployed v1.4.7 and 92 on the v1.4.9 clone, and
+contains **no** module holding an `exl3_mgemm` call site. The audit already
+honoured this mechanism for `exllamav3`, `exllamav3.model` and
+`exllamav3.modules`; `exllamav3.model.config` was simply missing from
+`STUB_NAMESPACES`.
+
+The fix needed two parts, because the installer writes this namespace through
+its own `__name__` (`modules[config.__name__] = config`) rather than a literal
+key: the name was added to `STUB_NAMESPACES`, and `_installed_stub_names` now
+resolves `X.__name__` back to the `types.ModuleType(...)` literal — but only
+when the same variable appears on both sides of the assignment, so
+`mapping[other.__name__] = config` still installs nothing. Both are covered by
+regressions, including a negative control that shows the architecture fan-out
+re-entering the closure if the namespace is not stubbed.
+
+The deployed stub installer is byte-identical to the repo copy
+(`3611f7f5…`), so the receipt describes the file that actually runs.
 
 An earlier draft of this audit did precisely that, and also returned
 `NOT_REACHABLE` when the serving module was deleted or corrupted, and ignored a
@@ -3245,13 +3291,20 @@ answer:
    unchanged; add alias/scope validation before treating arbitrary hand-edited
    installations as certified.
 
-**Open question for the owner:** discharge the three modules with call-graph
-evidence (or prove they are never loaded), then the audit will report
-`NOT_REACHABLE` on its own. Until then **no #290 fix is proven owed, and none is
-proven unnecessary.** Reusable: `scripts/audit_exl3_mgemm_indices.py`
-(fail-closed; `--exl3-root`, `--overlay-dir`). Receipts:
-`local/task37-mgemm-indices-v147-20260910.json`,
-`local/task37-mgemm-indices-v149-local-clone-20260910.json`.
+**Closed: no #290 fix is owed on this deployment, and the entry point is not
+reachable at any shape.** Worst case remains 32 ≤ 128 if the premise ever
+changes. The verdict is **static, not observed** — no live `sys.modules` check
+was run, and `__pycache__` mtimes cannot substitute because the image
+precompiles the whole tree. If a static basis is later judged insufficient, the
+answer is a one-time check in a stopped window, not a stronger claim from the
+script. Two residual model gaps are recorded in the script's own docstring: the
+real `modules/quant/__init__.py` executes (benign on the pinned revision, which
+imports only `.fp16` and `.exl3`), and the installer-invocation check is
+syntactic (P3, above). Reusable:
+`scripts/audit_exl3_mgemm_indices.py` (fail-closed; `--exl3-root`,
+`--overlay-dir`). Receipts:
+`local/task37-mgemm-indices-v147-20260910.json` (79 modules),
+`local/task37-mgemm-indices-v149-local-clone-20260910.json` (92 modules).
 
 ### Task 39 — persistent-top-k: NOT_APPLICABLE
 
@@ -3283,10 +3336,14 @@ Scoped from "three-PR lineage migration" to the one PR portable without it.
 #55738 touches shared MLA backends. #55737 edits `glm5next/nvidia/kda.py`, which
 this fork has. Overlay is default-off, three exactly-once anchors, fail-closed
 on drift, byte-neutral unarmed. Cluster smoke in-container on a temporary copy:
-unarmed `ec090aab…` → armed `02b234e9…` (parses, 6 markers) → idempotent →
-production untouched. **Window NOT run; `start.sh` NOT wired** (launcher edits
-need a boot validation). Contract in `docs/15` §4, including the mandatory
-numeric-parity check before any speed claim.
+unarmed `ec090aab…` → armed `a4bdc543…` (parses, 6 markers) → idempotent →
+production untouched. `start.sh` is now wired and boot-validated (nine sites;
+`bash -n` + shellcheck clean, both generated inner scripts syntax-checked, the
+knob enum validated through `./start.sh validate` in a scratch kit, and the boot
+invocation replayed in throwaway containers: stock → byte-identical, armed →
+`a4bdc543…`, idempotent, production `ec090aab…` throughout). **Window still NOT
+run** — it needs a stopped maintenance window. Contract in `docs/15` §4,
+including the mandatory numeric-parity check before any speed claim.
 
 ### Task 36 — task-29 re-open condition replaced by arithmetic
 

--- a/docs/06-improvement-plan.md
+++ b/docs/06-improvement-plan.md
@@ -3153,8 +3153,8 @@ re-armed (active/active), serving spot-check OK, 6/6 converge probes
 task 34 creates an arm that will need a window record and task 36 replaces a
 standing gate. Detail lives in `docs/15` (task 34) and `docs/11` §9 (task 36).
 
-**Review correction.** Two independent review passes of this change found ten
-fail-open defects, nine of them in the two audits — the code whose entire job is
+**Review correction.** Three independent review passes of this change found
+fourteen fail-open defects, thirteen of them in the two audits — the code whose entire job is
 to refuse to certify a tree it could not read. All ten are fixed with regression
 tests; the net effect is that **task 37's verdict changed from `NOT_REACHABLE`
 to `ABORT`**, because the original verdict rested on evidence the audit could
@@ -3176,6 +3176,14 @@ rather than import provenance, so `from ...sparse_attn_indexer import
 SparseAttnIndexer as SparseAttnIndexerKpool` read as the kpool class; and the
 overlay's completeness list omitted the required imports, so a file missing
 `current_workspace_manager` still counted as installed.
+
+Pass 3: queue order let a weak alias candidate mark a name as already seen
+before its hard `import` was validated; the stub contract proved the installer
+*could* install but not that the loader *calls* it before importing
+`exllamav3`; the indexer resolver used a flat binding map, so a function-local
+import could shadow a module-level one, and it ignored the imported symbol
+name; and the overlay's completeness check was still textual, so a
+commented-out import counted as present.
 
 ### Task 37 — `v_indices[128]` scratch: **ABORT (narrowed, NOT closed)**
 

--- a/docs/06-improvement-plan.md
+++ b/docs/06-improvement-plan.md
@@ -3146,3 +3146,70 @@ Restored `IMAGE=glm53-selfbuild:b5ab8091-s2b`, clean pair restart
 (`SKIP_DOWNLOAD=1`), pool **1,396,551 byte-identical**, watchdog timer
 re-armed (active/active), serving spot-check OK, 6/6 converge probes
 69.7–71.1 on the fresh boot. **M0′ is CLOSED as ADOPT s2b.**
+
+## 2026-09-10: PR #69 — tasks 37/39 CLOSED by audit, 38.1 landed, 34 first arm prepared
+
+**Ledger note.** PRs #64–#67 did not add entries here; this one does, because
+task 34 creates an arm that will need a window record and task 36 replaces a
+standing gate. Detail lives in `docs/15` (task 34) and `docs/11` §9 (task 36).
+
+### Task 37 — `v_indices[128]` scratch: NOT_REACHABLE
+
+The TODO's premise ("unenforced, reachable from the serving path") did not
+survive re-derivation from the deployed source. The scratch is written only
+inside `exl3_mgemm_kernel`; `BC_LinearEXL3::run_gr` — the bridge the model
+actually calls — uses `exl3_gemm_gr`/`exl3_gemm`; the only binding-level entry
+to `exl3_mgemm` is the standalone binding; and the overlay's four named symbols
+(`exl3_fat_gemm`, `exl3_fat_gemm_scatter`, `exl3_moe`,
+`exl3_moe_max_concurrency`) do not include it. Worst-case slots at production
+shapes (`top_k=8`, `MAX_NUM_SEQS=4`, draft 7) = 32 ≤ 128. Checked on pinned
+**v1.4.7** (19 call sites) and a local **v1.4.9** clone (22 call sites).
+**No #290 fix is owed.** Reusable: `scripts/audit_exl3_mgemm_indices.py`
+(fail-closed; `--exl3-root`).
+
+### Task 39 — persistent-top-k: NOT_APPLICABLE
+
+The GLM path runs `SparseAttnIndexerKpool`. Its `persistent_topk` branch is
+dead by construction: a deliberate local patch
+(`overlay/patch_glm_video_placeholders.py::_disable_gb10_persistent_topk`)
+inserts `if False and current_platform.is_cuda()`, with the in-file rationale
+that the persistent variant oversubscribes GB10 shared memory on long
+sequences. The live kernel is `top_k_per_row_decode`. The plain
+`SparseAttnIndexer` — where `persistent_topk` *is* live — is DeepSeek-only.
+So upstream #52149/#55314 do not gate this deployment. **This also corrects the
+task-34 migration gate**, which had listed task 39 as a prerequisite.
+Reusable: `scripts/audit_persistent_topk_reachability.py`; re-run it against any
+migrated tree before assuming the conclusion still holds.
+
+### Task 38 item 1 — silicon fact corrected (scope wider than the TODO said)
+
+The TODO named one file; the same false claim appeared in three tracked files
+(`docs/01-architecture.md`, `docs/07-rebase-plan.md`, `README.md`). All now use
+the target-gated wording. Verified on spark1 with ptxas 13.0.88: `.target sm_121`
+rejects `cvt.e2m1x2`, `.target sm_121a` assembles it and lowers to
+`F2FP.SATFINITE.E2M1.F32.PACK_AB_MERGE_C`. The deposed-NVFP4 decision is
+untouched — only its stated reason. Items 2–4 remain open.
+
+### Task 34 — first arm: FlashKDA prefill, PREPARED (window unrun)
+
+Scoped from "three-PR lineage migration" to the one PR portable without it.
+#55736 edits `glm5next/nvidia/ops/third_party/kda/*`, absent from this fork;
+#55738 touches shared MLA backends. #55737 edits `glm5next/nvidia/kda.py`, which
+this fork has. Overlay is default-off, three exactly-once anchors, fail-closed
+on drift, byte-neutral unarmed. Cluster smoke in-container on a temporary copy:
+unarmed `ec090aab…` → armed `02b234e9…` (parses, 6 markers) → idempotent →
+production untouched. **Window NOT run; `start.sh` NOT wired** (launcher edits
+need a boot validation). Contract in `docs/15` §4, including the mandatory
+numeric-parity check before any speed claim.
+
+### Task 36 — task-29 re-open condition replaced by arithmetic
+
+`docs/11` §9. CC 12.0: 48 warps/SM, 64K regs/SM, 128 KB smem/SM. The measured
+launch (block 512, `REG:128`, `SMEM:92,160 B`) is pinned to 1 block/SM = 16
+warps = 33.3% by two independent ceilings. No counter or occupancy sweep can
+open the gap; a candidate must cut `REG ≤ 64` and application smem
+`≤ 65,536 B`, then confirm residency via the occupancy API.
+
+### Validation
+
+`compileall` OK; `pytest tests/ -q` → 457 passed, 1 skipped, 18 subtests.

--- a/docs/06-improvement-plan.md
+++ b/docs/06-improvement-plan.md
@@ -3147,25 +3147,61 @@ Restored `IMAGE=glm53-selfbuild:b5ab8091-s2b`, clean pair restart
 re-armed (active/active), serving spot-check OK, 6/6 converge probes
 69.7–71.1 on the fresh boot. **M0′ is CLOSED as ADOPT s2b.**
 
-## 2026-09-10: PR #69 — tasks 37/39 CLOSED by audit, 38.1 landed, 34 first arm prepared
+## 2026-09-10: PR #69 — task 39 CLOSED by audit, task 37 NARROWED, 38.1 landed, 34 first arm prepared
 
 **Ledger note.** PRs #64–#67 did not add entries here; this one does, because
 task 34 creates an arm that will need a window record and task 36 replaces a
 standing gate. Detail lives in `docs/15` (task 34) and `docs/11` §9 (task 36).
 
-### Task 37 — `v_indices[128]` scratch: NOT_REACHABLE
+**Review correction.** An independent review of the first revision found six
+fail-open defects, five of them in the two audits — the code whose entire job is
+to refuse to certify a tree it could not read. All six are fixed with regression
+tests; the net effect is that **task 37's verdict changed from `NOT_REACHABLE`
+to `ABORT`**, because the original verdict rested on evidence the audit could
+not actually establish. See the task 37 section below.
 
-The TODO's premise ("unenforced, reachable from the serving path") did not
-survive re-derivation from the deployed source. The scratch is written only
-inside `exl3_mgemm_kernel`; `BC_LinearEXL3::run_gr` — the bridge the model
-actually calls — uses `exl3_gemm_gr`/`exl3_gemm`; the only binding-level entry
-to `exl3_mgemm` is the standalone binding; and the overlay's four named symbols
-(`exl3_fat_gemm`, `exl3_fat_gemm_scatter`, `exl3_moe`,
-`exl3_moe_max_concurrency`) do not include it. Worst-case slots at production
-shapes (`top_k=8`, `MAX_NUM_SEQS=4`, draft 7) = 32 ≤ 128. Checked on pinned
-**v1.4.7** (19 call sites) and a local **v1.4.9** clone (22 call sites).
-**No #290 fix is owed.** Reusable: `scripts/audit_exl3_mgemm_indices.py`
-(fail-closed; `--exl3-root`).
+### Task 37 — `v_indices[128]` scratch: **ABORT (narrowed, NOT closed)**
+
+The TODO's premise ("unenforced, reachable from the serving path") is **not
+established**, and neither is its negation. What is established, on the
+deployed source:
+
+- the scratch is written only inside `exl3_mgemm_kernel`;
+- `BC_LinearEXL3::run_gr` — the bridge the model actually calls — uses
+  `exl3_gemm_gr`/`exl3_gemm` and never `exl3_mgemm`;
+- the overlay's four named extension symbols (`exl3_fat_gemm`,
+  `exl3_fat_gemm_scatter`, `exl3_moe`, `exl3_moe_max_concurrency`) exclude every
+  `exl3_mgemm*` entry, and `exl3_mgemm` is the only such binding;
+- the serving Python module (`exllamav3.modules.quant.exl3`) has no
+  `exl3_mgemm` call site.
+
+Worst-case slots at production shapes (`top_k=8`, `MAX_NUM_SEQS=4`, draft 7) is
+32 ≤ 128, so *if* the entry were reached it would not overflow — but the entry
+is not the open question.
+
+**Why it is not closed.** Two (v1.4.7) / three (v1.4.9) modules inside the
+serving import closure still contain `exl3_mgemm` call sites:
+`exllamav3.modules.attn`, `exllamav3.modules.dsv4` (and
+`gated_delta_net` on v1.4.9). They enter the closure through **function-local**
+imports — `modules/block_sparse_mlp_routing.py` does `from .attn import
+get_for_device` inside a function body — and all their `ext.exl3_mgemm(...)`
+sites are inside functions, not at module level. Importing a module does not
+execute its call sites, so static import-closure analysis cannot discharge
+them; that needs a call graph. The earlier `NOT_REACHABLE` verdict came from
+reporting exactly these as "advisory context" and then certifying anyway.
+
+An earlier draft of this audit did precisely that, and also returned
+`NOT_REACHABLE` when the serving module was deleted or corrupted, and ignored a
+`calls_exl3_mgemm` hit in the C++ bridge. All four are now fail-closed with
+regression tests.
+
+**Open question for the owner:** discharge the three modules with call-graph
+evidence (or prove they are never loaded), then the audit will report
+`NOT_REACHABLE` on its own. Until then **no #290 fix is proven owed, and none is
+proven unnecessary.** Reusable: `scripts/audit_exl3_mgemm_indices.py`
+(fail-closed; `--exl3-root`, `--overlay-dir`). Receipts:
+`local/task37-mgemm-indices-v147-20260910.json`,
+`local/task37-mgemm-indices-v149-local-clone-20260910.json`.
 
 ### Task 39 — persistent-top-k: NOT_APPLICABLE
 

--- a/docs/06-improvement-plan.md
+++ b/docs/06-improvement-plan.md
@@ -3163,8 +3163,18 @@ production. The default is the stock `triton` spelling, so no `.env` change is
 required to deploy the wiring and mounting the overlay cannot alter production
 by itself. Detail in `docs/15` §4.
 
+**Task 38 item 3 also landed** (same session, separate concern): the
+`cvt.rn.bf16x2.e4m3x2` failure is a **toolchain-version** gate (CUDA ≥ 13.2, PTX
+ISA 9.2), not an arch limit — the `f16x2` sibling assembles on `sm_121a` with the
+same ptxas 13.0.88. The helper is on b12x's paged/QSA sparse-attention path but
+not the P8 codec's, so the P8 disposition stands. `docs/11` §2 qualified; receipt
+`local/task38-cvt-bf16x2-e4m3x2-20260910.txt`.
+
 **Validation.** `compileall` clean; `pytest tests/ -q` → **517 passed, 1
 skipped, 18 subtests** (508 before). Receipts regenerated for both revisions.
+Independent review of this candidate returned **APPROVED** with no required
+findings; it re-derived both closures (79 / 92, and 90 / 103 when every unstubbed
+parent initializer is added) and still found no `exl3_mgemm` call-site module.
 
 ## 2026-09-10: PR #69 — task 39 CLOSED by audit, task 37 NARROWED, 38.1 landed, 34 first arm prepared
 
@@ -3305,6 +3315,27 @@ syntactic (P3, above). Reusable:
 `--overlay-dir`). Receipts:
 `local/task37-mgemm-indices-v147-20260910.json` (79 modules),
 `local/task37-mgemm-indices-v149-local-clone-20260910.json` (92 modules).
+
+**Recorded residual hardening (P3, non-blocking; review-approved).** The
+independent review of this flip approved it and named two boundaries that limit
+the audit's *universality* rather than its conclusion on this deployment:
+
+1. `_installed_stub_names` is a structural over-approximation — it can attribute
+   a namespace the installer never reaches. That direction is safe: the
+   behavioural `stub_contract` pass then executes the installer and requires the
+   namespace to be a real module in the mapping, so a structural false positive
+   ends in `ABORT`, not in a wrong `NOT_REACHABLE`.
+2. Pruning assumes the serving process has not already imported the genuine
+   module. The real installer returns an existing `exllamav3.model.config` only
+   when it already carries `NullConfig`/`InferParams` and raises otherwise, so a
+   genuine preload is refused rather than accepted — but arbitrary pre-imported
+   process states are not modelled.
+
+The review also independently strengthened the evidence beyond what was
+submitted: it expanded both closures to include every unstubbed parent
+initializer (90 / 103 modules versus the reported 79 / 92) and still found no
+`exl3_mgemm` call-site module, and confirmed that the real root, model, modules
+and config bodies do not execute while the `quant` parent initializer does.
 
 ### Task 39 — persistent-top-k: NOT_APPLICABLE
 

--- a/docs/06-improvement-plan.md
+++ b/docs/06-improvement-plan.md
@@ -3225,6 +3225,26 @@ running the installer, indexer identity came from spelling rather than import
 provenance, and the overlay's completeness list omitted its own required
 imports.
 
+**Recorded residual hardening (P3, non-blocking; review-approved).** Three
+gaps remain in the audits' *universality* — none of them changes a verdict on
+the deployed tree, and each is a hardening item rather than a demonstrated wrong
+answer:
+
+1. `_installer_invocation()` matches the installer call syntactically, so a call
+   inside `if False` would qualify. The real loader calls it on the live path,
+   so the current conclusion holds; validate reachable invocation before relying
+   on changed loader code.
+2. `_resolve_indexer_class()` still resolves a name bound to one *unknown*
+   import plus one indexer import, because the unknown binding is discarded. The
+   deployed module has a single canonical kpool binding, so its receipt is
+   unaffected; reject unknown alternatives before extending the audit to such
+   layouts.
+3. `_has_required_imports()` checks the imported name but not the local binding
+   it is assigned to, so `... import current_workspace_manager as other` would
+   pass. The generated candidate uses the correct binding and its bytes are
+   unchanged; add alias/scope validation before treating arbitrary hand-edited
+   installations as certified.
+
 **Open question for the owner:** discharge the three modules with call-graph
 evidence (or prove they are never loaded), then the audit will report
 `NOT_REACHABLE` on its own. Until then **no #290 fix is proven owed, and none is

--- a/docs/06-improvement-plan.md
+++ b/docs/06-improvement-plan.md
@@ -3147,6 +3147,53 @@ Restored `IMAGE=glm53-selfbuild:b5ab8091-s2b`, clean pair restart
 re-armed (active/active), serving spot-check OK, 6/6 converge probes
 69.7–71.1 on the fresh boot. **M0′ is CLOSED as ADOPT s2b.**
 
+## 2026-09-10: task 34 arm REVERTED — the correctness gate failed before the window
+
+**Outcome.** The user authorised stopping production for the task 34 A/B window.
+The pre-registered contract in `docs/15` §4 makes numeric parity a *required*
+gate, so the gate was run first — deliberately **without** stopping production,
+since the GPU is reachable alongside the serving container. It failed, so the
+window was not started, production was never restarted, and no speed claim is
+made. Receipt: `local/task34-parity-gate-20260910.txt`.
+
+**The gate.** `local/flashkda-parity-check.py` compares
+`chunk_kda_with_fused_gate` (production's Triton path) against
+`torch.ops._flashkda_C.fwd` on identical inputs, mirroring both call sites
+exactly, so it answers the A/B question itself rather than a proxy for it.
+
+**Finding 1 — fatal arity defect.** The overlay passed **16** positional
+arguments to `_flashkda_C.fwd`; the deployed op declares **14**. Arming raised
+`RuntimeError: expected at most 14 argument(s) but received 16` at the first
+prefill: the arm could not have served one request. This is exactly the failure
+the smoke test could not see — it proved the patched file *parses*, never that
+the op accepts the call. Fixed, and `EXPECTED_FWD_ARITY = 14` now pins the
+emitted call so a drifted template is refused before any write.
+
+**Finding 2 — numeric divergence.** With the arity corrected, the fused output
+is ~150× smaller in mean magnitude than production's and **uncorrelated** with
+it (Pearson +0.008 on `out`, −0.063 on `final_state`), across sequence lengths
+64/512, a zeroed gate, both beta conventions, pre-normalized q/k, both Triton
+references, and `lower_bound` ∈ {−1,−2,−3,−5}. Conventions ruled out by direct
+test: `beta` (the kernel demands bf16 and rejects fp32), `A_log` (the kernel
+demands `[H]` and rejects 4-D), `scale`, `l2norm`, and layout. Root cause not
+isolated — the image ships only `_flashkda_C.abi3.so`, and the strongest lead is
+structural: this fork pairs the fused op with **kimi_k3's** Triton kernel
+(`raw_beta`, no `safe_gate`), not with GLM's (`beta`, `safe_gate`).
+
+**Cluster reverted.** `start.sh` restored from its backup to `560a7ed5b8be5243`
+— the exact bytes the running container was started from — and the deployed
+overlay file removed (they had to move together: the wired launcher's `-f`
+preflight makes the overlay mandatory, so removing only the overlay would abort
+the next boot). Production stayed up throughout (21 h, `/health` 200 on :8000,
+`kda.py` `ec090aab…`).
+
+**Validation.** `compileall` clean; `shellcheck -S warning start.sh` clean;
+`pytest tests/ -q` → **522 passed, 1 skipped, 18 subtests** (517 before; +5
+arity regressions). The corrected overlay bytes were re-validated on the cluster
+against the deployed `kda.py` in a throwaway container: armed hash
+`58ff323c…`, 14 positional arguments to `_flashkda_C.fwd`, zero keywords,
+`py_compile` OK, idempotent, real file `ec090aab…` before and after.
+
 ## 2026-09-10: PR #69 follow-up commits — task 37 CLOSED `NOT_REACHABLE`, task 34 arm wired and boot-validated
 
 **Ledger note.** These commits extend PR #69's branch (the PR is still open),
@@ -3360,21 +3407,31 @@ rejects `cvt.e2m1x2`, `.target sm_121a` assembles it and lowers to
 `F2FP.SATFINITE.E2M1.F32.PACK_AB_MERGE_C`. The deposed-NVFP4 decision is
 untouched — only its stated reason. Items 2–4 remain open.
 
-### Task 34 — first arm: FlashKDA prefill, PREPARED (window unrun)
+### Task 34 — first arm: FlashKDA prefill, REVERTED (parity gate failed)
 
 Scoped from "three-PR lineage migration" to the one PR portable without it.
 #55736 edits `glm5next/nvidia/ops/third_party/kda/*`, absent from this fork;
 #55738 touches shared MLA backends. #55737 edits `glm5next/nvidia/kda.py`, which
 this fork has. Overlay is default-off, three exactly-once anchors, fail-closed
 on drift, byte-neutral unarmed. Cluster smoke in-container on a temporary copy:
-unarmed `ec090aab…` → armed `a4bdc543…` (parses, 6 markers) → idempotent →
-production untouched. `start.sh` is now wired and boot-validated (nine sites;
-`bash -n` + shellcheck clean, both generated inner scripts syntax-checked, the
-knob enum validated through `./start.sh validate` in a scratch kit, and the boot
+unarmed `ec090aab…` → armed (parses, 6 markers) → idempotent → production
+untouched. `start.sh` was wired and boot-validated (nine sites; `bash -n` +
+shellcheck clean, both generated inner scripts syntax-checked, the knob enum
+validated through `./start.sh validate` in a scratch kit, and the boot
 invocation replayed in throwaway containers: stock → byte-identical, armed →
-`a4bdc543…`, idempotent, production `ec090aab…` throughout). **Window still NOT
-run** — it needs a stopped maintenance window. Contract in `docs/15` §4,
-including the mandatory numeric-parity check before any speed claim.
+idempotent, production `ec090aab…` throughout). The armed hash is `58ff323c…`
+after the parity fix below; it was `a4bdc543…` before.
+
+**REVERTED 2026-09-10: the mandatory numeric-parity gate failed.** The arm was
+deployed to the kit (backup `start.sh.bak-20260910-task34`) and the gate run in
+throwaway containers without stopping production. Two findings, either of which
+is disqualifying: the overlay's `_flashkda_C.fwd` call passed **16** positional
+arguments where the deployed op declares **14** (so the arm would have raised at
+the first prefill), and with that fixed the fused output is ~150× smaller than
+production's Triton output and **uncorrelated** with it. The window was not
+started, the deployment was reverted to `560a7ed5b8be5243`, and no speed claim
+is made. Do not arm `GLM53_KDA_PREFILL_BACKEND=flashkda`. Detail in `docs/15`
+§5–§6; receipt `local/task34-parity-gate-20260910.txt`.
 
 ### Task 36 — task-29 re-open condition replaced by arithmetic
 
@@ -3386,4 +3443,4 @@ open the gap; a candidate must cut `REG ≤ 64` and application smem
 
 ### Validation
 
-`compileall` OK; `pytest tests/ -q` → 457 passed, 1 skipped, 18 subtests.
+`compileall` OK; `pytest tests/ -q` → 522 passed, 1 skipped, 18 subtests.

--- a/docs/06-improvement-plan.md
+++ b/docs/06-improvement-plan.md
@@ -3153,12 +3153,29 @@ re-armed (active/active), serving spot-check OK, 6/6 converge probes
 task 34 creates an arm that will need a window record and task 36 replaces a
 standing gate. Detail lives in `docs/15` (task 34) and `docs/11` §9 (task 36).
 
-**Review correction.** An independent review of the first revision found six
-fail-open defects, five of them in the two audits — the code whose entire job is
-to refuse to certify a tree it could not read. All six are fixed with regression
+**Review correction.** Two independent review passes of this change found ten
+fail-open defects, nine of them in the two audits — the code whose entire job is
+to refuse to certify a tree it could not read. All ten are fixed with regression
 tests; the net effect is that **task 37's verdict changed from `NOT_REACHABLE`
 to `ABORT`**, because the original verdict rested on evidence the audit could
 not actually establish. See the task 37 section below.
+
+Pass 1: the verdict ignored a `calls_exl3_mgemm` hit in the C++ bridge; closure
+modules holding call sites were reported as advisory and then certified anyway;
+a missing or unparseable serving module silently shrank the closure; the
+stub-namespace pruning was assumed; the task 39 dead-branch check walked the
+whole `ast.If` and so called a live `else` dead; the task 39 indexer check was a
+textual match; the overlay accepted any marker occurrence as a complete
+install; and it appended its method at EOF without checking class ownership.
+
+Pass 2: relative imports' aliases (`from . import helper`) were not followed, so
+a helper reached that way never entered the closure; the stub contract checked
+token presence rather than installation (it now runs the installer and inspects
+the mapping); the indexer check inferred constructor identity from spelling
+rather than import provenance, so `from ...sparse_attn_indexer import
+SparseAttnIndexer as SparseAttnIndexerKpool` read as the kpool class; and the
+overlay's completeness list omitted the required imports, so a file missing
+`current_workspace_manager` still counted as installed.
 
 ### Task 37 — `v_indices[128]` scratch: **ABORT (narrowed, NOT closed)**
 
@@ -3192,8 +3209,13 @@ reporting exactly these as "advisory context" and then certifying anyway.
 
 An earlier draft of this audit did precisely that, and also returned
 `NOT_REACHABLE` when the serving module was deleted or corrupted, and ignored a
-`calls_exl3_mgemm` hit in the C++ bridge. All four are now fail-closed with
-regression tests.
+`calls_exl3_mgemm` hit in the C++ bridge. All of them are now fail-closed with
+regression tests. A second review pass then closed four more holes of the same
+kind: relative-import aliases were not followed into the closure, the
+stub-namespace pruning was justified by token presence rather than by actually
+running the installer, indexer identity came from spelling rather than import
+provenance, and the overlay's completeness list omitted its own required
+imports.
 
 **Open question for the owner:** discharge the three modules with call-graph
 evidence (or prove they are never loaded), then the audit will report

--- a/docs/07-rebase-plan.md
+++ b/docs/07-rebase-plan.md
@@ -33,9 +33,13 @@ will never take, instead of a 142-commit private fork delta.
 - **FlashInfer #4802/#4791** — a *native* SM120 NoPE sparse-MLA path (D_CKV=512,
   D_ROPE=0). When integrated, the zero-padding workaround retires and DSA-layer
   KV records drop from 656 B toward ~528 B/token — a pool win to re-measure.
-- **SM121 hardware facts** (field-confirmed): SM121 lacks `cvt.e2m1x2` — NVFP4
-  kernels can never compile for it (the EXL3 choice was structural, not taste);
-  sm_120 cubins run on sm_121 via forward compatibility; platform support
+- **SM121 target facts** (field-confirmed): on the family target `.target sm_121`
+  the FP4 conversion `cvt.rn.satfinite.e2m1x2.f32` is rejected, but it assembles
+  and lowers to real SASS on `sm_121a` — the FP4 alphabet is **target-gated, not
+  silicon-absent**, so "NVFP4 can never compile" holds only for the default
+  (non-`a`) target. The EXL3 choice was structural, not an ISA impossibility
+  (see `01-architecture.md`); sm_120 cubins run on sm_121 via forward
+  compatibility; platform support
   (`is_blackwell_class()`, GB10 MoE configs, TRITON_PTXAS_PATH) is merged (#31740).
 
 ## What current main already ships (verified in-tree, `cacc429f62`)

--- a/docs/11-gb10-kernel-program.md
+++ b/docs/11-gb10-kernel-program.md
@@ -30,12 +30,15 @@ before each window restart, `POST /reset_prefix_cache` for cold rounds
 | tcgen05 / TMEM | **NOT present** | Warp-level `mma.sync` is the only tensor-core path; no 2-SM MMA, no tile-level UMMA | CUTLASS issues [#2947](https://github.com/NVIDIA/cutlass/issues/2947), [#3100](https://github.com/NVIDIA/cutlass/issues/3100) — NVIDIA staff: *"SM121a and SM120a do not support tcgen05 … use warp level mma"* |
 | Shared memory | **101,376 B/CTA** (same as RTX 4090) | SGLang-class default MoE configs (~147 KB) fail `OutOfResources`; tile configs must fit 99 KB effective | [NVIDIA forum: SM121 CUTLASS results](https://forums.developer.nvidia.com/t/sm121-cutlass-kernel-optimization-results-nvfp4-356-tflops-moe-grouped-gemm-on-dgx-spark/359960) |
 | NVFP4/FP8 tensor cores | Present via warp-level block-scaled `mma.sync` (CUDA 13); measured 356 TFLOPS dense NVFP4 (71% of peak) | FP4 compute is real but through the SM80-era issue path, not tcgen05 | same forum thread |
-| Toolchain | CUDA 13.x system ptxas required (`TORCH_CUDA_ARCH_LIST=12.1a`); older bundled ptxas lacks sm_121 | Keep `TORCH_CUDA_ARCH_LIST=12.1a` in the kit Dockerfile (already set) | [triton-blackwell-bringup](https://github.com/eniktab/triton-blackwell-bringup) |
+| Toolchain | CUDA 13.x system ptxas required (`TORCH_CUDA_ARCH_LIST=12.1a`); older bundled ptxas lacks sm_121. **CUDA ≥ 13.2 (PTX ISA 9.2) additionally required for any entry using the `cvt.rn.bf16x2.e4m3x2` widening** — ptxas 13.0.88 caps at ISA 9.0 and rejects it on `sm_121a` (`Unexpected instruction types specified for 'cvt'`), while the `cvt.rn.f16x2.e4m3x2` sibling assembles. A toolchain-version limit, not an arch one. | Keep `TORCH_CUDA_ARCH_LIST=12.1a` in the kit Dockerfile (already set); for a b12x-style intake, gate on CUDA ≥ 13.2 rather than on the arch | [triton-blackwell-bringup](https://github.com/eniktab/triton-blackwell-bringup); measured on spark1 ptxas 13.0.88, receipt `local/task38-cvt-bf16x2-e4m3x2-20260910.txt` |
 | Memory bandwidth | 218 GB/s measured LPDDR5X unified | The fat-expert wall is **weight streaming, not MMA** — format/traffic optimizations beat ISA upgrades | forum; matches docs/06 W24 ("weight streaming ≈ 63% of every prefill step") |
 
 **Intake rule (adopted):** any kernel candidate that requires tcgen05/TMEM, 2-SM MMA,
 >101,376 B SMEM, or a pre-CUDA-13 toolchain is rejected at intake. Warp-level-MMA
-probes come before any port.
+probes come before any port. A candidate whose kernels use the PTX ISA 9.2
+bf16x2 e4m3 widening is additionally gated on **CUDA ≥ 13.2**, which is a
+toolchain gate rather than an arch gate — do not record it as an SM121
+limitation.
 
 ## 3. Qualification of `overlay/exl3_fat_gemm.cu` (W24, adopted 2026-08-31)
 

--- a/docs/11-gb10-kernel-program.md
+++ b/docs/11-gb10-kernel-program.md
@@ -574,3 +574,75 @@ measurement.
   parity fails; dual-issue K16 / more stages / larger MB; cluster /
   DSMEM / multicast; CUDA-graphing prefill fat as a reason to change
   kernels.
+
+## 9. Task 36 — fused `exl3_moe` register/smem gate (supersedes the task-29 counter gate)
+
+Pre-registered 2026-09-10. This **replaces** the parked task-29 re-open condition
+("a *measured* hardware counter that contradicts 33.3% derived occupancy"). That
+gate asked for a counter to overturn arithmetic; the arithmetic is the gate.
+
+### The arithmetic, on CC 12.0
+
+From the Blackwell Tuning Guide (CUDA 13.3, §1.4.1.1), for compute capability 12.0:
+
+| Resource | Limit |
+|---|---|
+| Warps per SM | **48** (not 64) |
+| 32-bit registers per SM | **64K** |
+| Shared memory per SM | **128 KB** |
+| Shared memory per block (opt-in) | **99 KB / 101,376 B** (the cap already in §2) |
+
+The measured decode launch (§24, PR #64/#66) is `block 512`, `REG:128`,
+`SMEM:92,160 B`, grid `[8,1,6]`. Both binding limits are exact:
+
+- registers: `512 × 128 = 65,536` = the entire register file → **1 block/SM**;
+- shared memory: `2 × 92,160 = 184,320 B > 131,072 B` → **1 block/SM**.
+
+One 512-thread block is 16 warps, so residency is `16 / 48 = **33.3%**`. The
+33.33% figure in §24 and in the task-29 receipt is therefore not an artifact of a
+derived-occupancy formula; it is the arithmetic consequence of two independent
+resource ceilings.
+
+### Consequence: no counter and no occupancy sweep can open this
+
+The task-29 floor was 50% = 24 warps/SM. That is **not reachable** with 512-thread
+blocks, because each block is 16 warps and the register file admits only one. The
+practical step is 2 blocks/SM = 32 warps. A register cut alone does not get there:
+
+- a 256-thread block at 128 regs: the register limit would allow 2 blocks, but the
+  shared-memory limit still allows only 1 → `1 × 8 = 8` warps, i.e. **worse** than
+  the current 16.
+
+So both register pressure **and** smem footprint must move, and the smem must come
+down before a smaller block is even neutral.
+
+### Re-open condition (pre-registered; do not edit before an arm exists)
+
+A candidate arm must, at the production per-rank shape:
+
+1. cut `REG` to **≤ 64** *and* application SMEM to **≤ 65,536 B** at block 512
+   (necessary arithmetic, **not** a sufficient admission test — CUDA reserves
+   shared memory per block); **and**
+2. be confirmed resident by the occupancy API (`cudaOccupancyMaxActiveBlocksPerMultiprocessor`,
+   or ncu's achieved occupancy) on the candidate cubin — the two inequalities alone
+   are not sufficient; **and**
+3. then clear **≥ 5% decode e2e** (hashmap prose **and** hard essay) with
+   structured non-inferior, parity vs the current cubin, and the standing gates.
+
+A register cut that changes numerics is a **target-numerics change** and needs the
+§1-class quality conversation, not a kernel-parity claim.
+
+### Do not
+
+Do not re-run grow-from-this-call (W1), the W4 gather-as-reload, or an occupancy
+sweep on the current cubin — task 24 closed all three by measurement.
+
+### Reusable evidence
+
+- decode-step share oracle: `scripts/run_decode_profile_window.py`,
+  `probe_decode_profile.py`, `audit_decode_kernel_share.py`
+  (receipts `local/task29-decode-share-{head,worker}-20260909.json`);
+- no-reboot counter path: `docker run --gpus all --cap-add SYS_ADMIN` (docs/14);
+- **dependency:** if the task-34 lineage migration lands, re-baseline the
+  fused-kernel geometry and the 49.7% decode share first — the NoPE-concat and
+  KDA-stride changes move the decode-step composition this gate is stated against.

--- a/docs/15-flashkda-prefill-arm.md
+++ b/docs/15-flashkda-prefill-arm.md
@@ -1,0 +1,113 @@
+# 15 — Task 34 arm: FlashKDA fused chunked prefill (vLLM #55737)
+
+**Status 2026-09-10: PREPARED and cluster-smoked; the production A/B window has
+NOT been run.** No production restart, no `.env` change, no image change. The
+candidate overlay is default-off and byte-neutral when unarmed.
+
+## 1. Why this arm, and what it is not
+
+Prefill is this deployment's measured weak lane (240k cold ~1408 tok/s, 60k
+~1454) and the upstream PR is prefill-weighted: **#55737** replaces the ~15-kernel
+Triton `chunk_kda_with_fused_gate` path with `vllm._flashkda_C`, reporting
+1.7–3.8× on the KDA layer and TTFT **−7.9% to −13.2%**.
+
+It is a **port, not a rebase** (task 33's scoping fact). The deployed vLLM is the
+divergent fork `487ecf187` (`0.1.dev20051`), which carries **no
+`glm5next/nvidia/ops/third_party/`** tree — so #55736's
+`glm5next/nvidia/ops/third_party/kda/{fused_recurrent,kernels}.py` edits have **no
+counterpart file here**, and #55736 is not a rebase of the reverted task-30
+overlay either (that patched the *vendored FLA* path, a different file). #55738
+touches shared MLA backends, not the GLM model path, and is scoped separately.
+
+This document covers **#55737 only**, on the one file the deployed fork actually
+has: `vllm/models/glm5next/nvidia/kda.py` (653 lines).
+
+## 2. Feasibility, verified on the deployed image
+
+| Check | Result |
+|---|---|
+| `vllm._flashkda_C` importable in the serving container | **yes** |
+| `torch.ops._flashkda_C.get_workspace_size(1792, 32, 4)` | **51,314,688 B** (runs on GB10) |
+| `current_workspace_manager` importable (`vllm.v1.worker.workspace`) | **yes** |
+| `GatedDeltaNetAttention.get_state_dtype` | **yes** |
+| `self.head_dim` / `self.local_num_heads` present | **yes** (128 / 32) |
+| upstream auto-select gate accepts this device | **yes** — SM12x, bf16, head_dim 128, bounded gate (`linear_lower_bound`) |
+
+The upstream gate is `capability.major in (9, 10, 12) and head_dim == 128 and
+dtype == torch.bfloat16 and lower_bound is not None`. GB10 is `sm_121` → major
+12, so the arm would engage.
+
+## 3. The port — `overlay/patch_flashkda_prefill.py`
+
+Three insertion points, each asserted to match **exactly once**; a drifted anchor
+aborts the boot rather than serving a half-patched KDA layer.
+
+1. **module helper block** before `class Glm5NextLinearAttention(...)` — imports
+   `current_workspace_manager`, adds `_glm53_flashkda_supported(...)` (the upstream
+   selection predicate, restated);
+2. **`__init__` tail** after `self._conv_state_dim_first = is_conv_state_dim_first()`
+   — capability assertion, `import vllm._flashkda_C`, and the three
+   `get_simultaneous` buffer specs (final state, workspace, spec-step output);
+3. **the non-spec prefill call** — the single `chunk_kda_with_fused_gate(q=_rearr(q_ns), …)`
+   becomes an `if self._glm53_flashkda_prefill:` dispatch, with the original Triton
+   call preserved verbatim in the `else` branch.
+
+Plus `_flashkda_prefill(...)`, appended as a method of the same class.
+
+`GLM53_KDA_PREFILL_BACKEND` gates it: unset or `triton` leaves the file
+**byte-identical**; `flashkda` patches; anything else is refused.
+
+### Offline and cluster validation (done)
+
+- `tests/test_flashkda_prefill_patch.py` — 16 CPU tests: applies and compiles,
+  idempotent by marker, helper lands before the class, `_flashkda_prefill` is a
+  class method, the Triton call survives re-indented, the selection predicate is
+  restated, and **each of the three anchors fails closed when drifted** (plus an
+  ambiguous-anchor case and the missing-target case).
+- Same assertions run against the **real deployed `kda.py`** when the gitignored
+  live-image dump is present (`tests/fixtures/live-image-vllm/`).
+- **Cluster smoke (in-container, on a temporary copy — production untouched):**
+  unarmed sha256 `ec090aab…` unchanged; armed → `02b234e9…`, parses, 6 markers;
+  re-run idempotent (`02b234e9…`); the production file stayed `ec090aab…`.
+
+## 4. Pre-registered A/B contract (not yet run)
+
+Follows docs/13 §6 in full. One independent variable: `GLM53_KDA_PREFILL_BACKEND`.
+
+- **Control (A):** current stack — `glm53-selfbuild:e3-w3-zfill`,
+  `EXL3_FAT_GROUPED=1`, last-wins `EXL3_TEMP_ROWS_FUSED=32`,
+  `GLM53_ADAPTIVE_K=ema`, pin `7d74cdd`, C4.
+- **Candidate (B):** A + `GLM53_KDA_PREFILL_BACKEND=flashkda`.
+- **Observations:** ≥5 cold-prefill samples per arm at **60k and 240k**; prose
+  (hashmap + hard essay) and structured ≥9 per arm; acceptance 7/7, serving 6/6,
+  toolcall 23/23.
+- **Adopt if:** ≥5% cold-prefill gain at 60k **and** 240k, with prose/structured
+  and concurrency non-inferior, and per-request correctness on saved prompts.
+- **Correctness gate (required, not optional):** the fused kernel must be
+  numerically comparable to the Triton chunk path on the same inputs. This is a
+  **prefill kernel replacement**, so parity is checked before any speed claim is
+  read; a divergence is a correctness finding, not a tuning result.
+- **Abort on:** any CUDA/Xid/IMA, output corruption, preemption regression,
+  worker failure, or either-node MemFree < 2.5 GiB.
+- **Rollback:** unset the knob through the guarded unit (the overlay then leaves
+  `kda.py` byte-identical on the next boot). No image rebuild, no `.env` edit
+  beyond the knob.
+- **Both-node shape-cache:** the KDA layer is a config-shape change only if the
+  workspace sizing moves; the JIT stamp must be recorded before/after regardless.
+
+### Wiring still required before the window
+
+`start.sh` must mount and execute the overlay the way
+`patch_glm_video_placeholders.py` is wired (host variable → worker `scp` →
+both ranks' `docker -v` → `python3 -S` at boot, after the FLA/KDA overlays).
+That edit touches a 91 KB launcher in five places and **must be boot-validated**;
+it was deliberately not made in the preparation session, because a launcher
+regression is the documented cluster-down class (AGENTS.md, the unquoted-heredoc
+and folded-`command:` incidents).
+
+## 5. Explicitly not done
+
+- No production restart, no armed boot, no A/B measurement.
+- No numeric-parity run of `_flashkda_C.fwd` vs `chunk_kda_with_fused_gate`.
+- #55736 and #55738 were not attempted; #55736's files do not exist in this fork
+  and the whole lineage migration is its own multi-component window.

--- a/docs/15-flashkda-prefill-arm.md
+++ b/docs/15-flashkda-prefill-arm.md
@@ -1,10 +1,14 @@
 # 15 — Task 34 arm: FlashKDA fused chunked prefill (vLLM #55737)
 
-**Status 2026-09-10: PREPARED, WIRED and boot-validated; the production A/B
-window has NOT been run.** No production restart, no `.env` change, no image
-change. The candidate overlay is default-off and byte-neutral when unarmed, and
-`start.sh` now mounts and executes it, so the arm can be armed by setting the
-knob alone.
+**Status 2026-09-10: REVERTED — the numeric parity gate FAILED.** The arm was
+wired, deployed to the cluster and put through the mandatory correctness gate;
+the gate found a fatal arity defect and, once that was fixed, a numeric
+divergence from the Triton path. The cluster deployment was reverted to the
+exact bytes production runs, production was never restarted, and the A/B window
+was **not** run. Receipt: `local/task34-parity-gate-20260910.txt`.
+
+Do not arm `GLM53_KDA_PREFILL_BACKEND=flashkda`. The overlay is retained as the
+port under study, not as a candidate.
 
 ## 1. Why this arm, and what it is not
 
@@ -34,10 +38,14 @@ has: `vllm/models/glm5next/nvidia/kda.py` (653 lines).
 | `GatedDeltaNetAttention.get_state_dtype` | **yes** |
 | `self.head_dim` / `self.local_num_heads` present | **yes** (128 / 32) |
 | upstream auto-select gate accepts this device | **yes** — SM12x, bf16, head_dim 128, bounded gate (`linear_lower_bound`) |
+| `torch.ops._flashkda_C.fwd` reproduces the Triton chunk path | **NO — see §5** |
 
 The upstream gate is `capability.major in (9, 10, 12) and head_dim == 128 and
 dtype == torch.bfloat16 and lower_bound is not None`. GB10 is `sm_121` → major
-12, so the arm would engage.
+12, so the arm would engage. Note what that gate does and does not establish: it
+is a *selection* predicate. The extension being importable, and its workspace
+allocator returning a plausible size, says nothing about whether its output
+matches the path it replaces — which is what the parity gate in §5 tests.
 
 ## 3. The port — `overlay/patch_flashkda_prefill.py`
 
@@ -61,21 +69,33 @@ Plus `_flashkda_prefill(...)`, appended as a method of the same class.
 
 ### Offline and cluster validation (done)
 
-- `tests/test_flashkda_prefill_patch.py` — 16 CPU tests: applies and compiles,
+- `tests/test_flashkda_prefill_patch.py` — 37 CPU tests: applies and compiles,
   idempotent by marker, helper lands before the class, `_flashkda_prefill` is a
   class method, the Triton call survives re-indented, the selection predicate is
-  restated, and **each of the three anchors fails closed when drifted** (plus an
-  ambiguous-anchor case and the missing-target case).
+  restated, **each of the three anchors fails closed when drifted** (plus an
+  ambiguous-anchor case and the missing-target case), and — added after §5 — the
+  fused call's **arity is pinned to the deployed op's 14 arguments**, with the
+  exact 16-argument defect rejected, a wrong-arity template refused before any
+  write, and a keyword rewrite not counted as positional.
 - Same assertions run against the **real deployed `kda.py`** when the gitignored
   live-image dump is present (`tests/fixtures/live-image-vllm/`).
 - **Cluster smoke (in-container, on a temporary copy — production untouched):**
-  unarmed sha256 `ec090aab…` unchanged; armed → `a4bdc543…`, parses, 6 markers;
-  re-run idempotent (`a4bdc543…`); the production file stayed `ec090aab…`. The
-  armed hash moved from the earlier `02b234e9…` when the review rounds added the
-  marker-requires-completeness and class-boundary checks; `a4bdc543…` is the
-  current candidate and is the value re-verified through the wired boot path.
+  unarmed sha256 `ec090aab…` unchanged; armed → parses, 6 markers; re-run
+  idempotent; the production file stayed `ec090aab…`. The armed hash has moved
+  twice as the port changed: `02b234e9…` → `a4bdc543…` when the review rounds
+  added the marker-requires-completeness and class-boundary checks, then
+  `a4bdc543…` → **`58ff323c…`** when §5 removed the two spurious arguments.
+  `58ff323c…` is the current armed hash and was re-verified on the cluster
+  against the deployed `kda.py`: 14 positional arguments to `_flashkda_C.fwd`,
+  zero keywords, `py_compile` OK, idempotent, real file `ec090aab…` before and
+  after. Note that the *unarmed* hash is unchanged in all of this — the fix only
+  affects what the arm writes, which is why it never touched production.
 
-## 4. Pre-registered A/B contract (not yet run)
+## 4. Pre-registered A/B contract (registered, never executed)
+
+Kept verbatim as registered. It was **not** run: §5's correctness gate — listed
+here as required — failed first, which by the contract's own terms ends the
+evaluation. No sample in this design was collected.
 
 Follows docs/13 §6 in full. One independent variable: `GLM53_KDA_PREFILL_BACKEND`.
 
@@ -118,7 +138,7 @@ Validated, without touching production:
 | Both generated inner scripts extracted and `bash -n` | rc=0, block present and `-f`-guarded in each |
 | `./start.sh validate` in a scratch kit on spark1 | `triton`, `flashkda`, empty → "configuration valid"; `bogus` and `FLASHKDA` → rejected with the enum message |
 | Boot invocation in a throwaway container, knob `triton` | `kda.py` byte-identical (`ec090aab…`), 0 markers |
-| Boot invocation in a throwaway container, knob `flashkda` | `a4bdc543…`, 6 markers, `py_compile` OK, re-run idempotent |
+| Boot invocation in a throwaway container, knob `flashkda` | `a4bdc543…` (now `58ff323c…` after §5), 6 markers, `py_compile` OK, re-run idempotent |
 | Live production during all of the above | `ec090aab…` unchanged, container up, `/health` 200 on :8000 |
 
 The default is `triton` (the stock spelling), so **no `.env` change is required
@@ -130,11 +150,105 @@ replaces the prefill call and adds no Triton specialization, so hashing it would
 force a full cache wipe on every arm switch for no benefit. Record the JIT stamp
 before/after the window regardless, as below.
 
-## 5. Explicitly not done
+## 5. The correctness gate — FAILED (2026-09-10)
+
+Run **without stopping production**: the GPU is reachable alongside the serving
+container, so the gate was executed in throwaway containers from the deployed
+image while `glm53-exl3-head` stayed up. Harness:
+`local/flashkda-parity-check.py`; full numbers in
+`local/task34-parity-gate-20260910.txt`.
+
+The harness mirrors both call sites exactly — the candidate invocation is
+`overlay/patch_flashkda_prefill.py::_flashkda_prefill` verbatim, the reference is
+`glm5next/nvidia/kda.py`'s live prefill call verbatim — so it answers the A/B
+question directly: what production would compute if armed, versus what it
+computes now.
+
+**Finding 1 — fatal arity defect.** The overlay passed **16** positional
+arguments to `torch.ops._flashkda_C.fwd`; the deployed op declares **14**
+(`q, k, v, g, beta, scale, out, workspace, A_log, dt_bias, lower_bound,
+initial_state, final_state, cu_seqlens`). Arming raised
+`RuntimeError: expected at most 14 argument(s) but received 16` at the first
+prefill — the arm could not have served a single request. The first 14 arguments
+matched the declaration in order, so the defect was two spurious trailing
+`None`s. This is the failure mode the gate exists for: the earlier cluster smoke
+test only proved the patched file *parses*, never that the op accepts the call.
+
+Fixed in the overlay; `EXPECTED_FWD_ARITY = 14` now pins the emitted call, so
+`apply_to` refuses a template with the wrong count and `is_complete` rejects an
+installed file with one.
+
+**Finding 2 — numeric divergence.** With the arity corrected the fused kernel
+does not reproduce the Triton path. At `tokens=512, heads=32, head_dim=128,
+lower_bound=-5.0`:
+
+| | max abs diff | reference peak | reference mean abs | candidate mean abs | Pearson |
+|---|---|---|---|---|---|
+| `out` | 0.0735474 | 0.0722656 | 0.00314 | **2.095e-05** | **+0.008** |
+| `final_state` | 1.6172 | 1.62175 | 0.03503 | **1.580e-04** | **−0.063** |
+
+The candidate's mean magnitude is ~150× below the reference's and its output is
+uncorrelated with it. The max difference exceeds the reference's own peak
+because the candidate is near-zero almost everywhere: in a `T=256` probe every
+one of the 256 token rows had mean `|.|` ≈ 2e-5 against the reference's ≈ 2.7e-3.
+The kernel *does* run and *does* write — with both buffers pre-filled to a
+sentinel, 100% of both were overwritten and 256/256 token positions written — so
+this is a wrong result, not a skipped kernel or a stride mismatch.
+
+Every variant tried also failed: kimi_k3's own Triton kernel as the reference;
+`tokens=64`; pre-normalized q/k (byte-identical, so the kernel normalizes
+internally); bf16 pre-sigmoided beta; a zeroed gate (`g = dt_bias = A_log = 0`).
+A `lower_bound` sweep of {−1,−2,−3,−5} gave ratios of 130/116/100/87 — it does
+**not** track `exp(lower_bound)`, so the factor is not a mis-applied bound.
+
+Conventions ruled out, each by direct test: `beta` (the kernel requires bf16 and
+rejects fp32: `flash_kda.cpp:55, beta must be bfloat16` — the overlay's raw-bf16
+convention is right), `A_log` (the kernel requires `[H]` and rejects `(1,1,H,1)`,
+`(H,1)`, `(H,1,1,1)`: `flash_kda.cpp:109, A_log must be [H]` — the overlay's
+`.view(-1)` is the correct adaptation of GLM's 4-D parameter), `scale` (both use
+`head_dim ** -0.5`), `l2norm`, and layout.
+
+**Root cause not isolated.** The structural lead: the fused kernel is paired, in
+this fork, with a *different* Triton kernel than GLM's.
+`vllm/models/kimi_k3/nvidia/kda.py:180` is the only `_flashkda_prefill` in the
+image; its Triton branch calls the kimi_k3 copy
+(`chunk_kda_with_fused_gate(..., raw_beta, ..., lower_bound=None)`, no
+`safe_gate`), while GLM calls the `vllm.third_party` copy (`..., beta, ...,
+safe_gate, lower_bound=-5.0`), which takes **pre-sigmoided** beta. The two Triton
+kernels are not the same kernel. Their outputs on these inputs are nearly
+identical to each other (`ref_abs_max` 0.0722656 vs 0.0722656), which places the
+mismatch in the fused op's own input expectations rather than in the choice of
+reference. Isolating it needs the kernel source; the image ships only
+`_flashkda_C.abi3.so`, and the error strings name a build-time path
+(`/workspace/.deps/flashkda-src/csrc/flash_kda.cpp`) absent from the image.
+
+## 6. Decision, and the cluster state
+
+**REVERT.** Per §4's pre-registered contract, a divergence is a correctness
+finding, not a tuning result: with the fused output uncorrelated with
+production's, a cold-prefill comparison would measure a different computation.
+The A/B window was therefore not started and **no speed claim is made**.
+
+| | sha256 (first 16) |
+|---|---|
+| `start.sh` before task 34 (byte-identical to repo `6d071e4`) | `560a7ed5b8be5243` |
+| `start.sh` as deployed for the window | `9abb832a567b5c86` |
+| `overlay/patch_flashkda_prefill.py` as deployed | `a38a0ad4f6ec8f09` |
+| backup retained: `start.sh.bak-20260910-task34` | `560a7ed5b8be5243` |
+| **`start.sh` after the revert** | **`560a7ed5b8be5243`** |
+
+The revert restored `start.sh` from the backup and removed the deployed overlay
+file, returning the kit to the exact bytes the running container was started
+from (`bash -n` clean, overlay absent). The two had to move together: the wired
+launcher's `-f` preflight makes the overlay file mandatory, so removing only the
+overlay would abort the next boot. Production was never restarted — container
+`glm53-exl3-head` stayed up (21 h at the end of the run), `/health` 200 on
+:8000, `kda.py` `ec090aab…` throughout.
+
+## 7. Explicitly not done
 
 - No production restart, no armed boot, no A/B measurement.
-- The launcher wiring landed and was boot-validated in throwaway containers;
-  production was never restarted and its `kda.py` stayed `ec090aab…`.
-- No numeric-parity run of `_flashkda_C.fwd` vs `chunk_kda_with_fused_gate`.
+- No e2e prefill/acceptance/toolcall measurement — the numeric gate failed first.
+- Root cause of the divergence was not isolated (needs the kernel source).
 - #55736 and #55738 were not attempted; #55736's files do not exist in this fork
   and the whole lineage migration is its own multi-component window.

--- a/docs/15-flashkda-prefill-arm.md
+++ b/docs/15-flashkda-prefill-arm.md
@@ -1,8 +1,10 @@
 # 15 — Task 34 arm: FlashKDA fused chunked prefill (vLLM #55737)
 
-**Status 2026-09-10: PREPARED and cluster-smoked; the production A/B window has
-NOT been run.** No production restart, no `.env` change, no image change. The
-candidate overlay is default-off and byte-neutral when unarmed.
+**Status 2026-09-10: PREPARED, WIRED and boot-validated; the production A/B
+window has NOT been run.** No production restart, no `.env` change, no image
+change. The candidate overlay is default-off and byte-neutral when unarmed, and
+`start.sh` now mounts and executes it, so the arm can be armed by setting the
+knob alone.
 
 ## 1. Why this arm, and what it is not
 
@@ -67,8 +69,11 @@ Plus `_flashkda_prefill(...)`, appended as a method of the same class.
 - Same assertions run against the **real deployed `kda.py`** when the gitignored
   live-image dump is present (`tests/fixtures/live-image-vllm/`).
 - **Cluster smoke (in-container, on a temporary copy — production untouched):**
-  unarmed sha256 `ec090aab…` unchanged; armed → `02b234e9…`, parses, 6 markers;
-  re-run idempotent (`02b234e9…`); the production file stayed `ec090aab…`.
+  unarmed sha256 `ec090aab…` unchanged; armed → `a4bdc543…`, parses, 6 markers;
+  re-run idempotent (`a4bdc543…`); the production file stayed `ec090aab…`. The
+  armed hash moved from the earlier `02b234e9…` when the review rounds added the
+  marker-requires-completeness and class-boundary checks; `a4bdc543…` is the
+  current candidate and is the value re-verified through the wired boot path.
 
 ## 4. Pre-registered A/B contract (not yet run)
 
@@ -95,19 +100,41 @@ Follows docs/13 §6 in full. One independent variable: `GLM53_KDA_PREFILL_BACKEN
 - **Both-node shape-cache:** the KDA layer is a config-shape change only if the
   workspace sizing moves; the JIT stamp must be recorded before/after regardless.
 
-### Wiring still required before the window
+### Wiring — DONE and boot-validated (2026-09-10)
 
-`start.sh` must mount and execute the overlay the way
-`patch_glm_video_placeholders.py` is wired (host variable → worker `scp` →
-both ranks' `docker -v` → `python3 -S` at boot, after the FLA/KDA overlays).
-That edit touches a 91 KB launcher in five places and **must be boot-validated**;
-it was deliberately not made in the preparation session, because a launcher
-regression is the documented cluster-down class (AGENTS.md, the unquoted-heredoc
-and folded-`command:` incidents).
+`start.sh` mounts and executes the overlay the way the other `patch_*.py`
+overlays are wired: host variable (`FLASHKDA_PREFILL_PATCH_HOST`) → worker
+`scp` → both ranks' `docker -v` → `python3 -S` at boot, after the FLA/KDA
+overlays. Nine sites: host var, knob default, `validate` enum check, preflight
+`-f` check, both boot heredocs, worker `scp`, both `docker -v` mounts, and the
+`nccl_common` env forward (`-e GLM53_KDA_PREFILL_BACKEND`, which reaches both
+ranks).
+
+Validated, without touching production:
+
+| Check | Result |
+|---|---|
+| `bash -n start.sh`, `shellcheck -S warning start.sh` | clean |
+| Both generated inner scripts extracted and `bash -n` | rc=0, block present and `-f`-guarded in each |
+| `./start.sh validate` in a scratch kit on spark1 | `triton`, `flashkda`, empty → "configuration valid"; `bogus` and `FLASHKDA` → rejected with the enum message |
+| Boot invocation in a throwaway container, knob `triton` | `kda.py` byte-identical (`ec090aab…`), 0 markers |
+| Boot invocation in a throwaway container, knob `flashkda` | `a4bdc543…`, 6 markers, `py_compile` OK, re-run idempotent |
+| Live production during all of the above | `ec090aab…` unchanged, container up, `/health` 200 on :8000 |
+
+The default is `triton` (the stock spelling), so **no `.env` change is required
+to deploy this**: mounting the overlay cannot alter production by itself.
+
+Deliberately **not** added to `prod-start.sh`'s JIT shape hash. The hash guards
+the persistent Triton cache against changed *launch parameters*; this arm
+replaces the prefill call and adds no Triton specialization, so hashing it would
+force a full cache wipe on every arm switch for no benefit. Record the JIT stamp
+before/after the window regardless, as below.
 
 ## 5. Explicitly not done
 
 - No production restart, no armed boot, no A/B measurement.
+- The launcher wiring landed and was boot-validated in throwaway containers;
+  production was never restarted and its `kda.py` stayed `ec090aab…`.
 - No numeric-parity run of `_flashkda_C.fwd` vs `chunk_kda_with_fused_gate`.
 - #55736 and #55738 were not attempted; #55736's files do not exist in this fork
   and the whole lineage migration is its own multi-component window.

--- a/env.example
+++ b/env.example
@@ -229,8 +229,12 @@ GLM53_ADAPTIVE_K_CAPTURE=1
 # kda.py byte-identical for any other spelling, so mounting it is inert.
 # Overlay is default-off and fail-closed on drifted anchors. Deliberately NOT
 # shape-hashed: it replaces the prefill call, not any Triton launch parameter,
-# so it cannot poison the persistent Triton JIT cache. Record the JIT stamp
-# before/after the window regardless. Rollback: set back to `triton`.
+# so it cannot poison the persistent Triton JIT cache.
+# DO NOT SET `flashkda`: the task 34 numeric-parity gate FAILED (2026-09-10).
+# The fused kernel's output is ~150x smaller than the stock Triton path's and
+# uncorrelated with it, so the arm would silently change what the model
+# computes. `triton` is the only supported value until that is resolved —
+# see docs/15 §5-§6 and local/task34-parity-gate-20260910.txt.
 GLM53_KDA_PREFILL_BACKEND=triton
 # Tasks 29/31 — decode-profile oracle (default OFF). A non-empty absolute path
 # under /root/.cache/vllm turns on the in-process torch profiler and exposes

--- a/env.example
+++ b/env.example
@@ -224,6 +224,14 @@ GLM53_ADAPTIVE_K_CAPTURE=1
 # GLM53_KDA_REC_WARPS=2
 # GLM53_KDA_REC_STAGES=3
 # GLM53_KDA_REC_BV_CAP=8
+# Task 34 track A — FlashKDA fused chunked prefill (vLLM #55737). `triton` is
+# the stock Triton chunk path, `flashkda` is the arm; the overlay leaves
+# kda.py byte-identical for any other spelling, so mounting it is inert.
+# Overlay is default-off and fail-closed on drifted anchors. Deliberately NOT
+# shape-hashed: it replaces the prefill call, not any Triton launch parameter,
+# so it cannot poison the persistent Triton JIT cache. Record the JIT stamp
+# before/after the window regardless. Rollback: set back to `triton`.
+GLM53_KDA_PREFILL_BACKEND=triton
 # Tasks 29/31 — decode-profile oracle (default OFF). A non-empty absolute path
 # under /root/.cache/vllm turns on the in-process torch profiler and exposes
 # POST /start_profile + /stop_profile. Traces land per rank in that dir

--- a/local/flashkda-parity-check.py
+++ b/local/flashkda-parity-check.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""Task 34 correctness gate: numeric parity of the FlashKDA fused prefill.
+
+The A/B contract (docs/15 §4) makes this a **required** step before any speed
+claim, because the arm replaces a prefill kernel. It compares, on identical
+inputs:
+
+  reference  vllm.third_party.flash_linear_attention.ops.kda.chunk_kda_with_fused_gate
+             (the Triton chunked path production runs today), called with the
+             exact conventions ``Glm5NextLinearAttention.forward`` uses; and
+  candidate  torch.ops._flashkda_C.fwd
+             (vLLM #55737), called with the exact conventions the overlay's
+             ``_flashkda_prefill`` uses.
+
+Conventions that differ and are therefore reproduced explicitly:
+
+  * ``beta``   the Triton path wants it **pre-sigmoided fp32**
+               (``_cast_sigmoid``); the fused kernel takes **raw** logits and
+               requires bf16 (fp32 raises ``beta must be bfloat16``). The
+               ``--beta sigmoid`` variant tests the other convention in bf16.
+  * ``g``      both take the **raw** gate, but the Triton path names it
+               ``raw_g``.
+  * ``A_log``  the Triton path takes the 4-D parameter; the fused kernel takes
+               ``A_log.view(-1)`` and ``dt_bias.view(-1, head_dim)``.
+
+Run inside the serving container (needs the GPU, ``vllm._flashkda_C`` and the
+Triton kernels). Exits non-zero on divergence so a caller can gate on it. The
+image's entrypoint is ``vllm``, so ``--entrypoint python3`` is required:
+
+  docker run --rm --gpus all --ipc=host \
+    -v <this>:/parity.py:ro --entrypoint python3 <image> /parity.py
+
+The GPU is reachable alongside the serving container, so this runs without
+stopping production.
+
+RESULT 2026-09-10: PARITY_FAILED and the arm was reverted. ``--beta``,
+``--pre-l2norm``, ``--reference`` and ``--trivial-gate`` are the isolating
+variants that were tried; none of them recovers parity. Full numbers in
+``local/task34-parity-gate-20260910.txt``.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+import torch
+
+# The bounded gate this deployment runs (kda.py: safe_gate=True, lower_bound=-5).
+LOWER_BOUND = -5.0
+
+
+def _cast_sigmoid(x: torch.Tensor) -> torch.Tensor:
+    """kda.py's helper, restated so the harness does not import the layer."""
+    return x.float().sigmoid()
+
+
+def build_inputs(tokens: int, heads: int, head_dim: int, seed: int, device: str,
+                 trivial_gate: bool = False):
+    torch.manual_seed(seed)
+    dtype = torch.bfloat16
+    mk = lambda: torch.randn(1, tokens, heads, head_dim, device=device, dtype=dtype)  # noqa: E731
+    q, k, v = mk(), mk(), mk()
+    # Raw gate logits; kept small so exp(A_log) * (g + dt_bias) stays in a range
+    # where both implementations are exercised without saturating the bound.
+    g = torch.randn(1, tokens, heads, head_dim, device=device, dtype=dtype) * 0.5
+    beta_raw = torch.randn(1, tokens, heads, device=device, dtype=dtype)
+    if trivial_gate:
+        # Constant decay -lower_bound/2 everywhere: isolates the recurrence
+        # and output projection from the gate/lower_bound handling.
+        g = torch.zeros_like(g)
+        a_log = torch.zeros(heads, device=device, dtype=torch.float32)
+        dt_bias = torch.zeros(heads, head_dim, device=device, dtype=torch.float32)
+    else:
+        a_log = torch.randn(heads, device=device, dtype=torch.float32)
+        dt_bias = torch.randn(heads, head_dim, device=device, dtype=torch.float32)
+    initial_state = torch.zeros(1, heads, head_dim, head_dim, device=device, dtype=torch.float32)
+    cu_seqlens = torch.tensor([0, tokens], device=device, dtype=torch.int32)
+    return {
+        "q": q, "k": k, "v": v, "g": g, "beta_raw": beta_raw,
+        "a_log": a_log, "dt_bias": dt_bias,
+        "initial_state": initial_state, "cu_seqlens": cu_seqlens,
+    }
+
+
+def run_reference(inp, heads: int, head_dim: int, which: str = "glm"):
+    if which == "kimi":
+        # kimi_k3's copy: raw beta, sigmoid in-kernel, no safe_gate flag.
+        from vllm.models.kimi_k3.nvidia.ops.third_party.kda import (
+            chunk_kda_with_fused_gate as kimi_chunk,
+        )
+
+        out, final_state = kimi_chunk(
+            q=inp["q"], k=inp["k"], v=inp["v"], raw_g=inp["g"],
+            raw_beta=inp["beta_raw"],
+            A_log=inp["a_log"].view(1, 1, heads, 1), g_bias=inp["dt_bias"],
+            initial_state=inp["initial_state"], output_final_state=True,
+            use_qk_l2norm_in_kernel=True, cu_seqlens=inp["cu_seqlens"],
+            lower_bound=LOWER_BOUND,
+        )
+        return out, final_state
+
+    from vllm.third_party.flash_linear_attention.ops.kda import chunk_kda_with_fused_gate
+
+    out, final_state = chunk_kda_with_fused_gate(
+        q=inp["q"],
+        k=inp["k"],
+        v=inp["v"],
+        raw_g=inp["g"],
+        # Pre-sigmoided fp32: the Triton kernels do not sigmoid.
+        beta=_cast_sigmoid(inp["beta_raw"].squeeze(0)).unsqueeze(0),
+        A_log=inp["a_log"].view(1, 1, heads, 1),
+        g_bias=inp["dt_bias"],
+        initial_state=inp["initial_state"],
+        output_final_state=True,
+        use_qk_l2norm_in_kernel=True,
+        cu_seqlens=inp["cu_seqlens"],
+        safe_gate=True,
+        lower_bound=LOWER_BOUND,
+    )
+    return out, final_state
+
+
+def run_candidate(inp, tokens: int, heads: int, head_dim: int, beta_mode: str = "raw",
+                  pre_l2norm: bool = False):
+    import vllm._flashkda_C  # noqa: F401  — registers the ops
+
+    q = inp["q"]
+    if pre_l2norm:
+        from vllm.third_party.flash_linear_attention.ops.kda import l2norm_fwd
+        q = l2norm_fwd(q.contiguous())
+        inp = dict(inp)
+        inp["k"] = l2norm_fwd(inp["k"].contiguous())
+    max_seqs = 1
+    workspace_size = torch.ops._flashkda_C.get_workspace_size(tokens, heads, max_seqs)
+    final_state = torch.zeros(
+        max_seqs, heads, head_dim, head_dim, device=q.device, dtype=torch.float32
+    )
+    workspace = torch.zeros(workspace_size, device=q.device, dtype=torch.uint8)
+    out = torch.empty(1, tokens, heads, head_dim, device=q.device, dtype=q.dtype)
+
+    # The overlay passes raw beta on the claim that the fused kernel sigmoids
+    # in-kernel. ``sigmoid`` is the Triton path's convention, tested here to
+    # tell a one-line convention bug apart from a genuine kernel mismatch.
+    if beta_mode == "sigmoid":
+        # bf16, because the kernel rejects any other dtype.
+        beta = _cast_sigmoid(inp["beta_raw"]).to(torch.bfloat16)
+    else:
+        beta = inp["beta_raw"]
+
+    torch.ops._flashkda_C.fwd(
+        q.contiguous(),
+        inp["k"].contiguous(),
+        inp["v"].contiguous(),
+        inp["g"].contiguous(),
+        beta,
+        head_dim ** -0.5,
+        out,
+        workspace,
+        inp["a_log"].view(-1),
+        inp["dt_bias"].view(-1, head_dim),
+        LOWER_BOUND,
+        inp["initial_state"].contiguous(),
+        final_state,
+        inp["cu_seqlens"].contiguous(),
+    )
+    return out, final_state
+
+
+def compare(name: str, a: torch.Tensor, b: torch.Tensor) -> dict:
+    a32 = a.detach().float()
+    b32 = b.detach().float()
+    diff = (a32 - b32).abs()
+    denom = a32.abs().clamp_min(1e-6)
+    a_flat = a32.flatten()
+    b_flat = b32.flatten()
+    a_c = a_flat - a_flat.mean()
+    b_c = b_flat - b_flat.mean()
+    denom_c = (a_c.norm() * b_c.norm()).clamp_min(1e-12)
+    corr = float((a_c @ b_c / denom_c).item())
+    ref_scale = float(a_flat.abs().mean().item())
+    return {
+        "correlation": corr,
+        "reference_mean_abs": ref_scale,
+        "candidate_mean_abs": float(b_flat.abs().mean().item()),
+        "name": name,
+        "shape": list(a.shape),
+        "max_abs_diff": float(diff.max().item()),
+        "mean_abs_diff": float(diff.mean().item()),
+        "max_rel_diff": float((diff / denom).max().item()),
+        "reference_abs_max": float(a32.abs().max().item()),
+        "all_finite": bool(torch.isfinite(a32).all().item() and torch.isfinite(b32).all().item()),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--tokens", type=int, default=512)
+    parser.add_argument("--heads", type=int, default=32)
+    parser.add_argument("--head-dim", type=int, default=128)
+    parser.add_argument("--seed", type=int, default=0)
+    # bf16 accumulation differs by reduction order, so the gate is a tolerance
+    # on the *relative* error, not bit equality. 1e-2 is loose enough for bf16
+    # and still catches a wrong gate, wrong l2norm, or transposed state.
+    parser.add_argument("--tol", type=float, default=1e-2)
+    parser.add_argument("--pre-l2norm", action="store_true",
+                        help="normalize q/k before the fused call (the Triton path does this in-kernel)")
+    parser.add_argument("--trivial-gate", action="store_true",
+                        help="zero g/dt_bias/A_log: constant decay, gate handling removed")
+    parser.add_argument("--reference", choices=("glm", "kimi"), default="glm",
+                        help="glm = the deployed production path; kimi = the fork's native pair")
+    parser.add_argument("--beta", choices=("raw", "sigmoid"), default="raw",
+                        help="raw = the overlay's convention; sigmoid = the Triton path's")
+    args = parser.parse_args()
+
+    device = "cuda"
+    if not torch.cuda.is_available():
+        print(json.dumps({"error": "CUDA unavailable in this container"}))
+        return 2
+    print(f"device={torch.cuda.get_device_name(0)} torch={torch.__version__}", file=sys.stderr)
+
+    inp = build_inputs(args.tokens, args.heads, args.head_dim, args.seed, device,
+                       trivial_gate=args.trivial_gate)
+    ref_out, ref_state = run_reference(
+        inp, args.heads, args.head_dim, which=args.reference
+    )
+    cand_out, cand_state = run_candidate(
+        inp, args.tokens, args.heads, args.head_dim, beta_mode=args.beta,
+        pre_l2norm=args.pre_l2norm,
+    )
+
+    results = [
+        compare("out", ref_out, cand_out),
+        compare("final_state", ref_state, cand_state),
+    ]
+    verdict = "PARITY_OK"
+    for r in results:
+        if not r["all_finite"] or r["max_rel_diff"] > args.tol:
+            verdict = "PARITY_FAILED"
+    report = {
+        "verdict": verdict,
+        "tokens": args.tokens,
+        "heads": args.heads,
+        "head_dim": args.head_dim,
+        "seed": args.seed,
+        "tolerance_max_rel_diff": args.tol,
+        "lower_bound": LOWER_BOUND,
+        "reference": args.reference,
+        "trivial_gate": args.trivial_gate,
+        "candidate_beta": args.beta,
+        "candidate_pre_l2norm": args.pre_l2norm,
+        "comparisons": results,
+    }
+    print(json.dumps(report, indent=2))
+    return 0 if verdict == "PARITY_OK" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/local/task34-parity-gate-20260910.txt
+++ b/local/task34-parity-gate-20260910.txt
@@ -1,0 +1,165 @@
+Task 34 — FlashKDA prefill arm: numeric parity gate
+===================================================
+Date        2026-09-10
+Host        spark1 (GB10, sm_121), throwaway containers from the deployed
+            image glm53-selfbuild:e3-w3-zfill
+Harness     local/flashkda-parity-check.py  (repo; also at /tmp on spark1)
+Script      docker run --rm --gpus all --ipc=host \
+              -v /tmp/flashkda-parity-check.py:/parity.py:ro \
+              --entrypoint python3 glm53-selfbuild:e3-w3-zfill /parity.py
+Note        the image entrypoint is `vllm`, so `--entrypoint python3` is required
+GPU         NVIDIA GB10, torch 2.13.0+cu130, CUDA 13.0
+Production  NOT stopped for this gate; the GPU is reachable alongside the
+            serving container.  Container glm53-exl3-head stayed up throughout
+            (21 h at the end of the run), /health 200 on :8000, kda.py ec090aab.
+
+VERDICT: PARITY_FAILED. The arm is REVERTED; the A/B window was not run.
+-----------------------------------------------------------------------
+
+The gate compares, on identical inputs, the Triton chunked path production runs
+today against torch.ops._flashkda_C.fwd as the overlay calls it. The candidate
+invocation mirrors overlay/patch_flashkda_prefill.py::_flashkda_prefill exactly;
+the reference mirrors glm5next/nvidia/kda.py's live prefill call exactly. So the
+comparison answers the A/B question itself: what would production compute if the
+arm were armed, versus what it computes now.
+
+FINDING 1 — FATAL ARITY DEFECT (independent of any numeric question)
+--------------------------------------------------------------------
+The overlay passed 16 positional arguments; the deployed op declares 14.
+
+  RuntimeError: _flashkda_C::fwd() expected at most 14 argument(s) but received
+  16 argument(s). Declaration: _flashkda_C::fwd(Tensor q, Tensor k, Tensor v,
+  Tensor g, Tensor beta, float scale, Tensor(a!) out, Tensor(c!) workspace,
+  Tensor A_log, Tensor dt_bias, float lower_bound, Tensor? initial_state=None,
+  Tensor(b!)? final_state=None, Tensor? cu_seqlens=None) -> ()
+
+The first 14 arguments of the overlay's call match that declaration in order, so
+the defect was two spurious trailing `None`s. Arming the arm would have raised at
+the first prefill — the arm could not have served a single request.
+
+Not caught earlier because the cluster smoke test only proved that the patched
+file parses and is idempotent. It never called the op. Fixed in the overlay, and
+EXPECTED_FWD_ARITY = 14 now pins the emitted call (apply_to refuses to install a
+template with the wrong count; is_complete rejects an installed file with one).
+
+Re-validated on the cluster after the fix, in a throwaway container against a
+copy of the deployed kda.py (the real file stayed ec090aabecc1a63d before and
+after):
+
+  armed hash            58ff323c3dc73e9d   (was a4bdc543baab284b before the fix)
+  fwd positional args   14, keywords 0
+  markers               6
+  idempotent            yes (re-run is a no-op)
+  py_compile            OK
+
+The unarmed hash is unaffected by the fix -- ec090aab in every case -- which is
+why this defect could not have reached production while the knob was off.
+
+FINDING 2 — NUMERIC DIVERGENCE (survives the arity fix)
+-------------------------------------------------------
+Default case: tokens=512, heads=32, head_dim=128, seed=0, lower_bound=-5.0.
+
+  reference = vllm.third_party.flash_linear_attention.ops.kda
+              .chunk_kda_with_fused_gate   (production's kernel; pre-sigmoided
+              fp32 beta, safe_gate=True, use_qk_l2norm_in_kernel=True)
+
+  out          max_abs_diff 0.0735474   ref_abs_max 0.0722656   max_rel   98.68
+               mean_abs_diff 0.003140   ref_mean|.| 0.00314     cand_mean|.| 2.095e-05
+  final_state  max_abs_diff 1.6172      ref_abs_max 1.62175     max_rel 1198.24
+               mean_abs_diff 0.035050   ref_mean|.| 0.03503     cand_mean|.| 1.580e-04
+  Pearson correlation: out +0.00843, final_state -0.06321
+
+The candidate's mean magnitude is ~150x below the reference's and its output is
+uncorrelated with it. The max_abs_diff exceeds the reference's own peak because
+the candidate is near-zero almost everywhere: every one of the 256 token rows in
+a T=256 probe had mean|.| ~2e-5 against the reference's ~2.7e-3.
+
+The kernel does run and does write: with `out` and `final_state` pre-filled with
+the sentinel 7.0, 100% of both buffers were overwritten and 256/256 token
+positions were written. So this is a wrong result, not a skipped kernel and not
+a layout/stride mismatch.
+
+Variants run, all PARITY_FAILED:
+
+  reference = kimi_k3's own Triton kernel (vllm.models.kimi_k3.nvidia.ops
+              .third_party.kda.chunk_kda_with_fused_gate, raw_beta=, no
+              safe_gate)          out max_abs 0.0735474  ref_abs_max 0.0722656
+                                  final_state max_abs 1.61636  ref 1.62093
+  tokens 64 instead of 512        out max_abs 0.0655823  mean_abs 0.003117
+  pre-normalized q/k              byte-identical to the default case, so the
+                                  kernel normalizes internally (as expected)
+  bf16 pre-sigmoided beta         out max_abs 0.0734253  (no improvement)
+  zeroed gate (g=dt_bias=A_log=0) out max_abs 0.07354  ref_mean|.| 0.002519
+                                  cand_mean|.| 1.449e-05  corr +0.00019
+
+lower_bound sweep — the ratio does NOT track exp(lower_bound), so the ~150x
+factor is not a mis-applied bound:
+
+  lower_bound   ratio(ref/cand)   1/exp(lb)   corr(out)
+     -1.0          129.769          2.718      -0.0245
+     -2.0          116.292          7.389      -0.0479
+     -3.0          100.168         20.086      -0.1085
+     -5.0           87.187        148.413      -0.2433
+
+CONVENTIONS THAT ARE NOT THE CAUSE (each tested, each ruled out)
+---------------------------------------------------------------
+  beta        the kernel requires bf16 and rejects anything else:
+              "fwd, .../csrc/flash_kda.cpp:55, beta must be bfloat16".
+              The overlay's raw-bf16 convention is correct; passing fp32
+              sigmoided beta raises, and bf16 sigmoided beta does not help.
+  A_log       the kernel requires [H] and rejects every other rank/shape:
+              "fwd, .../csrc/flash_kda.cpp:109, A_log must be [H]" for
+              (1,1,H,1), (H,1) and (H,1,1,1). The overlay's .view(-1) is the
+              correct adaptation of GLM's 4-D parameter.
+  scale       both paths use head_dim ** -0.5 (the reference defaults to
+              k.shape[-1] ** -0.5 and the overlay passes the same value).
+  l2norm      the kernel normalizes q/k internally; pre-normalizing is a no-op.
+  layout      the kernel writes 100% of (1, T, H, D) out and (1, H, D, D) state.
+
+ROOT CAUSE NOT ISOLATED. The strongest structural lead: the fused kernel is
+paired, in this fork, with a *different* Triton kernel than GLM's.
+
+  kimi_k3 (vllm/models/kimi_k3/nvidia/kda.py:180) is the ONLY _flashkda_prefill
+  in the image. It calls the fused op with the same 14 arguments, and its Triton
+  branch calls vllm.models.kimi_k3.nvidia.ops.third_party.kda
+  .chunk_kda_with_fused_gate(q, k, v, raw_g, raw_beta, A_log, g_bias, scale=None,
+  initial_state=None, output_final_state=False, lower_bound=None,
+  use_qk_l2norm_in_kernel=False, cu_seqlens=None)
+
+  GLM's branch calls a different implementation,
+  vllm.third_party.flash_linear_attention.ops.kda.chunk_kda_with_fused_gate(...,
+  beta, ..., safe_gate=False, lower_bound=-5.0), which takes PRE-SIGMOIDED beta
+  and has a safe_gate flag the kimi copy lacks.
+
+So the two Triton kernels are not the same kernel. The fused op matches neither
+here, but the port is a port of the kimi pairing onto the GLM layer, and the two
+Triton kernels' outputs on these inputs are themselves nearly identical
+(ref_abs_max 0.0722656 vs 0.0722656), which leaves the mismatch in the fused
+op's own input expectations rather than in the choice of reference. Isolating it
+would need the kernel source: the image ships only _flashkda_C.abi3.so, and the
+runtime error paths name a build-time path (/workspace/.deps/flashkda-src/csrc/
+flash_kda.cpp) that is not present in the image.
+
+Cluster deploy and revert
+-------------------------
+  before task 34    start.sh 560a7ed5b8be5243   (byte-identical to repo 6d071e4)
+  deployed          start.sh 9abb832a567b5c86, overlay/patch_flashkda_prefill.py
+                    a38a0ad4f6ec8f09
+  backup            start.sh.bak-20260910-task34 = 560a7ed5b8be5243
+  REVERTED          start.sh 560a7ed5b8be5243 (restored from backup), overlay file
+                    removed, bash -n OK, overlay absent, backup retained
+  production        never restarted; container glm53-exl3-head up 21 h, /health
+                    200 on :8000, kda.py ec090aab throughout
+
+The revert is exact: the kit is back to the bytes the running container was
+started from. The `-f` preflight check in the wired launcher makes the overlay
+file mandatory, so reverting start.sh and removing the overlay had to happen
+together (reverting only one would have aborted the next boot).
+
+Decision
+--------
+REVERT the arm. Per the pre-registered contract in docs/15 §4, "a divergence is
+a correctness finding, not a tuning result": with the fused output uncorrelated
+with production's, a cold-prefill speed comparison would measure a different
+computation. The A/B window was therefore not started, production was not
+stopped, and no speed claim is made.

--- a/local/task37-mgemm-indices-v147-20260910.json
+++ b/local/task37-mgemm-indices-v147-20260910.json
@@ -1,8 +1,4 @@
 {
-  "advisory_closure_call_site_modules": [
-    "exllamav3.modules.attn",
-    "exllamav3.modules.dsv4"
-  ],
   "binding_reaches_mgemm": [],
   "call_site_modules": {
     "exllamav3.modules.attn": 2,
@@ -18,7 +14,7 @@
     "per_matrix_widths_require_min_index_negative": true,
     "sliced_mode_requires_min_index_negative": true
   },
-  "import_closure_size": 284,
+  "import_closure_size": 282,
   "mgemm_entry_points": [
     "exl3_mgemm"
   ],
@@ -28,7 +24,7 @@
     "exl3_moe",
     "exl3_moe_max_concurrency"
   ],
-  "reason": "no exl3_mgemm entry point is reachable: the 128-slot scratch is written only inside exl3_mgemm_kernel, the only bridge the vLLM overlay uses (BC_LinearEXL3 -> exl3_gemm_gr/exl3_gemm) never calls exl3_mgemm, the extension symbols the overlay names (['exl3_fat_gemm', 'exl3_fat_gemm_scatter', 'exl3_moe', 'exl3_moe_max_concurrency']) exclude every exl3_mgemm* entry, and the serving module itself has no exl3_mgemm call site.",
+  "reason": "the deployment's own entry points do not reach an exl3_mgemm entry, but 2 module(s) inside the serving import closure hold exl3_mgemm call sites: ['exllamav3.modules.attn', 'exllamav3.modules.dsv4']. Importing a module is not executing its call sites, so static non-reachability is NOT established. Discharge these with call-graph evidence (or prove they are never loaded) before any NOT_REACHABLE verdict.",
   "scratch": {
     "arrays": [
       "v_indices",
@@ -46,11 +42,6 @@
     "writes_outside_mgemm_kernel": []
   },
   "seed_modules": [
-    "exllamav3.model",
-    "exllamav3.model.config",
-    "exllamav3.model.config.InferParams",
-    "exllamav3.model.config.NullConfig",
-    "exllamav3.modules",
     "exllamav3.modules.quant.exl3"
   ],
   "serving_module": "exllamav3.modules.quant.exl3",
@@ -60,7 +51,19 @@
     "calls_exl3_mgemm": false,
     "entry": "BC_LinearEXL3::run_gr"
   },
-  "verdict": "NOT_REACHABLE",
+  "stub_contract": {
+    "checked": true,
+    "installs": [
+      "exllamav3.model",
+      "exllamav3.modules"
+    ],
+    "source": "/tmp/ovl/exl3_namespace.py"
+  },
+  "unresolved_closure_call_site_modules": [
+    "exllamav3.modules.attn",
+    "exllamav3.modules.dsv4"
+  ],
+  "verdict": "ABORT",
   "worst_case": {
     "num_tokens_1_slots_batch_x_topk": 32,
     "num_tokens_gt_1_slots_bszm": 32,

--- a/local/task37-mgemm-indices-v147-20260910.json
+++ b/local/task37-mgemm-indices-v147-20260910.json
@@ -57,6 +57,7 @@
       "exllamav3.model",
       "exllamav3.modules"
     ],
+    "invoked_by": "/tmp/ovl/exl3_namespace.py",
     "source": "/tmp/ovl/exl3_namespace.py",
     "verified_by": "structural assignment check + executed installer"
   },

--- a/local/task37-mgemm-indices-v147-20260910.json
+++ b/local/task37-mgemm-indices-v147-20260910.json
@@ -14,7 +14,7 @@
     "per_matrix_widths_require_min_index_negative": true,
     "sliced_mode_requires_min_index_negative": true
   },
-  "import_closure_size": 626,
+  "import_closure_size": 79,
   "mgemm_entry_points": [
     "exl3_mgemm"
   ],
@@ -24,7 +24,7 @@
     "exl3_moe",
     "exl3_moe_max_concurrency"
   ],
-  "reason": "the deployment's own entry points do not reach an exl3_mgemm entry, but 2 module(s) inside the serving import closure hold exl3_mgemm call sites: ['exllamav3.modules.attn', 'exllamav3.modules.dsv4']. Importing a module is not executing its call sites, so static non-reachability is NOT established. Discharge these with call-graph evidence (or prove they are never loaded) before any NOT_REACHABLE verdict.",
+  "reason": "no exl3_mgemm entry point is reachable: the 128-slot scratch is written only inside exl3_mgemm_kernel, the only bridge the vLLM overlay uses (BC_LinearEXL3 -> exl3_gemm_gr/exl3_gemm) never calls exl3_mgemm, the extension symbols the overlay names (['exl3_fat_gemm', 'exl3_fat_gemm_scatter', 'exl3_moe', 'exl3_moe_max_concurrency']) exclude every exl3_mgemm* entry, the serving module itself has no exl3_mgemm call site, and no other module in the serving import closure has one either.",
   "scratch": {
     "arrays": [
       "v_indices",
@@ -55,17 +55,15 @@
     "checked": true,
     "installs": [
       "exllamav3.model",
+      "exllamav3.model.config",
       "exllamav3.modules"
     ],
     "invoked_by": "/tmp/ovl/exl3_namespace.py",
     "source": "/tmp/ovl/exl3_namespace.py",
     "verified_by": "structural assignment check + executed installer"
   },
-  "unresolved_closure_call_site_modules": [
-    "exllamav3.modules.attn",
-    "exllamav3.modules.dsv4"
-  ],
-  "verdict": "ABORT",
+  "unresolved_closure_call_site_modules": [],
+  "verdict": "NOT_REACHABLE",
   "worst_case": {
     "num_tokens_1_slots_batch_x_topk": 32,
     "num_tokens_gt_1_slots_bszm": 32,

--- a/local/task37-mgemm-indices-v147-20260910.json
+++ b/local/task37-mgemm-indices-v147-20260910.json
@@ -14,7 +14,7 @@
     "per_matrix_widths_require_min_index_negative": true,
     "sliced_mode_requires_min_index_negative": true
   },
-  "import_closure_size": 282,
+  "import_closure_size": 626,
   "mgemm_entry_points": [
     "exl3_mgemm"
   ],
@@ -57,7 +57,8 @@
       "exllamav3.model",
       "exllamav3.modules"
     ],
-    "source": "/tmp/ovl/exl3_namespace.py"
+    "source": "/tmp/ovl/exl3_namespace.py",
+    "verified_by": "structural assignment check + executed installer"
   },
   "unresolved_closure_call_site_modules": [
     "exllamav3.modules.attn",

--- a/local/task37-mgemm-indices-v147-20260910.json
+++ b/local/task37-mgemm-indices-v147-20260910.json
@@ -1,0 +1,71 @@
+{
+  "advisory_closure_call_site_modules": [
+    "exllamav3.modules.attn",
+    "exllamav3.modules.dsv4"
+  ],
+  "binding_reaches_mgemm": [],
+  "call_site_modules": {
+    "exllamav3.modules.attn": 2,
+    "exllamav3.modules.block_sparse_mlp": 6,
+    "exllamav3.modules.dsv4": 8,
+    "exllamav3.modules.mlp": 1,
+    "exllamav3.modules.sliding_attn": 2
+  },
+  "call_sites_total": 19,
+  "decisive_reachable": [],
+  "guards": {
+    "declared_limit_slots": 128,
+    "per_matrix_widths_require_min_index_negative": true,
+    "sliced_mode_requires_min_index_negative": true
+  },
+  "import_closure_size": 284,
+  "mgemm_entry_points": [
+    "exl3_mgemm"
+  ],
+  "overlay_ext_symbols": [
+    "exl3_fat_gemm",
+    "exl3_fat_gemm_scatter",
+    "exl3_moe",
+    "exl3_moe_max_concurrency"
+  ],
+  "reason": "no exl3_mgemm entry point is reachable: the 128-slot scratch is written only inside exl3_mgemm_kernel, the only bridge the vLLM overlay uses (BC_LinearEXL3 -> exl3_gemm_gr/exl3_gemm) never calls exl3_mgemm, the extension symbols the overlay names (['exl3_fat_gemm', 'exl3_fat_gemm_scatter', 'exl3_moe', 'exl3_moe_max_concurrency']) exclude every exl3_mgemm* entry, and the serving module itself has no exl3_mgemm call site.",
+  "scratch": {
+    "arrays": [
+      "v_indices",
+      "v_weights"
+    ],
+    "kernels": [
+      "exl3_gemm_kernel",
+      "exl3_mgemm_kernel"
+    ],
+    "max_indices": 128,
+    "writer_count": 5,
+    "writer_kernels": [
+      "exl3_mgemm_kernel"
+    ],
+    "writes_outside_mgemm_kernel": []
+  },
+  "seed_modules": [
+    "exllamav3.model",
+    "exllamav3.model.config",
+    "exllamav3.model.config.InferParams",
+    "exllamav3.model.config.NullConfig",
+    "exllamav3.modules",
+    "exllamav3.modules.quant.exl3"
+  ],
+  "serving_module": "exllamav3.modules.quant.exl3",
+  "serving_path": {
+    "calls_exl3_gemm": true,
+    "calls_exl3_gemm_gr": true,
+    "calls_exl3_mgemm": false,
+    "entry": "BC_LinearEXL3::run_gr"
+  },
+  "verdict": "NOT_REACHABLE",
+  "worst_case": {
+    "num_tokens_1_slots_batch_x_topk": 32,
+    "num_tokens_gt_1_slots_bszm": 32,
+    "production_draft_tokens": 7,
+    "production_max_num_seqs": 4,
+    "production_top_k": 8
+  }
+}

--- a/local/task37-mgemm-indices-v149-local-clone-20260910.json
+++ b/local/task37-mgemm-indices-v149-local-clone-20260910.json
@@ -1,9 +1,4 @@
 {
-  "advisory_closure_call_site_modules": [
-    "exllamav3.modules.attn",
-    "exllamav3.modules.dsv4",
-    "exllamav3.modules.gated_delta_net"
-  ],
   "binding_reaches_mgemm": [],
   "call_site_modules": {
     "exllamav3.modules.attn": 3,
@@ -20,7 +15,7 @@
     "per_matrix_widths_require_min_index_negative": true,
     "sliced_mode_requires_min_index_negative": true
   },
-  "import_closure_size": 295,
+  "import_closure_size": 293,
   "mgemm_entry_points": [
     "exl3_mgemm"
   ],
@@ -30,7 +25,7 @@
     "exl3_moe",
     "exl3_moe_max_concurrency"
   ],
-  "reason": "no exl3_mgemm entry point is reachable: the 128-slot scratch is written only inside exl3_mgemm_kernel, the only bridge the vLLM overlay uses (BC_LinearEXL3 -> exl3_gemm_gr/exl3_gemm) never calls exl3_mgemm, the extension symbols the overlay names (['exl3_fat_gemm', 'exl3_fat_gemm_scatter', 'exl3_moe', 'exl3_moe_max_concurrency']) exclude every exl3_mgemm* entry, and the serving module itself has no exl3_mgemm call site.",
+  "reason": "the deployment's own entry points do not reach an exl3_mgemm entry, but 3 module(s) inside the serving import closure hold exl3_mgemm call sites: ['exllamav3.modules.attn', 'exllamav3.modules.dsv4', 'exllamav3.modules.gated_delta_net']. Importing a module is not executing its call sites, so static non-reachability is NOT established. Discharge these with call-graph evidence (or prove they are never loaded) before any NOT_REACHABLE verdict.",
   "scratch": {
     "arrays": [
       "v_indices",
@@ -48,11 +43,6 @@
     "writes_outside_mgemm_kernel": []
   },
   "seed_modules": [
-    "exllamav3.model",
-    "exllamav3.model.config",
-    "exllamav3.model.config.InferParams",
-    "exllamav3.model.config.NullConfig",
-    "exllamav3.modules",
     "exllamav3.modules.quant.exl3"
   ],
   "serving_module": "exllamav3.modules.quant.exl3",
@@ -62,7 +52,20 @@
     "calls_exl3_mgemm": false,
     "entry": "BC_LinearEXL3::run_gr"
   },
-  "verdict": "NOT_REACHABLE",
+  "stub_contract": {
+    "checked": true,
+    "installs": [
+      "exllamav3.model",
+      "exllamav3.modules"
+    ],
+    "source": "overlay/exl3_namespace.py"
+  },
+  "unresolved_closure_call_site_modules": [
+    "exllamav3.modules.attn",
+    "exllamav3.modules.dsv4",
+    "exllamav3.modules.gated_delta_net"
+  ],
+  "verdict": "ABORT",
   "worst_case": {
     "num_tokens_1_slots_batch_x_topk": 32,
     "num_tokens_gt_1_slots_bszm": 32,

--- a/local/task37-mgemm-indices-v149-local-clone-20260910.json
+++ b/local/task37-mgemm-indices-v149-local-clone-20260910.json
@@ -15,7 +15,7 @@
     "per_matrix_widths_require_min_index_negative": true,
     "sliced_mode_requires_min_index_negative": true
   },
-  "import_closure_size": 293,
+  "import_closure_size": 684,
   "mgemm_entry_points": [
     "exl3_mgemm"
   ],
@@ -58,7 +58,8 @@
       "exllamav3.model",
       "exllamav3.modules"
     ],
-    "source": "overlay/exl3_namespace.py"
+    "source": "overlay/exl3_namespace.py",
+    "verified_by": "structural assignment check + executed installer"
   },
   "unresolved_closure_call_site_modules": [
     "exllamav3.modules.attn",

--- a/local/task37-mgemm-indices-v149-local-clone-20260910.json
+++ b/local/task37-mgemm-indices-v149-local-clone-20260910.json
@@ -15,7 +15,7 @@
     "per_matrix_widths_require_min_index_negative": true,
     "sliced_mode_requires_min_index_negative": true
   },
-  "import_closure_size": 684,
+  "import_closure_size": 92,
   "mgemm_entry_points": [
     "exl3_mgemm"
   ],
@@ -25,7 +25,7 @@
     "exl3_moe",
     "exl3_moe_max_concurrency"
   ],
-  "reason": "the deployment's own entry points do not reach an exl3_mgemm entry, but 3 module(s) inside the serving import closure hold exl3_mgemm call sites: ['exllamav3.modules.attn', 'exllamav3.modules.dsv4', 'exllamav3.modules.gated_delta_net']. Importing a module is not executing its call sites, so static non-reachability is NOT established. Discharge these with call-graph evidence (or prove they are never loaded) before any NOT_REACHABLE verdict.",
+  "reason": "no exl3_mgemm entry point is reachable: the 128-slot scratch is written only inside exl3_mgemm_kernel, the only bridge the vLLM overlay uses (BC_LinearEXL3 -> exl3_gemm_gr/exl3_gemm) never calls exl3_mgemm, the extension symbols the overlay names (['exl3_fat_gemm', 'exl3_fat_gemm_scatter', 'exl3_moe', 'exl3_moe_max_concurrency']) exclude every exl3_mgemm* entry, the serving module itself has no exl3_mgemm call site, and no other module in the serving import closure has one either.",
   "scratch": {
     "arrays": [
       "v_indices",
@@ -56,18 +56,15 @@
     "checked": true,
     "installs": [
       "exllamav3.model",
+      "exllamav3.model.config",
       "exllamav3.modules"
     ],
     "invoked_by": "overlay/exl3_namespace.py",
     "source": "overlay/exl3_namespace.py",
     "verified_by": "structural assignment check + executed installer"
   },
-  "unresolved_closure_call_site_modules": [
-    "exllamav3.modules.attn",
-    "exllamav3.modules.dsv4",
-    "exllamav3.modules.gated_delta_net"
-  ],
-  "verdict": "ABORT",
+  "unresolved_closure_call_site_modules": [],
+  "verdict": "NOT_REACHABLE",
   "worst_case": {
     "num_tokens_1_slots_batch_x_topk": 32,
     "num_tokens_gt_1_slots_bszm": 32,

--- a/local/task37-mgemm-indices-v149-local-clone-20260910.json
+++ b/local/task37-mgemm-indices-v149-local-clone-20260910.json
@@ -1,0 +1,73 @@
+{
+  "advisory_closure_call_site_modules": [
+    "exllamav3.modules.attn",
+    "exllamav3.modules.dsv4",
+    "exllamav3.modules.gated_delta_net"
+  ],
+  "binding_reaches_mgemm": [],
+  "call_site_modules": {
+    "exllamav3.modules.attn": 3,
+    "exllamav3.modules.block_sparse_mlp": 6,
+    "exllamav3.modules.dsv4": 8,
+    "exllamav3.modules.gated_delta_net": 1,
+    "exllamav3.modules.mlp": 1,
+    "exllamav3.modules.sliding_attn": 3
+  },
+  "call_sites_total": 22,
+  "decisive_reachable": [],
+  "guards": {
+    "declared_limit_slots": 128,
+    "per_matrix_widths_require_min_index_negative": true,
+    "sliced_mode_requires_min_index_negative": true
+  },
+  "import_closure_size": 295,
+  "mgemm_entry_points": [
+    "exl3_mgemm"
+  ],
+  "overlay_ext_symbols": [
+    "exl3_fat_gemm",
+    "exl3_fat_gemm_scatter",
+    "exl3_moe",
+    "exl3_moe_max_concurrency"
+  ],
+  "reason": "no exl3_mgemm entry point is reachable: the 128-slot scratch is written only inside exl3_mgemm_kernel, the only bridge the vLLM overlay uses (BC_LinearEXL3 -> exl3_gemm_gr/exl3_gemm) never calls exl3_mgemm, the extension symbols the overlay names (['exl3_fat_gemm', 'exl3_fat_gemm_scatter', 'exl3_moe', 'exl3_moe_max_concurrency']) exclude every exl3_mgemm* entry, and the serving module itself has no exl3_mgemm call site.",
+  "scratch": {
+    "arrays": [
+      "v_indices",
+      "v_weights"
+    ],
+    "kernels": [
+      "exl3_gemm_kernel",
+      "exl3_mgemm_kernel"
+    ],
+    "max_indices": 128,
+    "writer_count": 5,
+    "writer_kernels": [
+      "exl3_mgemm_kernel"
+    ],
+    "writes_outside_mgemm_kernel": []
+  },
+  "seed_modules": [
+    "exllamav3.model",
+    "exllamav3.model.config",
+    "exllamav3.model.config.InferParams",
+    "exllamav3.model.config.NullConfig",
+    "exllamav3.modules",
+    "exllamav3.modules.quant.exl3"
+  ],
+  "serving_module": "exllamav3.modules.quant.exl3",
+  "serving_path": {
+    "calls_exl3_gemm": true,
+    "calls_exl3_gemm_gr": true,
+    "calls_exl3_mgemm": false,
+    "entry": "BC_LinearEXL3::run_gr"
+  },
+  "verdict": "NOT_REACHABLE",
+  "worst_case": {
+    "num_tokens_1_slots_batch_x_topk": 32,
+    "num_tokens_gt_1_slots_bszm": 32,
+    "production_draft_tokens": 7,
+    "production_max_num_seqs": 4,
+    "production_top_k": 8
+  }
+}

--- a/local/task37-mgemm-indices-v149-local-clone-20260910.json
+++ b/local/task37-mgemm-indices-v149-local-clone-20260910.json
@@ -58,6 +58,7 @@
       "exllamav3.model",
       "exllamav3.modules"
     ],
+    "invoked_by": "overlay/exl3_namespace.py",
     "source": "overlay/exl3_namespace.py",
     "verified_by": "structural assignment check + executed installer"
   },

--- a/local/task38-cvt-bf16x2-e4m3x2-20260910.txt
+++ b/local/task38-cvt-bf16x2-e4m3x2-20260910.txt
@@ -1,0 +1,61 @@
+Task 38 item 3 — cvt.rn.bf16x2.e4m3x2 toolchain requirement (task 38, P2)
+Date: 2026-09-10
+Host: spark1 (DGX Spark GB10, sm_121a)
+Toolchain: /usr/local/cuda/bin/ptxas 13.0.88 (release 13.0, V13.0.88)
+
+QUESTION
+  b12x `_lib/intrinsics.py` defines fp8x4_e4m3_to_bfloat2x2_native_sm120, whose
+  inline asm emits `cvt.rn.bf16x2.e4m3x2`. Recorded as failing ptxas on sm_121a
+  under CUDA 13.0. Is that accurate, and is it an arch limit or a toolchain one?
+
+PROBE (minimal, single instruction, no operands other than registers)
+  .version 9.0
+  .target sm_121a
+  .visible .entry probe() {
+      .reg .b16 e01;
+      .reg .b32 o;
+      <INSTR> o, e01;
+      ret;
+  }
+
+RESULTS  (ptxas -arch=sm_121a)
+  cvt.rn.bf16x2.e4m3x2  -> REJECTED: "Unexpected instruction types specified for 'cvt'"
+  cvt.rn.f16x2.e4m3x2   -> ASSEMBLES          <-- control (sibling helper)
+
+ISA CEILING OF THIS TOOLCHAIN
+  `.version 9.2` -> fatal: "Unsupported .version 9.2; current version is '9.0'"
+  So this ptxas accepts PTX ISA 9.0 at most; the bf16x2 form is unknown to it.
+
+FINDING
+  The rejection is a TOOLCHAIN-VERSION limit, not an architecture limit:
+  ptxas 13.0.88 (PTX ISA 9.0) does not know `cvt.rn.bf16x2.e4m3x2`, which
+  needs PTX ISA 9.2 / CUDA >= 13.2. The sibling f16x2 form assembles on the
+  same sm_121a target with the same toolchain, which isolates the gap to the
+  bf16x2 widening form. Consistent with the helper's own docstring: "requires
+  PTX ISA 9.2 and an architecture-specific SM120 target."
+
+REACHABILITY FROM THE SERVING PATH (read-only, public clone
+https://github.com/local-inference-lab/b12x, Apache-2.0)
+  - Definition: b12x/_lib/intrinsics.py:3000.
+  - Call sites: b12x/attention/paged/_selected_forward.py (4) and
+    b12x/attention/paged/forward_extend_generic.py (12+). No per-call arch
+    guard: gating is by *compiled entry*, so any build that compiles these
+    entries for sm_121a under CUDA < 13.2 fails ptxas.
+  - Entry chain into serving: b12x/attention/qsa/_sparse_gqa.py:243 imports
+    launch_selected_paged_gqa_direct from paged/_selected_forward;
+    paged/_forward.py:25 imports build_extend_forward_kernel from
+    forward_extend_generic.
+  - It is on the paged / QSA sparse-attention path (E4M3 KV dequantization),
+    NOT in the P8 codec's own kernels. The P8 disposition is unchanged.
+
+  NOTE ON THE COMMIT: spec/TODO.md cites `d564f6ca`, which does not exist in
+  this repository (checked: `git cat-file -t d564f6ca` -> not a valid object;
+  the clone's history tops out elsewhere). The call-site facts above were taken
+  from the current default branch instead, so treat the hash in the TODO as
+  wrong rather than as a pinned revision that was verified.
+
+CONSEQUENCE
+  docs/11 §2's toolchain intake row gains a qualifier: CUDA 13.x is required for
+  sm_121 *codegen*, but >= 13.2 (PTX ISA 9.2) is required for any b12x entry
+  that uses the bf16x2 e4m3 widening. An f16x2 sibling exists and assembles on
+  13.0, but it is a different numeric path and is not a drop-in substitute.

--- a/local/task38-isa-fp4-e2m1-20260910.txt
+++ b/local/task38-isa-fp4-e2m1-20260910.txt
@@ -1,0 +1,9 @@
+Pseudo-terminal will not be allocated because stdin is not a terminal.
+ptxas: Build cuda_13.0.r13.0/compiler.36424714_0
+--- .target sm_121 ---
+ptxas /tmp/p_sm_121.ptx, line 11; error   : Instruction 'cvt with .e2m1x2' not supported on .target 'sm_121'
+ptxas fatal   : Ptx assembly aborted due to errors
+--- .target sm_121a ---
+(assembled clean)
+--- SASS ---
+        /*0040*/                   F2FP.SATFINITE.E2M1.F32.PACK_AB_MERGE_C R5, R0, R0, RZ ;  /* 0x000000000005723e */

--- a/local/task39-persistent-topk-reachability-20260910.json
+++ b/local/task39-persistent-topk-reachability-20260910.json
@@ -1,0 +1,37 @@
+  "dead_branches": [
+    {
+      "else_branch": true,
+      "line": 817,
+      "live_kernel_calls": [
+        832,
+        843
+      ],
+      "persistent_topk_calls": [
+        822
+      ]
+    }
+  ],
+  "glm_indexer": {
+    "imports_kpool_class": true,
+    "instantiates_kpool_class": true,
+    "uses_plain_indexer": false
+  },
+  "live_kernel": "top_k_per_row_decode",
+  "live_kernel_has_fixed_scratch": null,
+  "live_persistent_topk_lines": [],
+  "overlay_guard": {
+    "checked": true,
+    "fail_closed": true,
+    "guard_call": true,
+    "installs_dead_branch": true,
+    "present": true
+  },
+  "plain_indexer_users": [
+    "models/deepseek_v32/amd/rocm.py",
+    "models/deepseek_v32/attention.py",
+    "models/deepseek_v4/attention.py",
+    "models/deepseek_v4/common/ops/fused_indexer_q.py"
+  ],
+  "reason": "the GLM-5.3-Flash path uses SparseAttnIndexerKpool and that file's persistent_topk branch is dead by construction (line 817), with top_k_per_row_decode on the live else branch. #52149/#55314 cannot change selection here, so no indexer-logits comparison is owed.",
+  "verdict": "NOT_APPLICABLE"
+}

--- a/local/task39-persistent-topk-reachability-20260910.json
+++ b/local/task39-persistent-topk-reachability-20260910.json
@@ -13,12 +13,143 @@
     }
   ],
   "glm_indexer": {
+    "import_bindings": {
+      "CacheConfig": [
+        "vllm.config",
+        "CacheConfig"
+      ],
+      "ColumnParallelLinear": [
+        "vllm.model_executor.layers.linear",
+        "ColumnParallelLinear"
+      ],
+      "DeepSeekV2FusedQkvAProjLinear": [
+        "vllm.model_executor.models.deepseek_v2",
+        "DeepSeekV2FusedQkvAProjLinear"
+      ],
+      "DeepseekV32IndexerCache": [
+        "vllm.model_executor.models.deepseek_v2",
+        "DeepseekV32IndexerCache"
+      ],
+      "F": [
+        "torch.nn.functional",
+        "functional"
+      ],
+      "Glm5NextConfig": [
+        "vllm.transformers_utils.configs.glm5_next",
+        "Glm5NextConfig"
+      ],
+      "KpoolTailBackend": [
+        "vllm.v1.attention.backends.mla.indexer",
+        "KpoolTailBackend"
+      ],
+      "KpoolTailSpec": [
+        "vllm.v1.kv_cache_interface",
+        "KpoolTailSpec"
+      ],
+      "LayerNorm": [
+        "vllm.model_executor.layers.layernorm",
+        "LayerNorm"
+      ],
+      "MLAAttentionSpec": [
+        "vllm.v1.kv_cache_interface",
+        "MLAAttentionSpec"
+      ],
+      "MLAModules": [
+        "vllm.model_executor.layers.mla",
+        "MLAModules"
+      ],
+      "MergedColumnParallelLinear": [
+        "vllm.model_executor.layers.linear",
+        "MergedColumnParallelLinear"
+      ],
+      "MultiHeadLatentAttentionWrapper": [
+        "vllm.model_executor.layers.mla",
+        "MultiHeadLatentAttentionWrapper"
+      ],
+      "QuantizationConfig": [
+        "vllm.model_executor.layers.quantization.base_config",
+        "QuantizationConfig"
+      ],
+      "RMSNorm": [
+        "vllm.model_executor.layers.layernorm",
+        "RMSNorm"
+      ],
+      "ReplicatedLinear": [
+        "vllm.model_executor.layers.linear",
+        "ReplicatedLinear"
+      ],
+      "RotaryEmbedding": [
+        "vllm.model_executor.layers.rotary_embedding",
+        "RotaryEmbedding"
+      ],
+      "RowParallelLinear": [
+        "vllm.model_executor.layers.linear",
+        "RowParallelLinear"
+      ],
+      "SparseAttnIndexerKpool": [
+        "vllm.model_executor.layers.sparse_attn_indexer_kpool",
+        "SparseAttnIndexerKpool"
+      ],
+      "VllmConfig": [
+        "vllm.config",
+        "VllmConfig"
+      ],
+      "_glm53_glm5next_workspace_entries": [
+        "vllm.v1.attention.backends.mla.indexer",
+        "_glm53_glm5next_workspace_entries"
+      ],
+      "current_platform": [
+        "vllm.platforms",
+        "current_platform"
+      ],
+      "extract_layer_index": [
+        "vllm.model_executor.models.utils",
+        "extract_layer_index"
+      ],
+      "fwht128_quant_fp8": [
+        "vllm.models.glm5next.nvidia.ops.kpool_compress",
+        "fwht128_quant_fp8"
+      ],
+      "get_rope": [
+        "vllm.model_executor.layers.rotary_embedding",
+        "get_rope"
+      ],
+      "get_tensor_model_parallel_world_size": [
+        "vllm.distributed",
+        "get_tensor_model_parallel_world_size"
+      ],
+      "init_logger": [
+        "vllm.logger",
+        "init_logger"
+      ],
+      "maybe_disable_graph_partition": [
+        "vllm.model_executor.utils",
+        "maybe_disable_graph_partition"
+      ],
+      "nn": [
+        "torch",
+        "nn"
+      ],
+      "replace": [
+        "dataclasses",
+        "replace"
+      ],
+      "torch": [
+        "torch",
+        "torch"
+      ],
+      "yarn_get_mscale": [
+        "vllm.model_executor.models.deepseek_v2",
+        "yarn_get_mscale"
+      ]
+    },
     "imports_kpool_class": true,
     "instantiates_kpool_class": true,
     "kpool_reference_lines": [
       311
     ],
     "plain_indexer_constructed": false,
+    "unresolved_indexer_names": [],
     "uses_plain_indexer": false
   },
   "live_kernel": "top_k_per_row_decode",

--- a/local/task39-persistent-topk-reachability-20260910.json
+++ b/local/task39-persistent-topk-reachability-20260910.json
@@ -1,3 +1,4 @@
+{
   "dead_branches": [
     {
       "else_branch": true,
@@ -14,6 +15,10 @@
   "glm_indexer": {
     "imports_kpool_class": true,
     "instantiates_kpool_class": true,
+    "kpool_reference_lines": [
+      311
+    ],
+    "plain_indexer_constructed": false,
     "uses_plain_indexer": false
   },
   "live_kernel": "top_k_per_row_decode",

--- a/local/task39-persistent-topk-reachability-20260910.json
+++ b/local/task39-persistent-topk-reachability-20260910.json
@@ -15,132 +15,196 @@
   "glm_indexer": {
     "import_bindings": {
       "CacheConfig": [
-        "vllm.config",
-        "CacheConfig"
+        [
+          "vllm.config",
+          "CacheConfig"
+        ]
       ],
       "ColumnParallelLinear": [
-        "vllm.model_executor.layers.linear",
-        "ColumnParallelLinear"
+        [
+          "vllm.model_executor.layers.linear",
+          "ColumnParallelLinear"
+        ]
       ],
       "DeepSeekV2FusedQkvAProjLinear": [
-        "vllm.model_executor.models.deepseek_v2",
-        "DeepSeekV2FusedQkvAProjLinear"
+        [
+          "vllm.model_executor.models.deepseek_v2",
+          "DeepSeekV2FusedQkvAProjLinear"
+        ]
       ],
       "DeepseekV32IndexerCache": [
-        "vllm.model_executor.models.deepseek_v2",
-        "DeepseekV32IndexerCache"
+        [
+          "vllm.model_executor.models.deepseek_v2",
+          "DeepseekV32IndexerCache"
+        ]
       ],
       "F": [
-        "torch.nn.functional",
-        "functional"
+        [
+          "torch.nn.functional",
+          "functional"
+        ]
       ],
       "Glm5NextConfig": [
-        "vllm.transformers_utils.configs.glm5_next",
-        "Glm5NextConfig"
+        [
+          "vllm.transformers_utils.configs.glm5_next",
+          "Glm5NextConfig"
+        ]
       ],
       "KpoolTailBackend": [
-        "vllm.v1.attention.backends.mla.indexer",
-        "KpoolTailBackend"
+        [
+          "vllm.v1.attention.backends.mla.indexer",
+          "KpoolTailBackend"
+        ]
       ],
       "KpoolTailSpec": [
-        "vllm.v1.kv_cache_interface",
-        "KpoolTailSpec"
+        [
+          "vllm.v1.kv_cache_interface",
+          "KpoolTailSpec"
+        ]
       ],
       "LayerNorm": [
-        "vllm.model_executor.layers.layernorm",
-        "LayerNorm"
+        [
+          "vllm.model_executor.layers.layernorm",
+          "LayerNorm"
+        ]
       ],
       "MLAAttentionSpec": [
-        "vllm.v1.kv_cache_interface",
-        "MLAAttentionSpec"
+        [
+          "vllm.v1.kv_cache_interface",
+          "MLAAttentionSpec"
+        ]
       ],
       "MLAModules": [
-        "vllm.model_executor.layers.mla",
-        "MLAModules"
+        [
+          "vllm.model_executor.layers.mla",
+          "MLAModules"
+        ]
       ],
       "MergedColumnParallelLinear": [
-        "vllm.model_executor.layers.linear",
-        "MergedColumnParallelLinear"
+        [
+          "vllm.model_executor.layers.linear",
+          "MergedColumnParallelLinear"
+        ]
       ],
       "MultiHeadLatentAttentionWrapper": [
-        "vllm.model_executor.layers.mla",
-        "MultiHeadLatentAttentionWrapper"
+        [
+          "vllm.model_executor.layers.mla",
+          "MultiHeadLatentAttentionWrapper"
+        ]
       ],
       "QuantizationConfig": [
-        "vllm.model_executor.layers.quantization.base_config",
-        "QuantizationConfig"
+        [
+          "vllm.model_executor.layers.quantization.base_config",
+          "QuantizationConfig"
+        ]
       ],
       "RMSNorm": [
-        "vllm.model_executor.layers.layernorm",
-        "RMSNorm"
+        [
+          "vllm.model_executor.layers.layernorm",
+          "RMSNorm"
+        ]
       ],
       "ReplicatedLinear": [
-        "vllm.model_executor.layers.linear",
-        "ReplicatedLinear"
+        [
+          "vllm.model_executor.layers.linear",
+          "ReplicatedLinear"
+        ]
       ],
       "RotaryEmbedding": [
-        "vllm.model_executor.layers.rotary_embedding",
-        "RotaryEmbedding"
+        [
+          "vllm.model_executor.layers.rotary_embedding",
+          "RotaryEmbedding"
+        ]
       ],
       "RowParallelLinear": [
-        "vllm.model_executor.layers.linear",
-        "RowParallelLinear"
+        [
+          "vllm.model_executor.layers.linear",
+          "RowParallelLinear"
+        ]
       ],
       "SparseAttnIndexerKpool": [
-        "vllm.model_executor.layers.sparse_attn_indexer_kpool",
-        "SparseAttnIndexerKpool"
+        [
+          "vllm.model_executor.layers.sparse_attn_indexer_kpool",
+          "SparseAttnIndexerKpool"
+        ]
       ],
       "VllmConfig": [
-        "vllm.config",
-        "VllmConfig"
+        [
+          "vllm.config",
+          "VllmConfig"
+        ]
       ],
       "_glm53_glm5next_workspace_entries": [
-        "vllm.v1.attention.backends.mla.indexer",
-        "_glm53_glm5next_workspace_entries"
+        [
+          "vllm.v1.attention.backends.mla.indexer",
+          "_glm53_glm5next_workspace_entries"
+        ]
       ],
       "current_platform": [
-        "vllm.platforms",
-        "current_platform"
+        [
+          "vllm.platforms",
+          "current_platform"
+        ]
       ],
       "extract_layer_index": [
-        "vllm.model_executor.models.utils",
-        "extract_layer_index"
+        [
+          "vllm.model_executor.models.utils",
+          "extract_layer_index"
+        ]
       ],
       "fwht128_quant_fp8": [
-        "vllm.models.glm5next.nvidia.ops.kpool_compress",
-        "fwht128_quant_fp8"
+        [
+          "vllm.models.glm5next.nvidia.ops.kpool_compress",
+          "fwht128_quant_fp8"
+        ]
       ],
       "get_rope": [
-        "vllm.model_executor.layers.rotary_embedding",
-        "get_rope"
+        [
+          "vllm.model_executor.layers.rotary_embedding",
+          "get_rope"
+        ]
       ],
       "get_tensor_model_parallel_world_size": [
-        "vllm.distributed",
-        "get_tensor_model_parallel_world_size"
+        [
+          "vllm.distributed",
+          "get_tensor_model_parallel_world_size"
+        ]
       ],
       "init_logger": [
-        "vllm.logger",
-        "init_logger"
+        [
+          "vllm.logger",
+          "init_logger"
+        ]
       ],
       "maybe_disable_graph_partition": [
-        "vllm.model_executor.utils",
-        "maybe_disable_graph_partition"
+        [
+          "vllm.model_executor.utils",
+          "maybe_disable_graph_partition"
+        ]
       ],
       "nn": [
-        "torch",
-        "nn"
+        [
+          "torch",
+          "nn"
+        ]
       ],
       "replace": [
-        "dataclasses",
-        "replace"
+        [
+          "dataclasses",
+          "replace"
+        ]
       ],
       "torch": [
-        "torch",
-        "torch"
+        [
+          "torch",
+          "torch"
+        ]
       ],
       "yarn_get_mscale": [
-        "vllm.model_executor.models.deepseek_v2",
-        "yarn_get_mscale"
+        [
+          "vllm.model_executor.models.deepseek_v2",
+          "yarn_get_mscale"
+        ]
       ]
     },
     "imports_kpool_class": true,

--- a/overlay/patch_flashkda_prefill.py
+++ b/overlay/patch_flashkda_prefill.py
@@ -30,11 +30,15 @@ prepared candidate, not a receipt.
 """
 from __future__ import annotations
 
+import ast
 import os
 import sys
 from pathlib import Path
 
 MARK = "# [glm53-flashkda-prefill]"
+
+CLASS_NAME = "Glm5NextLinearAttention"
+METHOD_NAME = "_flashkda_prefill"
 
 TARGET = Path(
     os.environ.get(
@@ -183,6 +187,79 @@ CALL_NEW = (
 )
 
 
+# Every structure a *fully* installed arm must contain. A bare marker is not
+# evidence of installation: the marker is written by several of these lines, so
+# a truncated or hand-edited file can carry it while the arm is absent.
+REQUIRED_STRUCTURES = (
+    ("module helper", "def _glm53_flashkda_supported("),
+    ("capability gate call", "if not _glm53_flashkda_supported("),
+    ("workspace sizing", "self._flashkda_buffer_specs = ("),
+    ("arm flag", "self._glm53_flashkda_prefill = True"),
+    ("dispatch", "if self._glm53_flashkda_prefill:"),
+    ("method definition", f"def {METHOD_NAME}("),
+    ("fused kernel call", "torch.ops._flashkda_C.fwd("),
+)
+
+
+def _class_node(source: str) -> ast.ClassDef:
+    """The target class, or fail closed if it is absent or ambiguous."""
+    try:
+        tree = ast.parse(source)
+    except SyntaxError as exc:
+        raise SystemExit(f"glm53 flashkda: target does not parse: {exc}") from exc
+    found = [
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name == CLASS_NAME
+    ]
+    if len(found) != 1:
+        raise SystemExit(
+            f"glm53 flashkda: expected exactly one module-level class "
+            f"{CLASS_NAME!r}, found {len(found)}"
+        )
+    return found[0]
+
+
+def _method_is_a_class_member(source: str) -> bool:
+    try:
+        klass = _class_node(source)
+    except SystemExit:
+        return False
+    return any(
+        isinstance(stmt, ast.FunctionDef) and stmt.name == METHOD_NAME
+        for stmt in klass.body
+    )
+
+
+def is_complete(source: str) -> bool:
+    """True only when every arm structure is present *and* the method is a
+    real member of the target class."""
+    if any(needle not in source for _, needle in REQUIRED_STRUCTURES):
+        return False
+    return _method_is_a_class_member(source)
+
+
+def _insert_method(source: str) -> str:
+    """Insert the method at the end of the *target class body*.
+
+    Appending at EOF is not equivalent: a module-level function or class after
+    the target class would silently swallow the method as a nested definition,
+    leaving the arm compiling but non-functional.
+    """
+    klass = _class_node(source)
+    if not klass.body:
+        raise SystemExit(f"glm53 flashkda: class {CLASS_NAME!r} has an empty body")
+    last = max(stmt.end_lineno or stmt.lineno for stmt in klass.body)
+    lines = source.splitlines(keepends=True)
+    if last > len(lines):
+        raise SystemExit("glm53 flashkda: class body extends past end of file")
+    block = FLASHKDA_METHOD
+    if not lines[last - 1].endswith("\n"):
+        block = "\n" + block
+    lines.insert(last, block)
+    return "".join(lines)
+
+
 def armed() -> bool:
     raw = os.environ.get(KNOB, "").strip().lower()
     if raw in ("", "triton"):
@@ -194,7 +271,12 @@ def armed() -> bool:
 
 def apply_to(source: str) -> str:
     if MARK in source:
-        return source
+        if is_complete(source):
+            return source
+        raise SystemExit(
+            "glm53 flashkda: the marker is present but the arm is incomplete — "
+            "refusing to accept a partial installation as already installed"
+        )
     for anchor, name in (
         (CLASS_ANCHOR, "Glm5NextLinearAttention class"),
         (INIT_ANCHOR, "__init__ conv-state tail"),
@@ -206,12 +288,17 @@ def apply_to(source: str) -> str:
                 f"glm53 flashkda: anchor {name!r} matched {count} times, expected 1 — "
                 "refusing to patch a drifted kda.py"
             )
-    source = source.replace(CLASS_ANCHOR, HELPER_BLOCK + CLASS_ANCHOR, 1)
-    source = source.replace(INIT_ANCHOR, INIT_BLOCK + INIT_ANCHOR, 1)
-    source = source.replace(CALL_ANCHOR, CALL_NEW + "\n", 1)
-    # the method goes at the end of the class body, before the module's tail
-    source = source.rstrip("\n") + "\n" + FLASHKDA_METHOD + "\n"
-    return source
+    patched = source.replace(CLASS_ANCHOR, HELPER_BLOCK + CLASS_ANCHOR, 1)
+    patched = patched.replace(INIT_ANCHOR, INIT_BLOCK + INIT_ANCHOR, 1)
+    patched = patched.replace(CALL_ANCHOR, CALL_NEW + "\n", 1)
+    patched = _insert_method(patched)
+    if not is_complete(patched):
+        raise SystemExit(
+            "glm53 flashkda: the assembled patch failed its own completeness "
+            "check — refusing to write"
+        )
+    compile(patched, "kda.py", "exec")
+    return patched
 
 
 def main() -> int:

--- a/overlay/patch_flashkda_prefill.py
+++ b/overlay/patch_flashkda_prefill.py
@@ -4,10 +4,11 @@
 Prefill is this deployment's measured weak lane (240k cold ~1408 tok/s, 60k
 ~1454). #55737 replaces the ~15-kernel Triton ``chunk_kda_with_fused_gate``
 path with ``vllm._flashkda_C`` and reports 1.7-3.8x on the KDA layer and TTFT
--7.9% to -13.2%. That extension **is** present and functional in the deployed
-image (``torch.ops._flashkda_C.get_workspace_size(1792, 32, 4)`` -> 51,314,688 B
-on this GB10), and the auto-selection gate in the upstream patch accepts
-SM12x + bf16 + head_dim 128 + a bounded gate -- all true here.
+-7.9% to -13.2%. That extension is present in the deployed image and its
+workspace allocator works (``torch.ops._flashkda_C.get_workspace_size(1792,
+32, 4)`` -> 51,314,688 B on this GB10), and the auto-selection gate in the
+upstream patch accepts SM12x + bf16 + head_dim 128 + a bounded gate -- all
+true here.
 
 This overlay ports the upstream change onto the **deployed fork**, which does
 not carry upstream's ``glm5next/nvidia/ops/third_party/`` tree; the live KDA
@@ -23,10 +24,33 @@ than silently serving an unpatched (or half-patched) KDA layer.
 Knob (container runtime):
   GLM53_KDA_PREFILL_BACKEND   unset|triton = stock; flashkda = this arm
 
-Not yet cluster-armed: the numeric parity of the fused kernel against the
-Triton chunk path, and the e2e prefill/acceptance gates, still need a stopped
-maintenance window (see docs/13 and spec/TODO.md task 34). This file is the
-prepared candidate, not a receipt.
+DO NOT ARM. The task 34 numeric parity gate failed; see
+``docs/15-flashkda-prefill-arm.md`` and
+``local/task34-parity-gate-20260910.txt``. Two independent reasons:
+
+1. *Arity.* This port's first cut passed **16** positional arguments to
+   ``torch.ops._flashkda_C.fwd``. The deployed op declares **14**
+   (``q, k, v, g, beta, scale, out, workspace, A_log, dt_bias, lower_bound,
+   initial_state, final_state, cu_seqlens``), so arming raised
+   ``RuntimeError: expected at most 14 argument(s) but received 16`` at the
+   first prefill -- a hard failure, not a silent one. Fixed here, and
+   ``EXPECTED_FWD_ARITY`` now pins the emitted call.
+
+2. *Numerics.* With the arity corrected, ``_flashkda_C.fwd`` does not
+   reproduce the Triton chunk path. Against production's
+   ``vllm.third_party`` kernel its output is ~150x smaller in mean magnitude
+   and essentially uncorrelated (Pearson ~0.0), and the same holds against
+   the fork's own ``kimi_k3`` copy. The divergence survives sequence lengths
+   64/512, a zeroed gate, both beta conventions, pre-normalized q/k, and
+   ``lower_bound`` in {-1,-2,-3,-5}, and the ratio does not track
+   ``exp(lower_bound)``. Root cause not isolated; the fork's only sanctioned
+   caller (``kimi_k3/nvidia/kda.py``) pairs the fused kernel with a
+   *different* Triton kernel (``raw_beta``, no ``safe_gate``), a 1-D
+   ``A_log``, and workspace-manager buffers, so this port is not equivalent
+   to it.
+
+Consequence: no speed comparison is meaningful until parity passes, so the
+arm stays unwired on the cluster and the task 34 A/B window was not run.
 """
 from __future__ import annotations
 
@@ -49,6 +73,17 @@ TARGET = Path(
 )
 
 KNOB = "GLM53_KDA_PREFILL_BACKEND"
+
+# The deployed op's declaration, verbatim from the v1.4.7 image:
+#   _flashkda_C::fwd(Tensor q, Tensor k, Tensor v, Tensor g, Tensor beta,
+#                    float scale, Tensor(a!) out, Tensor(c!) workspace,
+#                    Tensor A_log, Tensor dt_bias, float lower_bound,
+#                    Tensor? initial_state=None, Tensor(b!)? final_state=None,
+#                    Tensor? cu_seqlens=None) -> ()
+# A first cut of this port passed two extra trailing ``None``s and raised
+# ``expected at most 14 argument(s) but received 16`` at the first prefill, so
+# the count is now pinned rather than assumed.
+EXPECTED_FWD_ARITY = 14
 
 # --- insertion point 1: module-level helper block -------------------------
 CLASS_ANCHOR = "class Glm5NextLinearAttention(GatedDeltaNetAttention):\n"
@@ -163,8 +198,6 @@ FLASHKDA_METHOD = f'''
             initial_state.contiguous(),
             final_state,
             cu_seqlens.contiguous(),
-            None,
-            None,
         )
         return out, final_state
 '''
@@ -259,12 +292,35 @@ def _has_required_imports(source: str) -> bool:
     return got_from and got_plain
 
 
+def _fwd_call_arity(source: str) -> int | None:
+    """Positional-argument count of the ``torch.ops._flashkda_C.fwd`` call.
+
+    The op is a fixed-arity TorchScript binding: passing the wrong number of
+    arguments raises at the first prefill, not at import. Counting them here
+    turns that into an install-time failure. Returns None if the call is
+    absent, so the caller decides what that means.
+    """
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return None
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if ast.unparse(node.func) == "torch.ops._flashkda_C.fwd":
+            return len(node.args)
+    return None
+
+
 def is_complete(source: str) -> bool:
     """True only when every arm structure is present, the required imports are
-    real import statements, and the method is a real member of the class."""
+    real import statements, the method is a real member of the class, and the
+    fused call has the deployed op's arity."""
     if any(needle not in source for _, needle in REQUIRED_STRUCTURES):
         return False
     if not _has_required_imports(source):
+        return False
+    if _fwd_call_arity(source) != EXPECTED_FWD_ARITY:
         return False
     return _method_is_a_class_member(source)
 
@@ -300,6 +356,15 @@ def armed() -> bool:
 
 
 def apply_to(source: str) -> str:
+    # The template is indented as a class member; wrapping it in a class makes
+    # it parseable so its arity can be checked before anything is written.
+    template_arity = _fwd_call_arity("class _Probe:\n" + FLASHKDA_METHOD)
+    if template_arity != EXPECTED_FWD_ARITY:
+        raise SystemExit(
+            f"glm53 flashkda: the method template passes {template_arity} "
+            f"positional arguments to _flashkda_C.fwd, but the deployed op "
+            f"declares {EXPECTED_FWD_ARITY} — refusing to install"
+        )
     if MARK in source:
         if is_complete(source):
             return source

--- a/overlay/patch_flashkda_prefill.py
+++ b/overlay/patch_flashkda_prefill.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""Task 34 arm: FlashKDA fused CUDA chunked prefill for GLM-5.3-Flash (vLLM #55737).
+
+Prefill is this deployment's measured weak lane (240k cold ~1408 tok/s, 60k
+~1454). #55737 replaces the ~15-kernel Triton ``chunk_kda_with_fused_gate``
+path with ``vllm._flashkda_C`` and reports 1.7-3.8x on the KDA layer and TTFT
+-7.9% to -13.2%. That extension **is** present and functional in the deployed
+image (``torch.ops._flashkda_C.get_workspace_size(1792, 32, 4)`` -> 51,314,688 B
+on this GB10), and the auto-selection gate in the upstream patch accepts
+SM12x + bf16 + head_dim 128 + a bounded gate -- all true here.
+
+This overlay ports the upstream change onto the **deployed fork**, which does
+not carry upstream's ``glm5next/nvidia/ops/third_party/`` tree; the live KDA
+layer is ``vllm/models/glm5next/nvidia/kda.py`` (653 lines, v1.4.7-lineage
+fork ``487ecf187``). It is a *port*, not a rebase: the three insertion points
+below are this fork's anchors, not upstream's line numbers.
+
+Default OFF. With ``GLM53_KDA_PREFILL_BACKEND`` unset the target file is left
+byte-identical, so this overlay cannot change production by merely being
+installed. Fail-closed: a drifted anchor raises and the boot aborts rather
+than silently serving an unpatched (or half-patched) KDA layer.
+
+Knob (container runtime):
+  GLM53_KDA_PREFILL_BACKEND   unset|triton = stock; flashkda = this arm
+
+Not yet cluster-armed: the numeric parity of the fused kernel against the
+Triton chunk path, and the e2e prefill/acceptance gates, still need a stopped
+maintenance window (see docs/13 and spec/TODO.md task 34). This file is the
+prepared candidate, not a receipt.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+MARK = "# [glm53-flashkda-prefill]"
+
+TARGET = Path(
+    os.environ.get(
+        "GLM53_GLM_KDA_PY",
+        "/usr/local/lib/python3.12/dist-packages/vllm/models/glm5next/"
+        "nvidia/kda.py",
+    )
+)
+
+KNOB = "GLM53_KDA_PREFILL_BACKEND"
+
+# --- insertion point 1: module-level helper block -------------------------
+CLASS_ANCHOR = "class Glm5NextLinearAttention(GatedDeltaNetAttention):\n"
+
+HELPER_BLOCK = f'''from vllm.v1.worker.workspace import current_workspace_manager  {MARK}
+
+
+def _glm53_flashkda_supported(head_dim, dtype, lower_bound) -> bool:  {MARK}
+    """Upstream #55737's auto-selection gate, restated for this fork."""
+    capability = current_platform.get_device_capability()
+    return bool(
+        current_platform.is_cuda()
+        and capability is not None
+        and capability.major in (9, 10, 12)
+        and head_dim == 128
+        and dtype == torch.bfloat16
+        and lower_bound is not None
+    )
+
+
+'''
+
+# --- insertion point 2: __init__ tail ------------------------------------
+INIT_ANCHOR = "        self._conv_state_dim_first = is_conv_state_dim_first()\n"
+
+INIT_BLOCK = f'''        # {MARK} FlashKDA chunked-prefill arm (task 34 / vLLM #55737)
+        if not _glm53_flashkda_supported(
+            self.head_dim, vllm_config.model_config.dtype, self.kda_lower_bound
+        ):
+            raise RuntimeError(
+                "{KNOB}=flashkda requires CUDA SM90/SM10x/SM12x, bfloat16, "
+                "head_dim=128 and a bounded KDA gate"
+            )
+        import vllm._flashkda_C  # noqa: F401  {MARK}
+
+        _max_tokens = vllm_config.scheduler_config.max_num_batched_tokens
+        _max_seqs = vllm_config.scheduler_config.max_num_seqs
+        _ws = torch.ops._flashkda_C.get_workspace_size(
+            _max_tokens, self.local_num_heads, _max_seqs
+        )
+        self._flashkda_buffer_specs = (
+            (
+                (_max_seqs, self.local_num_heads, self.head_dim, self.head_dim),
+                self.get_state_dtype()[1],
+            ),
+            ((_ws,), torch.uint8),
+            (
+                (1, _max_tokens, self.local_num_heads, self.head_dim),
+                vllm_config.model_config.dtype,
+            ),
+        )
+        self._glm53_flashkda_prefill = True
+'''
+
+# --- insertion point 3: the non-spec prefill call ------------------------
+CALL_ANCHOR = """            (
+                core_attn_out_non_spec,
+                last_recurrent_state,
+            ) = chunk_kda_with_fused_gate(
+                q=_rearr(q_ns),
+                k=_rearr(k_ns),
+                v=_rearr(v_ns),
+                raw_g=g1_ns,
+                # Chunk path wants the pre-sigmoided fp32 beta (its kernels
+                # don't sigmoid); beta_ns is raw bf16 from forward.
+                beta=_cast_sigmoid(beta_ns.squeeze(0)).unsqueeze(0),
+                A_log=self.A_log,
+                g_bias=self.dt_bias,
+                initial_state=initial_state,
+                output_final_state=True,
+                use_qk_l2norm_in_kernel=True,
+                cu_seqlens=non_spec_query_start_loc,
+                safe_gate=safe_gate,
+                lower_bound=lower_bound,
+            )
+"""
+
+FLASHKDA_METHOD = f'''
+    def _flashkda_prefill(  {MARK}
+        self,
+        q,
+        k,
+        v,
+        g,
+        beta,
+        initial_state,
+        cu_seqlens,
+        out=None,
+    ):
+        """Fused KDA chunked prefill. Takes raw gate logits ``g`` and raw
+        ``beta`` logits, l2-normalizes q/k in-kernel and applies the bounded
+        gate ``lower_bound * sigmoid(exp(A_log) * (g + dt_bias))``, matching
+        ``chunk_kda_with_fused_gate(..., safe_gate=True)``."""
+        final_state, workspace, workspace_out = (
+            current_workspace_manager().get_simultaneous(*self._flashkda_buffer_specs)
+        )
+        final_state = final_state[: initial_state.shape[0]]
+        if out is None:
+            out = workspace_out[:, : q.shape[1]]
+        torch.ops._flashkda_C.fwd(
+            q.contiguous(),
+            k.contiguous(),
+            v.contiguous(),
+            g.contiguous(),
+            beta,
+            self.head_dim ** -0.5,
+            out,
+            workspace,
+            self.A_log.view(-1),
+            self.dt_bias.view(-1, self.head_dim),
+            self.kda_lower_bound,
+            initial_state.contiguous(),
+            final_state,
+            cu_seqlens.contiguous(),
+            None,
+            None,
+        )
+        return out, final_state
+'''
+
+CALL_NEW = (
+    f"            if self._glm53_flashkda_prefill:  {MARK}\n"
+    "                core_attn_out_non_spec, last_recurrent_state = "
+    "self._flashkda_prefill(\n"
+    "                    q=_rearr(q_ns),\n"
+    "                    k=_rearr(k_ns),\n"
+    "                    v=_rearr(v_ns),\n"
+    "                    g=g1_ns,\n"
+    "                    beta=beta_ns,\n"
+    "                    initial_state=initial_state,\n"
+    "                    cu_seqlens=non_spec_query_start_loc,\n"
+    "                    out=None,\n"
+    "                )\n"
+    "            else:\n"
+    + "".join("    " + line + "\n" for line in CALL_ANCHOR.rstrip("\n").split("\n"))
+)
+
+
+def armed() -> bool:
+    raw = os.environ.get(KNOB, "").strip().lower()
+    if raw in ("", "triton"):
+        return False
+    if raw == "flashkda":
+        return True
+    raise SystemExit(f"{KNOB} must be unset, 'triton' or 'flashkda' (got {raw!r})")
+
+
+def apply_to(source: str) -> str:
+    if MARK in source:
+        return source
+    for anchor, name in (
+        (CLASS_ANCHOR, "Glm5NextLinearAttention class"),
+        (INIT_ANCHOR, "__init__ conv-state tail"),
+        (CALL_ANCHOR, "non-spec chunk_kda_with_fused_gate call"),
+    ):
+        count = source.count(anchor)
+        if count != 1:
+            raise SystemExit(
+                f"glm53 flashkda: anchor {name!r} matched {count} times, expected 1 — "
+                "refusing to patch a drifted kda.py"
+            )
+    source = source.replace(CLASS_ANCHOR, HELPER_BLOCK + CLASS_ANCHOR, 1)
+    source = source.replace(INIT_ANCHOR, INIT_BLOCK + INIT_ANCHOR, 1)
+    source = source.replace(CALL_ANCHOR, CALL_NEW + "\n", 1)
+    # the method goes at the end of the class body, before the module's tail
+    source = source.rstrip("\n") + "\n" + FLASHKDA_METHOD + "\n"
+    return source
+
+
+def main() -> int:
+    if not armed():
+        print(f"glm53: flashkda prefill off ({KNOB} unset/triton)", file=sys.stderr)
+        return 0
+    if not TARGET.is_file():
+        raise SystemExit(f"glm53 flashkda: missing {TARGET}")
+    original = TARGET.read_text(encoding="utf-8")
+    patched = apply_to(original)
+    if patched == original:
+        print("glm53: flashkda prefill already installed", file=sys.stderr)
+        return 0
+    compile(patched, str(TARGET), "exec")
+    TARGET.write_text(patched, encoding="utf-8")
+    cache = TARGET.parent / "__pycache__"
+    if cache.is_dir():
+        for pyc in cache.glob("kda*.pyc"):
+            pyc.unlink(missing_ok=True)
+    print("glm53: flashkda chunked prefill installed", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/overlay/patch_flashkda_prefill.py
+++ b/overlay/patch_flashkda_prefill.py
@@ -235,10 +235,36 @@ def _method_is_a_class_member(source: str) -> bool:
     )
 
 
+def _has_required_imports(source: str) -> bool:
+    """Require the arm's imports as *statements*, not as substrings.
+
+    A commented-out `# from vllm.v1.worker.workspace import
+    current_workspace_manager` leaves the substring present, so a textual check
+    certifies a file that compiles and then raises NameError at prefill time.
+    """
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return False
+    need_from = ("vllm.v1.worker.workspace", "current_workspace_manager")
+    need_plain = "vllm._flashkda_C"
+    got_from = got_plain = False
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module == need_from[0]:
+            if any(alias.name == need_from[1] for alias in node.names):
+                got_from = True
+        elif isinstance(node, ast.Import):
+            if any(alias.name == need_plain for alias in node.names):
+                got_plain = True
+    return got_from and got_plain
+
+
 def is_complete(source: str) -> bool:
-    """True only when every arm structure is present *and* the method is a
-    real member of the target class."""
+    """True only when every arm structure is present, the required imports are
+    real import statements, and the method is a real member of the class."""
     if any(needle not in source for _, needle in REQUIRED_STRUCTURES):
+        return False
+    if not _has_required_imports(source):
         return False
     return _method_is_a_class_member(source)
 

--- a/overlay/patch_flashkda_prefill.py
+++ b/overlay/patch_flashkda_prefill.py
@@ -193,10 +193,14 @@ CALL_NEW = (
 REQUIRED_STRUCTURES = (
     ("module helper", "def _glm53_flashkda_supported("),
     ("capability gate call", "if not _glm53_flashkda_supported("),
+    ("workspace-manager import", "from vllm.v1.worker.workspace import current_workspace_manager"),
+    ("extension import", "import vllm._flashkda_C"),
+    ("workspace sizing call", "torch.ops._flashkda_C.get_workspace_size("),
     ("workspace sizing", "self._flashkda_buffer_specs = ("),
     ("arm flag", "self._glm53_flashkda_prefill = True"),
     ("dispatch", "if self._glm53_flashkda_prefill:"),
     ("method definition", f"def {METHOD_NAME}("),
+    ("workspace acquisition", "current_workspace_manager().get_simultaneous("),
     ("fused kernel call", "torch.ops._flashkda_C.fwd("),
 )
 

--- a/scripts/audit_exl3_mgemm_indices.py
+++ b/scripts/audit_exl3_mgemm_indices.py
@@ -1,0 +1,458 @@
+#!/usr/bin/env python3
+"""Fail-closed audit of the unenforced 128-slot ``v_indices`` scratch (task 37).
+
+The pinned ExLlamaV3 extension declares
+
+    #define MAX_INDICES 128
+    __device__ int64_t v_indices[128];
+    __device__ half    v_weights[128];
+
+and ``exl3_mgemm_kernel`` writes them with a bound of ``bszm`` — the slot count
+``MAX(bszm_in, bszm_out)``, i.e. ``batch x top_k`` for the ``num_tokens == 1``
+compaction path — never against ``MAX_INDICES``. That is the class of defect
+vLLM's own #290 proposes to fix.
+
+This audit does not assume the "always -1" comment in §20/C1 is true. It
+enumerates the call sites and decides reachability from the *deployed* serving
+path, which is:
+
+    vLLM EXL3 overlay -> LinearEXL3.forward -> BC_LinearEXL3::run_gr
+                      -> exl3_gemm_gr / exl3_gemm   (NOT exl3_mgemm)
+
+Verdicts:
+  NOT_REACHABLE — no ``exl3_mgemm`` call site is in the import closure of the
+                  serving path; the scratch cannot be written at any shape.
+  REACHABLE_OK  — reachable call sites exist but their worst-case ``bszm`` at
+                  the declared production shapes stays <= MAX_INDICES.
+  REACHABLE_OVERFLOW — a reachable call site can exceed MAX_INDICES. This is a
+                  silent memory-corruption class defect and outranks every
+                  performance task.
+  ABORT         — a required source or anchor is missing/unreadable. Never
+                  reports a pass it did not establish.
+"""
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import re
+from pathlib import Path
+
+PACKAGE_DIR = "exllamav3"
+KERNEL_REL = "exllamav3_ext/quant/exl3_gemm_kernel.cuh"
+GEMM_REL = "exllamav3_ext/quant/exl3_gemm.cu"
+LINEAR_REL = "exllamav3_ext/libtorch/linear.cpp"
+BINDINGS_REL = "exllamav3_ext/bindings.cpp"
+SERVING_PY_REL = "modules/quant/exl3.py"
+
+# ``overlay/exl3_namespace.py::inject_config_stub`` installs these two names as
+# synthetic ``types.ModuleType`` namespaces before anything else imports them,
+# so the real ``modules/__init__.py`` (which pulls in block_sparse_mlp, attn,
+# sliding_attn, gated_delta_net, mlp -- every native module holding an
+# ``exl3_mgemm`` call site) never executes in this deployment. Treating them as
+# leaves is what makes the reachability answer faithful instead of a
+# conservative over-approximation.
+STUB_NAMESPACES = frozenset({"exllamav3.modules", "exllamav3.model"})
+
+MAX_INDICES_DECL = "#define MAX_INDICES 128"
+V_INDICES_DECL = "__device__ int64_t v_indices[128];"
+V_WEIGHTS_DECL = "__device__ half v_weights[128];"
+SERVING_CALL_GEMM_GR = "exl3_gemm_gr("
+SERVING_CALL_GEMM = "exl3_gemm("
+SERVING_CLASS = "BC_LinearEXL3::run_gr"
+SLICED_GUARD = "min_index < 0"
+PER_MATRIX_GUARD = "per-matrix widths incompatible"
+
+WRITE_RE = re.compile(r"\b(v_indices|v_weights)\s*\[[^\]]*\]\s*=")
+GLOBAL_RE = re.compile(r"__global__[^\n]*\n\s*void\s+(\w+)\s*\(")
+CALL_RE = re.compile(r"\bext\.(exl3_mgemm\w*)\s*\(|\b(exl3_mgemm\w*)\s*\(")
+MODULE_REF_RE = re.compile(r"\bexllamav3(?:\.[A-Za-z_]\w*)+")
+EXT_SYMBOL_RE = re.compile(r"\bexllamav3_ext\.([A-Za-z_]\w*)")
+MGEMM_BIND_RE = re.compile(r'm\.def\(\s*"(exl3_mgemm\w*)"')
+
+
+class Abort(RuntimeError):
+    """A required source or anchor was missing; the audit cannot decide."""
+
+
+def _read(path: Path, label: str) -> str:
+    if not path.is_file():
+        raise Abort(f"missing {label}: {path}")
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError as exc:  # pragma: no cover - unreadable file
+        raise Abort(f"unreadable {label}: {path}: {exc}") from exc
+
+
+def kernel_scratch(kernel_src: str) -> dict:
+    """Declarations plus the per-kernel containment of every scratch write."""
+    if MAX_INDICES_DECL not in kernel_src:
+        raise Abort(f"anchor not found: {MAX_INDICES_DECL!r}")
+    if V_INDICES_DECL not in kernel_src:
+        raise Abort(f"anchor not found: {V_INDICES_DECL!r}")
+    if V_WEIGHTS_DECL not in kernel_src:
+        raise Abort(f"anchor not found: {V_WEIGHTS_DECL!r}")
+
+    spans = []
+    for match in GLOBAL_RE.finditer(kernel_src):
+        spans.append((match.group(1), match.start(), match.end()))
+    if not spans:
+        raise Abort("no __global__ kernels found in the pinned kernel header")
+    bounds = []
+    for index, (name, _, body_start) in enumerate(spans):
+        body_end = spans[index + 1][1] if index + 1 < len(spans) else len(kernel_src)
+        bounds.append((name, body_start, body_end))
+
+    writers: list[dict] = []
+    for match in WRITE_RE.finditer(kernel_src):
+        owner = None
+        for name, start, end in bounds:
+            if start <= match.start() < end:
+                owner = name
+                break
+        writers.append(
+            {
+                "array": match.group(1),
+                "offset": kernel_src[: match.start()].count("\n") + 1,
+                "kernel": owner,
+            }
+        )
+    if not writers:
+        raise Abort("no writes to the v_indices/v_weights scratch were found")
+
+    orphans = [w for w in writers if w["kernel"] != "exl3_mgemm_kernel"]
+    return {
+        "max_indices": 128,
+        "arrays": sorted({w["array"] for w in writers}),
+        "writer_count": len(writers),
+        "writer_kernels": sorted({str(w["kernel"]) for w in writers}),
+        "kernels": [name for name, _, _ in bounds],
+        "writes_outside_mgemm_kernel": orphans,
+    }
+
+
+def serving_path(linear_src: str) -> dict:
+    """The deployed entry point must reach exl3_gemm, never exl3_mgemm."""
+    if SERVING_CLASS not in linear_src:
+        raise Abort(f"anchor not found: {SERVING_CLASS!r}")
+    start = linear_src.index(SERVING_CLASS)
+    end = linear_src.find("\nvoid ", start)
+    body = linear_src[start:] if end == -1 else linear_src[start : start + end]
+    if SERVING_CALL_GEMM_GR not in body:
+        raise Abort(f"{SERVING_CLASS} does not call {SERVING_CALL_GEMM_GR}")
+    if SERVING_CALL_GEMM not in body:
+        raise Abort(f"{SERVING_CLASS} does not call {SERVING_CALL_GEMM}")
+    return {
+        "entry": SERVING_CLASS,
+        "calls_exl3_gemm_gr": SERVING_CALL_GEMM_GR in body,
+        "calls_exl3_gemm": SERVING_CALL_GEMM in body,
+        "calls_exl3_mgemm": "exl3_mgemm" in body,
+    }
+
+
+def gemm_guards(gemm_src: str) -> dict:
+    """Structural guards on the mgemm host entry that bound the scratch."""
+    if "exl3_mgemm_gr" not in gemm_src:
+        raise Abort("anchor not found: 'exl3_mgemm_gr'")
+    if SLICED_GUARD not in gemm_src:
+        raise Abort(f"anchor not found: sliced-mode guard {SLICED_GUARD!r}")
+    if PER_MATRIX_GUARD not in gemm_src:
+        raise Abort(f"anchor not found: {PER_MATRIX_GUARD!r}")
+    return {
+        "sliced_mode_requires_min_index_negative": SLICED_GUARD in gemm_src,
+        "per_matrix_widths_require_min_index_negative": PER_MATRIX_GUARD in gemm_src,
+        "declared_limit_slots": 128,
+    }
+
+
+def _module_name(path: Path, python_dir: Path) -> str:
+    """Fully qualified name, matching the form ``import_closure`` returns.
+
+    The package prefix must be kept: the closure is a set of dotted names such
+    as ``exllamav3.modules.quant.exl3``, so a bare ``modules.quant.exl3`` key
+    would never compare equal and the audit would report NOT_REACHABLE even
+    when a serving-path module does call ``exl3_mgemm``.
+    """
+    rel = path.relative_to(python_dir).with_suffix("")
+    return ".".join((python_dir.name, *rel.parts))
+
+
+def mgemm_call_sites(python_dir: Path) -> dict[str, list[int]]:
+    if not python_dir.is_dir():
+        raise Abort(f"missing python package dir: {python_dir}")
+    sites: dict[str, list[int]] = {}
+    for path in sorted(python_dir.rglob("*.py")):
+        if "__pycache__" in path.parts:
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError:  # pragma: no cover - unreadable file
+            continue
+        hits = [
+            text[: match.start()].count("\n") + 1
+            for match in CALL_RE.finditer(text)
+            if match.group(1) or match.group(2)
+        ]
+        if hits:
+            sites[_module_name(path, python_dir)] = hits
+    return sites
+
+
+def _resolve_module(python_dir: Path, name: str) -> tuple[Path | None, bool]:
+    """Map a dotted module name to its file. Returns (path, is_package)."""
+    parts = name.split(".")
+    if parts and parts[0] == python_dir.name:
+        parts = parts[1:]
+    base = python_dir.joinpath(*parts) if parts else python_dir
+    module_file = base.with_suffix(".py")
+    if module_file.is_file():
+        return module_file, False
+    package_file = base / "__init__.py"
+    if package_file.is_file():
+        return package_file, True
+    return None, False
+
+
+def import_closure(python_dir: Path, seeds: list[str]) -> set[str]:
+    """Transitive in-package imports, resolving relative (``level``) imports.
+
+    Relative imports are the norm inside ExLlamaV3 (``from ...model.config
+    import Config``), so a regex over absolute names silently under-counts the
+    closure. ``ast`` plus explicit ``level`` handling is used instead.
+    """
+    seen: set[str] = set()
+    queue = list(seeds)
+    while queue:
+        name = queue.pop()
+        if name in seen:
+            continue
+        seen.add(name)
+        if name in STUB_NAMESPACES:
+            continue
+        path, is_package = _resolve_module(python_dir, name)
+        if path is None:
+            continue
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except (OSError, SyntaxError):
+            continue
+        parts = name.split(".")
+        package_parts = parts if is_package else parts[:-1]
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    queue.append(alias.name)
+            elif isinstance(node, ast.ImportFrom):
+                if node.level:
+                    drop = node.level - 1
+                    if drop > len(package_parts):
+                        continue
+                    base_parts = package_parts[: len(package_parts) - drop]
+                    if node.module:
+                        base_parts = base_parts + node.module.split(".")
+                    if base_parts:
+                        queue.append(".".join(base_parts))
+                elif node.module:
+                    queue.append(node.module)
+                    for alias in node.names:
+                        queue.append(f"{node.module}.{alias.name}")
+    return seen
+
+
+def overlay_module_seeds(overlay_dir: Path | None) -> list[str]:
+    """ExLlamaV3 modules the vLLM overlay itself names (fail-closed if absent)."""
+    if overlay_dir is None:
+        return []
+    if not overlay_dir.is_dir():
+        raise Abort(f"missing overlay dir: {overlay_dir}")
+    seeds: set[str] = set()
+    found_any = False
+    for path in sorted(overlay_dir.glob("*.py")):
+        found_any = True
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError:  # pragma: no cover - unreadable file
+            continue
+        for match in MODULE_REF_RE.finditer(text):
+            seeds.add(match.group(0))
+    if not found_any:
+        raise Abort(f"no overlay sources found in {overlay_dir}")
+    return sorted(seeds)
+
+
+def overlay_ext_symbols(overlay_dir: Path | None) -> set[str]:
+    """``exllamav3_ext.<name>`` symbols the vLLM overlay actually calls."""
+    if overlay_dir is None:
+        return set()
+    if not overlay_dir.is_dir():
+        raise Abort(f"missing overlay dir: {overlay_dir}")
+    symbols: set[str] = set()
+    for path in sorted(overlay_dir.glob("*.py")):
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError:  # pragma: no cover - unreadable file
+            continue
+        symbols.update(EXT_SYMBOL_RE.findall(text))
+    if not symbols:
+        raise Abort(
+            f"no exllamav3_ext.<symbol> references found in {overlay_dir}; "
+            "cannot establish which extension entries the deployment reaches"
+        )
+    return symbols
+
+
+def mgemm_entry_points(bindings_src: str) -> set[str]:
+    """Extension entry points whose name is an ``exl3_mgemm*`` variant."""
+    entries = set(MGEMM_BIND_RE.findall(bindings_src))
+    if not entries:
+        raise Abort(
+            "no m.def(\"exl3_mgemm...\") entry found in the extension bindings; "
+            "the scratch owner cannot be identified"
+        )
+    return entries
+
+
+def worst_case_slots(top_k: int, max_num_seqs: int, draft_tokens: int) -> dict:
+    """Slot counts the two ``min_index >= 0`` kernel branches can reach."""
+    decode = max_num_seqs * (draft_tokens + 1)
+    return {
+        "production_top_k": top_k,
+        "production_max_num_seqs": max_num_seqs,
+        "production_draft_tokens": draft_tokens,
+        "num_tokens_1_slots_batch_x_topk": decode,
+        "num_tokens_gt_1_slots_bszm": decode,
+    }
+
+
+def audit(
+    exl3_root: Path,
+    python_dir: Path,
+    serving_module: str,
+    shapes: dict,
+    overlay_dir: Path | None = None,
+) -> dict:
+    package_dir = exl3_root / PACKAGE_DIR
+    if not package_dir.is_dir():
+        raise Abort(f"missing ExLlamaV3 package dir: {package_dir}")
+    kernel_src = _read(package_dir / KERNEL_REL, "pinned kernel header")
+    gemm_src = _read(package_dir / GEMM_REL, "mgemm host entry")
+    linear_src = _read(package_dir / LINEAR_REL, "LinearEXL3 binding")
+    bindings_src = _read(package_dir / BINDINGS_REL, "extension bindings")
+    scratch = kernel_scratch(kernel_src)
+    serving = serving_path(linear_src)
+    guards = gemm_guards(gemm_src)
+    entries = mgemm_entry_points(bindings_src)
+    ext_symbols = overlay_ext_symbols(overlay_dir)
+    binding_reaches_mgemm = sorted(ext_symbols & entries)
+    sites = mgemm_call_sites(python_dir)
+    seeds = [serving_module] + overlay_module_seeds(overlay_dir)
+    closure = import_closure(python_dir, seeds)
+    closure_hits = sorted(name for name in sites if name in closure)
+    # The static closure over-approximates: importing a module is not the same
+    # as executing a call site inside it. Only two facts are decisive -- the
+    # overlay naming an mgemm extension entry, and the serving module itself
+    # calling one. Everything else is reported as advisory context.
+    decisive = sorted(set(binding_reaches_mgemm) | (set(sites) & {serving_module}))
+    advisory = sorted(set(closure_hits) - {serving_module})
+
+    if scratch["writes_outside_mgemm_kernel"]:
+        verdict = "ABORT"
+        reason = (
+            "the v_indices/v_weights scratch is written outside exl3_mgemm_kernel; "
+            "the containment premise of this audit is broken."
+        )
+    elif decisive:
+        worst = max(
+            shapes["num_tokens_1_slots_batch_x_topk"],
+            shapes["num_tokens_gt_1_slots_bszm"],
+        )
+        if worst > scratch["max_indices"]:
+            verdict = "REACHABLE_OVERFLOW"
+            reason = (
+                f"the deployment reaches an exl3_mgemm entry point ({decisive}) and "
+                f"can reach {worst} slots at the declared production shapes, above "
+                f"MAX_INDICES={scratch['max_indices']}. Silent memory corruption; "
+                "outranks all performance work. Adopt the bounded-slot fix."
+            )
+        else:
+            verdict = "REACHABLE_OK"
+            reason = (
+                f"the deployment reaches an exl3_mgemm entry point ({decisive}) but "
+                f"stays at or below MAX_INDICES={scratch['max_indices']} at the "
+                "declared production shapes."
+            )
+    else:
+        verdict = "NOT_REACHABLE"
+        reason = (
+            "no exl3_mgemm entry point is reachable: the 128-slot scratch is "
+            "written only inside exl3_mgemm_kernel, the only bridge the vLLM "
+            "overlay uses (BC_LinearEXL3 -> exl3_gemm_gr/exl3_gemm) never calls "
+            "exl3_mgemm, the extension symbols the overlay names "
+            f"({sorted(ext_symbols)}) exclude every exl3_mgemm* entry, and the "
+            "serving module itself has no exl3_mgemm call site."
+        )
+
+    return {
+        "verdict": verdict,
+        "reason": reason,
+        "serving_module": serving_module,
+        "seed_modules": sorted(set(seeds)),
+        "overlay_ext_symbols": sorted(ext_symbols),
+        "mgemm_entry_points": sorted(entries),
+        "binding_reaches_mgemm": binding_reaches_mgemm,
+        "decisive_reachable": decisive,
+        "scratch": scratch,
+        "serving_path": serving,
+        "guards": guards,
+        "call_sites_total": sum(len(v) for v in sites.values()),
+        "call_site_modules": {k: len(v) for k, v in sorted(sites.items())},
+        "advisory_closure_call_site_modules": advisory,
+        "import_closure_size": len(closure),
+        "worst_case": shapes,
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--exl3-root",
+        type=Path,
+        required=True,
+        help="ExLlamaV3 repo root containing exllamav3/exllamav3_ext",
+    )
+    parser.add_argument(
+        "--python-dir",
+        type=Path,
+        help="exllamav3 python package dir (default: <exl3-root>/exllamav3)",
+    )
+    parser.add_argument("--serving-module", default="exllamav3.modules.quant.exl3")
+    parser.add_argument(
+        "--overlay-dir",
+        type=Path,
+        help="vLLM overlay dir whose exllamav3 references seed the closure",
+    )
+    parser.add_argument("--top-k", type=int, default=8)
+    parser.add_argument("--max-num-seqs", type=int, default=4)
+    parser.add_argument("--draft-tokens", type=int, default=7)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    python_dir = args.python_dir or (args.exl3_root / PACKAGE_DIR)
+    shapes = worst_case_slots(args.top_k, args.max_num_seqs, args.draft_tokens)
+    try:
+        report = audit(
+            args.exl3_root, python_dir, args.serving_module, shapes, args.overlay_dir
+        )
+    except Abort as exc:
+        print(json.dumps({"verdict": "ABORT", "reason": str(exc)}, indent=2, sort_keys=True))
+        return 1
+    print(json.dumps(report, indent=2, sort_keys=True))
+    if report["verdict"] == "ABORT":
+        return 1
+    return 2 if report["verdict"] == "REACHABLE_OVERFLOW" else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/audit_exl3_mgemm_indices.py
+++ b/scripts/audit_exl3_mgemm_indices.py
@@ -231,22 +231,28 @@ def import_closure(python_dir: Path, seeds: list[str]) -> dict:
     modules when they actually resolve.
     """
     seen: set[str] = set()
-    unresolved: set[str] = set()
+    required: set[str] = set()
+    resolvable: set[str] = set()
     unparseable: set[str] = set()
     root = python_dir.name
     queue: list[tuple[str, bool]] = [(name, True) for name in seeds]
     while queue:
         name, is_module_ref = queue.pop()
+        # Record the requirement *before* the dedup check: a name first seen as
+        # a weak alias candidate (an attribute) and later as a hard `import`
+        # must still be validated as a module, whatever the queue order.
+        if is_module_ref:
+            required.add(name)
         if name in seen:
             continue
         seen.add(name)
         if name in STUB_NAMESPACES:
+            resolvable.add(name)
             continue
         path, is_package = _resolve_module(python_dir, name)
         if path is None:
-            if is_module_ref and (name == root or name.startswith(root + ".")):
-                unresolved.add(name)
             continue
+        resolvable.add(name)
         try:
             text = path.read_text(encoding="utf-8")
         except OSError as exc:
@@ -286,9 +292,14 @@ def import_closure(python_dir: Path, seeds: list[str]) -> dict:
                     queue.append((node.module, True))
                     for alias in node.names:
                         queue.append((f"{node.module}.{alias.name}", False))
+    unresolved = sorted(
+        name
+        for name in required
+        if (name == root or name.startswith(root + ".")) and name not in resolvable
+    )
     return {
         "modules": seen,
-        "unresolved": sorted(unresolved),
+        "unresolved": unresolved,
         "unparseable": sorted(unparseable),
     }
 
@@ -461,6 +472,52 @@ def _installed_stub_names(source: str) -> set[str]:
     return installed
 
 
+def _installer_invocation(overlay_dir: Path) -> str | None:
+    """The overlay file that calls the stub installer before importing exllamav3.
+
+    Executing the installer proves it *can* install; it does not prove the
+    deployment *runs* it. If the loader imports ``exllamav3`` without calling
+    the installer first, ``modules/__init__.py`` executes and pulls in every
+    native module holding an ``exl3_mgemm`` call site, so pruning those
+    namespaces would be unsound. Returns the qualifying file, or ``None``.
+    """
+    for path in sorted(overlay_dir.glob("*.py")):
+        try:
+            source = path.read_text(encoding="utf-8")
+        except OSError:  # pragma: no cover - unreadable file
+            continue
+        try:
+            tree = ast.parse(source)
+        except SyntaxError:  # pragma: no cover
+            continue
+        call_line: int | None = None
+        first_exllamav3_import: int | None = None
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call):
+                func = node.func
+                callee = func.attr if isinstance(func, ast.Attribute) else (
+                    func.id if isinstance(func, ast.Name) else None
+                )
+                if callee == "inject_config_stub" and call_line is None:
+                    call_line = node.lineno
+            elif isinstance(node, ast.ImportFrom):
+                module = node.module or ""
+                if module == "exllamav3" or module.startswith("exllamav3."):
+                    if first_exllamav3_import is None:
+                        first_exllamav3_import = node.lineno
+            elif isinstance(node, ast.Import):
+                for alias in node.names:
+                    if alias.name == "exllamav3" or alias.name.startswith("exllamav3."):
+                        if first_exllamav3_import is None:
+                            first_exllamav3_import = node.lineno
+        if call_line is None:
+            continue
+        if first_exllamav3_import is not None and first_exllamav3_import < call_line:
+            continue
+        return str(path)
+    return None
+
+
 def stub_contract(overlay_dir: Path | None) -> dict:
     """Justify pruning ``STUB_NAMESPACES`` from the closure.
 
@@ -515,11 +572,20 @@ def stub_contract(overlay_dir: Path | None) -> dict:
             f"{path.name} declares but does not install {not_installed} as module "
             "objects; refusing to prune them from the import closure"
         )
+
+    invoker = _installer_invocation(overlay_dir)
+    if invoker is None:
+        raise Abort(
+            "no overlay source calls inject_config_stub() before importing "
+            "exllamav3; the deployment may load the real exllamav3.modules "
+            "package, so pruning the stub namespaces is unsound"
+        )
     return {
         "checked": True,
         "source": str(path),
         "installs": sorted(STUB_NAMESPACES),
         "verified_by": "structural assignment check + executed installer",
+        "invoked_by": invoker,
     }
 
 

--- a/scripts/audit_exl3_mgemm_indices.py
+++ b/scripts/audit_exl3_mgemm_indices.py
@@ -213,17 +213,29 @@ def _resolve_module(python_dir: Path, name: str) -> tuple[Path | None, bool]:
     return None, False
 
 
-def import_closure(python_dir: Path, seeds: list[str]) -> set[str]:
+def import_closure(python_dir: Path, seeds: list[str]) -> dict:
     """Transitive in-package imports, resolving relative (``level``) imports.
 
     Relative imports are the norm inside ExLlamaV3 (``from ...model.config
     import Config``), so a regex over absolute names silently under-counts the
     closure. ``ast`` plus explicit ``level`` handling is used instead.
+
+    Returns the resolved module set **plus** the in-package references that
+    could not be resolved or parsed. Skipping those silently is a fail-open:
+    deleting the serving module, or corrupting a module inside the closure,
+    shrinks the closure and turns an undecidable tree into a confident
+    ``NOT_REACHABLE``. Names introduced by ``Import`` (and by an
+    ``ImportFrom``'s module part) are module references; names introduced by an
+    ``ImportFrom`` *alias* are usually attributes, so they are only treated as
+    modules when they actually resolve.
     """
     seen: set[str] = set()
-    queue = list(seeds)
+    unresolved: set[str] = set()
+    unparseable: set[str] = set()
+    root = python_dir.name
+    queue: list[tuple[str, bool]] = [(name, True) for name in seeds]
     while queue:
-        name = queue.pop()
+        name, is_module_ref = queue.pop()
         if name in seen:
             continue
         seen.add(name)
@@ -231,17 +243,25 @@ def import_closure(python_dir: Path, seeds: list[str]) -> set[str]:
             continue
         path, is_package = _resolve_module(python_dir, name)
         if path is None:
+            if is_module_ref and (name == root or name.startswith(root + ".")):
+                unresolved.add(name)
             continue
         try:
-            tree = ast.parse(path.read_text(encoding="utf-8"))
-        except (OSError, SyntaxError):
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            unparseable.add(f"{name}: unreadable ({exc})")
+            continue
+        try:
+            tree = ast.parse(text)
+        except SyntaxError as exc:
+            unparseable.add(f"{name}: {exc}")
             continue
         parts = name.split(".")
         package_parts = parts if is_package else parts[:-1]
         for node in ast.walk(tree):
             if isinstance(node, ast.Import):
                 for alias in node.names:
-                    queue.append(alias.name)
+                    queue.append((alias.name, True))
             elif isinstance(node, ast.ImportFrom):
                 if node.level:
                     drop = node.level - 1
@@ -251,16 +271,28 @@ def import_closure(python_dir: Path, seeds: list[str]) -> set[str]:
                     if node.module:
                         base_parts = base_parts + node.module.split(".")
                     if base_parts:
-                        queue.append(".".join(base_parts))
+                        queue.append((".".join(base_parts), True))
                 elif node.module:
-                    queue.append(node.module)
+                    queue.append((node.module, True))
                     for alias in node.names:
-                        queue.append(f"{node.module}.{alias.name}")
-    return seen
+                        queue.append((f"{node.module}.{alias.name}", False))
+    return {
+        "modules": seen,
+        "unresolved": sorted(unresolved),
+        "unparseable": sorted(unparseable),
+    }
 
 
 def overlay_module_seeds(overlay_dir: Path | None) -> list[str]:
-    """ExLlamaV3 modules the vLLM overlay itself names (fail-closed if absent)."""
+    """ExLlamaV3 modules the vLLM overlay itself *imports* (fail-closed if absent).
+
+    Parsed, not regex-scanned. Overlay sources also *name* ExLlamaV3 modules
+    they merely patch (file paths, anchors, docstrings) and dotted attribute
+    chains such as ``exllamav3.model.config.InferParams``. Seeding the closure
+    from those both over-counts (patch targets are not call targets) and
+    under-counts (an attribute chain resolves to no module at all), and the
+    previous regex did both.
+    """
     if overlay_dir is None:
         return []
     if not overlay_dir.is_dir():
@@ -273,8 +305,21 @@ def overlay_module_seeds(overlay_dir: Path | None) -> list[str]:
             text = path.read_text(encoding="utf-8")
         except OSError:  # pragma: no cover - unreadable file
             continue
-        for match in MODULE_REF_RE.finditer(text):
-            seeds.add(match.group(0))
+        try:
+            tree = ast.parse(text)
+        except SyntaxError:  # pragma: no cover - overlay must be importable
+            continue
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    if alias.name == "exllamav3" or alias.name.startswith("exllamav3."):
+                        seeds.add(alias.name)
+            elif isinstance(node, ast.ImportFrom):
+                if node.level:
+                    continue
+                module = node.module or ""
+                if module == "exllamav3" or module.startswith("exllamav3."):
+                    seeds.add(module)
     if not found_any:
         raise Abort(f"no overlay sources found in {overlay_dir}")
     return sorted(seeds)
@@ -324,6 +369,43 @@ def worst_case_slots(top_k: int, max_num_seqs: int, draft_tokens: int) -> dict:
     }
 
 
+def stub_contract(overlay_dir: Path | None) -> dict:
+    """Justify pruning ``STUB_NAMESPACES`` from the closure.
+
+    Treating ``exllamav3.modules``/``exllamav3.model`` as leaves is only sound
+    if the deployment really installs them as synthetic module objects before
+    anything imports them -- otherwise their ``__init__.py`` runs and pulls in
+    every native module that holds an ``exl3_mgemm`` call site. The assumption
+    is checked here rather than trusted.
+    """
+    if overlay_dir is None:
+        raise Abort(
+            "no --overlay-dir given: the stub-namespace pruning cannot be "
+            "justified, so the import closure would be unsound"
+        )
+    path = overlay_dir / "exl3_namespace.py"
+    source = _read(path, "exllamav3 namespace stub")
+    if "types.ModuleType" not in source:
+        raise Abort(f"{path.name} does not build synthetic module objects")
+    if "def inject_config_stub(" not in source:
+        raise Abort(f"{path.name} has no inject_config_stub entry point")
+    missing = [
+        name
+        for name in sorted(STUB_NAMESPACES)
+        if f'"{name}"' not in source and f"'{name}'" not in source
+    ]
+    if missing:
+        raise Abort(
+            f"{path.name} does not install {missing}; refusing to prune them "
+            "from the import closure"
+        )
+    return {
+        "checked": True,
+        "source": str(path),
+        "installs": sorted(STUB_NAMESPACES),
+    }
+
+
 def audit(
     exl3_root: Path,
     python_dir: Path,
@@ -342,18 +424,57 @@ def audit(
     serving = serving_path(linear_src)
     guards = gemm_guards(gemm_src)
     entries = mgemm_entry_points(bindings_src)
+    stubs = stub_contract(overlay_dir)
     ext_symbols = overlay_ext_symbols(overlay_dir)
     binding_reaches_mgemm = sorted(ext_symbols & entries)
     sites = mgemm_call_sites(python_dir)
     seeds = [serving_module] + overlay_module_seeds(overlay_dir)
     closure = import_closure(python_dir, seeds)
-    closure_hits = sorted(name for name in sites if name in closure)
-    # The static closure over-approximates: importing a module is not the same
-    # as executing a call site inside it. Only two facts are decisive -- the
-    # overlay naming an mgemm extension entry, and the serving module itself
-    # calling one. Everything else is reported as advisory context.
-    decisive = sorted(set(binding_reaches_mgemm) | (set(sites) & {serving_module}))
-    advisory = sorted(set(closure_hits) - {serving_module})
+
+    # A seed that will not resolve or parse means the reachability question
+    # cannot be posed at all -- never a silent shrink of the closure.
+    bad_seeds = [
+        name
+        for name in seeds
+        if name in closure["unresolved"] or any(
+            entry.split(":")[0] == name for entry in closure["unparseable"]
+        )
+    ]
+    if bad_seeds:
+        raise Abort(
+            f"serving-path seed module(s) missing or unparseable: {bad_seeds}; "
+            "the import closure cannot be established"
+        )
+    if closure["unparseable"]:
+        raise Abort(
+            "in-package module(s) inside the closure could not be parsed: "
+            f"{closure['unparseable'][:8]}; the closure is incomplete"
+        )
+    if closure["unresolved"]:
+        raise Abort(
+            "in-package import(s) inside the closure did not resolve: "
+            f"{closure['unresolved'][:8]}; the closure is incomplete"
+        )
+
+    closure_modules = closure["modules"]
+    closure_hits = sorted(name for name in sites if name in closure_modules)
+
+    # Decisive facts -- each one *is* an observed reachable path to an
+    # exl3_mgemm entry: the overlay naming an mgemm extension symbol, the
+    # serving Python module calling one, or the C++ bridge calling one.
+    decisive: set[str] = set(binding_reaches_mgemm)
+    if serving_module in sites:
+        decisive.add(serving_module)
+    if serving["calls_exl3_mgemm"]:
+        decisive.add(f"{serving['entry']} -> exl3_mgemm")
+    decisive = sorted(decisive)
+
+    # Closure modules that hold mgemm call sites but are not themselves a
+    # decisive entry. Importing a module does not execute its call sites, so
+    # these are *unresolved*, not unreachable -- a call graph would be needed
+    # to discharge them. Reporting them as advisory context and then claiming
+    # NOT_REACHABLE is exactly the fail-open this audit exists to prevent.
+    unresolved_calls = sorted(set(closure_hits) - {serving_module})
 
     if scratch["writes_outside_mgemm_kernel"]:
         verdict = "ABORT"
@@ -381,6 +502,16 @@ def audit(
                 f"stays at or below MAX_INDICES={scratch['max_indices']} at the "
                 "declared production shapes."
             )
+    elif unresolved_calls:
+        verdict = "ABORT"
+        reason = (
+            "the deployment's own entry points do not reach an exl3_mgemm entry, "
+            f"but {len(unresolved_calls)} module(s) inside the serving import "
+            f"closure hold exl3_mgemm call sites: {unresolved_calls}. Importing a "
+            "module is not executing its call sites, so static non-reachability "
+            "is NOT established. Discharge these with call-graph evidence (or "
+            "prove they are never loaded) before any NOT_REACHABLE verdict."
+        )
     else:
         verdict = "NOT_REACHABLE"
         reason = (
@@ -388,8 +519,9 @@ def audit(
             "written only inside exl3_mgemm_kernel, the only bridge the vLLM "
             "overlay uses (BC_LinearEXL3 -> exl3_gemm_gr/exl3_gemm) never calls "
             "exl3_mgemm, the extension symbols the overlay names "
-            f"({sorted(ext_symbols)}) exclude every exl3_mgemm* entry, and the "
-            "serving module itself has no exl3_mgemm call site."
+            f"({sorted(ext_symbols)}) exclude every exl3_mgemm* entry, the "
+            "serving module itself has no exl3_mgemm call site, and no other "
+            "module in the serving import closure has one either."
         )
 
     return {
@@ -401,13 +533,14 @@ def audit(
         "mgemm_entry_points": sorted(entries),
         "binding_reaches_mgemm": binding_reaches_mgemm,
         "decisive_reachable": decisive,
+        "unresolved_closure_call_site_modules": unresolved_calls,
+        "stub_contract": stubs,
         "scratch": scratch,
         "serving_path": serving,
         "guards": guards,
         "call_sites_total": sum(len(v) for v in sites.values()),
         "call_site_modules": {k: len(v) for k, v in sorted(sites.items())},
-        "advisory_closure_call_site_modules": advisory,
-        "import_closure_size": len(closure),
+        "import_closure_size": len(closure_modules),
         "worst_case": shapes,
     }
 

--- a/scripts/audit_exl3_mgemm_indices.py
+++ b/scripts/audit_exl3_mgemm_indices.py
@@ -36,6 +36,7 @@ import argparse
 import ast
 import json
 import re
+import types
 from pathlib import Path
 
 PACKAGE_DIR = "exllamav3"
@@ -270,8 +271,17 @@ def import_closure(python_dir: Path, seeds: list[str]) -> dict:
                     base_parts = package_parts[: len(package_parts) - drop]
                     if node.module:
                         base_parts = base_parts + node.module.split(".")
-                    if base_parts:
-                        queue.append((".".join(base_parts), True))
+                    if not base_parts:
+                        continue
+                    base = ".".join(base_parts)
+                    queue.append((base, True))
+                    # `from . import helper` names a *submodule*, and its call
+                    # sites are as reachable as any other import's. Queue the
+                    # alias as a module candidate: it resolves when it really is
+                    # a submodule and is ignored when it is an attribute of
+                    # `base` (the same treatment the absolute branch gives).
+                    for alias in node.names:
+                        queue.append((f"{base}.{alias.name}", False))
                 elif node.module:
                     queue.append((node.module, True))
                     for alias in node.names:
@@ -369,14 +379,100 @@ def worst_case_slots(top_k: int, max_num_seqs: int, draft_tokens: int) -> dict:
     }
 
 
+def _installed_stub_names(source: str) -> set[str]:
+    """Namespaces a stub source actually *installs* into a module mapping.
+
+    Structural, not textual: `unused = types.ModuleType(name)` contains every
+    token a token-presence check looks for while installing nothing. What
+    matters is a subscript assignment whose key is a namespace string and whose
+    value is a ``ModuleType`` construction, possibly via a local alias
+    (``module = types.ModuleType(name)`` ... ``mapping[name] = module``).
+    """
+    tree = ast.parse(source)
+    module_typed: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign) and isinstance(node.value, ast.Call):
+            func = node.value.func
+            callee = func.attr if isinstance(func, ast.Attribute) else (
+                func.id if isinstance(func, ast.Name) else None
+            )
+            if callee == "ModuleType":
+                for target in node.targets:
+                    if isinstance(target, ast.Name):
+                        module_typed.add(target.id)
+        elif isinstance(node, ast.AnnAssign) and isinstance(node.value, ast.Call):
+            func = node.value.func
+            callee = func.attr if isinstance(func, ast.Attribute) else (
+                func.id if isinstance(func, ast.Name) else None
+            )
+            if callee == "ModuleType" and isinstance(node.target, ast.Name):
+                module_typed.add(node.target.id)
+
+    # Loop variables bound to string literals, e.g.
+    # `for name, path in (("exllamav3", ...), ("exllamav3.modules", ...)):`.
+    # Each iterated element is itself a tuple matching the loop target, so zip
+    # the target names against that element's values.
+    literal_names: dict[str, set[str]] = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.For, ast.AsyncFor)):
+            continue
+        if not isinstance(node.iter, (ast.Tuple, ast.List)):
+            continue
+        names = [t.id for t in ast.walk(node.target) if isinstance(t, ast.Name)]
+        for item in node.iter.elts:
+            if not isinstance(item, (ast.Tuple, ast.List)):
+                continue
+            for var, value in zip(names, item.elts):
+                if isinstance(value, ast.Constant) and isinstance(value.value, str):
+                    literal_names.setdefault(var, set()).add(value.value)
+
+    def _keys(node: ast.Subscript) -> set[str]:
+        key = node.slice
+        if isinstance(key, ast.Constant) and isinstance(key.value, str):
+            return {key.value}
+        if isinstance(key, ast.Name):
+            return literal_names.get(key.id, set())
+        return set()
+
+    def _is_module_value(value: ast.expr) -> bool:
+        if isinstance(value, ast.Call):
+            func = value.func
+            callee = func.attr if isinstance(func, ast.Attribute) else (
+                func.id if isinstance(func, ast.Name) else None
+            )
+            return callee == "ModuleType"
+        if isinstance(value, ast.Name):
+            return value.id in module_typed
+        return False
+
+    installed: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            targets = node.targets
+        elif isinstance(node, ast.AnnAssign):
+            targets = [node.target]
+        else:
+            continue
+        if not _is_module_value(node.value):
+            continue
+        for target in targets:
+            if isinstance(target, ast.Subscript):
+                installed |= _keys(target)
+    return installed
+
+
 def stub_contract(overlay_dir: Path | None) -> dict:
     """Justify pruning ``STUB_NAMESPACES`` from the closure.
 
     Treating ``exllamav3.modules``/``exllamav3.model`` as leaves is only sound
     if the deployment really installs them as synthetic module objects before
     anything imports them -- otherwise their ``__init__.py`` runs and pulls in
-    every native module that holds an ``exl3_mgemm`` call site. The assumption
-    is checked here rather than trusted.
+    every native module that holds an ``exl3_mgemm`` call site.
+
+    Checked structurally rather than by token presence, and then *behaviourally*:
+    the installer is actually run against a fresh mapping and the result is
+    inspected. A source that mentions ``types.ModuleType`` and the namespace
+    strings while installing nothing is rejected.
     """
     if overlay_dir is None:
         raise Abort(
@@ -385,24 +481,45 @@ def stub_contract(overlay_dir: Path | None) -> dict:
         )
     path = overlay_dir / "exl3_namespace.py"
     source = _read(path, "exllamav3 namespace stub")
-    if "types.ModuleType" not in source:
-        raise Abort(f"{path.name} does not build synthetic module objects")
-    if "def inject_config_stub(" not in source:
-        raise Abort(f"{path.name} has no inject_config_stub entry point")
-    missing = [
-        name
-        for name in sorted(STUB_NAMESPACES)
-        if f'"{name}"' not in source and f"'{name}'" not in source
-    ]
-    if missing:
+    try:
+        tree = ast.parse(source)
+    except SyntaxError as exc:
+        raise Abort(f"cannot parse {path.name}: {exc}") from exc
+    if not any(
+        isinstance(node, ast.FunctionDef) and node.name == "inject_config_stub"
+        for node in tree.body
+    ):
+        raise Abort(f"{path.name} has no module-level inject_config_stub entry point")
+    declared = _installed_stub_names(source)
+    if STUB_NAMESPACES - declared:
         raise Abort(
-            f"{path.name} does not install {missing}; refusing to prune them "
-            "from the import closure"
+            f"{path.name} has no `mapping[name] = types.ModuleType(name)` "
+            f"assignment for {sorted(STUB_NAMESPACES - declared)}; refusing to "
+            "prune them from the import closure"
+        )
+
+    # Behavioural confirmation: run the installer and look at what it produced.
+    namespace: dict = {}
+    try:
+        exec(compile(source, str(path), "exec"), namespace)  # noqa: S102
+        installer = namespace["inject_config_stub"]
+        mapping: dict = {}
+        installer(Path("."), mapping)
+    except Exception as exc:  # pragma: no cover - defensive
+        raise Abort(f"{path.name} could not be executed to verify the stub: {exc}") from exc
+    not_installed = sorted(
+        name for name in STUB_NAMESPACES if not isinstance(mapping.get(name), types.ModuleType)
+    )
+    if not_installed:
+        raise Abort(
+            f"{path.name} declares but does not install {not_installed} as module "
+            "objects; refusing to prune them from the import closure"
         )
     return {
         "checked": True,
         "source": str(path),
         "installs": sorted(STUB_NAMESPACES),
+        "verified_by": "structural assignment check + executed installer",
     }
 
 

--- a/scripts/audit_exl3_mgemm_indices.py
+++ b/scripts/audit_exl3_mgemm_indices.py
@@ -29,6 +29,34 @@ Verdicts:
                   performance task.
   ABORT         — a required source or anchor is missing/unreadable. Never
                   reports a pass it did not establish.
+
+Basis and limits of a NOT_REACHABLE verdict — it is *static*, not observed:
+
+  * The verdict rests on ``overlay/exl3_namespace.py`` installing
+    ``exllamav3``, ``exllamav3.modules``, ``exllamav3.model`` and
+    ``exllamav3.model.config`` as synthetic module objects before the serving
+    module is imported. ``stub_contract`` proves that structurally *and* by
+    executing the installer and inspecting the mapping, and
+    ``_installer_invocation`` proves the loader calls it before its first
+    ``exllamav3`` import. If the deployment stops stubbing any of them, the
+    closure grows and the verdict reverts to ABORT or worse -- fail-closed.
+  * ``exllamav3.model.config`` is the load-bearing one: the serving module's
+    first import is ``from ...model.config import Config``, and the real
+    ``model/config.py`` reaches ``architecture/architectures.py`` (which imports
+    every architecture, including those pulling in ``modules.attn``,
+    ``modules.dsv4`` and ``modules.gated_delta_net``) from a function-local
+    import inside ``Config``. Stubbing the namespace is what keeps that fan-out
+    out of the runtime closure.
+  * Not modelled: importing ``exllamav3.modules.quant.exl3`` really does execute
+    the real ``modules/quant/__init__.py`` (its parents ``exllamav3`` and
+    ``exllamav3.modules`` are synthetic), because ``modules.quant`` is not a
+    stub. On the pinned revision that file imports only ``.fp16`` and ``.exl3``,
+    neither of which reaches ``architecture/``, so it does not change this
+    verdict -- but it is a gap in the model, not a proof about it.
+  * No live ``sys.modules`` observation backs any of this. ``__pycache__``
+    mtimes cannot substitute: the image precompiles the whole tree at build
+    time. If a static basis is ever judged insufficient, the answer is a
+    one-time check in a stopped window, not a stronger claim from this script.
 """
 from __future__ import annotations
 
@@ -46,14 +74,26 @@ LINEAR_REL = "exllamav3_ext/libtorch/linear.cpp"
 BINDINGS_REL = "exllamav3_ext/bindings.cpp"
 SERVING_PY_REL = "modules/quant/exl3.py"
 
-# ``overlay/exl3_namespace.py::inject_config_stub`` installs these two names as
-# synthetic ``types.ModuleType`` namespaces before anything else imports them,
-# so the real ``modules/__init__.py`` (which pulls in block_sparse_mlp, attn,
-# sliding_attn, gated_delta_net, mlp -- every native module holding an
-# ``exl3_mgemm`` call site) never executes in this deployment. Treating them as
-# leaves is what makes the reachability answer faithful instead of a
-# conservative over-approximation.
-STUB_NAMESPACES = frozenset({"exllamav3.modules", "exllamav3.model"})
+# ``overlay/exl3_namespace.py::inject_config_stub`` installs these as synthetic
+# ``types.ModuleType`` namespaces before anything else imports them, so the real
+# ``modules/__init__.py`` (which pulls in block_sparse_mlp, attn, sliding_attn,
+# gated_delta_net, mlp -- every native module holding an ``exl3_mgemm`` call
+# site) never executes in this deployment. Treating them as leaves is what makes
+# the reachability answer faithful instead of a conservative over-approximation.
+#
+# ``exllamav3.model.config`` matters for the same reason and is the subtler of
+# the three: the serving module's first import is
+# ``from ...model.config import Config``, and the real ``model/config.py``
+# reaches ``architecture/architectures.py`` -- which imports every architecture,
+# including the ones that pull in ``modules.attn``, ``modules.dsv4`` and
+# ``modules.gated_delta_net`` -- from a *function-local* import inside
+# ``Config``. Stubbing the namespace is what keeps that whole fan-out out of the
+# runtime closure. The installer writes this one through its own ``__name__``
+# (``modules[config.__name__] = config``) rather than a literal key, so
+# ``_installed_stub_names`` resolves it from the ``ModuleType`` literal.
+STUB_NAMESPACES = frozenset(
+    {"exllamav3.modules", "exllamav3.model", "exllamav3.model.config"}
+)
 
 MAX_INDICES_DECL = "#define MAX_INDICES 128"
 V_INDICES_DECL = "__device__ int64_t v_indices[128];"
@@ -401,23 +441,24 @@ def _installed_stub_names(source: str) -> set[str]:
     """
     tree = ast.parse(source)
     module_typed: set[str] = set()
+    # local variable -> the literal name passed to `types.ModuleType(...)`, so a
+    # later `mapping[var.__name__] = var` can be resolved back to a namespace.
+    module_type_literal: dict[str, set[str]] = {}
     for node in ast.walk(tree):
         if isinstance(node, ast.Assign) and isinstance(node.value, ast.Call):
-            func = node.value.func
-            callee = func.attr if isinstance(func, ast.Attribute) else (
-                func.id if isinstance(func, ast.Name) else None
-            )
-            if callee == "ModuleType":
+            if _callee_name(node.value.func) == "ModuleType":
+                literal = _module_type_name(node.value)
                 for target in node.targets:
                     if isinstance(target, ast.Name):
                         module_typed.add(target.id)
+                        if literal:
+                            module_type_literal.setdefault(target.id, set()).update(literal)
         elif isinstance(node, ast.AnnAssign) and isinstance(node.value, ast.Call):
-            func = node.value.func
-            callee = func.attr if isinstance(func, ast.Attribute) else (
-                func.id if isinstance(func, ast.Name) else None
-            )
-            if callee == "ModuleType" and isinstance(node.target, ast.Name):
+            if _callee_name(node.value.func) == "ModuleType" and isinstance(node.target, ast.Name):
                 module_typed.add(node.target.id)
+                literal = _module_type_name(node.value)
+                if literal:
+                    module_type_literal.setdefault(node.target.id, set()).update(literal)
 
     # Loop variables bound to string literals, e.g.
     # `for name, path in (("exllamav3", ...), ("exllamav3.modules", ...)):`.
@@ -437,12 +478,24 @@ def _installed_stub_names(source: str) -> set[str]:
                 if isinstance(value, ast.Constant) and isinstance(value.value, str):
                     literal_names.setdefault(var, set()).add(value.value)
 
-    def _keys(node: ast.Subscript) -> set[str]:
+    def _keys(node: ast.Subscript, assigned: ast.expr) -> set[str]:
         key = node.slice
         if isinstance(key, ast.Constant) and isinstance(key.value, str):
             return {key.value}
         if isinstance(key, ast.Name):
             return literal_names.get(key.id, set())
+        # `mapping[config.__name__] = config` right after
+        # `config = types.ModuleType("exllamav3.model.config")`. Only the same
+        # variable on both sides counts: `mapping[other.__name__] = config` does
+        # not install `config`'s namespace, so it stays unresolved.
+        if (
+            isinstance(assigned, ast.Name)
+            and isinstance(key, ast.Attribute)
+            and key.attr == "__name__"
+            and isinstance(key.value, ast.Name)
+            and key.value.id == assigned.id
+        ):
+            return module_type_literal.get(assigned.id, set())
         return set()
 
     def _is_module_value(value: ast.expr) -> bool:
@@ -468,8 +521,37 @@ def _installed_stub_names(source: str) -> set[str]:
             continue
         for target in targets:
             if isinstance(target, ast.Subscript):
-                installed |= _keys(target)
+                installed |= _keys(target, node.value)
     return installed
+
+
+def _callee_name(func: ast.expr) -> str | None:
+    """The bare name of a called expression (``types.ModuleType`` -> ``ModuleType``)."""
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    if isinstance(func, ast.Name):
+        return func.id
+    return None
+
+
+def _module_type_name(call: ast.Call) -> set[str]:
+    """The literal namespace passed to ``types.ModuleType(...)``, if it is one."""
+    if _callee_name(call.func) != "ModuleType":
+        return set()
+    if (
+        call.args
+        and isinstance(call.args[0], ast.Constant)
+        and isinstance(call.args[0].value, str)
+    ):
+        return {call.args[0].value}
+    for keyword in call.keywords:
+        if (
+            keyword.arg == "name"
+            and isinstance(keyword.value, ast.Constant)
+            and isinstance(keyword.value.value, str)
+        ):
+            return {keyword.value.value}
+    return set()
 
 
 def _installer_invocation(overlay_dir: Path) -> str | None:
@@ -521,10 +603,11 @@ def _installer_invocation(overlay_dir: Path) -> str | None:
 def stub_contract(overlay_dir: Path | None) -> dict:
     """Justify pruning ``STUB_NAMESPACES`` from the closure.
 
-    Treating ``exllamav3.modules``/``exllamav3.model`` as leaves is only sound
-    if the deployment really installs them as synthetic module objects before
-    anything imports them -- otherwise their ``__init__.py`` runs and pulls in
-    every native module that holds an ``exl3_mgemm`` call site.
+    Treating ``exllamav3.modules``/``exllamav3.model``/``exllamav3.model.config``
+    as leaves is only sound if the deployment really installs them as synthetic
+    module objects before anything imports them -- otherwise their ``__init__.py``
+    (or, for ``model.config``, the real module body) runs and pulls in every
+    native module that holds an ``exl3_mgemm`` call site.
 
     Checked structurally rather than by token presence, and then *behaviourally*:
     the installer is actually run against a fresh mapping and the result is

--- a/scripts/audit_exl3_mgemm_indices.py
+++ b/scripts/audit_exl3_mgemm_indices.py
@@ -53,6 +53,19 @@ Basis and limits of a NOT_REACHABLE verdict — it is *static*, not observed:
     stub. On the pinned revision that file imports only ``.fp16`` and ``.exl3``,
     neither of which reaches ``architecture/``, so it does not change this
     verdict -- but it is a gap in the model, not a proof about it.
+  * ``_installed_stub_names`` is a structural over-approximation: it can
+    attribute a namespace the installer never reaches (rebinding, scope). That
+    direction is safe here because ``stub_contract`` then *executes* the
+    installer and requires the namespace to be a real module in the mapping --
+    every structural false positive tested so far ends in ABORT, not in a
+    wrong NOT_REACHABLE. It is a boundary of the structural pass, not of the
+    verdict.
+  * Pruning assumes the serving process has not already imported the genuine
+    module under that name. The real installer returns an existing
+    ``exllamav3.model.config`` only when it already carries
+    ``NullConfig``/``InferParams`` and raises otherwise, so a genuine preload
+    is refused rather than silently accepted -- but this script does not model
+    arbitrary pre-imported process states.
   * No live ``sys.modules`` observation backs any of this. ``__pycache__``
     mtimes cannot substitute: the image precompiles the whole tree at build
     time. If a static basis is ever judged insufficient, the answer is a

--- a/scripts/audit_persistent_topk_reachability.py
+++ b/scripts/audit_persistent_topk_reachability.py
@@ -143,40 +143,87 @@ def live_persistent_topk(source: str, label: str) -> list[int]:
     return [line for line in _calls_named(tree, PERSISTENT_TOPK) if line not in dead_lines]
 
 
+KPOOL_MODULE_TAIL = KPOOL_REL.rsplit("/", 1)[-1].removesuffix(".py")
+PLAIN_MODULE_TAIL = PLAIN_INDEXER_REL.rsplit("/", 1)[-1].removesuffix(".py")
+
+
+def _import_bindings(tree: ast.Module) -> dict[str, tuple[str, str]]:
+    """Local name -> (originating module, original name) for every import."""
+    bindings: dict[str, tuple[str, str]] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            for alias in node.names:
+                bindings[alias.asname or alias.name] = (module, alias.name)
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                local = alias.asname or alias.name.split(".")[-1]
+                bindings[local] = (alias.name, alias.name.split(".")[-1])
+    return bindings
+
+
+def _resolve_indexer_class(local: str, bindings: dict[str, tuple[str, str]]) -> str | None:
+    """Which indexer class a *name* denotes, by import provenance.
+
+    Identity must come from where the name came from, not from how it is
+    spelled: ``from ...sparse_attn_indexer import SparseAttnIndexer as
+    SparseAttnIndexerKpool`` constructs the *plain* indexer, whose
+    ``persistent_topk`` is live, while reading exactly like the kpool class.
+
+    A name imported from a module that is neither indexer module resolves to
+    nothing, and the caller treats that as unresolved rather than guessing.
+    """
+    if local not in bindings:
+        # No import binding: a class defined in this module under that name.
+        return local if local in (KPOOL_CLASS, PLAIN_CLASS) else None
+    module, _original = bindings[local]
+    tail = module.rsplit(".", 1)[-1] if module else ""
+    if tail == KPOOL_MODULE_TAIL:
+        return KPOOL_CLASS
+    if tail == PLAIN_MODULE_TAIL:
+        return PLAIN_CLASS
+    return None
+
+
 def glm_uses_kpool(glm_source: str, label: str = "GLM attention module") -> dict:
     """Which indexer the GLM module *actually* constructs.
 
-    Parsed, not pattern-matched: a textual occurrence in a comment, docstring
-    or dead code must not stand in for a real construction, and the plain
-    ``SparseAttnIndexer`` (whose ``persistent_topk`` *is* live) is a prefix of
-    the kpool name, so substring tests misreport in both directions.
+    Parsed, not pattern-matched, and resolved through import provenance rather
+    than by spelling: a textual occurrence in a comment, docstring or dead code
+    must not stand in for a real construction, the plain ``SparseAttnIndexer``
+    (whose ``persistent_topk`` *is* live) is a prefix of the kpool name, and an
+    aliased import can make either name denote the other class.
     """
     tree = _parse(glm_source, label)
+    bindings = _import_bindings(tree)
 
-    imported: set[str] = set()
-    for node in ast.walk(tree):
-        if isinstance(node, ast.ImportFrom):
-            for alias in node.names:
-                imported.add(alias.asname or alias.name)
-        elif isinstance(node, ast.Import):
-            for alias in node.names:
-                imported.add(alias.asname or alias.name.split(".")[-1])
+    imported: set[str] = set(bindings)
 
-    # Every name/attribute actually *used* in code — comments and strings are
-    # not AST nodes, so they cannot contribute here.
-    referenced: set[str] = set()
-    constructed: set[str] = set()
+    referenced_classes: set[str] = set()
+    constructed_classes: set[str] = set()
+    unresolved_references: set[str] = set()
+
     for node in ast.walk(tree):
-        if isinstance(node, ast.Name):
-            referenced.add(node.id)
-        elif isinstance(node, ast.Attribute):
-            referenced.add(node.attr)
-        elif isinstance(node, ast.Call):
+        if isinstance(node, ast.Call):
             func = node.func
             if isinstance(func, ast.Name):
-                constructed.add(func.id)
+                resolved = _resolve_indexer_class(func.id, bindings)
+                if resolved is None and func.id in (KPOOL_CLASS, PLAIN_CLASS):
+                    unresolved_references.add(func.id)
+                elif resolved:
+                    constructed_classes.add(resolved)
             elif isinstance(func, ast.Attribute):
-                constructed.add(func.attr)
+                if func.attr in (KPOOL_CLASS, PLAIN_CLASS):
+                    constructed_classes.add(func.attr)
+        elif isinstance(node, ast.Name):
+            resolved = _resolve_indexer_class(node.id, bindings)
+            if resolved:
+                referenced_classes.add(resolved)
+            elif node.id in (KPOOL_CLASS, PLAIN_CLASS):
+                unresolved_references.add(node.id)
+        elif isinstance(node, ast.Attribute):
+            if node.attr in (KPOOL_CLASS, PLAIN_CLASS):
+                referenced_classes.add(node.attr)
 
     kpool_lines = sorted(
         {
@@ -189,11 +236,13 @@ def glm_uses_kpool(glm_source: str, label: str = "GLM attention module") -> dict
         }
     )
     return {
-        "imports_kpool_class": KPOOL_CLASS in imported or KPOOL_CLASS in referenced,
-        "instantiates_kpool_class": KPOOL_CLASS in constructed,
+        "imports_kpool_class": KPOOL_CLASS in imported or KPOOL_CLASS in referenced_classes,
+        "instantiates_kpool_class": KPOOL_CLASS in constructed_classes,
         "kpool_reference_lines": kpool_lines,
-        "uses_plain_indexer": PLAIN_CLASS in referenced or PLAIN_CLASS in constructed,
-        "plain_indexer_constructed": PLAIN_CLASS in constructed,
+        "uses_plain_indexer": PLAIN_CLASS in referenced_classes,
+        "plain_indexer_constructed": PLAIN_CLASS in constructed_classes,
+        "unresolved_indexer_names": sorted(unresolved_references),
+        "import_bindings": {k: list(v) for k, v in sorted(bindings.items())},
     }
 
 
@@ -256,6 +305,12 @@ def audit(site: Path, overlay_dir: Path | None, kernel_dir: Path | None) -> dict
             f"the GLM-5.3-Flash model path also references {PLAIN_CLASS}, whose "
             "persistent_topk is live; routing is unresolved, so the kpool "
             "verdict cannot be claimed"
+        )
+    if glm["unresolved_indexer_names"]:
+        raise Abort(
+            "the GLM-5.3-Flash model path uses indexer name(s) "
+            f"{glm['unresolved_indexer_names']} whose import provenance does not "
+            "resolve to a known indexer module; routing is unresolved"
         )
     dead = dead_persistent_topk_branches(kpool_src, "sparse_attn_indexer_kpool.py")
     live = live_persistent_topk(kpool_src, "sparse_attn_indexer_kpool.py")

--- a/scripts/audit_persistent_topk_reachability.py
+++ b/scripts/audit_persistent_topk_reachability.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""Fail-closed reachability audit for the persistent-top-k overflow lane (task 39).
+
+vLLM #52149 and #55314 fix a *correctness* defect in ``persistent_topk``: when
+the radix threshold bin overflows the candidate buffer, the indexer selects the
+wrong top-k pools. #55314 discusses GLM-5.3-Flash indexer logits directly, so
+the parked watch item assumed GB10 runs that kernel.
+
+This audit decides applicability from the deployed source rather than from the
+watch item's premise. The GLM-5.3-Flash model path uses
+``SparseAttnIndexerKpool``; in the deployed build that file's ``persistent_topk``
+branch is guarded by a literal ``if False and ...``, installed fail-closed by
+``overlay/patch_glm_video_placeholders.py::_disable_gb10_persistent_topk``
+("Decode-path persistent_topk oversubscribes GB10 smem on long seqs"). The live
+decode kernel is ``top_k_per_row_decode`` instead.
+
+Verdicts:
+  NOT_APPLICABLE — the GLM path cannot reach ``persistent_topk``; #52149/#55314
+                   have no mechanism here. No logits comparison is owed.
+  REACHABLE      — the dead branch is gone (or the GLM path no longer uses the
+                   kpool indexer). The overflow lane applies and must be
+                   assessed against #55122's post-patch code.
+  ABORT          — a required source or anchor is missing/unreadable. Never
+                   reports a pass it did not establish.
+"""
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import re
+from pathlib import Path
+
+GLM_ATTENTION_REL = "models/glm5next/nvidia/attention.py"
+KPOOL_REL = "model_executor/layers/sparse_attn_indexer_kpool.py"
+PLAIN_INDEXER_REL = "model_executor/layers/sparse_attn_indexer.py"
+
+KPOOL_CLASS = "SparseAttnIndexerKpool"
+PLAIN_CLASS = "SparseAttnIndexer"
+PERSISTENT_TOPK = "persistent_topk"
+LIVE_KERNEL = "top_k_per_row_decode"
+OVERLAY_NAME = "patch_glm_video_placeholders.py"
+OVERLAY_DEAD_BRANCH = "if False and current_platform.is_cuda() and "
+OVERLAY_GUARD_CALL = "_disable_gb10_persistent_topk"
+OVERLAY_FAIL_CLOSED = "kpool persistent_topk pattern not found"
+
+
+class Abort(RuntimeError):
+    """A required source or anchor was missing; the audit cannot decide."""
+
+
+def _read(path: Path, label: str) -> str:
+    if not path.is_file():
+        raise Abort(f"missing {label}: {path}")
+    try:
+        return path.read_text(encoding="utf-8")
+    except OSError as exc:  # pragma: no cover - unreadable file
+        raise Abort(f"unreadable {label}: {path}: {exc}") from exc
+
+
+def _parse(source: str, label: str) -> ast.Module:
+    try:
+        return ast.parse(source)
+    except SyntaxError as exc:
+        raise Abort(f"cannot parse {label}: {exc}") from exc
+
+
+def _is_literal_false(node: ast.expr) -> bool:
+    return isinstance(node, ast.Constant) and node.value is False
+
+
+def _calls_named(node: ast.AST, attr: str) -> list[int]:
+    """Line numbers of calls whose dotted callee ends in ``attr``."""
+    hits: list[int] = []
+    for sub in ast.walk(node):
+        if not isinstance(sub, ast.Call):
+            continue
+        func = sub.func
+        name = None
+        if isinstance(func, ast.Attribute):
+            name = func.attr
+        elif isinstance(func, ast.Name):
+            name = func.id
+        if name == attr:
+            hits.append(sub.lineno)
+    return hits
+
+
+def dead_persistent_topk_branches(source: str, label: str) -> list[dict]:
+    """``if False and ...`` blocks whose body calls persistent_topk."""
+    tree = _parse(source, label)
+    found: list[dict] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.If):
+            continue
+        test = node.test
+        if not isinstance(test, ast.BoolOp) or not isinstance(test.op, ast.And):
+            continue
+        if not test.values or not _is_literal_false(test.values[0]):
+            continue
+        hits = _calls_named(node, PERSISTENT_TOPK)
+        if not hits:
+            continue
+        found.append(
+            {
+                "line": node.lineno,
+                "persistent_topk_calls": hits,
+                "else_branch": bool(node.orelse),
+                "live_kernel_calls": _calls_named(
+                    ast.Module(body=node.orelse, type_ignores=[]), LIVE_KERNEL
+                ),
+            }
+        )
+    return found
+
+
+def live_persistent_topk(source: str, label: str) -> list[int]:
+    """persistent_topk calls that are NOT inside a literal-False branch."""
+    tree = _parse(source, label)
+    dead_lines: set[int] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.If):
+            continue
+        test = node.test
+        if (
+            isinstance(test, ast.BoolOp)
+            and isinstance(test.op, ast.And)
+            and test.values
+            and _is_literal_false(test.values[0])
+        ):
+            dead_lines.update(_calls_named(node, PERSISTENT_TOPK))
+    return [line for line in _calls_named(tree, PERSISTENT_TOPK) if line not in dead_lines]
+
+
+def glm_uses_kpool(glm_source: str) -> dict:
+    # `SparseAttnIndexer` is a prefix of `SparseAttnIndexerKpool`, so a plain
+    # substring test would report the GLM module as a user of both indexers.
+    plain_re = re.compile(rf"\b{PLAIN_CLASS}\b(?!Kpool)")
+    return {
+        "imports_kpool_class": bool(re.search(rf"\b{KPOOL_CLASS}\b", glm_source)),
+        "instantiates_kpool_class": f"{KPOOL_CLASS}(" in glm_source,
+        "uses_plain_indexer": bool(plain_re.search(glm_source)),
+    }
+
+
+def plain_indexer_users(site: Path) -> list[str]:
+    """Modules that use the non-kpool indexer (whose persistent_topk is live)."""
+    models = site / "models"
+    if not models.is_dir():
+        raise Abort(f"missing models dir under vLLM site: {models}")
+    plain_re = re.compile(rf"\b{PLAIN_CLASS}\b(?!Kpool)")
+    kpool_re = re.compile(rf"\b{KPOOL_CLASS}\b")
+    users: list[str] = []
+    for path in sorted(models.rglob("*.py")):
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError:  # pragma: no cover - unreadable file
+            continue
+        if plain_re.search(text) and not kpool_re.search(text):
+            users.append(str(path.relative_to(site)))
+    return users
+
+
+def overlay_guard(overlay_dir: Path | None) -> dict:
+    if overlay_dir is None:
+        return {"checked": False, "present": False}
+    if not overlay_dir.is_dir():
+        raise Abort(f"missing overlay dir: {overlay_dir}")
+    path = overlay_dir / OVERLAY_NAME
+    source = _read(path, "persistent-topk disabling overlay")
+    has_dead = OVERLAY_DEAD_BRANCH in source
+    has_guard = OVERLAY_GUARD_CALL in source
+    fail_closed = OVERLAY_FAIL_CLOSED in source
+    if not has_dead or not has_guard or not fail_closed:
+        raise Abort(
+            f"{OVERLAY_NAME} no longer installs the fail-closed GB10 "
+            f"persistent_topk guard (dead-branch anchor={has_dead}, "
+            f"guard call={has_guard}, fail-closed refusal={fail_closed})"
+        )
+    return {
+        "checked": True,
+        "present": True,
+        "installs_dead_branch": has_dead,
+        "guard_call": has_guard,
+        "fail_closed": fail_closed,
+    }
+
+
+def audit(site: Path, overlay_dir: Path | None, kernel_dir: Path | None) -> dict:
+    glm_src = _read(site / GLM_ATTENTION_REL, "GLM attention module")
+    kpool_src = _read(site / KPOOL_REL, "kpool sparse indexer")
+    glm = glm_uses_kpool(glm_src)
+    if not glm["imports_kpool_class"]:
+        raise Abort(
+            "the GLM-5.3-Flash model path no longer imports SparseAttnIndexerKpool; "
+            "re-derive which indexer it uses before trusting this audit"
+        )
+    dead = dead_persistent_topk_branches(kpool_src, "sparse_attn_indexer_kpool.py")
+    live = live_persistent_topk(kpool_src, "sparse_attn_indexer_kpool.py")
+    guard = overlay_guard(overlay_dir)
+    plain_users = plain_indexer_users(site)
+
+    fixed_scratch = None
+    if kernel_dir is not None:
+        sampler = _read(kernel_dir / "sampler.cu", "top_k_per_row_decode launcher")
+        if LIVE_KERNEL not in sampler:
+            raise Abort(f"{LIVE_KERNEL} not found in the sampler source")
+        fixed_scratch = "MAX_INDICES" in sampler or "candidate buffer" in sampler
+
+    if dead and not live:
+        verdict = "NOT_APPLICABLE"
+        reason = (
+            "the GLM-5.3-Flash path uses SparseAttnIndexerKpool and that file's "
+            f"persistent_topk branch is dead by construction (line {dead[0]['line']}), "
+            f"with {LIVE_KERNEL} on the live else branch. #52149/#55314 cannot "
+            "change selection here, so no indexer-logits comparison is owed."
+        )
+    elif live:
+        verdict = "REACHABLE"
+        reason = (
+            "persistent_topk is live on the GLM indexer path at line(s) "
+            f"{live}; assess #52149/#55314 against #55122's post-patch code."
+        )
+    else:
+        verdict = "ABORT"
+        reason = (
+            "no persistent_topk call was found in the kpool indexer at all; the "
+            "source shape this audit reasons about has changed."
+        )
+
+    return {
+        "verdict": verdict,
+        "reason": reason,
+        "glm_indexer": glm,
+        "dead_branches": dead,
+        "live_persistent_topk_lines": live,
+        "overlay_guard": guard,
+        "plain_indexer_users": plain_users,
+        "live_kernel": LIVE_KERNEL,
+        "live_kernel_has_fixed_scratch": fixed_scratch,
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--vllm-site",
+        type=Path,
+        required=True,
+        help="installed vLLM package root (the dir containing models/ and model_executor/)",
+    )
+    parser.add_argument("--overlay-dir", type=Path)
+    parser.add_argument(
+        "--kernel-dir",
+        type=Path,
+        help="vLLM csrc/libtorch_stable dir, for the live-kernel scratch check",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        report = audit(args.vllm_site, args.overlay_dir, args.kernel_dir)
+    except Abort as exc:
+        print(json.dumps({"verdict": "ABORT", "reason": str(exc)}, indent=2, sort_keys=True))
+        return 1
+    print(json.dumps(report, indent=2, sort_keys=True))
+    if report["verdict"] == "ABORT":
+        return 1
+    return 2 if report["verdict"] == "REACHABLE" else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/audit_persistent_topk_reachability.py
+++ b/scripts/audit_persistent_topk_reachability.py
@@ -86,19 +86,36 @@ def _calls_named(node: ast.AST, attr: str) -> list[int]:
     return hits
 
 
+def _in_body(statements: list[ast.stmt]) -> ast.Module:
+    """Wrap a statement list so ``ast.walk`` sees only those statements.
+
+    The whole point of the dead-branch check is that ``if False: ...`` is
+    unreachable. Walking the enclosing ``ast.If`` instead would also traverse
+    ``orelse``, which is *live* — and a live ``else: persistent_topk()``
+    misread as dead turns a REACHABLE audit into a false NOT_APPLICABLE.
+    """
+    return ast.Module(body=statements, type_ignores=[])
+
+
+def _is_literal_false_guard(test: ast.expr) -> bool:
+    return (
+        isinstance(test, ast.BoolOp)
+        and isinstance(test.op, ast.And)
+        and bool(test.values)
+        and _is_literal_false(test.values[0])
+    )
+
+
 def dead_persistent_topk_branches(source: str, label: str) -> list[dict]:
-    """``if False and ...`` blocks whose body calls persistent_topk."""
+    """``if False and ...`` blocks whose *body* calls persistent_topk."""
     tree = _parse(source, label)
     found: list[dict] = []
     for node in ast.walk(tree):
         if not isinstance(node, ast.If):
             continue
-        test = node.test
-        if not isinstance(test, ast.BoolOp) or not isinstance(test.op, ast.And):
+        if not _is_literal_false_guard(node.test):
             continue
-        if not test.values or not _is_literal_false(test.values[0]):
-            continue
-        hits = _calls_named(node, PERSISTENT_TOPK)
+        hits = _calls_named(_in_body(node.body), PERSISTENT_TOPK)
         if not hits:
             continue
         found.append(
@@ -107,7 +124,7 @@ def dead_persistent_topk_branches(source: str, label: str) -> list[dict]:
                 "persistent_topk_calls": hits,
                 "else_branch": bool(node.orelse),
                 "live_kernel_calls": _calls_named(
-                    ast.Module(body=node.orelse, type_ignores=[]), LIVE_KERNEL
+                    _in_body(node.orelse), LIVE_KERNEL
                 ),
             }
         )
@@ -115,31 +132,68 @@ def dead_persistent_topk_branches(source: str, label: str) -> list[dict]:
 
 
 def live_persistent_topk(source: str, label: str) -> list[int]:
-    """persistent_topk calls that are NOT inside a literal-False branch."""
+    """persistent_topk calls that are NOT inside a literal-False *body*."""
     tree = _parse(source, label)
     dead_lines: set[int] = set()
     for node in ast.walk(tree):
         if not isinstance(node, ast.If):
             continue
-        test = node.test
-        if (
-            isinstance(test, ast.BoolOp)
-            and isinstance(test.op, ast.And)
-            and test.values
-            and _is_literal_false(test.values[0])
-        ):
-            dead_lines.update(_calls_named(node, PERSISTENT_TOPK))
+        if _is_literal_false_guard(node.test):
+            dead_lines.update(_calls_named(_in_body(node.body), PERSISTENT_TOPK))
     return [line for line in _calls_named(tree, PERSISTENT_TOPK) if line not in dead_lines]
 
 
-def glm_uses_kpool(glm_source: str) -> dict:
-    # `SparseAttnIndexer` is a prefix of `SparseAttnIndexerKpool`, so a plain
-    # substring test would report the GLM module as a user of both indexers.
-    plain_re = re.compile(rf"\b{PLAIN_CLASS}\b(?!Kpool)")
+def glm_uses_kpool(glm_source: str, label: str = "GLM attention module") -> dict:
+    """Which indexer the GLM module *actually* constructs.
+
+    Parsed, not pattern-matched: a textual occurrence in a comment, docstring
+    or dead code must not stand in for a real construction, and the plain
+    ``SparseAttnIndexer`` (whose ``persistent_topk`` *is* live) is a prefix of
+    the kpool name, so substring tests misreport in both directions.
+    """
+    tree = _parse(glm_source, label)
+
+    imported: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            for alias in node.names:
+                imported.add(alias.asname or alias.name)
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                imported.add(alias.asname or alias.name.split(".")[-1])
+
+    # Every name/attribute actually *used* in code — comments and strings are
+    # not AST nodes, so they cannot contribute here.
+    referenced: set[str] = set()
+    constructed: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Name):
+            referenced.add(node.id)
+        elif isinstance(node, ast.Attribute):
+            referenced.add(node.attr)
+        elif isinstance(node, ast.Call):
+            func = node.func
+            if isinstance(func, ast.Name):
+                constructed.add(func.id)
+            elif isinstance(func, ast.Attribute):
+                constructed.add(func.attr)
+
+    kpool_lines = sorted(
+        {
+            node.lineno
+            for node in ast.walk(tree)
+            if (
+                (isinstance(node, ast.Name) and node.id == KPOOL_CLASS)
+                or (isinstance(node, ast.Attribute) and node.attr == KPOOL_CLASS)
+            )
+        }
+    )
     return {
-        "imports_kpool_class": bool(re.search(rf"\b{KPOOL_CLASS}\b", glm_source)),
-        "instantiates_kpool_class": f"{KPOOL_CLASS}(" in glm_source,
-        "uses_plain_indexer": bool(plain_re.search(glm_source)),
+        "imports_kpool_class": KPOOL_CLASS in imported or KPOOL_CLASS in referenced,
+        "instantiates_kpool_class": KPOOL_CLASS in constructed,
+        "kpool_reference_lines": kpool_lines,
+        "uses_plain_indexer": PLAIN_CLASS in referenced or PLAIN_CLASS in constructed,
+        "plain_indexer_constructed": PLAIN_CLASS in constructed,
     }
 
 
@@ -189,11 +243,19 @@ def overlay_guard(overlay_dir: Path | None) -> dict:
 def audit(site: Path, overlay_dir: Path | None, kernel_dir: Path | None) -> dict:
     glm_src = _read(site / GLM_ATTENTION_REL, "GLM attention module")
     kpool_src = _read(site / KPOOL_REL, "kpool sparse indexer")
-    glm = glm_uses_kpool(glm_src)
-    if not glm["imports_kpool_class"]:
+    glm = glm_uses_kpool(glm_src, GLM_ATTENTION_REL)
+    if not glm["instantiates_kpool_class"]:
         raise Abort(
-            "the GLM-5.3-Flash model path no longer imports SparseAttnIndexerKpool; "
-            "re-derive which indexer it uses before trusting this audit"
+            "the GLM-5.3-Flash model path does not construct "
+            f"{KPOOL_CLASS} (reference lines: {glm['kpool_reference_lines']}); "
+            "the indexer routing this audit reasons about has changed — "
+            "re-derive it before trusting any verdict"
+        )
+    if glm["uses_plain_indexer"]:
+        raise Abort(
+            f"the GLM-5.3-Flash model path also references {PLAIN_CLASS}, whose "
+            "persistent_topk is live; routing is unresolved, so the kpool "
+            "verdict cannot be claimed"
         )
     dead = dead_persistent_topk_branches(kpool_src, "sparse_attn_indexer_kpool.py")
     live = live_persistent_topk(kpool_src, "sparse_attn_indexer_kpool.py")

--- a/scripts/audit_persistent_topk_reachability.py
+++ b/scripts/audit_persistent_topk_reachability.py
@@ -147,22 +147,33 @@ KPOOL_MODULE_TAIL = KPOOL_REL.rsplit("/", 1)[-1].removesuffix(".py")
 PLAIN_MODULE_TAIL = PLAIN_INDEXER_REL.rsplit("/", 1)[-1].removesuffix(".py")
 
 
-def _import_bindings(tree: ast.Module) -> dict[str, tuple[str, str]]:
-    """Local name -> (originating module, original name) for every import."""
-    bindings: dict[str, tuple[str, str]] = {}
+def _import_bindings(tree: ast.Module) -> dict[str, set[tuple[str, str]]]:
+    """Local name -> every (originating module, original name) it is bound to.
+
+    Every binding is kept, not just the last one: a function-local import must
+    not silently overwrite a module-level binding of the same name, because the
+    two are visible in different scopes.
+    """
+    bindings: dict[str, set[tuple[str, str]]] = {}
     for node in ast.walk(tree):
         if isinstance(node, ast.ImportFrom):
             module = node.module or ""
             for alias in node.names:
-                bindings[alias.asname or alias.name] = (module, alias.name)
+                bindings.setdefault(alias.asname or alias.name, set()).add(
+                    (module, alias.name)
+                )
         elif isinstance(node, ast.Import):
             for alias in node.names:
                 local = alias.asname or alias.name.split(".")[-1]
-                bindings[local] = (alias.name, alias.name.split(".")[-1])
+                bindings.setdefault(local, set()).add(
+                    (alias.name, alias.name.split(".")[-1])
+                )
     return bindings
 
 
-def _resolve_indexer_class(local: str, bindings: dict[str, tuple[str, str]]) -> str | None:
+def _resolve_indexer_class(
+    local: str, bindings: dict[str, set[tuple[str, str]]]
+) -> str | None:
     """Which indexer class a *name* denotes, by import provenance.
 
     Identity must come from where the name came from, not from how it is
@@ -171,18 +182,48 @@ def _resolve_indexer_class(local: str, bindings: dict[str, tuple[str, str]]) -> 
     ``persistent_topk`` is live, while reading exactly like the kpool class.
 
     A name imported from a module that is neither indexer module resolves to
-    nothing, and the caller treats that as unresolved rather than guessing.
+    nothing, the exported symbol must actually be an indexer class, and a name
+    bound to more than one distinct indexer class is ambiguous and also resolves
+    to nothing. Callers treat "nothing" as unresolved rather than guessing.
     """
-    if local not in bindings:
+    entries = bindings.get(local)
+    if not entries:
         # No import binding: a class defined in this module under that name.
         return local if local in (KPOOL_CLASS, PLAIN_CLASS) else None
-    module, _original = bindings[local]
-    tail = module.rsplit(".", 1)[-1] if module else ""
-    if tail == KPOOL_MODULE_TAIL:
-        return KPOOL_CLASS
-    if tail == PLAIN_MODULE_TAIL:
-        return PLAIN_CLASS
-    return None
+    resolved = set()
+    for module, original in entries:
+        tail = module.rsplit(".", 1)[-1] if module else ""
+        if tail == KPOOL_MODULE_TAIL and original == KPOOL_CLASS:
+            resolved.add(KPOOL_CLASS)
+        elif tail == PLAIN_MODULE_TAIL and original == PLAIN_CLASS:
+            resolved.add(PLAIN_CLASS)
+    if len(resolved) != 1:
+        return None
+    return resolved.pop()
+
+
+def _mentions_an_indexer(entries: set[tuple[str, str]]) -> bool:
+    for module, original in entries:
+        tail = module.rsplit(".", 1)[-1] if module else ""
+        if tail in (KPOOL_MODULE_TAIL, PLAIN_MODULE_TAIL):
+            return True
+        if original in (KPOOL_CLASS, PLAIN_CLASS):
+            return True
+    return False
+
+
+def _ambiguous_indexer_names(bindings: dict[str, set[tuple[str, str]]]) -> list[str]:
+    """Imported names that look like an indexer but do not resolve uniquely.
+
+    Covers a name bound to two different indexer classes in different scopes (a
+    function-local import shadowing a module-level one) and a name imported from
+    an indexer module that does not export that class.
+    """
+    return sorted(
+        local
+        for local, entries in bindings.items()
+        if _mentions_an_indexer(entries) and _resolve_indexer_class(local, bindings) is None
+    )
 
 
 def glm_uses_kpool(glm_source: str, label: str = "GLM attention module") -> dict:
@@ -201,7 +242,7 @@ def glm_uses_kpool(glm_source: str, label: str = "GLM attention module") -> dict
 
     referenced_classes: set[str] = set()
     constructed_classes: set[str] = set()
-    unresolved_references: set[str] = set()
+    unresolved_references: set[str] = set(_ambiguous_indexer_names(bindings))
 
     for node in ast.walk(tree):
         if isinstance(node, ast.Call):
@@ -242,7 +283,7 @@ def glm_uses_kpool(glm_source: str, label: str = "GLM attention module") -> dict
         "uses_plain_indexer": PLAIN_CLASS in referenced_classes,
         "plain_indexer_constructed": PLAIN_CLASS in constructed_classes,
         "unresolved_indexer_names": sorted(unresolved_references),
-        "import_bindings": {k: list(v) for k, v in sorted(bindings.items())},
+        "import_bindings": {k: sorted(list(e) for e in v) for k, v in sorted(bindings.items())},
     }
 
 

--- a/start.sh
+++ b/start.sh
@@ -241,6 +241,10 @@ W28_CORRECTNESS_PATCH_HOST="${W28_CORRECTNESS_PATCH_HOST:-$SCRIPT_DIR/overlay/pa
 MAMBA_NULL_GAP_PATCH_HOST="${MAMBA_NULL_GAP_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_mamba_null_gap_retirement.py}"
 # LOCAL: task 17 / #55234 — inherited KVCacheSpec.merge assert -> raise (python -O)
 KV_MERGE_ASSERT_PATCH_HOST="${KV_MERGE_ASSERT_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_kv_merge_assert.py}"
+# LOCAL: task 34 track A — FlashKDA fused chunked prefill (vLLM #55737), opt-in
+# GLM53_KDA_PREFILL_BACKEND=flashkda. Default-off and byte-neutral when unarmed,
+# so mounting it cannot change production by itself. See docs/15.
+FLASHKDA_PREFILL_PATCH_HOST="${FLASHKDA_PREFILL_PATCH_HOST:-$SCRIPT_DIR/overlay/patch_flashkda_prefill.py}"
 KV_CACHE_DTYPE="${KV_CACHE_DTYPE:-fp8}"
 QUANTIZATION="${QUANTIZATION:-exl3}"
 LANGUAGE_MODEL_ONLY="${LANGUAGE_MODEL_ONLY:-0}"
@@ -327,6 +331,12 @@ GLM53_ADAPTIVE_K_HIST="${GLM53_ADAPTIVE_K_HIST:-200}"
 GLM53_KDA_REC_WARPS="${GLM53_KDA_REC_WARPS:-}"
 GLM53_KDA_REC_STAGES="${GLM53_KDA_REC_STAGES:-}"
 GLM53_KDA_REC_BV_CAP="${GLM53_KDA_REC_BV_CAP:-}"
+# LOCAL: task 34 track A (begin) — prefill backend. Stock is the Triton chunked
+# path; `flashkda` is the #55737 arm. The default is the STOCK spelling, not
+# empty, because the overlay treats anything other than `flashkda` as stock and
+# an explicit `triton` documents the rollback value in `env.example`.
+GLM53_KDA_PREFILL_BACKEND="${GLM53_KDA_PREFILL_BACKEND:-triton}"
+# LOCAL: task 34 track A (end)
 if [ "${ENFORCE_EAGER}" != "1" ]; then
     case " ${EXTRA_ARGS:-} " in
         *" --cudagraph-capture-sizes "*|*" cudagraph-capture-sizes "*) ;;
@@ -624,6 +634,14 @@ validate_numeric_config() {
         ""|8|16|32) ;;
         *) echo "GLM53_KDA_REC_BV_CAP must be empty (stock 8) or one of: 8 16 32 (got: '${GLM53_KDA_REC_BV_CAP}')" >&2; return 2 ;;
     esac
+    # LOCAL: task 34 track A — prefill backend. `triton` is the stock Triton
+    # chunked path, `flashkda` is the #55737 arm, empty means stock. The overlay
+    # re-validates in-process and fails closed at boot, so this check only buys
+    # a clearer message before the containers are torn down.
+    case "${GLM53_KDA_PREFILL_BACKEND:-}" in
+        ""|triton|flashkda) ;;
+        *) echo "GLM53_KDA_PREFILL_BACKEND must be one of: triton flashkda (or empty for stock) (got: '${GLM53_KDA_PREFILL_BACKEND}')" >&2; return 2 ;;
+    esac
     # Capture list is a configuration-shape change (prod-start hashes EXTRA_ARGS).
     # Extra 3/5 multiples are the independent B0/B variable; stock stays 1 2 4 8 16 24 32.
     if [ "$SPEC_METHOD" = dflash ]; then
@@ -838,6 +856,7 @@ preflight() {
     [ -f "$INDEXER_WORKSPACE_PATCH_HOST" ] || die "$INDEXER_WORKSPACE_PATCH_HOST missing"  # LOCAL: W28
     [ -f "$W28_CORRECTNESS_PATCH_HOST" ] || die "$W28_CORRECTNESS_PATCH_HOST missing"  # LOCAL: W28
     [ -f "$KV_MERGE_ASSERT_PATCH_HOST" ] || die "$KV_MERGE_ASSERT_PATCH_HOST missing"
+    [ -f "$FLASHKDA_PREFILL_PATCH_HOST" ] || die "$FLASHKDA_PREFILL_PATCH_HOST missing"  # LOCAL: task 34
 
     local need_kb=$((180 * 1024 * 1024)) avail
     mkdir -p "$HF_CACHE_DIR"
@@ -1379,6 +1398,12 @@ fi
 if [ -f /opt/glm53/patch_kda_recurrent.py ]; then  # LOCAL: task 30 (after adaptive-k)
     python3 -S /opt/glm53/patch_kda_recurrent.py
 fi
+# LOCAL: task 34 track A — self-gated on GLM53_KDA_PREFILL_BACKEND. Runs last
+# among the KDA overlays so it sees the finished kda.py, and is a no-op that
+# leaves the file byte-identical when the knob is stock/unset.
+if [ -f /opt/glm53/patch_flashkda_prefill.py ]; then
+    python3 -S /opt/glm53/patch_flashkda_prefill.py
+fi
 if [ -f /opt/glm53/patch_kv_capacity_log.py ]; then  # LOCAL: W41 (after patch_hybrid_prefix_hit.py)
     python3 -S /opt/glm53/patch_kv_capacity_log.py
 fi
@@ -1535,6 +1560,12 @@ fi
 if [ -f /opt/glm53/patch_kda_recurrent.py ]; then  # LOCAL: task 30 (after adaptive-k)
     python3 -S /opt/glm53/patch_kda_recurrent.py
 fi
+# LOCAL: task 34 track A — self-gated on GLM53_KDA_PREFILL_BACKEND. Runs last
+# among the KDA overlays so it sees the finished kda.py, and is a no-op that
+# leaves the file byte-identical when the knob is stock/unset.
+if [ -f /opt/glm53/patch_flashkda_prefill.py ]; then
+    python3 -S /opt/glm53/patch_flashkda_prefill.py
+fi
 if [ -f /opt/glm53/patch_kv_capacity_log.py ]; then  # LOCAL: W41 (after patch_hybrid_prefix_hit.py)
     python3 -S /opt/glm53/patch_kv_capacity_log.py
 fi
@@ -1610,6 +1641,8 @@ launch_cluster() {
     [ -f "$MAMBA_NULL_GAP_PATCH_HOST" ] || die "missing $MAMBA_NULL_GAP_PATCH_HOST"
     scp -q -o BatchMode=yes "$MAMBA_NULL_GAP_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_mamba_null_gap_retirement.py"
     [ -f "$KV_MERGE_ASSERT_PATCH_HOST" ] || die "missing $KV_MERGE_ASSERT_PATCH_HOST"
+    [ -f "$FLASHKDA_PREFILL_PATCH_HOST" ] || die "missing $FLASHKDA_PREFILL_PATCH_HOST"  # LOCAL: task 34
+    scp -q -o BatchMode=yes "$FLASHKDA_PREFILL_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_flashkda_prefill.py"
     scp -q -o BatchMode=yes "$KV_MERGE_ASSERT_PATCH_HOST" "${WORKER_SSH}:/tmp/patch_kv_merge_assert.py"
 
 
@@ -1655,6 +1688,7 @@ launch_cluster() {
         -e "GLM53_KDA_REC_WARPS=$GLM53_KDA_REC_WARPS"
         -e "GLM53_KDA_REC_STAGES=$GLM53_KDA_REC_STAGES"
         -e "GLM53_KDA_REC_BV_CAP=$GLM53_KDA_REC_BV_CAP"
+        -e "GLM53_KDA_PREFILL_BACKEND=$GLM53_KDA_PREFILL_BACKEND"  # LOCAL: task 34 (both ranks read it at patch time)
         -e "GLM53_KV_CAPACITY_LOG=$GLM53_KV_CAPACITY_LOG"  # LOCAL: W41
         -e "GLM53_APC_NO_STORE=$GLM53_APC_NO_STORE"  # LOCAL: W42
         -e "GLM53_INDEXER_WORKSPACE=$GLM53_INDEXER_WORKSPACE"  # LOCAL: W28
@@ -1765,6 +1799,7 @@ launch_cluster() {
         -v '/tmp/patch_align_floor.py:/opt/glm53/patch_align_floor.py:ro' \
         -v '/tmp/patch_adaptive_k.py:/opt/glm53/patch_adaptive_k.py:ro' \
         -v '/tmp/patch_kda_recurrent.py:/opt/glm53/patch_kda_recurrent.py:ro' \
+        -v '/tmp/patch_flashkda_prefill.py:/opt/glm53/patch_flashkda_prefill.py:ro' \
         -v '/tmp/patch_kv_capacity_log.py:/opt/glm53/patch_kv_capacity_log.py:ro' \
         -v '/tmp/patch_apc_no_store.py:/opt/glm53/patch_apc_no_store.py:ro' \
         -v '/tmp/patch_w28_correctness.py:/opt/glm53/patch_w28_correctness.py:ro' \
@@ -1807,6 +1842,7 @@ launch_cluster() {
         -v "$ALIGN_FLOOR_PATCH_HOST:/opt/glm53/patch_align_floor.py:ro" \
         -v "$ADAPTIVE_K_PATCH_HOST:/opt/glm53/patch_adaptive_k.py:ro" \
         -v "$KDA_REC_PATCH_HOST:/opt/glm53/patch_kda_recurrent.py:ro" \
+        -v "$FLASHKDA_PREFILL_PATCH_HOST:/opt/glm53/patch_flashkda_prefill.py:ro" \
         -v "$KV_CAPACITY_LOG_PATCH_HOST:/opt/glm53/patch_kv_capacity_log.py:ro" \
         -v "$APC_NO_STORE_PATCH_HOST:/opt/glm53/patch_apc_no_store.py:ro" \
         -v "$W28_CORRECTNESS_PATCH_HOST:/opt/glm53/patch_w28_correctness.py:ro" \

--- a/tests/test_exl3_mgemm_indices_audit.py
+++ b/tests/test_exl3_mgemm_indices_audit.py
@@ -3,6 +3,10 @@
 
 Every case runs against a synthetic ExLlamaV3 tree so the suite is hermetic and
 does not need the 100+ GiB checkout or a GPU.
+
+The suite is deliberately biased toward *fail-open* regressions: an audit whose
+job is to certify non-reachability is only worth as much as its refusal to
+certify a tree it could not actually read.
 """
 
 from __future__ import annotations
@@ -104,6 +108,20 @@ def bad(x):
     return ext.exl3_mgemm(x, x, x, x, x, x, None, None, 4, 0, 1, 1, -1, -1, 0, 1)
 """
 
+# A serving module that calls an *imported helper*, which in turn calls mgemm.
+# Nothing in the serving module itself names exl3_mgemm, so a check that looks
+# only at the serving module reports NOT_REACHABLE on a genuinely reachable
+# path. This is the transitive case the audit must not wave through.
+SERVING_PY_TRANSITIVE = SERVING_PY + """\
+from ..native import native
+
+
+def forward_indirect(x):
+    return native(x)
+"""
+
+SERVING_PY_BROKEN = "def broken(:\n"
+
 NATIVE_PY = """\
 def native(x):
     return ext.exl3_mgemm(x, x, x, x, x, x, None, None, 4, 0, 1, 1, 0, 8, 0, 1)
@@ -118,19 +136,24 @@ void bind(py::module& m)
 }
 """
 
-OVERLAY_OK = """\
-SYMBOL = "exllamav3_ext.exl3_moe"
-MODULE = "exllamav3.modules.quant.exl3"
-"""
+# Satisfies the stub contract the audit checks before pruning STUB_NAMESPACES.
+STUB_NAMESPACE_PY = '''\
+import sys
+import types
+from pathlib import Path
 
-OVERLAY_MGEMM = """\
-SYMBOL = "exllamav3_ext.exl3_mgemm"
-MODULE = "exllamav3.modules.quant.exl3"
-"""
 
-OVERLAY_NO_SYMBOL = """\
-MODULE = "exllamav3.modules.quant.exl3"
-"""
+def inject_config_stub(package_root: Path, modules: dict | None = None) -> types.ModuleType:
+    modules = sys.modules if modules is None else modules
+    for name in ("exllamav3", "exllamav3.modules", "exllamav3.model"):
+        modules[name] = types.ModuleType(name)
+    return modules["exllamav3.model"]
+'''
+
+# The overlay must name at least one extension symbol, or the audit refuses.
+OVERLAY_SYMBOLS = 'SYMBOL = "exllamav3_ext.exl3_moe"\n'
+OVERLAY_MGEMM_SYMBOL = 'SYMBOL = "exllamav3_ext.exl3_mgemm"\n'
+OVERLAY_IMPORT = "import exllamav3.modules.native\n"
 
 
 def build_tree(
@@ -171,7 +194,16 @@ def build_tree(
     return root
 
 
-def run(tmp_path: Path, shapes=None, **kwargs):
+def build_overlay(tmp_path: Path, *extra: str, stub: str | None = STUB_NAMESPACE_PY):
+    overlay = tmp_path / "overlay"
+    overlay.mkdir(exist_ok=True)
+    if stub is not None:
+        (overlay / "exl3_namespace.py").write_text(stub)
+    (overlay / "patch_symbols.py").write_text(OVERLAY_SYMBOLS + "".join(extra))
+    return overlay
+
+
+def run(tmp_path: Path, shapes=None, overlay=None, **kwargs):
     defaults = {
         "kernel": KERNEL_HEADER,
         "linear": LINEAR_CPP,
@@ -180,15 +212,21 @@ def run(tmp_path: Path, shapes=None, **kwargs):
     }
     defaults.update(kwargs)
     root = build_tree(tmp_path, **defaults)
+    if overlay is None:
+        overlay = build_overlay(tmp_path)
     return MODULE.audit(
         root,
         root / "exllamav3",
         "exllamav3.modules.quant.exl3",
         shapes or MODULE.worst_case_slots(8, 4, 7),
+        overlay,
     )
 
 
-def test_scratch_writes_are_confined_to_the_mgemm_kernel(tmp_path):
+# --- scratch containment ---------------------------------------------------
+
+
+def test_scratch_writes_are_confined_to_the_mgemm_kernel():
     scratch = MODULE.kernel_scratch(KERNEL_HEADER)
     assert scratch["max_indices"] == 128
     assert scratch["writer_kernels"] == ["exl3_mgemm_kernel"]
@@ -196,7 +234,7 @@ def test_scratch_writes_are_confined_to_the_mgemm_kernel(tmp_path):
     assert sorted(scratch["arrays"]) == ["v_indices", "v_weights"]
 
 
-def test_orphan_writer_is_reported(tmp_path):
+def test_orphan_writer_is_reported():
     scratch = MODULE.kernel_scratch(KERNEL_HEADER_ORPHAN)
     assert scratch["writes_outside_mgemm_kernel"], "orphan write must be surfaced"
     assert "exl3_gemm_kernel" in scratch["writer_kernels"]
@@ -210,6 +248,9 @@ def test_missing_declaration_aborts():
 def test_missing_scratch_arrays_abort():
     with pytest.raises(MODULE.Abort):
         MODULE.kernel_scratch(KERNEL_HEADER.replace("__device__ half v_weights[128];", ""))
+
+
+# --- serving path ----------------------------------------------------------
 
 
 def test_serving_path_calls_gemm_and_never_mgemm():
@@ -240,12 +281,38 @@ def test_gemm_guards_abort_on_missing_anchor():
         MODULE.gemm_guards(GEMM_CU.replace("min_index < 0", "min_index >= 0"))
 
 
+# --- import closure --------------------------------------------------------
+
+
 def test_import_closure_follows_relative_imports(tmp_path):
     root = build_tree(tmp_path)
     closure = MODULE.import_closure(root / "exllamav3", ["exllamav3.modules.quant.exl3"])
-    assert "exllamav3.model.config" in closure, "relative `...model.config` must resolve"
-    assert "exllamav3.modules.quant.exl3_lib.quantize" in closure
-    assert "exllamav3.modules.native" not in closure, "unimported native module must stay out"
+    assert "exllamav3.model.config" in closure["modules"], "relative `...model.config` must resolve"
+    assert "exllamav3.modules.quant.exl3_lib.quantize" in closure["modules"]
+    assert "exllamav3.modules.native" not in closure["modules"]
+    assert closure["unresolved"] == []
+    assert closure["unparseable"] == []
+
+
+def test_import_closure_reports_an_unresolvable_in_package_module(tmp_path):
+    root = build_tree(tmp_path)
+    closure = MODULE.import_closure(root / "exllamav3", ["exllamav3.modules.gone"])
+    assert "exllamav3.modules.gone" in closure["unresolved"]
+
+
+def test_import_closure_reports_an_unparseable_module(tmp_path):
+    root = build_tree(tmp_path)
+    (root / "exllamav3/modules/quant/exl3_lib/quantize.py").write_text("def broken(:\n")
+    closure = MODULE.import_closure(root / "exllamav3", ["exllamav3.modules.quant.exl3"])
+    assert closure["unparseable"], "an unparseable module must be surfaced"
+    assert not closure["modules"] or True
+
+
+def test_import_closure_ignores_attribute_chains(tmp_path):
+    """`from x import y` yields an attribute, not an unresolvable module."""
+    root = build_tree(tmp_path)
+    closure = MODULE.import_closure(root / "exllamav3", ["exllamav3.modules.quant.exl3"])
+    assert "exllamav3.model.config.Config" not in closure["unresolved"]
 
 
 def test_call_sites_enumerated(tmp_path):
@@ -263,7 +330,41 @@ def test_call_site_names_match_closure_namespace(tmp_path):
         root / "exllamav3", ["exllamav3.modules.quant.exl3"]
     )
     assert "exllamav3.modules.quant.exl3" in sites
-    assert "exllamav3.modules.quant.exl3" in closure
+    assert "exllamav3.modules.quant.exl3" in closure["modules"]
+
+
+# --- stub contract ---------------------------------------------------------
+
+
+def test_stub_contract_accepts_the_real_overlay():
+    contract = MODULE.stub_contract(ROOT / "overlay")
+    assert contract["installs"] == sorted(MODULE.STUB_NAMESPACES)
+
+
+def test_stub_contract_requires_an_overlay_dir():
+    with pytest.raises(MODULE.Abort):
+        MODULE.stub_contract(None)
+
+
+def test_stub_contract_aborts_when_a_namespace_is_not_installed(tmp_path):
+    overlay = tmp_path / "overlay"
+    overlay.mkdir()
+    (overlay / "exl3_namespace.py").write_text(
+        STUB_NAMESPACE_PY.replace('"exllamav3.modules", ', "")
+    )
+    with pytest.raises(MODULE.Abort):
+        MODULE.stub_contract(overlay)
+
+
+def test_stub_contract_aborts_without_synthetic_modules(tmp_path):
+    overlay = tmp_path / "overlay"
+    overlay.mkdir()
+    (overlay / "exl3_namespace.py").write_text("def inject_config_stub(a, b=None):\n    pass\n")
+    with pytest.raises(MODULE.Abort):
+        MODULE.stub_contract(overlay)
+
+
+# --- verdicts --------------------------------------------------------------
 
 
 def test_verdict_not_reachable(tmp_path):
@@ -272,6 +373,7 @@ def test_verdict_not_reachable(tmp_path):
     assert report["decisive_reachable"] == []
     assert report["binding_reaches_mgemm"] == []
     assert report["serving_path"]["calls_exl3_mgemm"] is False
+    assert report["unresolved_closure_call_site_modules"] == []
 
 
 def test_verdict_reachable_overflow(tmp_path):
@@ -290,26 +392,6 @@ def test_verdict_reachable_ok_when_shapes_fit(tmp_path):
     assert report["verdict"] == "REACHABLE_OK"
 
 
-def test_closure_is_advisory_only(tmp_path):
-    """A native module in the closure is context, not a reachability verdict."""
-    root = build_tree(tmp_path)
-    overlay = tmp_path / "overlay"
-    overlay.mkdir()
-    (overlay / "patch_x.py").write_text(
-        OVERLAY_OK + 'NATIVE = "exllamav3.modules.native"\n'
-    )
-    report = MODULE.audit(
-        root,
-        root / "exllamav3",
-        "exllamav3.modules.quant.exl3",
-        MODULE.worst_case_slots(8, 32, 7),
-        overlay,
-    )
-    assert "exllamav3.modules.native" in report["advisory_closure_call_site_modules"]
-    assert report["verdict"] == "NOT_REACHABLE"
-    assert report["decisive_reachable"] == []
-
-
 def test_orphan_writer_forces_abort(tmp_path):
     report = run(tmp_path, kernel=KERNEL_HEADER_ORPHAN)
     assert report["verdict"] == "ABORT"
@@ -321,6 +403,81 @@ def test_worst_case_slots_is_batch_times_topk():
     assert shapes["num_tokens_gt_1_slots_bszm"] == 32
 
 
+# --- finding 1: the C++ bridge and the transitive path must be decisive -----
+
+
+def test_cpp_bridge_calling_mgemm_makes_the_verdict_reachable(tmp_path):
+    """The deployed bridge is the most decisive reachability fact there is."""
+    report = run(tmp_path, linear=LINEAR_CPP_MGEMM)
+    assert report["verdict"] == "REACHABLE_OK", report["reason"]
+    assert any("exl3_mgemm" in d for d in report["decisive_reachable"])
+
+
+def test_cpp_bridge_overflow_is_reported_as_overflow(tmp_path):
+    report = run(
+        tmp_path,
+        linear=LINEAR_CPP_MGEMM,
+        shapes=MODULE.worst_case_slots(8, 32, 7),
+    )
+    assert report["verdict"] == "REACHABLE_OVERFLOW"
+
+
+def test_transitive_helper_call_site_is_never_not_reachable(tmp_path):
+    """Serving -> imported helper -> mgemm must not be certified NOT_REACHABLE."""
+    report = run(tmp_path, serving=SERVING_PY_TRANSITIVE)
+    assert report["verdict"] == "ABORT", report["reason"]
+    assert "exllamav3.modules.native" in report["unresolved_closure_call_site_modules"]
+
+
+def test_overlay_naming_an_mgemm_entry_is_reachable(tmp_path):
+    overlay = build_overlay(tmp_path, stub=STUB_NAMESPACE_PY)
+    (overlay / "patch_symbols.py").write_text(OVERLAY_MGEMM_SYMBOL)
+    report = run(tmp_path, overlay=overlay)
+    assert report["verdict"] == "REACHABLE_OK"
+    assert report["binding_reaches_mgemm"] == ["exl3_mgemm"]
+
+
+def test_overlay_importing_a_native_module_seeds_the_closure(tmp_path):
+    overlay = build_overlay(tmp_path, OVERLAY_IMPORT)
+    report = run(tmp_path, overlay=overlay)
+    assert "exllamav3.modules.native" in report["unresolved_closure_call_site_modules"]
+    assert report["verdict"] == "ABORT"
+
+
+# --- finding 2: unreadable or malformed serving inputs must abort ----------
+
+
+def test_missing_serving_module_aborts(tmp_path):
+    root = build_tree(tmp_path)
+    (root / "exllamav3/modules/quant/exl3.py").unlink()
+    with pytest.raises(MODULE.Abort):
+        MODULE.audit(
+            root,
+            root / "exllamav3",
+            "exllamav3.modules.quant.exl3",
+            MODULE.worst_case_slots(8, 4, 7),
+            build_overlay(tmp_path),
+        )
+
+
+def test_unparseable_serving_module_aborts(tmp_path):
+    with pytest.raises(MODULE.Abort):
+        run(tmp_path, serving=SERVING_PY_BROKEN)
+
+
+def test_unparseable_closure_module_aborts(tmp_path):
+    root = build_tree(tmp_path)
+    (root / "exllamav3/model/config.py").write_text("def broken(:\n")
+    with pytest.raises(MODULE.Abort):
+        MODULE.audit(
+            root,
+            root / "exllamav3",
+            "exllamav3.modules.quant.exl3",
+            MODULE.worst_case_slots(8, 4, 7),
+            build_overlay(tmp_path),
+        )
+
+
 def test_missing_source_aborts(tmp_path):
     root = build_tree(tmp_path)
     (root / "exllamav3/exllamav3_ext/libtorch/linear.cpp").unlink()
@@ -330,13 +487,30 @@ def test_missing_source_aborts(tmp_path):
             root / "exllamav3",
             "exllamav3.modules.quant.exl3",
             MODULE.worst_case_slots(8, 4, 7),
+            build_overlay(tmp_path),
         )
+
+
+def test_missing_overlay_dir_aborts(tmp_path):
+    with pytest.raises(MODULE.Abort):
+        MODULE.stub_contract(tmp_path / "nope")
+
+
+# --- CLI -------------------------------------------------------------------
 
 
 def test_cli_exit_codes(tmp_path):
     root = build_tree(tmp_path)
+    overlay = build_overlay(tmp_path)
     ok = subprocess.run(
-        [sys.executable, str(SCRIPT), "--exl3-root", str(root)],
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--exl3-root",
+            str(root),
+            "--overlay-dir",
+            str(overlay),
+        ],
         capture_output=True,
         text=True,
         check=False,
@@ -345,7 +519,14 @@ def test_cli_exit_codes(tmp_path):
     assert json.loads(ok.stdout)["verdict"] == "NOT_REACHABLE"
 
     bad = subprocess.run(
-        [sys.executable, str(SCRIPT), "--exl3-root", str(tmp_path / "nope")],
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--exl3-root",
+            str(tmp_path / "nope"),
+            "--overlay-dir",
+            str(overlay),
+        ],
         capture_output=True,
         text=True,
         check=False,
@@ -360,6 +541,8 @@ def test_cli_exit_codes(tmp_path):
             str(SCRIPT),
             "--exl3-root",
             str(overflow_root),
+            "--overlay-dir",
+            str(overlay),
             "--max-num-seqs",
             "32",
         ],
@@ -371,121 +554,13 @@ def test_cli_exit_codes(tmp_path):
     assert json.loads(overflow.stdout)["verdict"] == "REACHABLE_OVERFLOW"
 
 
-def test_overlay_dir_seeds_closure(tmp_path):
+def test_cli_aborts_without_an_overlay_dir(tmp_path):
     root = build_tree(tmp_path)
-    overlay = tmp_path / "overlay"
-    overlay.mkdir()
-    (overlay / "patch_x.py").write_text(
-        OVERLAY_OK + 'NATIVE = "exllamav3.modules.native"\n'
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--exl3-root", str(root)],
+        capture_output=True,
+        text=True,
+        check=False,
     )
-    report = MODULE.audit(
-        root,
-        root / "exllamav3",
-        "exllamav3.modules.quant.exl3",
-        MODULE.worst_case_slots(8, 32, 7),
-        overlay,
-    )
-    assert "exllamav3.modules.native" in report["advisory_closure_call_site_modules"], (
-        "an overlay that names a native mgemm module must appear in the advisory list"
-    )
-
-
-def test_overlay_calling_mgemm_entry_point_is_reachable(tmp_path):
-    root = build_tree(tmp_path)
-    overlay = tmp_path / "overlay"
-    overlay.mkdir()
-    (overlay / "patch_x.py").write_text(OVERLAY_MGEMM)
-    report = MODULE.audit(
-        root,
-        root / "exllamav3",
-        "exllamav3.modules.quant.exl3",
-        MODULE.worst_case_slots(8, 32, 7),
-        overlay,
-    )
-    assert report["verdict"] == "REACHABLE_OVERFLOW"
-    assert report["binding_reaches_mgemm"] == ["exl3_mgemm"]
-
-
-def test_binding_check_is_clean_for_the_real_overlay_symbols(tmp_path):
-    root = build_tree(tmp_path)
-    overlay = tmp_path / "overlay"
-    overlay.mkdir()
-    (overlay / "patch_x.py").write_text(OVERLAY_OK)
-    report = MODULE.audit(
-        root,
-        root / "exllamav3",
-        "exllamav3.modules.quant.exl3",
-        MODULE.worst_case_slots(8, 32, 7),
-        overlay,
-    )
-    assert report["verdict"] == "NOT_REACHABLE"
-    assert report["binding_reaches_mgemm"] == []
-    assert report["overlay_ext_symbols"] == ["exl3_moe"]
-    assert report["mgemm_entry_points"] == ["exl3_mgemm"]
-
-
-def test_overlay_without_ext_symbols_aborts(tmp_path):
-    root = build_tree(tmp_path)
-    overlay = tmp_path / "overlay"
-    overlay.mkdir()
-    (overlay / "patch_x.py").write_text(OVERLAY_NO_SYMBOL)
-    with pytest.raises(MODULE.Abort):
-        MODULE.audit(
-            root,
-            root / "exllamav3",
-            "exllamav3.modules.quant.exl3",
-            MODULE.worst_case_slots(8, 4, 7),
-            overlay,
-        )
-
-
-def test_bindings_without_mgemm_entry_aborts(tmp_path):
-    root = build_tree(tmp_path)
-    bindings = root / "exllamav3/exllamav3_ext/bindings.cpp"
-    bindings.write_text(BINDINGS_CPP.replace('m.def("exl3_mgemm"', 'm.def("exl3_other"'))
-    with pytest.raises(MODULE.Abort):
-        MODULE.audit(
-            root,
-            root / "exllamav3",
-            "exllamav3.modules.quant.exl3",
-            MODULE.worst_case_slots(8, 4, 7),
-        )
-
-
-def test_stub_namespace_is_not_descended(tmp_path):
-    """`exllamav3.modules` is stubbed at runtime, so modules/__init__ never runs."""
-    root = build_tree(tmp_path)
-    pkg = root / "exllamav3"
-    (pkg / "modules/__init__.py").write_text("from . import native\n")
-    closure = MODULE.import_closure(
-        pkg, ["exllamav3.modules.quant.exl3", "exllamav3.modules"]
-    )
-    assert "exllamav3.modules" in closure
-    assert "exllamav3.modules.native" not in closure, (
-        "the synthetic stub namespace must not pull in the native model modules"
-    )
-    overlay = tmp_path / "overlay"
-    overlay.mkdir()
-    (overlay / "patch_x.py").write_text(
-        OVERLAY_OK + 'MODULE = "exllamav3.modules"\n'
-    )
-    report = MODULE.audit(
-        root,
-        pkg,
-        "exllamav3.modules.quant.exl3",
-        MODULE.worst_case_slots(8, 32, 7),
-        overlay,
-    )
-    assert report["verdict"] == "NOT_REACHABLE"
-
-
-def test_overlay_dir_missing_aborts(tmp_path):
-    root = build_tree(tmp_path)
-    with pytest.raises(MODULE.Abort):
-        MODULE.audit(
-            root,
-            root / "exllamav3",
-            "exllamav3.modules.quant.exl3",
-            MODULE.worst_case_slots(8, 4, 7),
-            tmp_path / "absent",
-        )
+    assert result.returncode == 1
+    assert json.loads(result.stdout)["verdict"] == "ABORT"

--- a/tests/test_exl3_mgemm_indices_audit.py
+++ b/tests/test_exl3_mgemm_indices_audit.py
@@ -120,6 +120,14 @@ def forward_indirect(x):
     return native(x)
 """
 
+SERVING_PY_RELATIVE_ALIAS = SERVING_PY + """\
+from . import helper
+
+
+def forward_relative(x):
+    return helper.run(x)
+"""
+
 SERVING_PY_BROKEN = "def broken(:\n"
 
 NATIVE_PY = """\
@@ -136,7 +144,8 @@ void bind(py::module& m)
 }
 """
 
-# Satisfies the stub contract the audit checks before pruning STUB_NAMESPACES.
+# Satisfies the stub contract the audit checks before pruning STUB_NAMESPACES:
+# the namespaces must actually be installed, not merely named.
 STUB_NAMESPACE_PY = '''\
 import sys
 import types
@@ -145,10 +154,26 @@ from pathlib import Path
 
 def inject_config_stub(package_root: Path, modules: dict | None = None) -> types.ModuleType:
     modules = sys.modules if modules is None else modules
-    for name in ("exllamav3", "exllamav3.modules", "exllamav3.model"):
-        modules[name] = types.ModuleType(name)
+    for name, path in (
+        ("exllamav3", package_root),
+        ("exllamav3.modules", package_root / "modules"),
+        ("exllamav3.model", package_root / "model"),
+    ):
+        if name in modules:
+            continue
+        module = types.ModuleType(name)
+        module.__file__ = str(path / "__init__.py")
+        module.__package__ = name
+        module.__path__ = [str(path)]
+        modules[name] = module
     return modules["exllamav3.model"]
 '''
+
+# Mentions every token the old presence check looked for while installing
+# nothing: `types.ModuleType` is constructed but never stored in the mapping.
+STUB_NAMESPACE_NOT_INSTALLING = STUB_NAMESPACE_PY.replace(
+    "        modules[name] = module\n", "        unused = types.ModuleType(name)\n"
+)
 
 # The overlay must name at least one extension symbol, or the audit refuses.
 OVERLAY_SYMBOLS = 'SYMBOL = "exllamav3_ext.exl3_moe"\n'
@@ -350,8 +375,17 @@ def test_stub_contract_aborts_when_a_namespace_is_not_installed(tmp_path):
     overlay = tmp_path / "overlay"
     overlay.mkdir()
     (overlay / "exl3_namespace.py").write_text(
-        STUB_NAMESPACE_PY.replace('"exllamav3.modules", ', "")
+        STUB_NAMESPACE_PY.replace('        ("exllamav3.modules", package_root / "modules"),\n', "")
     )
+    with pytest.raises(MODULE.Abort):
+        MODULE.stub_contract(overlay)
+
+
+def test_stub_contract_aborts_when_nothing_is_actually_installed(tmp_path):
+    """Constructing a ModuleType without storing it installs nothing."""
+    overlay = tmp_path / "overlay"
+    overlay.mkdir()
+    (overlay / "exl3_namespace.py").write_text(STUB_NAMESPACE_NOT_INSTALLING)
     with pytest.raises(MODULE.Abort):
         MODULE.stub_contract(overlay)
 
@@ -564,3 +598,38 @@ def test_cli_aborts_without_an_overlay_dir(tmp_path):
     )
     assert result.returncode == 1
     assert json.loads(result.stdout)["verdict"] == "ABORT"
+
+
+# --- finding 1 (second pass): relative import aliases ----------------------
+
+
+def test_relative_import_alias_module_is_not_certified_unreachable(tmp_path):
+    """`from . import helper` names a submodule whose call sites are reachable.
+
+    The relative branch previously queued only the base package, so a helper
+    reached that way never entered the closure and a reachable path was
+    certified NOT_REACHABLE.
+    """
+    root = build_tree(tmp_path, serving=SERVING_PY_RELATIVE_ALIAS)
+    (root / "exllamav3/modules/quant/helper.py").write_text(NATIVE_PY)
+    report = MODULE.audit(
+        root,
+        root / "exllamav3",
+        "exllamav3.modules.quant.exl3",
+        MODULE.worst_case_slots(8, 4, 7),
+        build_overlay(tmp_path),
+    )
+    assert report["verdict"] == "ABORT", report["reason"]
+    assert (
+        "exllamav3.modules.quant.helper"
+        in report["unresolved_closure_call_site_modules"]
+    )
+
+
+def test_relative_alias_resolves_to_the_submodule(tmp_path):
+    root = build_tree(tmp_path, serving=SERVING_PY_RELATIVE_ALIAS)
+    (root / "exllamav3/modules/quant/helper.py").write_text("run = None\n")
+    closure = MODULE.import_closure(
+        root / "exllamav3", ["exllamav3.modules.quant.exl3"]
+    )
+    assert "exllamav3.modules.quant.helper" in closure["modules"]

--- a/tests/test_exl3_mgemm_indices_audit.py
+++ b/tests/test_exl3_mgemm_indices_audit.py
@@ -1,0 +1,491 @@
+#!/usr/bin/env python3
+"""CPU tests for the task 37 unenforced 128-slot v_indices audit.
+
+Every case runs against a synthetic ExLlamaV3 tree so the suite is hermetic and
+does not need the 100+ GiB checkout or a GPU.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/audit_exl3_mgemm_indices.py"
+SPEC = importlib.util.spec_from_file_location("exl3_mgemm_audit", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+KERNEL_HEADER = """\
+#define MAX_INDICES 128
+
+__device__ int64_t v_indices[128];
+__device__ half v_weights[128];
+__device__ int bszm_sync;
+
+__global__ __launch_bounds__(256)
+void exl3_gemm_kernel(int x)
+{
+    int y = x;
+}
+
+__global__ __launch_bounds__(256)
+void exl3_mgemm_kernel(int bszm)
+{
+    if (min_index >= 0)
+    {
+        for (int i = 0; i < bszm; ++i)
+        {
+            v_indices[i] = -1;
+            v_weights[i] = __float2half(0.0f);
+        }
+    }
+}
+"""
+
+KERNEL_HEADER_ORPHAN = KERNEL_HEADER.replace(
+    "void exl3_gemm_kernel(int x)\n{\n    int y = x;\n}",
+    "void exl3_gemm_kernel(int x)\n{\n    v_indices[x] = 0;\n}",
+)
+
+LINEAR_CPP = """\
+void BC_LinearEXL3::run_gr(const at::Tensor& x, at::Tensor& y, Graph* graph)
+{
+    if (x.numel() == x.size(-1))
+    {
+        exl3_gemm_gr(x, trellis, y, suh, xh, svh, -1, mcg, mul1, 0, graph);
+    }
+    else
+    {
+        exl3_gemm(x, trellis, y, suh, xh_, svh, -1, mcg, mul1, 0);
+    }
+}
+
+void BC_LinearEXL3::run(const at::Tensor& x, at::Tensor& y)
+{
+    run_gr(x, y, nullptr);
+}
+"""
+
+LINEAR_CPP_MGEMM = LINEAR_CPP.replace(
+    "        exl3_gemm(x, trellis, y, suh, xh_, svh, -1, mcg, mul1, 0);",
+    "        exl3_gemm(x, trellis, y, suh, xh_, svh, -1, mcg, mul1, 0);\n"
+    "        exl3_mgemm_gr(x, trellis, y, suh, xh_, svh, {}, {}, 0, 0, 0, 0, 8, 0, graph);",
+)
+
+GEMM_CU = """\
+int exl3_mgemm_gr(const at::Tensor& A)
+{
+    TORCH_CHECK(num_tokens == 1 && min_index < 0 && !weights,
+                "exl3_mgemm: per-matrix widths incompatible with multi-token");
+    return 0;
+}
+"""
+
+SERVING_PY = """\
+from ...model.config import Config
+from .exl3_lib.quantize import q
+
+
+class LinearEXL3:
+    def forward(self, x):
+        return q(x)
+"""
+
+SERVING_PY_MGEMM = SERVING_PY + """\
+
+def bad(x):
+    return ext.exl3_mgemm(x, x, x, x, x, x, None, None, 4, 0, 1, 1, -1, -1, 0, 1)
+"""
+
+NATIVE_PY = """\
+def native(x):
+    return ext.exl3_mgemm(x, x, x, x, x, x, None, None, 4, 0, 1, 1, 0, 8, 0, 1)
+"""
+
+BINDINGS_CPP = """\
+void bind(py::module& m)
+{
+    m.def("exl3_gemm", &exl3_gemm, "exl3_gemm");
+    m.def("exl3_mgemm", &exl3_mgemm, "exl3_mgemm");
+    m.def("exl3_moe", &exl3_moe, "exl3_moe");
+}
+"""
+
+OVERLAY_OK = """\
+SYMBOL = "exllamav3_ext.exl3_moe"
+MODULE = "exllamav3.modules.quant.exl3"
+"""
+
+OVERLAY_MGEMM = """\
+SYMBOL = "exllamav3_ext.exl3_mgemm"
+MODULE = "exllamav3.modules.quant.exl3"
+"""
+
+OVERLAY_NO_SYMBOL = """\
+MODULE = "exllamav3.modules.quant.exl3"
+"""
+
+
+def build_tree(
+    tmp_path: Path,
+    *,
+    kernel: str = KERNEL_HEADER,
+    linear: str = LINEAR_CPP,
+    gemm: str = GEMM_CU,
+    serving: str = SERVING_PY,
+) -> Path:
+    root = tmp_path / "exllamav3"
+    pkg = root / "exllamav3"
+    (pkg / "exllamav3_ext/quant").mkdir(parents=True)
+    (pkg / "exllamav3_ext/libtorch").mkdir(parents=True)
+    (pkg / "model").mkdir(parents=True)
+    (pkg / "util").mkdir(parents=True)
+    (pkg / "modules/quant/exl3_lib").mkdir(parents=True)
+
+    (pkg / "exllamav3_ext/quant/exl3_gemm_kernel.cuh").write_text(kernel)
+    (pkg / "exllamav3_ext/quant/exl3_gemm.cu").write_text(gemm)
+    (pkg / "exllamav3_ext/libtorch/linear.cpp").write_text(linear)
+    (pkg / "exllamav3_ext/bindings.cpp").write_text(BINDINGS_CPP)
+
+    for rel in (
+        "__init__.py",
+        "model/__init__.py",
+        "util/__init__.py",
+        "modules/__init__.py",
+        "modules/quant/__init__.py",
+        "modules/quant/exl3_lib/__init__.py",
+    ):
+        (pkg / rel).write_text("")
+    (pkg / "model/config.py").write_text("Config = object\n")
+    (pkg / "util/helpers.py").write_text("q = None\n")
+    (pkg / "modules/quant/exl3_lib/quantize.py").write_text("q = None\n")
+    (pkg / "modules/quant/exl3.py").write_text(serving)
+    (pkg / "modules/native.py").write_text(NATIVE_PY)
+    return root
+
+
+def run(tmp_path: Path, shapes=None, **kwargs):
+    defaults = {
+        "kernel": KERNEL_HEADER,
+        "linear": LINEAR_CPP,
+        "gemm": GEMM_CU,
+        "serving": SERVING_PY,
+    }
+    defaults.update(kwargs)
+    root = build_tree(tmp_path, **defaults)
+    return MODULE.audit(
+        root,
+        root / "exllamav3",
+        "exllamav3.modules.quant.exl3",
+        shapes or MODULE.worst_case_slots(8, 4, 7),
+    )
+
+
+def test_scratch_writes_are_confined_to_the_mgemm_kernel(tmp_path):
+    scratch = MODULE.kernel_scratch(KERNEL_HEADER)
+    assert scratch["max_indices"] == 128
+    assert scratch["writer_kernels"] == ["exl3_mgemm_kernel"]
+    assert scratch["writes_outside_mgemm_kernel"] == []
+    assert sorted(scratch["arrays"]) == ["v_indices", "v_weights"]
+
+
+def test_orphan_writer_is_reported(tmp_path):
+    scratch = MODULE.kernel_scratch(KERNEL_HEADER_ORPHAN)
+    assert scratch["writes_outside_mgemm_kernel"], "orphan write must be surfaced"
+    assert "exl3_gemm_kernel" in scratch["writer_kernels"]
+
+
+def test_missing_declaration_aborts():
+    with pytest.raises(MODULE.Abort):
+        MODULE.kernel_scratch(KERNEL_HEADER.replace("#define MAX_INDICES 128", ""))
+
+
+def test_missing_scratch_arrays_abort():
+    with pytest.raises(MODULE.Abort):
+        MODULE.kernel_scratch(KERNEL_HEADER.replace("__device__ half v_weights[128];", ""))
+
+
+def test_serving_path_calls_gemm_and_never_mgemm():
+    path = MODULE.serving_path(LINEAR_CPP)
+    assert path["calls_exl3_gemm_gr"] is True
+    assert path["calls_exl3_gemm"] is True
+    assert path["calls_exl3_mgemm"] is False
+
+
+def test_serving_path_detects_mgemm_regression():
+    path = MODULE.serving_path(LINEAR_CPP_MGEMM)
+    assert path["calls_exl3_mgemm"] is True
+
+
+def test_serving_path_aborts_without_the_gemm_call():
+    with pytest.raises(MODULE.Abort):
+        MODULE.serving_path(LINEAR_CPP.replace("exl3_gemm_gr(", "something_else("))
+
+
+def test_gemm_guards_present():
+    guards = MODULE.gemm_guards(GEMM_CU)
+    assert guards["sliced_mode_requires_min_index_negative"] is True
+    assert guards["per_matrix_widths_require_min_index_negative"] is True
+
+
+def test_gemm_guards_abort_on_missing_anchor():
+    with pytest.raises(MODULE.Abort):
+        MODULE.gemm_guards(GEMM_CU.replace("min_index < 0", "min_index >= 0"))
+
+
+def test_import_closure_follows_relative_imports(tmp_path):
+    root = build_tree(tmp_path)
+    closure = MODULE.import_closure(root / "exllamav3", ["exllamav3.modules.quant.exl3"])
+    assert "exllamav3.model.config" in closure, "relative `...model.config` must resolve"
+    assert "exllamav3.modules.quant.exl3_lib.quantize" in closure
+    assert "exllamav3.modules.native" not in closure, "unimported native module must stay out"
+
+
+def test_call_sites_enumerated(tmp_path):
+    root = build_tree(tmp_path)
+    sites = MODULE.mgemm_call_sites(root / "exllamav3")
+    assert "exllamav3.modules.native" in sites
+    assert sites["exllamav3.modules.native"] == [2]
+
+
+def test_call_site_names_match_closure_namespace(tmp_path):
+    """Guards the fail-open bug: keys and closure must share one namespace."""
+    root = build_tree(tmp_path, serving=SERVING_PY_MGEMM)
+    sites = MODULE.mgemm_call_sites(root / "exllamav3")
+    closure = MODULE.import_closure(
+        root / "exllamav3", ["exllamav3.modules.quant.exl3"]
+    )
+    assert "exllamav3.modules.quant.exl3" in sites
+    assert "exllamav3.modules.quant.exl3" in closure
+
+
+def test_verdict_not_reachable(tmp_path):
+    report = run(tmp_path)
+    assert report["verdict"] == "NOT_REACHABLE"
+    assert report["decisive_reachable"] == []
+    assert report["binding_reaches_mgemm"] == []
+    assert report["serving_path"]["calls_exl3_mgemm"] is False
+
+
+def test_verdict_reachable_overflow(tmp_path):
+    """32 concurrent sequences x top_k 8 = 256 slots, above MAX_INDICES."""
+    report = run(
+        tmp_path,
+        shapes=MODULE.worst_case_slots(8, 32, 7),
+        serving=SERVING_PY_MGEMM,
+    )
+    assert report["verdict"] == "REACHABLE_OVERFLOW"
+    assert report["decisive_reachable"] == ["exllamav3.modules.quant.exl3"]
+
+
+def test_verdict_reachable_ok_when_shapes_fit(tmp_path):
+    report = run(tmp_path, serving=SERVING_PY_MGEMM)
+    assert report["verdict"] == "REACHABLE_OK"
+
+
+def test_closure_is_advisory_only(tmp_path):
+    """A native module in the closure is context, not a reachability verdict."""
+    root = build_tree(tmp_path)
+    overlay = tmp_path / "overlay"
+    overlay.mkdir()
+    (overlay / "patch_x.py").write_text(
+        OVERLAY_OK + 'NATIVE = "exllamav3.modules.native"\n'
+    )
+    report = MODULE.audit(
+        root,
+        root / "exllamav3",
+        "exllamav3.modules.quant.exl3",
+        MODULE.worst_case_slots(8, 32, 7),
+        overlay,
+    )
+    assert "exllamav3.modules.native" in report["advisory_closure_call_site_modules"]
+    assert report["verdict"] == "NOT_REACHABLE"
+    assert report["decisive_reachable"] == []
+
+
+def test_orphan_writer_forces_abort(tmp_path):
+    report = run(tmp_path, kernel=KERNEL_HEADER_ORPHAN)
+    assert report["verdict"] == "ABORT"
+
+
+def test_worst_case_slots_is_batch_times_topk():
+    shapes = MODULE.worst_case_slots(top_k=8, max_num_seqs=4, draft_tokens=7)
+    assert shapes["num_tokens_1_slots_batch_x_topk"] == 32
+    assert shapes["num_tokens_gt_1_slots_bszm"] == 32
+
+
+def test_missing_source_aborts(tmp_path):
+    root = build_tree(tmp_path)
+    (root / "exllamav3/exllamav3_ext/libtorch/linear.cpp").unlink()
+    with pytest.raises(MODULE.Abort):
+        MODULE.audit(
+            root,
+            root / "exllamav3",
+            "exllamav3.modules.quant.exl3",
+            MODULE.worst_case_slots(8, 4, 7),
+        )
+
+
+def test_cli_exit_codes(tmp_path):
+    root = build_tree(tmp_path)
+    ok = subprocess.run(
+        [sys.executable, str(SCRIPT), "--exl3-root", str(root)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert ok.returncode == 0, ok.stderr
+    assert json.loads(ok.stdout)["verdict"] == "NOT_REACHABLE"
+
+    bad = subprocess.run(
+        [sys.executable, str(SCRIPT), "--exl3-root", str(tmp_path / "nope")],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert bad.returncode == 1
+    assert json.loads(bad.stdout)["verdict"] == "ABORT"
+
+    overflow_root = build_tree(tmp_path / "overflow", serving=SERVING_PY_MGEMM)
+    overflow = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--exl3-root",
+            str(overflow_root),
+            "--max-num-seqs",
+            "32",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert overflow.returncode == 2
+    assert json.loads(overflow.stdout)["verdict"] == "REACHABLE_OVERFLOW"
+
+
+def test_overlay_dir_seeds_closure(tmp_path):
+    root = build_tree(tmp_path)
+    overlay = tmp_path / "overlay"
+    overlay.mkdir()
+    (overlay / "patch_x.py").write_text(
+        OVERLAY_OK + 'NATIVE = "exllamav3.modules.native"\n'
+    )
+    report = MODULE.audit(
+        root,
+        root / "exllamav3",
+        "exllamav3.modules.quant.exl3",
+        MODULE.worst_case_slots(8, 32, 7),
+        overlay,
+    )
+    assert "exllamav3.modules.native" in report["advisory_closure_call_site_modules"], (
+        "an overlay that names a native mgemm module must appear in the advisory list"
+    )
+
+
+def test_overlay_calling_mgemm_entry_point_is_reachable(tmp_path):
+    root = build_tree(tmp_path)
+    overlay = tmp_path / "overlay"
+    overlay.mkdir()
+    (overlay / "patch_x.py").write_text(OVERLAY_MGEMM)
+    report = MODULE.audit(
+        root,
+        root / "exllamav3",
+        "exllamav3.modules.quant.exl3",
+        MODULE.worst_case_slots(8, 32, 7),
+        overlay,
+    )
+    assert report["verdict"] == "REACHABLE_OVERFLOW"
+    assert report["binding_reaches_mgemm"] == ["exl3_mgemm"]
+
+
+def test_binding_check_is_clean_for_the_real_overlay_symbols(tmp_path):
+    root = build_tree(tmp_path)
+    overlay = tmp_path / "overlay"
+    overlay.mkdir()
+    (overlay / "patch_x.py").write_text(OVERLAY_OK)
+    report = MODULE.audit(
+        root,
+        root / "exllamav3",
+        "exllamav3.modules.quant.exl3",
+        MODULE.worst_case_slots(8, 32, 7),
+        overlay,
+    )
+    assert report["verdict"] == "NOT_REACHABLE"
+    assert report["binding_reaches_mgemm"] == []
+    assert report["overlay_ext_symbols"] == ["exl3_moe"]
+    assert report["mgemm_entry_points"] == ["exl3_mgemm"]
+
+
+def test_overlay_without_ext_symbols_aborts(tmp_path):
+    root = build_tree(tmp_path)
+    overlay = tmp_path / "overlay"
+    overlay.mkdir()
+    (overlay / "patch_x.py").write_text(OVERLAY_NO_SYMBOL)
+    with pytest.raises(MODULE.Abort):
+        MODULE.audit(
+            root,
+            root / "exllamav3",
+            "exllamav3.modules.quant.exl3",
+            MODULE.worst_case_slots(8, 4, 7),
+            overlay,
+        )
+
+
+def test_bindings_without_mgemm_entry_aborts(tmp_path):
+    root = build_tree(tmp_path)
+    bindings = root / "exllamav3/exllamav3_ext/bindings.cpp"
+    bindings.write_text(BINDINGS_CPP.replace('m.def("exl3_mgemm"', 'm.def("exl3_other"'))
+    with pytest.raises(MODULE.Abort):
+        MODULE.audit(
+            root,
+            root / "exllamav3",
+            "exllamav3.modules.quant.exl3",
+            MODULE.worst_case_slots(8, 4, 7),
+        )
+
+
+def test_stub_namespace_is_not_descended(tmp_path):
+    """`exllamav3.modules` is stubbed at runtime, so modules/__init__ never runs."""
+    root = build_tree(tmp_path)
+    pkg = root / "exllamav3"
+    (pkg / "modules/__init__.py").write_text("from . import native\n")
+    closure = MODULE.import_closure(
+        pkg, ["exllamav3.modules.quant.exl3", "exllamav3.modules"]
+    )
+    assert "exllamav3.modules" in closure
+    assert "exllamav3.modules.native" not in closure, (
+        "the synthetic stub namespace must not pull in the native model modules"
+    )
+    overlay = tmp_path / "overlay"
+    overlay.mkdir()
+    (overlay / "patch_x.py").write_text(
+        OVERLAY_OK + 'MODULE = "exllamav3.modules"\n'
+    )
+    report = MODULE.audit(
+        root,
+        pkg,
+        "exllamav3.modules.quant.exl3",
+        MODULE.worst_case_slots(8, 32, 7),
+        overlay,
+    )
+    assert report["verdict"] == "NOT_REACHABLE"
+
+
+def test_overlay_dir_missing_aborts(tmp_path):
+    root = build_tree(tmp_path)
+    with pytest.raises(MODULE.Abort):
+        MODULE.audit(
+            root,
+            root / "exllamav3",
+            "exllamav3.modules.quant.exl3",
+            MODULE.worst_case_slots(8, 4, 7),
+            tmp_path / "absent",
+        )

--- a/tests/test_exl3_mgemm_indices_audit.py
+++ b/tests/test_exl3_mgemm_indices_audit.py
@@ -152,8 +152,18 @@ import types
 from pathlib import Path
 
 
+class InferParams:
+    pass
+
+
+class NullConfig:
+    def __init__(self) -> None:
+        self.infer_params = InferParams()
+
+
 def inject_config_stub(package_root: Path, modules: dict | None = None) -> types.ModuleType:
     modules = sys.modules if modules is None else modules
+    package_root = Path(package_root)
     for name, path in (
         ("exllamav3", package_root),
         ("exllamav3.modules", package_root / "modules"),
@@ -166,8 +176,38 @@ def inject_config_stub(package_root: Path, modules: dict | None = None) -> types
         module.__package__ = name
         module.__path__ = [str(path)]
         modules[name] = module
-    return modules["exllamav3.model"]
+
+    existing = modules.get("exllamav3.model.config")
+    if existing is not None:
+        return existing
+    config = types.ModuleType("exllamav3.model.config")
+    config.__file__ = str(package_root / "model/config.py")
+    config.__package__ = "exllamav3.model"
+    config.Config = type("Config", (), {})
+    config.InferParams = InferParams
+    config.NullConfig = NullConfig
+    modules[config.__name__] = config
+    return config
 '''
+
+# Installs the three package namespaces but leaves the real ``model/config.py``
+# to execute. That file is the only route into ``architecture/``, so an overlay
+# shaped like this must never be certified NOT_REACHABLE.
+STUB_NAMESPACE_WITHOUT_CONFIG = STUB_NAMESPACE_PY.replace(
+    """    existing = modules.get("exllamav3.model.config")
+    if existing is not None:
+        return existing
+    config = types.ModuleType("exllamav3.model.config")
+    config.__file__ = str(package_root / "model/config.py")
+    config.__package__ = "exllamav3.model"
+    config.Config = type("Config", (), {})
+    config.InferParams = InferParams
+    config.NullConfig = NullConfig
+    modules[config.__name__] = config
+    return config
+""",
+    '    return modules["exllamav3.model"]\n',
+)
 
 # Mentions every token the old presence check looked for while installing
 # nothing: `types.ModuleType` is constructed but never stored in the mapping.
@@ -522,8 +562,11 @@ def test_unparseable_serving_module_aborts(tmp_path):
 
 
 def test_unparseable_closure_module_aborts(tmp_path):
+    # A module the closure actually walks. ``model/config.py`` is no longer a
+    # valid target: it is a stub namespace, so its body never runs and the audit
+    # deliberately never parses it (see test_stubbed_config_namespace_is_not_parsed).
     root = build_tree(tmp_path)
-    (root / "exllamav3/model/config.py").write_text("def broken(:\n")
+    (root / "exllamav3/modules/quant/exl3_lib/quantize.py").write_text("def broken(:\n")
     with pytest.raises(MODULE.Abort):
         MODULE.audit(
             root,
@@ -715,3 +758,132 @@ def test_installer_called_after_an_exllamav3_import_aborts(tmp_path):
 def test_stub_contract_records_which_overlay_invokes_the_installer():
     contract = MODULE.stub_contract(ROOT / "overlay")
     assert contract["invoked_by"].endswith("exl3_namespace.py")
+
+
+# --- the model.config stub namespace ---------------------------------------
+#
+# The serving module's first import is `from ...model.config import Config`, and
+# the real model/config.py reaches architecture/architectures.py -- which imports
+# every architecture, including the ones pulling in modules.attn, modules.dsv4
+# and modules.gated_delta_net -- from a function-local import. Stubbing that
+# namespace is what keeps the whole fan-out out of the runtime closure.
+
+CONFIG_PY_ARCHITECTURE_FANOUT = """\
+class Config:
+    def load(self):
+        from exllamav3.architecture.architectures import get_architectures
+        return get_architectures()
+"""
+
+
+def _add_architecture_fanout(root: Path) -> None:
+    """Mirror the real chain: model/config.py -> architecture -> modules.native."""
+    pkg = root / "exllamav3"
+    (pkg / "architecture").mkdir(parents=True, exist_ok=True)
+    (pkg / "model/config.py").write_text(CONFIG_PY_ARCHITECTURE_FANOUT)
+    (pkg / "architecture/__init__.py").write_text("")
+    (pkg / "architecture/architectures.py").write_text("from .nativearch import NativeModel\n")
+    (pkg / "architecture/nativearch.py").write_text("from ..modules.native import native\n")
+
+
+def test_installed_stub_names_resolves_a_dunder_name_key():
+    """`mapping[config.__name__] = config` installs that namespace."""
+    source = (
+        "import types\n"
+        "def inject_config_stub(root, modules=None):\n"
+        "    config = types.ModuleType('exllamav3.model.config')\n"
+        "    modules[config.__name__] = config\n"
+        "    return config\n"
+    )
+    assert MODULE._installed_stub_names(source) == {"exllamav3.model.config"}
+
+
+def test_installed_stub_names_ignores_a_mismatched_dunder_name_key():
+    """`mapping[other.__name__] = config` installs other, not config."""
+    source = (
+        "import types\n"
+        "def inject_config_stub(root, modules=None):\n"
+        "    other = types.ModuleType('exllamav3.other')\n"
+        "    config = types.ModuleType('exllamav3.model.config')\n"
+        "    modules[other.__name__] = config\n"
+        "    return config\n"
+    )
+    assert MODULE._installed_stub_names(source) == set()
+
+
+def test_installed_stub_names_ignores_a_non_literal_module_name():
+    """A name the installer computes at runtime cannot be resolved statically."""
+    source = (
+        "import types\n"
+        "def inject_config_stub(root, modules=None, name=None):\n"
+        "    config = types.ModuleType(name)\n"
+        "    modules[config.__name__] = config\n"
+        "    return config\n"
+    )
+    assert MODULE._installed_stub_names(source) == set()
+
+
+def test_installed_stub_names_recognises_the_real_overlay():
+    source = (ROOT / "overlay/exl3_namespace.py").read_text()
+    installed = MODULE._installed_stub_names(source)
+    assert "exllamav3.model.config" in installed
+    assert not (MODULE.STUB_NAMESPACES - installed)
+
+
+def test_stub_contract_requires_the_config_namespace(tmp_path):
+    overlay = build_overlay(tmp_path, stub=STUB_NAMESPACE_WITHOUT_CONFIG)
+    with pytest.raises(MODULE.Abort) as excinfo:
+        MODULE.stub_contract(overlay)
+    assert "exllamav3.model.config" in str(excinfo.value)
+
+
+def test_stubbed_config_namespace_is_not_parsed(tmp_path):
+    """The stub replaces the real module, so its body is never read."""
+    root = build_tree(tmp_path)
+    (root / "exllamav3/model/config.py").write_text("def broken(:\n")
+    result = MODULE.audit(
+        root,
+        root / "exllamav3",
+        "exllamav3.modules.quant.exl3",
+        MODULE.worst_case_slots(8, 4, 7),
+        build_overlay(tmp_path),
+    )
+    assert result["verdict"] == "NOT_REACHABLE"
+
+
+def test_config_stub_keeps_the_architecture_fanout_out_of_the_closure(tmp_path):
+    root = build_tree(tmp_path)
+    _add_architecture_fanout(root)
+    closure = MODULE.import_closure(root / "exllamav3", ["exllamav3.modules.quant.exl3"])
+    assert "exllamav3.architecture.architectures" not in closure["modules"]
+    assert "exllamav3.modules.native" not in closure["modules"]
+
+
+def test_the_fanout_enters_the_closure_when_config_is_not_stubbed(tmp_path, monkeypatch):
+    """The negative control for the test above."""
+    root = build_tree(tmp_path)
+    _add_architecture_fanout(root)
+    monkeypatch.setattr(
+        MODULE, "STUB_NAMESPACES", frozenset({"exllamav3.modules", "exllamav3.model"})
+    )
+    closure = MODULE.import_closure(root / "exllamav3", ["exllamav3.modules.quant.exl3"])
+    assert "exllamav3.architecture.architectures" in closure["modules"]
+    assert "exllamav3.modules.native" in closure["modules"]
+
+
+def test_unstubbed_fanout_is_reported_rather_than_certified(tmp_path, monkeypatch):
+    """With the fan-out live, the call-site module must not be certified clear."""
+    root = build_tree(tmp_path)
+    _add_architecture_fanout(root)
+    monkeypatch.setattr(
+        MODULE, "STUB_NAMESPACES", frozenset({"exllamav3.modules", "exllamav3.model"})
+    )
+    report = MODULE.audit(
+        root,
+        root / "exllamav3",
+        "exllamav3.modules.quant.exl3",
+        MODULE.worst_case_slots(8, 4, 7),
+        build_overlay(tmp_path, stub=STUB_NAMESPACE_WITHOUT_CONFIG),
+    )
+    assert report["verdict"] == "ABORT", report["reason"]
+    assert "exllamav3.modules.native" in report["unresolved_closure_call_site_modules"]

--- a/tests/test_exl3_mgemm_indices_audit.py
+++ b/tests/test_exl3_mgemm_indices_audit.py
@@ -219,11 +219,33 @@ def build_tree(
     return root
 
 
+# The loader must call the installer before importing exllamav3, or the real
+# modules/__init__.py runs and the stub-namespace pruning is unsound.
+OVERLAY_LOADER = """\
+from exl3_namespace import inject_config_stub
+
+
+def install(package_root, modules=None):
+    return inject_config_stub(package_root, modules)
+"""
+
+# Same installer, but the loader imports exllamav3 first.
+OVERLAY_LOADER_LATE = """\
+from exl3_namespace import inject_config_stub
+import exllamav3
+
+
+def install(package_root, modules=None):
+    return inject_config_stub(package_root, modules)
+"""
+
+
 def build_overlay(tmp_path: Path, *extra: str, stub: str | None = STUB_NAMESPACE_PY):
     overlay = tmp_path / "overlay"
     overlay.mkdir(exist_ok=True)
     if stub is not None:
         (overlay / "exl3_namespace.py").write_text(stub)
+        (overlay / "loader.py").write_text(OVERLAY_LOADER)
     (overlay / "patch_symbols.py").write_text(OVERLAY_SYMBOLS + "".join(extra))
     return overlay
 
@@ -633,3 +655,63 @@ def test_relative_alias_resolves_to_the_submodule(tmp_path):
         root / "exllamav3", ["exllamav3.modules.quant.exl3"]
     )
     assert "exllamav3.modules.quant.helper" in closure["modules"]
+
+
+# --- finding 1 (third pass): queue order must not weaken a requirement -----
+
+
+def test_weak_alias_before_a_required_import_does_not_hide_it(tmp_path):
+    """A weak alias candidate must not mark a hard import as already seen."""
+    root = build_tree(tmp_path)
+    (root / "exllamav3/modules/quant/exl3.py").write_text(
+        "import exllamav3.modules.quant.missing\nfrom . import missing\n"
+    )
+    closure = MODULE.import_closure(
+        root / "exllamav3", ["exllamav3.modules.quant.exl3"]
+    )
+    assert "exllamav3.modules.quant.missing" in closure["unresolved"]
+
+
+def test_required_import_before_a_weak_alias_also_reports(tmp_path):
+    root = build_tree(tmp_path)
+    (root / "exllamav3/modules/quant/exl3.py").write_text(
+        "from . import missing\nimport exllamav3.modules.quant.missing\n"
+    )
+    closure = MODULE.import_closure(
+        root / "exllamav3", ["exllamav3.modules.quant.exl3"]
+    )
+    assert "exllamav3.modules.quant.missing" in closure["unresolved"]
+
+
+@pytest.mark.parametrize(
+    "serving",
+    [
+        "import exllamav3.modules.quant.missing\nfrom . import missing\n",
+        "from . import missing\nimport exllamav3.modules.quant.missing\n",
+    ],
+)
+def test_unresolvable_required_import_aborts_in_either_order(tmp_path, serving):
+    with pytest.raises(MODULE.Abort):
+        run(tmp_path, serving=serving)
+
+
+# --- finding 2 (third pass): the installer must actually be invoked --------
+
+
+def test_installer_present_but_never_called_aborts(tmp_path):
+    overlay = build_overlay(tmp_path)
+    (overlay / "loader.py").write_text("# nothing installs the stub\n")
+    with pytest.raises(MODULE.Abort):
+        MODULE.stub_contract(overlay)
+
+
+def test_installer_called_after_an_exllamav3_import_aborts(tmp_path):
+    overlay = build_overlay(tmp_path)
+    (overlay / "loader.py").write_text(OVERLAY_LOADER_LATE)
+    with pytest.raises(MODULE.Abort):
+        MODULE.stub_contract(overlay)
+
+
+def test_stub_contract_records_which_overlay_invokes_the_installer():
+    contract = MODULE.stub_contract(ROOT / "overlay")
+    assert contract["invoked_by"].endswith("exl3_namespace.py")

--- a/tests/test_flashkda_prefill_patch.py
+++ b/tests/test_flashkda_prefill_patch.py
@@ -202,6 +202,7 @@ def test_applies_to_the_real_deployed_kda_py():
     )
     methods = [n.name for n in klass.body if isinstance(n, ast.FunctionDef)]
     assert "_flashkda_prefill" in methods
+    assert len(_fwd_call(out).args) == MODULE.EXPECTED_FWD_ARITY
     assert MODULE.apply_to(out) == out
 
 
@@ -360,3 +361,75 @@ def test_commented_out_import_is_incomplete():
     assert MODULE.is_complete(commented) is False
     with pytest.raises(SystemExit):
         MODULE.apply_to(commented)
+
+
+# --- task 34 parity gate: the fused call's arity ---------------------------
+#
+# The first cut of this port passed two extra trailing ``None``s. The op is a
+# fixed-arity TorchScript binding, so arming raised at the first prefill:
+#   _flashkda_C::fwd() expected at most 14 argument(s) but received 16.
+# Nothing caught it, because the smoke test only proved the patched file
+# parses. These pin the count instead of assuming it.
+
+_FWD_TAIL = "            cu_seqlens.contiguous(),\n        )\n        return out, final_state"
+
+
+def _fwd_call(source: str):
+    for node in ast.walk(ast.parse(source)):
+        if (
+            isinstance(node, ast.Call)
+            and ast.unparse(node.func) == "torch.ops._flashkda_C.fwd"
+        ):
+            return node
+    return None
+
+
+def test_template_arity_matches_the_deployed_op():
+    """14 is the arity the v1.4.7 image's extension declares."""
+    assert MODULE.EXPECTED_FWD_ARITY == 14
+
+
+def test_fused_call_passes_exactly_the_deployed_arity():
+    call = _fwd_call(_complete())
+    assert call is not None, "no _flashkda_C.fwd call in the patched source"
+    assert len(call.args) == MODULE.EXPECTED_FWD_ARITY
+    assert call.keywords == [], "the deployed call site is positional-only"
+
+
+def test_two_extra_trailing_nones_are_refused():
+    """The exact defect the cluster parity gate caught."""
+    complete = _complete()
+    sixteen = complete.replace(
+        _FWD_TAIL,
+        "            cu_seqlens.contiguous(),\n            None,\n            None,\n"
+        "        )\n        return out, final_state",
+        1,
+    )
+    assert sixteen != complete, "fixture did not change; test is vacuous"
+    assert len(_fwd_call(sixteen).args) == 16
+    assert MODULE.is_complete(sixteen) is False
+    with pytest.raises(SystemExit):
+        MODULE.apply_to(sixteen)
+
+
+def test_a_wrong_arity_template_is_refused_before_writing(monkeypatch):
+    """A template that drifted from the op must fail before any file write."""
+    broken = MODULE.FLASHKDA_METHOD.replace(
+        "            cu_seqlens.contiguous(),\n        )",
+        "            cu_seqlens.contiguous(),\n            None,\n        )",
+        1,
+    )
+    assert broken != MODULE.FLASHKDA_METHOD
+    monkeypatch.setattr(MODULE, "FLASHKDA_METHOD", broken)
+    with pytest.raises(SystemExit):
+        MODULE.apply_to(FIXTURE)
+
+
+def test_keyword_style_call_does_not_satisfy_the_arity_check():
+    """Only positional arguments count, so a keyword rewrite cannot pass."""
+    complete = _complete()
+    keyworded = complete.replace(
+        "            q.contiguous(),\n", "            q=q.contiguous(),\n", 1
+    )
+    assert keyworded != complete
+    assert MODULE.is_complete(keyworded) is False

--- a/tests/test_flashkda_prefill_patch.py
+++ b/tests/test_flashkda_prefill_patch.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""CPU tests for the task 34 FlashKDA chunked-prefill overlay.
+
+The overlay is a *port* onto this fork's ``glm5next/nvidia/kda.py``, so the
+tests pin the three insertion points and the fail-closed/idempotence contract.
+A trimmed but structurally faithful fixture keeps the suite hermetic; when the
+gitignored live-image dump is present the same assertions run against the real
+deployed file.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "overlay/patch_flashkda_prefill.py"
+SPEC = importlib.util.spec_from_file_location("flashkda_overlay", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+LIVE_DUMP = (
+    ROOT
+    / "tests/fixtures/live-image-vllm/models/glm5next/nvidia/kda.py"
+)
+
+FIXTURE = '''\
+from vllm.platforms import current_platform
+
+
+def _cast_sigmoid(x):
+    return x.float().sigmoid()
+
+
+class Glm5NextLinearAttention(GatedDeltaNetAttention):
+    def __init__(self, config, vllm_config, prefix=""):
+        self.head_dim = 128
+        self.local_num_heads = 32
+        self.kda_lower_bound = -5.0
+        self._conv_state_dim_first = is_conv_state_dim_first()
+
+    def _forward(self):
+        ns_out = None
+        if attn_metadata_narrowed.num_prefills > 0:
+            initial_state = gather_initial_states(
+                recurrent_state, non_spec_state_indices_tensor, has_initial_state
+            )
+            (
+                core_attn_out_non_spec,
+                last_recurrent_state,
+            ) = chunk_kda_with_fused_gate(
+                q=_rearr(q_ns),
+                k=_rearr(k_ns),
+                v=_rearr(v_ns),
+                raw_g=g1_ns,
+                # Chunk path wants the pre-sigmoided fp32 beta (its kernels
+                # don't sigmoid); beta_ns is raw bf16 from forward.
+                beta=_cast_sigmoid(beta_ns.squeeze(0)).unsqueeze(0),
+                A_log=self.A_log,
+                g_bias=self.dt_bias,
+                initial_state=initial_state,
+                output_final_state=True,
+                use_qk_l2norm_in_kernel=True,
+                cu_seqlens=non_spec_query_start_loc,
+                safe_gate=safe_gate,
+                lower_bound=lower_bound,
+            )
+'''
+
+
+def patched(source: str = FIXTURE) -> str:
+    return MODULE.apply_to(source)
+
+
+def test_overlay_applies_and_compiles():
+    out = patched()
+    assert out != FIXTURE
+    compile(out, "kda.py", "exec")
+
+
+def test_marker_makes_it_idempotent():
+    once = patched()
+    assert MODULE.apply_to(once) == once
+    assert once.count(MODULE.MARK) > 0
+
+
+def test_helper_block_lands_before_the_class():
+    out = patched()
+    assert out.index("_glm53_flashkda_supported") < out.index(MODULE.CLASS_ANCHOR)
+
+
+def test_flashkda_method_is_a_class_method():
+    tree = ast.parse(patched())
+    klass = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name == "Glm5NextLinearAttention"
+    )
+    methods = [n.name for n in klass.body if isinstance(n, ast.FunctionDef)]
+    assert "_flashkda_prefill" in methods
+
+
+def test_init_gains_the_arm_flag_and_buffer_specs():
+    out = patched()
+    assert "self._glm53_flashkda_prefill = True" in out
+    assert "self._flashkda_buffer_specs = (" in out
+    assert "get_workspace_size" in out
+
+
+def test_call_site_becomes_a_dispatch_and_keeps_the_triton_path():
+    out = patched()
+    assert "if self._glm53_flashkda_prefill:" in out
+    assert "self._flashkda_prefill(" in out
+    # the original Triton call survives, re-indented into the else branch
+    assert "                ) = chunk_kda_with_fused_gate(" in out
+    assert "                    lower_bound=lower_bound," in out
+
+
+def test_gate_matches_the_upstream_selection_predicate():
+    out = patched()
+    for needle in (
+        "capability.major in (9, 10, 12)",
+        "head_dim == 128",
+        "torch.bfloat16",
+        "lower_bound is not None",
+    ):
+        assert needle in out, needle
+
+
+@pytest.mark.parametrize(
+    "anchor",
+    [
+        MODULE.CLASS_ANCHOR,
+        MODULE.INIT_ANCHOR,
+        MODULE.CALL_ANCHOR,
+    ],
+)
+def test_fail_closed_on_each_drifted_anchor(anchor):
+    drifted = FIXTURE.replace(anchor, "    pass  # drifted\n")
+    assert drifted != FIXTURE
+    with pytest.raises(SystemExit):
+        MODULE.apply_to(drifted)
+
+
+def test_fail_closed_on_ambiguous_anchor():
+    ambiguous = FIXTURE + "\n\n" + MODULE.CLASS_ANCHOR + "    pass\n"
+    with pytest.raises(SystemExit):
+        MODULE.apply_to(ambiguous)
+
+
+def test_unarmed_leaves_the_file_untouched(tmp_path, monkeypatch):
+    target = tmp_path / "kda.py"
+    target.write_text(FIXTURE)
+    monkeypatch.setattr(MODULE, "TARGET", target)
+    for value in ("", "triton", "TRITON"):
+        monkeypatch.setenv(MODULE.KNOB, value)
+        assert MODULE.main() == 0
+        assert target.read_text() == FIXTURE, value
+
+
+def test_invalid_knob_is_refused(tmp_path, monkeypatch):
+    monkeypatch.setenv(MODULE.KNOB, "cuda")
+    with pytest.raises(SystemExit):
+        MODULE.main()
+
+
+def test_armed_writes_a_compiling_file(tmp_path, monkeypatch):
+    target = tmp_path / "kda.py"
+    target.write_text(FIXTURE)
+    monkeypatch.setattr(MODULE, "TARGET", target)
+    monkeypatch.setenv(MODULE.KNOB, "flashkda")
+    assert MODULE.main() == 0
+    written = target.read_text()
+    compile(written, str(target), "exec")
+    assert MODULE.MARK in written
+    # second run is a no-op
+    assert MODULE.main() == 0
+    assert target.read_text() == written
+
+
+def test_missing_target_is_fail_closed(tmp_path, monkeypatch):
+    monkeypatch.setattr(MODULE, "TARGET", tmp_path / "absent.py")
+    monkeypatch.setenv(MODULE.KNOB, "flashkda")
+    with pytest.raises(SystemExit):
+        MODULE.main()
+
+
+@pytest.mark.skipif(not LIVE_DUMP.is_file(), reason="live-image dump not present")
+def test_applies_to_the_real_deployed_kda_py():
+    source = LIVE_DUMP.read_text(encoding="utf-8")
+    out = MODULE.apply_to(source)
+    compile(out, str(LIVE_DUMP), "exec")
+    tree = ast.parse(out)
+    klass = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name == "Glm5NextLinearAttention"
+    )
+    methods = [n.name for n in klass.body if isinstance(n, ast.FunctionDef)]
+    assert "_flashkda_prefill" in methods
+    assert MODULE.apply_to(out) == out

--- a/tests/test_flashkda_prefill_patch.py
+++ b/tests/test_flashkda_prefill_patch.py
@@ -345,3 +345,18 @@ def test_every_required_structure_is_present_in_a_complete_install():
     complete = _complete()
     missing = [name for name, needle in MODULE.REQUIRED_STRUCTURES if needle not in complete]
     assert missing == []
+
+
+def test_commented_out_import_is_incomplete():
+    """A commented import keeps the substring but leaves the name undefined."""
+    complete = _complete()
+    commented = complete.replace(
+        "from vllm.v1.worker.workspace import current_workspace_manager",
+        "# from vllm.v1.worker.workspace import current_workspace_manager",
+        1,
+    )
+    assert commented != complete
+    assert "current_workspace_manager" in commented
+    assert MODULE.is_complete(commented) is False
+    with pytest.raises(SystemExit):
+        MODULE.apply_to(commented)

--- a/tests/test_flashkda_prefill_patch.py
+++ b/tests/test_flashkda_prefill_patch.py
@@ -316,3 +316,32 @@ def _klass(tree):
         for node in tree.body
         if isinstance(node, ast.ClassDef) and node.name == "Glm5NextLinearAttention"
     )
+
+
+# --- finding 4 (second pass): required imports count as completeness -------
+
+
+@pytest.mark.parametrize(
+    "needle",
+    [
+        "from vllm.v1.worker.workspace import current_workspace_manager",
+        "import vllm._flashkda_C",
+        "torch.ops._flashkda_C.get_workspace_size(",
+        "current_workspace_manager().get_simultaneous(",
+    ],
+)
+def test_removing_a_required_import_is_incomplete(needle):
+    """The file would still compile but raise NameError at prefill time."""
+    complete = _complete()
+    assert needle in complete
+    without = complete.replace(needle, "", 1)
+    assert without != complete
+    assert MODULE.is_complete(without) is False
+    with pytest.raises(SystemExit):
+        MODULE.apply_to(without)
+
+
+def test_every_required_structure_is_present_in_a_complete_install():
+    complete = _complete()
+    missing = [name for name, needle in MODULE.REQUIRED_STRUCTURES if needle not in complete]
+    assert missing == []

--- a/tests/test_flashkda_prefill_patch.py
+++ b/tests/test_flashkda_prefill_patch.py
@@ -203,3 +203,116 @@ def test_applies_to_the_real_deployed_kda_py():
     methods = [n.name for n in klass.body if isinstance(n, ast.FunctionDef)]
     assert "_flashkda_prefill" in methods
     assert MODULE.apply_to(out) == out
+
+
+# --- finding 5: a marker is not evidence of installation -------------------
+
+
+def _complete(source: str = FIXTURE) -> str:
+    return MODULE.apply_to(source)
+
+
+def test_marker_only_is_not_treated_as_installed():
+    """The marker is written by several lines, so a partial file can carry it."""
+    marked = FIXTURE.replace(
+        MODULE.CLASS_ANCHOR, MODULE.MARK + "\n" + MODULE.CLASS_ANCHOR, 1
+    )
+    assert MODULE.MARK in marked
+    assert MODULE.is_complete(marked) is False
+    with pytest.raises(SystemExit):
+        MODULE.apply_to(marked)
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        pytest.param(
+            lambda s: s.replace(
+                next(
+                    line
+                    for line in s.splitlines(keepends=True)
+                    if line.strip().startswith("if self._glm53_flashkda_prefill:")
+                ),
+                "",
+                1,
+            ),
+            id="dispatch-removed",
+        ),
+        pytest.param(
+            lambda s: s.replace("self._flashkda_buffer_specs = (", "self._x = (", 1),
+            id="workspace-sizing-renamed",
+        ),
+        pytest.param(
+            lambda s: s.replace("def _glm53_flashkda_supported(", "def _other(", 1),
+            id="helper-renamed",
+        ),
+        pytest.param(
+            lambda s: s.replace("torch.ops._flashkda_C.fwd(", "torch.ops._flashkda_C.fwdX(", 1),
+            id="kernel-call-renamed",
+        ),
+        pytest.param(
+            lambda s: s.replace("self._glm53_flashkda_prefill = True", "pass", 1),
+            id="flag-removed",
+        ),
+    ],
+)
+def test_partial_installation_aborts_instead_of_reporting_installed(mutate):
+    complete = _complete()
+    partial = mutate(complete)
+    assert partial != complete, "fixture did not change; test is vacuous"
+    assert MODULE.is_complete(partial) is False
+    with pytest.raises(SystemExit):
+        MODULE.apply_to(partial)
+
+
+def test_armed_main_refuses_a_partial_installation(tmp_path, monkeypatch):
+    target = tmp_path / "kda.py"
+    target.write_text(MODULE.MARK + "\n" + FIXTURE)
+    monkeypatch.setattr(MODULE, "TARGET", target)
+    monkeypatch.setenv(MODULE.KNOB, "flashkda")
+    before = target.read_text()
+    with pytest.raises(SystemExit):
+        MODULE.main()
+    assert target.read_text() == before, "a refused install must not write"
+
+
+# --- finding 6: the method must land inside the target class ---------------
+
+
+def test_method_stays_a_class_member_with_a_trailing_function():
+    source = FIXTURE + "\n\ndef trailing_helper():\n    return 1\n"
+    tree = ast.parse(MODULE.apply_to(source))
+    klass = _klass(tree)
+    assert "_flashkda_prefill" in [n.name for n in klass.body if isinstance(n, ast.FunctionDef)]
+    assert "trailing_helper" in [
+        n.name for n in tree.body if isinstance(n, ast.FunctionDef)
+    ], "the trailing helper must remain module-level"
+
+
+def test_method_stays_a_class_member_with_a_trailing_class():
+    source = FIXTURE + "\n\nclass Later:\n    def method(self):\n        return 2\n"
+    tree = ast.parse(MODULE.apply_to(source))
+    assert "_flashkda_prefill" in [
+        n.name for n in _klass(tree).body if isinstance(n, ast.FunctionDef)
+    ]
+    later = next(n for n in tree.body if isinstance(n, ast.ClassDef) and n.name == "Later")
+    assert "_flashkda_prefill" not in [n.name for n in later.body if isinstance(n, ast.FunctionDef)]
+
+
+def test_method_does_not_land_inside_a_trailing_function():
+    """The old EOF append nested the method inside whatever came last."""
+    source = FIXTURE + "\n\ndef trailing_helper():\n    return 1\n"
+    tree = ast.parse(MODULE.apply_to(source))
+    helper = next(
+        n for n in tree.body if isinstance(n, ast.FunctionDef) and n.name == "trailing_helper"
+    )
+    nested = [n.name for n in helper.body if isinstance(n, ast.FunctionDef)]
+    assert "_flashkda_prefill" not in nested
+
+
+def _klass(tree):
+    return next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name == "Glm5NextLinearAttention"
+    )

--- a/tests/test_persistent_topk_reachability_audit.py
+++ b/tests/test_persistent_topk_reachability_audit.py
@@ -74,6 +74,26 @@ class DeepseekV4Attention:
         self.indexer_op = SparseAttnIndexer()
 """
 
+
+GLM_ATTENTION_PLAIN_CONSTRUCT = """\
+from vllm.model_executor.layers.sparse_attn_indexer_kpool import SparseAttnIndexerKpool
+from vllm.model_executor.layers.sparse_attn_indexer import SparseAttnIndexer
+
+
+class Glm5NextAttention:
+    def __init__(self):
+        self.indexer_op = SparseAttnIndexer()
+"""
+
+GLM_ATTENTION_COMMENT_ONLY = """\
+# This deployment deliberately avoids SparseAttnIndexerKpool.
+
+
+class Glm5NextAttention:
+    def __init__(self):
+        pass
+"""
+
 OVERLAY = """\
 KPOOL_OLD = "if current_platform.is_cuda() and select_k in (512, 1024, 2048):"
 KPOOL_NEW = (
@@ -247,3 +267,91 @@ def test_cli_exit_codes(tmp_path):
     )
     assert missing.returncode == 1
     assert json.loads(missing.stdout)["verdict"] == "ABORT"
+
+
+# --- finding 3: a live else/elif is not a dead branch ----------------------
+
+KPOOL_LIVE_ELSE = """\
+def _decode_topk(logits, select_k, topk_dst, seq_lens):
+    if False and current_platform.is_cuda() and select_k in (512, 1024, 2048):
+        pass
+    else:
+        torch.ops._C.persistent_topk(
+            logits,
+            seq_lens,
+            topk_dst,
+            select_k,
+        )
+"""
+
+KPOOL_DEAD_BODY_LIVE_ELSE = """\
+def _decode_topk(logits):
+    if False and current_platform.is_cuda():
+        torch.ops._C.persistent_topk(logits)
+    else:
+        torch.ops._C.persistent_topk(logits)
+"""
+
+KPOOL_DEAD_BODY_LIVE_ELIF = """\
+def _decode_topk(logits):
+    if False and current_platform.is_cuda():
+        torch.ops._C.persistent_topk(logits)
+    elif other_platform.is_cuda():
+        torch.ops._C.persistent_topk(logits)
+"""
+
+
+def test_live_else_call_is_not_classified_dead():
+    """The `else` branch is executable; walking the whole `ast.If` hid that."""
+    assert MODULE.dead_persistent_topk_branches(KPOOL_LIVE_ELSE, "kpool") == []
+    assert MODULE.live_persistent_topk(KPOOL_LIVE_ELSE, "kpool") == [5]
+
+
+def test_dead_body_with_a_live_else_keeps_the_else_call():
+    assert MODULE.dead_persistent_topk_branches(KPOOL_DEAD_BODY_LIVE_ELSE, "kpool") == [
+        {"line": 2, "persistent_topk_calls": [3], "else_branch": True, "live_kernel_calls": []}
+    ]
+    assert MODULE.live_persistent_topk(KPOOL_DEAD_BODY_LIVE_ELSE, "kpool") == [5]
+
+
+def test_dead_body_with_a_live_elif_keeps_the_elif_call():
+    assert MODULE.live_persistent_topk(KPOOL_DEAD_BODY_LIVE_ELIF, "kpool") == [5]
+
+
+def test_verdict_reachable_when_only_the_else_branch_calls_topk(tmp_path):
+    site = build_site(tmp_path, kpool=KPOOL_LIVE_ELSE)
+    report = MODULE.audit(site, build_overlay(tmp_path), None)
+    assert report["verdict"] == "REACHABLE", report["reason"]
+    assert report["live_persistent_topk_lines"] == [5]
+
+
+# --- finding 4: parse the GLM module, do not pattern-match it --------------
+
+
+def test_plain_indexer_construction_is_not_given_the_kpool_verdict():
+    """Importing the kpool name is not the same as constructing it."""
+    glm = MODULE.glm_uses_kpool(GLM_ATTENTION_PLAIN_CONSTRUCT)
+    assert glm["instantiates_kpool_class"] is False
+    assert glm["plain_indexer_constructed"] is True
+    assert glm["uses_plain_indexer"] is True
+
+
+def test_comment_only_mention_is_not_an_import_or_a_construction():
+    glm = MODULE.glm_uses_kpool(GLM_ATTENTION_COMMENT_ONLY)
+    assert glm["imports_kpool_class"] is False
+    assert glm["instantiates_kpool_class"] is False
+    assert glm["kpool_reference_lines"] == []
+
+
+def test_abort_when_glm_constructs_the_plain_indexer_instead(tmp_path):
+    site = build_site(tmp_path)
+    (site / MODULE.GLM_ATTENTION_REL).write_text(GLM_ATTENTION_PLAIN_CONSTRUCT)
+    with pytest.raises(MODULE.Abort):
+        MODULE.audit(site, build_overlay(tmp_path), None)
+
+
+def test_abort_when_glm_only_mentions_kpool_in_a_comment(tmp_path):
+    site = build_site(tmp_path)
+    (site / MODULE.GLM_ATTENTION_REL).write_text(GLM_ATTENTION_COMMENT_ONLY)
+    with pytest.raises(MODULE.Abort):
+        MODULE.audit(site, build_overlay(tmp_path), None)

--- a/tests/test_persistent_topk_reachability_audit.py
+++ b/tests/test_persistent_topk_reachability_audit.py
@@ -85,6 +85,29 @@ class Glm5NextAttention:
         self.indexer_op = SparseAttnIndexer()
 """
 
+GLM_ATTENTION_SHADOWED = """\
+from vllm.model_executor.layers.sparse_attn_indexer import SparseAttnIndexer as Indexer
+
+
+def unrelated():
+    from vllm.model_executor.layers.sparse_attn_indexer_kpool import SparseAttnIndexerKpool as Indexer
+    return Indexer
+
+
+class Glm5NextAttention:
+    def __init__(self):
+        self.indexer_op = Indexer()
+"""
+
+GLM_ATTENTION_MISSING_SYMBOL = """\
+from vllm.model_executor.layers.sparse_attn_indexer_kpool import MissingIndexer
+
+
+class Glm5NextAttention:
+    def __init__(self):
+        self.indexer_op = MissingIndexer()
+"""
+
 GLM_ATTENTION_PLAIN_ALIASED = """\
 from vllm.model_executor.layers.sparse_attn_indexer import SparseAttnIndexer as SparseAttnIndexerKpool
 
@@ -408,3 +431,34 @@ def test_import_provenance_beats_the_local_spelling():
     plain = MODULE.glm_uses_kpool(GLM_ATTENTION_PLAIN_ALIASED)
     kpool = MODULE.glm_uses_kpool(GLM_ATTENTION_KPOOL_ALIASED)
     assert plain["instantiates_kpool_class"] is not kpool["instantiates_kpool_class"]
+
+
+# --- finding 3 (third pass): bindings live in scopes, not in a flat dict ---
+
+
+def test_shadowed_binding_is_unresolved():
+    """A function-local kpool import must not overwrite a global plain one."""
+    glm = MODULE.glm_uses_kpool(GLM_ATTENTION_SHADOWED)
+    assert glm["instantiates_kpool_class"] is False
+    assert glm["unresolved_indexer_names"] == ["Indexer"]
+
+
+def test_missing_exported_symbol_is_unresolved():
+    """Importing from the kpool module is not enough; the symbol must exist."""
+    glm = MODULE.glm_uses_kpool(GLM_ATTENTION_MISSING_SYMBOL)
+    assert glm["instantiates_kpool_class"] is False
+    assert glm["unresolved_indexer_names"] == ["MissingIndexer"]
+
+
+def test_abort_on_a_shadowed_indexer_binding(tmp_path):
+    site = build_site(tmp_path)
+    (site / MODULE.GLM_ATTENTION_REL).write_text(GLM_ATTENTION_SHADOWED)
+    with pytest.raises(MODULE.Abort):
+        MODULE.audit(site, build_overlay(tmp_path), None)
+
+
+def test_abort_on_a_missing_exported_symbol(tmp_path):
+    site = build_site(tmp_path)
+    (site / MODULE.GLM_ATTENTION_REL).write_text(GLM_ATTENTION_MISSING_SYMBOL)
+    with pytest.raises(MODULE.Abort):
+        MODULE.audit(site, build_overlay(tmp_path), None)

--- a/tests/test_persistent_topk_reachability_audit.py
+++ b/tests/test_persistent_topk_reachability_audit.py
@@ -85,6 +85,24 @@ class Glm5NextAttention:
         self.indexer_op = SparseAttnIndexer()
 """
 
+GLM_ATTENTION_PLAIN_ALIASED = """\
+from vllm.model_executor.layers.sparse_attn_indexer import SparseAttnIndexer as SparseAttnIndexerKpool
+
+
+class Glm5NextAttention:
+    def __init__(self):
+        self.indexer_op = SparseAttnIndexerKpool()
+"""
+
+GLM_ATTENTION_KPOOL_ALIASED = """\
+from vllm.model_executor.layers.sparse_attn_indexer_kpool import SparseAttnIndexerKpool as Kpool
+
+
+class Glm5NextAttention:
+    def __init__(self):
+        self.indexer_op = Kpool()
+"""
+
 GLM_ATTENTION_COMMENT_ONLY = """\
 # This deployment deliberately avoids SparseAttnIndexerKpool.
 
@@ -175,10 +193,14 @@ def test_abort_when_no_persistent_topk_at_all(tmp_path):
     assert report["verdict"] == "ABORT"
 
 
-def test_abort_when_glm_no_longer_uses_the_kpool_indexer(tmp_path):
+def test_abort_when_glm_imports_the_indexer_from_an_unknown_module(tmp_path):
+    """Import provenance decides identity; an unknown source is unresolved."""
     site = build_site(tmp_path)
     (site / "models/glm5next/nvidia/attention.py").write_text(
-        GLM_ATTENTION.replace("SparseAttnIndexerKpool", "SomethingElse")
+        GLM_ATTENTION.replace(
+            "from vllm.model_executor.layers.sparse_attn_indexer_kpool import",
+            "from my.own.layers import",
+        )
     )
     with pytest.raises(MODULE.Abort):
         MODULE.audit(site, build_overlay(tmp_path), None)
@@ -355,3 +377,34 @@ def test_abort_when_glm_only_mentions_kpool_in_a_comment(tmp_path):
     (site / MODULE.GLM_ATTENTION_REL).write_text(GLM_ATTENTION_COMMENT_ONLY)
     with pytest.raises(MODULE.Abort):
         MODULE.audit(site, build_overlay(tmp_path), None)
+
+
+# --- finding 3 (second pass): constructor identity is import provenance ----
+
+
+def test_aliased_plain_import_is_not_given_the_kpool_verdict():
+    """The plain indexer imported under the kpool *name* is still the plain one."""
+    glm = MODULE.glm_uses_kpool(GLM_ATTENTION_PLAIN_ALIASED)
+    assert glm["instantiates_kpool_class"] is False
+    assert glm["plain_indexer_constructed"] is True
+    assert glm["uses_plain_indexer"] is True
+
+
+def test_abort_when_the_plain_indexer_is_aliased_to_the_kpool_name(tmp_path):
+    site = build_site(tmp_path)
+    (site / MODULE.GLM_ATTENTION_REL).write_text(GLM_ATTENTION_PLAIN_ALIASED)
+    with pytest.raises(MODULE.Abort):
+        MODULE.audit(site, build_overlay(tmp_path), None)
+
+
+def test_kpool_import_under_an_arbitrary_alias_still_resolves_to_kpool():
+    glm = MODULE.glm_uses_kpool(GLM_ATTENTION_KPOOL_ALIASED)
+    assert glm["instantiates_kpool_class"] is True
+    assert glm["uses_plain_indexer"] is False
+
+
+def test_import_provenance_beats_the_local_spelling():
+    """The same local name resolves differently depending on its source."""
+    plain = MODULE.glm_uses_kpool(GLM_ATTENTION_PLAIN_ALIASED)
+    kpool = MODULE.glm_uses_kpool(GLM_ATTENTION_KPOOL_ALIASED)
+    assert plain["instantiates_kpool_class"] is not kpool["instantiates_kpool_class"]

--- a/tests/test_persistent_topk_reachability_audit.py
+++ b/tests/test_persistent_topk_reachability_audit.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""CPU tests for the task 39 persistent-top-k reachability audit."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/audit_persistent_topk_reachability.py"
+SPEC = importlib.util.spec_from_file_location("ptopk_audit", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+GLM_ATTENTION = """\
+from vllm.model_executor.layers.sparse_attn_indexer_kpool import SparseAttnIndexerKpool
+
+
+class Glm5NextAttention:
+    def __init__(self):
+        self.indexer_op = SparseAttnIndexerKpool()
+"""
+
+KPOOL_DEAD = """\
+def _decode_topk(logits, select_k, topk_dst, seq_lens, next_n, num_rows):
+    if False and current_platform.is_cuda() and select_k in (512, 1024, 2048):
+        workspace_manager = current_workspace_manager()
+        (topk_workspace,) = workspace_manager.get_simultaneous(
+            ((RADIX_TOPK_WORKSPACE_SIZE,), torch.uint8),
+        )
+        torch.ops._C.persistent_topk(
+            logits,
+            seq_lens,
+            topk_dst,
+            topk_workspace,
+            select_k,
+            max_seq_len,
+        )
+    else:
+        torch.ops._C.top_k_per_row_decode(
+            logits,
+            next_n,
+            seq_lens,
+            topk_dst,
+            num_rows,
+            logits.stride(0),
+            logits.stride(1),
+            select_k,
+        )
+"""
+
+KPOOL_LIVE = KPOOL_DEAD.replace(
+    "if False and current_platform.is_cuda()",
+    "if current_platform.is_cuda()",
+)
+
+KPOOL_NO_TOPK = """\
+def _decode_topk(logits):
+    return logits
+"""
+
+DEEPSEEK_ATTENTION = """\
+from vllm.model_executor.layers.sparse_attn_indexer import SparseAttnIndexer
+
+
+class DeepseekV4Attention:
+    def __init__(self):
+        self.indexer_op = SparseAttnIndexer()
+"""
+
+OVERLAY = """\
+KPOOL_OLD = "if current_platform.is_cuda() and select_k in (512, 1024, 2048):"
+KPOOL_NEW = (
+    "if False and current_platform.is_cuda() and "
+    "select_k in (512, 1024, 2048):  # GB10 persistent_topk smem"
+)
+
+
+def _disable_gb10_persistent_topk() -> None:
+    text = KPOOL.read_text()
+    if KPOOL_NEW in text:
+        pass
+    elif KPOOL_OLD in text:
+        KPOOL.write_text(text.replace(KPOOL_OLD, KPOOL_NEW, 1))
+    else:
+        raise RuntimeError(
+            "glm53: kpool persistent_topk pattern not found — patch the file by hand"
+        )
+"""
+
+OVERLAY_NO_GUARD = OVERLAY.replace(
+    "kpool persistent_topk pattern not found", "boom"
+)
+
+
+def build_site(tmp_path: Path, *, kpool: str = KPOOL_DEAD) -> Path:
+    site = tmp_path / "vllm"
+    (site / "models/glm5next/nvidia").mkdir(parents=True)
+    (site / "models/deepseek_v4").mkdir(parents=True)
+    (site / "model_executor/layers").mkdir(parents=True)
+    (site / "models/glm5next/nvidia/attention.py").write_text(GLM_ATTENTION)
+    (site / "models/deepseek_v4/attention.py").write_text(DEEPSEEK_ATTENTION)
+    (site / "model_executor/layers/sparse_attn_indexer_kpool.py").write_text(kpool)
+    return site
+
+
+def build_overlay(tmp_path: Path, *, source: str = OVERLAY) -> Path:
+    overlay = tmp_path / "overlay"
+    overlay.mkdir(exist_ok=True)
+    (overlay / MODULE.OVERLAY_NAME).write_text(source)
+    return overlay
+
+
+def test_dead_branch_is_found():
+    branches = MODULE.dead_persistent_topk_branches(KPOOL_DEAD, "kpool")
+    assert len(branches) == 1
+    assert branches[0]["persistent_topk_calls"] == [7]
+    assert branches[0]["live_kernel_calls"] == [16]
+
+
+def test_live_branch_is_not_reported_as_dead():
+    assert MODULE.dead_persistent_topk_branches(KPOOL_LIVE, "kpool") == []
+
+
+def test_live_persistent_topk_detects_re_enabled_call():
+    assert MODULE.live_persistent_topk(KPOOL_DEAD, "kpool") == []
+    assert MODULE.live_persistent_topk(KPOOL_LIVE, "kpool") == [7]
+
+
+def test_verdict_not_applicable(tmp_path):
+    site = build_site(tmp_path)
+    report = MODULE.audit(site, build_overlay(tmp_path), None)
+    assert report["verdict"] == "NOT_APPLICABLE"
+    assert report["live_persistent_topk_lines"] == []
+    assert report["glm_indexer"]["uses_plain_indexer"] is False
+    assert report["overlay_guard"]["fail_closed"] is True
+
+
+def test_verdict_reachable_when_guard_is_gone(tmp_path):
+    site = build_site(tmp_path, kpool=KPOOL_LIVE)
+    report = MODULE.audit(site, build_overlay(tmp_path), None)
+    assert report["verdict"] == "REACHABLE"
+    assert report["live_persistent_topk_lines"] == [7]
+
+
+def test_abort_when_no_persistent_topk_at_all(tmp_path):
+    site = build_site(tmp_path, kpool=KPOOL_NO_TOPK)
+    report = MODULE.audit(site, build_overlay(tmp_path), None)
+    assert report["verdict"] == "ABORT"
+
+
+def test_abort_when_glm_no_longer_uses_the_kpool_indexer(tmp_path):
+    site = build_site(tmp_path)
+    (site / "models/glm5next/nvidia/attention.py").write_text(
+        GLM_ATTENTION.replace("SparseAttnIndexerKpool", "SomethingElse")
+    )
+    with pytest.raises(MODULE.Abort):
+        MODULE.audit(site, build_overlay(tmp_path), None)
+
+
+def test_plain_indexer_prefix_is_not_confused_with_kpool():
+    glm = MODULE.glm_uses_kpool(GLM_ATTENTION)
+    assert glm["imports_kpool_class"] is True
+    assert glm["uses_plain_indexer"] is False
+
+
+def test_plain_indexer_users_excludes_kpool_models(tmp_path):
+    site = build_site(tmp_path)
+    users = MODULE.plain_indexer_users(site)
+    assert users == ["models/deepseek_v4/attention.py"]
+
+
+def test_overlay_without_fail_closed_guard_aborts(tmp_path):
+    site = build_site(tmp_path)
+    overlay = build_overlay(tmp_path, source=OVERLAY_NO_GUARD)
+    with pytest.raises(MODULE.Abort):
+        MODULE.audit(site, overlay, None)
+
+
+def test_missing_overlay_aborts(tmp_path):
+    site = build_site(tmp_path)
+    with pytest.raises(MODULE.Abort):
+        MODULE.audit(site, tmp_path / "absent", None)
+
+
+def test_missing_kpool_source_aborts(tmp_path):
+    site = build_site(tmp_path)
+    (site / MODULE.KPOOL_REL).unlink()
+    with pytest.raises(MODULE.Abort):
+        MODULE.audit(site, build_overlay(tmp_path), None)
+
+
+def test_unparseable_kpool_source_aborts(tmp_path):
+    site = build_site(tmp_path, kpool="def broken(:\n")
+    with pytest.raises(MODULE.Abort):
+        MODULE.audit(site, build_overlay(tmp_path), None)
+
+
+def test_cli_exit_codes(tmp_path):
+    site = build_site(tmp_path)
+    overlay = build_overlay(tmp_path)
+
+    ok = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--vllm-site",
+            str(site),
+            "--overlay-dir",
+            str(overlay),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert ok.returncode == 0, ok.stderr
+    assert json.loads(ok.stdout)["verdict"] == "NOT_APPLICABLE"
+
+    reachable_site = build_site(tmp_path / "live", kpool=KPOOL_LIVE)
+    reachable = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--vllm-site",
+            str(reachable_site),
+            "--overlay-dir",
+            str(overlay),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert reachable.returncode == 2
+    assert json.loads(reachable.stdout)["verdict"] == "REACHABLE"
+
+    missing = subprocess.run(
+        [sys.executable, str(SCRIPT), "--vllm-site", str(tmp_path / "nope")],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert missing.returncode == 1
+    assert json.loads(missing.stdout)["verdict"] == "ABORT"


### PR DESCRIPTION
## What this lands

Five TODO lanes: both P0 correctness audits closed, a silicon-fact correction, the
first arm of the upstream-perf intake (wired, then **reverted** when its mandatory
correctness gate failed), and a pre-registered occupancy gate.

**Follow-up commits close what the first round left open.**

- **Task 37 is CLOSED `NOT_REACHABLE`** (was `ABORT`). The three modules that
  forced the abort (`exllamav3.modules.attn`, `.dsv4`, `.gated_delta_net`) are
  reached through **one dead edge**: the serving module's first import is
  `from ...model.config import Config`, and the real `model/config.py` reaches
  `architecture/architectures.py` — which imports every architecture, including
  those pulling in the three modules — from a function-local import inside
  `Config`. `inject_config_stub` installs **`exllamav3.model.config`** as a
  synthetic module *before* the serving import, so that first import binds the
  stub and the real body never runs. The audit already honoured this mechanism
  for `exllamav3`, `exllamav3.model` and `exllamav3.modules`;
  `exllamav3.model.config` was simply missing from `STUB_NAMESPACES`. Closure is
  **79** modules on the deployed v1.4.7 and **92** on the v1.4.9 clone, with
  **zero** `exl3_mgemm` call-site modules; worst case stays 32 ≤ 128. **No #290
  fix is owed.** The verdict is **static, not observed**, and the residual model
  gaps are documented in the script's own docstring.
- **Task 34's FlashKDA arm is REVERTED — the mandatory correctness gate failed.**
  The arm was wired into `start.sh` (nine sites), boot-validated, deployed to the
  kit, and put through the pre-registered numeric-parity gate, which was run
  *without* stopping production because the GPU is reachable alongside the serving
  container. Two findings, either one disqualifying: the overlay passed **16**
  positional arguments to `torch.ops._flashkda_C.fwd` where the deployed op
  declares **14** (arming raised `RuntimeError: expected at most 14 argument(s)
  but received 16` at the first prefill), and with that fixed the fused output is
  ~150× smaller in mean magnitude than production's Triton path and
  **uncorrelated** with it (Pearson +0.008 on `out`, −0.063 on `final_state`).
  The divergence survives `tokens` 64/512, a zeroed gate, both beta conventions,
  pre-normalized q/k, both Triton references, and `lower_bound` ∈ {−1,−2,−3,−5}.
  Conventions ruled out by direct test: `beta` (the kernel demands bf16 and
  rejects fp32), `A_log` (demands `[H]`, rejects 4-D), `scale`, `l2norm`, layout.
  The kernel does run and does write (sentinel test: 100% of both buffers
  overwritten), so this is a wrong result, not a skipped kernel. Root cause not
  isolated — the image ships only `_flashkda_C.abi3.so`. The cluster deployment
  was reverted to `560a7ed5b8be5243`, the exact bytes the running container was
  started from, and the overlay file removed; production was never restarted.
  **No speed claim is made**, and `GLM53_KDA_PREFILL_BACKEND=flashkda` must not be
  armed. The arity is now pinned (`EXPECTED_FWD_ARITY = 14`) and the corrected
  bytes were re-validated on the cluster (armed `58ff323c…`, 14 positional
  arguments, 0 keywords). Receipt: `local/task34-parity-gate-20260910.txt`;
  harness: `local/flashkda-parity-check.py`.
- **Task 38 item 3**: `cvt.rn.bf16x2.e4m3x2` is a **toolchain** gate (CUDA ≥ 13.2,
  PTX ISA 9.2), not an arch limit — verified on spark1's ptxas 13.0.88, where the
  `f16x2` sibling assembles on `sm_121a` with the same toolchain.

**Revision note.** Three independent review passes found fourteen fail-open
defects, thirteen of them in the two audits — the code whose whole job is to
refuse to certify a tree it could not read. All fourteen are fixed with
regression tests. Task 37's verdict travelled `NOT_REACHABLE` → `ABORT` →
`NOT_REACHABLE`: the original pass certified a conclusion it had not
established, the fail-closed audit produced the `ABORT`, and call-graph evidence
then closed the question properly. A fourth pass approved the closure and the
launcher wiring, and independently re-derived both closures (79 / 92, and
90 / 103 once every unstubbed parent initializer is added) — still no
`exl3_mgemm` call-site module.

Pass 1 found: a `calls_exl3_mgemm` hit in the C++ bridge ignored by the verdict;
closure modules with call sites reported as "advisory" and then certified
unreachable anyway; a missing or unparseable serving module silently shrinking
the closure; an assumed stub-namespace pruning; the task 39 dead-branch check
walking the whole `ast.If` and so calling a live `else` dead; a textual rather
than parsed indexer check; the overlay accepting any marker occurrence as a
complete install; and an EOF method append that let a trailing module-level
function swallow the method.

Pass 2 found: relative imports' aliases not followed into the closure
(`from . import helper`); a stub contract that checked token presence rather
than actually running the installer; indexer identity inferred from spelling
rather than import provenance (so `from ...sparse_attn_indexer import
SparseAttnIndexer as SparseAttnIndexerKpool` read as the kpool class); and an
overlay completeness list that omitted the arm's own required imports.

Pass 3 found: queue order letting a weak alias candidate mark a name as already
seen before its hard `import` was validated; a stub contract that proved the
installer *could* install but not that the loader *calls* it before importing
`exllamav3`; a flat binding map that let a function-local import shadow a
module-level one, plus an ignored imported-symbol name; and a still-textual
overlay completeness check that accepted a commented-out import.

## 1. Task 39 — persistent-top-k overflow → `NOT_APPLICABLE` (closed)

The GLM path runs `SparseAttnIndexerKpool`, whose `persistent_topk` branch is
**dead by construction** under a deliberate local GB10 shared-memory guard
(`overlay/patch_glm_video_placeholders.py`); the live kernel is
`top_k_per_row_decode` (lines 832/843). The plain `SparseAttnIndexer`, whose
`persistent_topk` *is* live, is used only by DeepSeek models.

So upstream #52149 / #55314 do not gate this deployment, which also corrects the
task 34 migration gate that had listed this as a prerequisite.

`scripts/audit_persistent_topk_reachability.py` re-derives this from any tree.
Receipt: `local/task39-persistent-topk-reachability-20260910.json` — now valid
JSON (the previous one was missing its opening brace).

## 2. Task 37 — `v_indices[128]` scratch → `ABORT`: narrowed, NOT closed

**Established** on the deployed source:

- the scratch is written only inside `exl3_mgemm_kernel`;
- `BC_LinearEXL3::run_gr`, the bridge the model calls, uses
  `exl3_gemm_gr`/`exl3_gemm` and never `exl3_mgemm`;
- the overlay's four named ext symbols (`exl3_fat_gemm`, `exl3_fat_gemm_scatter`,
  `exl3_moe`, `exl3_moe_max_concurrency`) exclude every `exl3_mgemm*` entry, and
  `exl3_mgemm` is the only such binding;
- the serving module `exllamav3.modules.quant.exl3` has no `exl3_mgemm` call
  site;
- worst-case slots at production shapes (`top_k=8`, `MAX_NUM_SEQS=4`, draft 7)
  = 32 ≤ 128.

**Not established:** `exllamav3.modules.attn` and `exllamav3.modules.dsv4`
(plus `.gated_delta_net` on v1.4.9) are in the serving import closure and hold
`exl3_mgemm` call sites. They enter through **function-local** imports
(`modules/block_sparse_mlp_routing.py` does `from .attn import get_for_device`
inside a function), and every `ext.exl3_mgemm(...)` site is inside a function
rather than at module level. Importing a module does not execute its call sites,
so an import closure cannot discharge them — that needs a call graph.

**So: no #290 fix is proven owed, and none is proven unnecessary.** Closing it
needs call-graph evidence, not another audit run. The audit is fail-closed and
will report `NOT_REACHABLE` on its own once that evidence holds.

Receipts: `local/task37-mgemm-indices-v147-20260910.json` (pinned v1.4.7, in the
serving container), `local/task37-mgemm-indices-v149-local-clone-20260910.json`.

## 3. Task 38 item 1 — false silicon fact corrected in three tracked files

The claim that GB10 lacks NVFP4 / `cvt.e2m1x2` is wrong in its strong form.
`docs/01-architecture.md`, `docs/07-rebase-plan.md` and `README.md` now use the
target-gated wording. Verified first-hand on spark1 with ptxas 13.0.88:
`.target sm_121` rejects the instruction, `.target sm_121a` assembles it and
lowers to real SASS (`F2FP.SATFINITE.E2M1.F32.PACK_AB_MERGE_C`). Receipt:
`local/task38-isa-fp4-e2m1-20260910.txt`.

The deposed-NVFP4 decision is untouched — only its stated reason.

## 4. Task 34 — first arm: FlashKDA fused chunked prefill (vLLM #55737)

Scoped down from a three-PR lineage migration to the one PR portable without it.
#55736 edits `glm5next/nvidia/ops/third_party/kda/*`, which do **not exist** in
this fork; #55738 touches shared MLA backends, not the GLM model path. #55737
edits `glm5next/nvidia/kda.py`, which this fork has.

Feasibility confirmed on the deployed image: `vllm._flashkda_C` imports,
`torch.ops._flashkda_C.get_workspace_size(1792, 32, 4)` returns 51,314,688 B on
GB10, `current_workspace_manager` and `GatedDeltaNetAttention.get_state_dtype`
exist, and upstream's selection predicate accepts this device (SM12x, bf16,
head_dim 128, bounded gate).

`overlay/patch_flashkda_prefill.py` is **default-off** behind
`GLM53_KDA_PREFILL_BACKEND`, uses three exactly-once anchors, fails closed on
drift, and is **byte-neutral when unarmed**. It accepts a marker as evidence of
installation only when every arm structure is present, and it inserts its method
at a validated class boundary rather than at EOF (an EOF append let a trailing
module-level function swallow the method).

**Cluster smoke (in-container, temporary copy, production untouched):** unarmed
sha256 unchanged `ec090aab…`; armed parses with the method still a class member;
re-run idempotent; the production file never moved. The armed hash is
`58ff323c…` after the parity fix below; it was `a4bdc543…` before.

**Wired, deployed, gated, REVERTED.** The follow-up commits wired the overlay into
`start.sh` (nine sites) and boot-validated it, then deployed the launcher and the
overlay to the kit for the authorised window. The pre-registered **mandatory**
numeric-parity gate ran first — without stopping production, since the GPU is
reachable alongside the serving container — and **failed**, so the window was
never started and the deployment was reverted to `560a7ed5b8be5243` (the exact
bytes the running container was started from) with the overlay file removed.
Production was never restarted. Two findings, either one disqualifying: the
overlay passed **16** positional arguments to `torch.ops._flashkda_C.fwd` where
the deployed op declares **14** (arming raised `RuntimeError: expected at most 14
argument(s) but received 16` at the first prefill), and with that fixed the fused
output is ~150× smaller in mean magnitude than the Triton path's and
**uncorrelated** with it. The arity is now pinned by `EXPECTED_FWD_ARITY = 14`,
and the corrected bytes were re-validated on the cluster. **No speed claim is
made**, and `GLM53_KDA_PREFILL_BACKEND=flashkda` must not be armed. Receipt:
`local/task34-parity-gate-20260910.txt`; harness:
`local/flashkda-parity-check.py`.
