### PR TITLE
docs/16: state the outstanding §6 qualification evidence plainly

### DIFF
--- a/docs/16-exl3-v149-pin-intake.md
+++ b/docs/16-exl3-v149-pin-intake.md
@@ -148,7 +148,8 @@ is a statement about *compatibility*, not a completed qualification. The task's
 prescribed procedure is the §6 measurement contract, and it was not met, so
 **adoption qualification stays PENDING** until either the full §6 sequence runs
 on a quiet node or the owner grants an explicit exception for this currency
-bump. The remaining gap is bookkeeping-grade, not a suspected defect.
+bump. Qualification evidence remains outstanding; nothing found so far suggests
+a defect.
 
 Note that `IMAGE` is part of `prod-start.sh`'s JIT shape hash, so the window
 wiped and rebuilt the Triton/TileLang caches on both nodes. The candidate's


### PR DESCRIPTION
Replaces #71, which GitHub reported as conflicting: that branch and the squashed #70 both *added* `docs/16` relative to the merge base, an add/add conflict. This branch is built directly on the merged `main` (`d550c4e`), so the PR is exactly one hunk and merges cleanly. No history was rewritten.

## Change

`docs/16-exl3-v149-pin-intake.md`, §4 closing paragraph:

```diff
-bump. The remaining gap is bookkeeping-grade, not a suspected defect.
+bump. Qualification evidence remains outstanding; nothing found so far suggests
+a defect.
```

## Why

Review flagged that "bookkeeping-grade" understated the outstanding measurement requirement. The pending status was already explicit; this only removes the phrase that could be read as downgrading the gap. It changes no behavior, test, or validation result.

## Scope

One file, one sentence. `git diff origin/main HEAD` is exactly the hunk above. No code, test, or receipt change. The rest of #70 (the ExLlamaV3 v1.4.9 pin, the build/overlay changes, the three `prod-start.sh` fixes, and the receipts) is already on `main` as `d550c4e`.
