### PR TITLE
Task 35 §6 qualification harness, task 38 e2m1 silicon probe, and the cluster fixes they exposed

### DIFF
--- a/docs/01-architecture.md
+++ b/docs/01-architecture.md
@@ -42,6 +42,15 @@ carrying `.target sm_121`, so an FP4 intrinsic that only assembles under the
 `a` suffix fails in the default build. Treat "NVFP4 can never compile on GB10"
 as a toolchain claim about the default target, not a hardware fact.
 
+**Silicon-confirmed 2026-09-11.** The instruction does not merely assemble, it
+*executes* correctly on both dies: 12/12 probe cases match the PTX ISA on spark1
+and spark2, with `a` in the upper nibble and `b` in the lower, saturating, and
+round-to-nearest-even on the exact midpoint. The probe
+(`scripts/probe_isa_e2m1_silicon.py`) JITs a one-kernel PTX module through the
+CUDA driver and needs no host compiler and no stopped window — a 1-byte
+allocation and a single-thread launch succeed with production running. Receipt
+`local/task38-isa-e2m1-silicon-20260911.txt`.
+
 The predecessor NVFP4 deployment of this same model ran through Marlin-style
 emulation and was deposed on memory and throughput grounds, not on an ISA
 impossibility. That decision stands; only its stated reason is corrected here.

--- a/docs/06-improvement-plan.md
+++ b/docs/06-improvement-plan.md
@@ -3483,7 +3483,43 @@ The TODO named one file; the same false claim appeared in three tracked files
 the target-gated wording. Verified on spark1 with ptxas 13.0.88: `.target sm_121`
 rejects `cvt.e2m1x2`, `.target sm_121a` assembles it and lowers to
 `F2FP.SATFINITE.E2M1.F32.PACK_AB_MERGE_C`. The deposed-NVFP4 decision is
-untouched — only its stated reason. Items 2–4 remain open.
+untouched — only its stated reason.
+
+### Task 38 item 2 — silicon probe CLOSED: the instruction executes (2026-09-11)
+
+Upgrades item 1 from toolchain-confirmed to **silicon-confirmed**:
+`SILICON_CONFIRMED` on **both** dies, 12/12 cases matching the PTX ISA on each,
+0 reversed. `scripts/probe_isa_e2m1_silicon.py` (driver JIT via `ctypes`; no
+host compiler, no stopped window). Receipt
+`local/task38-isa-e2m1-silicon-20260911.txt`.
+
+**The item was scoped as "blocked on a stopped maintenance window" and that was
+wrong.** The original probe hit `CUDA_ERROR_OUT_OF_MEMORY` against running
+production, which was attributed to `cuDevicePrimaryCtxRetain`. Measured here:
+primary-context retain, a 1-byte `cuMemAlloc`, a single-thread `cuLaunchKernel`
+and a 1-byte D2H copy **all succeed with production up and healthy**. The
+blocker was the probe's memory footprint, not the primary context. The ISA phase
+was consequently removed from `scripts/run_v149_qualification_window.py`: the
+window must not stop production for a measurement that does not need it.
+
+Three implementation facts were each a silent failure first, and are the reason
+the probe is worth keeping:
+
+- The destination must be `.b8` with `st.global.u8`. `.b32`/`st.global.u32` makes
+  ptxas reject the instruction ("Arguments mismatch for instruction 'cvt'") and
+  the driver then rejects the module with `CUDA_ERROR_INVALID_PTX` (218).
+- The operands must be passed as **kernel parameters**. With
+  `mov.f32 %f1, 0f3F800000` ptxas materializes only the top byte of each constant
+  and **every case reads `0x00`** — a clean, silent, wrong answer that would have
+  been reported as a hardware result.
+- `kernelParams` is an array of pointers, one per parameter; passing a pointer to
+  a whole argument struct segfaults the host process.
+
+The recorded `0x42` for `(1.0, 2.0)` is consistent with the original probe having
+been fed `(2.0, 1.0)`; under the spec order that pair encodes as `0x24`. The
+observed table is authoritative and covers saturation and the rounding midpoint.
+
+Only the **optional** TP1 memory measurement remains open from task 38.
 
 ### Task 34 — first arm: FlashKDA prefill, REVERTED (parity gate failed)
 

--- a/docs/06-improvement-plan.md
+++ b/docs/06-improvement-plan.md
@@ -3507,13 +3507,25 @@ the probe is worth keeping:
 
 - The destination must be `.b8` with `st.global.u8`. `.b32`/`st.global.u32` makes
   ptxas reject the instruction ("Arguments mismatch for instruction 'cvt'") and
-  the driver then rejects the module with `CUDA_ERROR_INVALID_PTX` (218).
+  the driver then rejects the module with `CUDA_ERROR_INVALID_PTX` (218). The PTX
+  ISA says so directly: "When converting to .e2m1x2 data formats, the destination
+  operand d has .b8 type."
 - The operands must be passed as **kernel parameters**. With
-  `mov.f32 %f1, 0f3F800000` ptxas materializes only the top byte of each constant
-  and **every case reads `0x00`** — a clean, silent, wrong answer that would have
-  been reported as a hardware result.
+  `mov.f32 %f1, 0f3F800000` **every case read `0x00`** — a clean, silent, wrong
+  answer that would otherwise have been reported as a hardware result. The
+  immediate form's root cause was never established: `mov.f32` with a valid
+  immediate is legal PTX a conforming ptxas must materialize, so a ptxas defect is
+  a hypothesis, not a finding, and a bug in that earlier probe variant explains
+  the same symptom. Nothing rests on it — the parameter-fed form is correct
+  regardless, and the judge rejects an all-`0x00` result outright.
 - `kernelParams` is an array of pointers, one per parameter; passing a pointer to
   a whole argument struct segfaults the host process.
+
+The PTX ISA document does **not** list `cvt.rn.satfinite.e2m1x2.f32` for
+`sm_121a` (it lists sm_100a/sm_110a/sm_120a and their family variants), so
+ptxas 13.0.88 accepting `.target sm_121a` is toolchain behaviour beyond the
+documented matrix. These receipts, not the document, are what establish GB10
+behaviour — which is why the silicon probe was worth running.
 
 The recorded `0x42` for `(1.0, 2.0)` is consistent with the original probe having
 been fed `(2.0, 1.0)`; under the spec order that pair encodes as `0x24`. The

--- a/docs/16-exl3-v149-pin-intake.md
+++ b/docs/16-exl3-v149-pin-intake.md
@@ -317,6 +317,71 @@ copies the preflight `.env` backup back and verifies its sha256, so this is part
 of the pre-window baseline and survives the window's restore path. Receipt:
 `local/spark1-gid-fix-20260911.txt`.
 
+### Cluster validation of the harness bytes (2026-09-11)
+
+The publication gate wants the exact candidate bytes exercised on the target
+cluster, not only under pytest on the Mac. The A-B-B-A path cannot run while the
+clock fault holds, so the deepest non-destructive boundary was validated
+instead: `preflight`.
+
+`preflight` stops nothing. It checks the file layout, records the effective
+environment, hashes the runner/probe/auditor and the two production scripts,
+waits for the server to drain, and confirms both arm images already exist on
+BOTH nodes. Its only write is a timestamped `.env` backup, the same artifact
+every window creates.
+
+The head-node checkout `~/GLM-5.3-Flash-EXL3-2x-DGX-Sparks` is **not a git
+repository**, so it does not track the branch, and its `scripts/` held an
+earlier revision of all three harness files. The shared helper
+(`run_decode_profile_window.py`) already matched, which is what made the
+staleness invisible. The three files were staged and moved into place with an
+atomic same-filesystem rename. The stale revision returned
+`pool_capacity_before = None`; the current bytes return a parsed capacity, so
+the refresh was not cosmetic.
+
+Result: `EXIT=0`, with `pool_capacity_before = '1396551 tokens; concurrency
+1.40x'`, `jit_stamp = 7b09229c3b6f`, `/health` 200, and both arm images present
+on both nodes. Production was never stopped.
+
+`preflight` was run **twice**, because review found a defect in the runner after
+the first run (`phase_rearm` did not attempt the second timer when the first
+start *raised* rather than merely exiting nonzero). The first run exercised
+runner `e542c168…` as of `11dfda1`; the second exercised runner `8919aa64…` as of
+`736ac64`, the published revision. Only the runner differed — the probe and
+auditor hashes are identical throughout, and all three matched the published
+revision on both the Mac and the head node before the second run. Receipt:
+`local/task35b-cluster-preflight-20260911.txt`.
+
+This is a **partial** pass: it does not exercise the arm switch (`disarm` →
+`arm_a` → `measure_a` → …), which is the part that stops and restarts
+production, and it produces no timing number. Review approval of the runner does
+not certify that execution either.
+
+### Review rounds
+
+Four review rounds ran against the harness.
+
+- **Round 1 — eleven findings.** Two would have aborted a healthy window, two
+  would have produced wrong numbers, and the rest were fail-closed or evidence
+  gaps. Fixed in `cc12e74`.
+- **Round 2 — two regressions plus six partials.** Both regressions were
+  introduced by the round-1 fixes. Fixed in `97a2c61`.
+- **Round 3 — six findings, plus two live-node defects** that only appeared when
+  the exact bytes were exercised against production: `systemctl is-active`
+  prints `inactive` for a **nonexistent** unit too (rc=4 vs rc=3), so the
+  fail-closed quiescence check could read a wrong-user query as disarmed; and a
+  fixed 5 s poll made a short timeout block for a full interval. Fixed in
+  `11dfda1`.
+- **Round 4 — one finding.** `phase_rearm` attempted both timers independently
+  for a nonzero exit code but not for a raised exception. `win.run()` raises
+  `subprocess.TimeoutExpired` on a hung `systemctl start`, which broke out of
+  the loop and left the second timer down with no per-unit record — the exact
+  one-timer-left-down outcome the ordering fix existed to prevent. The same
+  unguarded-loop shape was fixed in `timer_states()`, `_active_services()`, and
+  `phase_disarm`, where a hung first query or stop hid the second unit.
+  Reproduced against the pre-fix revision (only the watchdog timer attempted,
+  `rearm_failures` absent) and covered by three regression tests.
+
 ## 5. What the window broke, and the three fixes it produced
 
 Items 1 and 2 are defects in `local/prod-start.sh` that only a *new image tag*

--- a/docs/16-exl3-v149-pin-intake.md
+++ b/docs/16-exl3-v149-pin-intake.md
@@ -183,6 +183,16 @@ source prefix that differ on every boot, and the shared helper's first
 `kv_cache` match is a startup patch message whose value is identical on every
 arm (see the fixes in commits 5baf82a and cc12e74).
 
+The measurement probe's streaming reader was **also defective** and is fixed in
+the same commit: it read the SSE stream in 4096-byte blocks, which measured TTFT
+as "time until 4096 bytes arrived" and compressed the decode interval, inflating
+the reported rate by roughly 2.8x. The earlier smoke figures for this harness
+(structured 84.3/85.4, essay 14.9, hashmap 20.3 tok/s) were artifacts of that
+bug and must not be cited. Corrected on production: structured 30.1 tok/s
+(TTFT 0.62 s), hashmap 14.7 tok/s, with `ttft + decode == wall` holding exactly.
+Those lower numbers are consistent with the 507 MHz clock fault below, which the
+inflated ones were not. Detail: `local/probe-timing-defect-20260911.txt`.
+
 ### What this harness does NOT cover
 
 This is a **narrowed** contract, and an ADOPT from it is a statement about

--- a/docs/16-exl3-v149-pin-intake.md
+++ b/docs/16-exl3-v149-pin-intake.md
@@ -209,6 +209,30 @@ on excluded runs rather than their reason text (the probe reports a stream error
 before the NaN check, so a NaN run that also errored carries an error string as
 its reason) and requires a non-empty JIT shape stamp per arm.
 
+The registry of attempts is **enforced**, not merely recorded: the judge reads
+`probe_blocks` and rejects any block that did not succeed, and it also re-reads
+the evidence a failed attempt left behind. Without that, a resumed arm replaces
+the selected probe path and an earlier corrupted attempt disappears behind a
+clean retry. A receipt that registers no blocks at all is rejected too, so the
+gate cannot be satisfied by omission.
+
+Three further fail-closed properties were added after live-node measurement. A
+resumed window that starts at an `arm_*`/`measure_*` phase re-establishes the
+disarm prerequisite, because automatic recovery re-arms the timers and the
+documented continuation would otherwise measure with the watchdog able to
+enqueue a restart mid-block. Preemption telemetry returns `None` rather than
+`0.0` when the counter is unreadable, so two failed samples cannot present as an
+accepted zero delta. And quiescence and timer state are read from the return
+code, not from stdout: `systemctl is-active` prints `inactive` for a genuinely
+inactive unit (rc=3) **and** for a unit that does not exist (rc=4), verified on
+the live node, so a wrong-user or renamed-unit query would otherwise look
+disarmed. Disarm now requires a provable `inactive`, and rearm attempts both
+timers independently so a persistent failure on one cannot leave the other down.
+Cold-prefill validation likewise requires an explicit `cached_tokens == 0`;
+missing cache telemetry is not measured zero usage. The audit receipt is derived
+by suffixing, so a receipt named without a `-window-` token no longer collides
+with its own audit output.
+
 The measurement probe's streaming reader was **also defective** and is fixed in
 the same commit: it read the SSE stream in 4096-byte blocks, which measured TTFT
 as "time until 4096 bytes arrived" and compressed the decode interval, inflating
@@ -250,12 +274,48 @@ minimum clock — 22.9 TFLOP/s against 94.8 TFLOP/s on spark2 for the same bf16
 8192³ matmul, with no throttle reason reported, persistence enabled, normal
 temperature and no Xid. Cold prefill measures ~582 tok/s against the standing
 ~1454 tok/s receipt, so a prefill arm run in this state would measure the fault
-rather than the candidate. A reboot is required. Receipt:
+rather than the candidate. Receipt:
 `local/spark1-head-clock-507mhz-20260911.txt`.
+
+**The reboot did not clear it.** The head was rebooted
+(`b3ab1d6f…` → `4b52ad93…`) and re-measured on the fresh boot: still 507 MHz at
+96% utilisation, still **23.8 TFLOP/s** against the worker's 94.8. The following
+were ruled out on both nodes: no active throttle reason (all nine reasons "Not
+Active"), identical application clocks (`clocks.applications.gr` = 2418 MHz on
+both, and the worker reaches 2411), no clock-lock call anywhere in the systemd
+or user-unit configuration, persistence enabled on both, no `nvpmodel` power
+mode, no CPU contention (load 1.39 vs 0.60), and a normal 41-44 C. Throughput
+tracks the clock exactly (23.8 × 2431/507 = 114 TFLOP/s), so the GPU computes
+correctly and merely never leaves minimum clock. A cap that survives a reboot
+with no software throttle is a hardware or firmware condition on the head node
+and needs vendor-level diagnosis; GB10 exposes no power-supply telemetry, so the
+240 W USB-C PD input is the one remaining user-checkable item. Receipt:
+`local/spark1-head-clock-post-reboot-20260911.txt`.
+
+An idle clock reading is uninformative — GB10 parks at 507 MHz when idle — so
+the window must not be started until a **load** measurement shows
+≥ 2000 MHz and ≥ 80 TFLOP/s.
 
 Note that `IMAGE` is part of `prod-start.sh`'s JIT shape hash, so the window
 wiped and rebuilt the Triton/TileLang caches on both nodes. The candidate's
 numbers are therefore post-rebuild and directly comparable to the standing band.
+
+### Operational note: the reboot exposed a per-rank RoCE GID mismatch
+
+Rebooting the head took production down and it did not come back on its own:
+`vllm-glm53exl3.service` failed three start attempts because `start.sh` resolved
+one GID index (`NCCL_IB_GID_INDEX=3`) for both ranks while the nodes' rail-1
+RoCE v2 entries sat at **different** indices — head `gid3`, worker `gid4`. The
+head's reboot bounced the QSFP link and the link-down/up cycle reordered the
+worker's GID table (the worker was never rebooted). The same `.env` value is in
+the pre-task35 backup, so this is not a task 35 regression.
+
+Fixed by setting the per-rank override `start.sh` prescribes — `HEAD_GID=3` and
+`WORKER_GID=4` in `.env`, with a timestamped backup — after which production came
+up normally (`/health` 200, both containers on the v149 image). `phase_restore`
+copies the preflight `.env` backup back and verifies its sha256, so this is part
+of the pre-window baseline and survives the window's restore path. Receipt:
+`local/spark1-gid-fix-20260911.txt`.
 
 ## 5. What the window broke, and the three fixes it produced
 

--- a/docs/16-exl3-v149-pin-intake.md
+++ b/docs/16-exl3-v149-pin-intake.md
@@ -166,7 +166,18 @@ re-judged without touching the cluster.
 | Warmup | one predeclared 32-token pass per arm boot |
 | Non-inferiority band | `structured` 0.97, all other lanes 0.95 (candidate ÷ control, on arm medians) |
 | Drift limit | control drift `abs(a − a2) / max(a, a2)` > **0.05** → INCONCLUSIVE |
+| Candidate drift | candidate drift `abs(b − b2) / max(b, b2)` > **0.05** → INCONCLUSIVE |
+| Within-arm variability | `(max − min) / median` for one arm's own runs > **0.30** → INCONCLUSIVE |
 | Verdicts | ADOPT / REVERT / INCONCLUSIVE / ABORT |
+
+The variability limit is deliberately strict, and it is not a substitute for the
+drift limit: drift compares an arm's *median* against its partner's, so two arms
+can agree on their medians while neither has a settled number. A lane of nine
+observations in which four sit near 1 and four near 1000 has a matching median on
+both candidate arms and would otherwise ADOPT. An unsettled arm yields
+INCONCLUSIVE, not ABORT: the window ran and is valid, it simply cannot decide.
+The asymmetry is intentional — a false INCONCLUSIVE costs a re-run, a false
+ADOPT does not.
 
 The band is one-sided on purpose. v1.4.9 was taken for currency and correctness
 and **no speed claim is made**, so the question the window answers is "does the
@@ -182,6 +193,21 @@ the pre-window capacity. That check is only meaningful because the capacity is
 source prefix that differ on every boot, and the shared helper's first
 `kv_cache` match is a startup patch message whose value is identical on every
 arm (see the fixes in commits 5baf82a and cc12e74).
+
+Receipt integrity is enforced rather than assumed. The per-arm boot identity
+(`docker inspect .State.StartedAt`) is captured on **both** nodes and must be
+non-empty; the measurement phase refuses to run when the token cannot be read or
+when either container restarted since the arm phase, so observations cannot be
+attributed to a boot that was never verified. Each measurement block is
+registered in the receipt *before* it runs, so a failed block stays visible to
+the judge instead of disappearing down the retry path. Receipt writes are
+best-effort: a full disk or a read-only path must not stop the window from
+restarting production or re-arming the timers. Quiescence fails closed — an
+unreadable service state or a failed job query counts as busy, so the window
+cannot declare quiet on absent evidence. The judge inspects the raw `nan` flag
+on excluded runs rather than their reason text (the probe reports a stream error
+before the NaN check, so a NaN run that also errored carries an error string as
+its reason) and requires a non-empty JIT shape stamp per arm.
 
 The measurement probe's streaming reader was **also defective** and is fixed in
 the same commit: it read the SSE stream in 4096-byte blocks, which measured TTFT

--- a/docs/16-exl3-v149-pin-intake.md
+++ b/docs/16-exl3-v149-pin-intake.md
@@ -176,11 +176,36 @@ control drift beyond the limit returns INCONCLUSIVE rather than a verdict, per
 
 Arm identity is verified on **both** nodes — container image tag and the
 in-container `exllamav3` distribution version, because `exllamav3.__version__`
-is unset — and the KV pool line is captured per arm. The pool line must equal
-the pre-window line. That check is only meaningful because the line is extracted
-specifically: the shared helper's first `kv_cache` match is a startup patch
-message whose value is identical on every arm, which would have made the gate
-vacuous (see the fix in commit 5baf82a).
+is unset — and the KV pool capacity is captured per arm. The capacity must equal
+the pre-window capacity. That check is only meaningful because the capacity is
+*parsed*, not compared as a log line: the line carries a timestamp, PID and
+source prefix that differ on every boot, and the shared helper's first
+`kv_cache` match is a startup patch message whose value is identical on every
+arm (see the fixes in commits 5baf82a and cc12e74).
+
+### What this harness does NOT cover
+
+This is a **narrowed** contract, and an ADOPT from it is a statement about
+throughput on the lanes measured, **not** a completed `docs/13` §6
+qualification. `docs/13` §6 asks for more than this harness collects, and the
+gap is recorded here rather than silently absorbed. The audit output carries the
+same statement in its `scope` field so a receipt cannot be read as more than it
+is.
+
+Not covered:
+
+- **temp-1 production cells.** §6 asks for both temp-0 diagnostic and temp-1
+  production cells; this harness runs temp-0 only.
+- **The §6 serving gates** — toolcall, thinking/SSE, long-form and the
+  mixed-cache soak. `local/acceptance.sh` is run after restore and its return
+  code is gated, but it is not a substitute for those.
+- **The prescribed drained-APC reset and cache-counter traffic audit** for cold
+  rounds. Cold runs are validated by `cached_tokens == 0` and a fresh salt
+  instead, which rejects a warm hit but does not perform the §6 reset.
+
+Closing the qualification therefore still needs either those measurements or an
+owner-approved narrowing. This document records which of the two has happened;
+right now, neither has.
 
 ### Blocker: head-GPU clock fault (2026-09-11)
 

--- a/docs/16-exl3-v149-pin-intake.md
+++ b/docs/16-exl3-v149-pin-intake.md
@@ -151,6 +151,47 @@ on a quiet node or the owner grants an explicit exception for this currency
 bump. Qualification evidence remains outstanding; nothing found so far suggests
 a defect.
 
+### Pre-registered contract for the §6 qualification run
+
+Registered 2026-09-11 **before** the run. The constants live in
+`scripts/audit_v149_qualification.py`, which is the offline judge; the window
+runner records raw evidence and decides nothing, so the same capture can be
+re-judged without touching the cluster.
+
+| | |
+|---|---|
+| Arms | `a` = v1.4.7, `b` = v1.4.9, `b2` = v1.4.9, `a2` = v1.4.7 (A-B-B-A) |
+| Decode lanes | `structured`, `essay`, `hashmap` — **9** observations per arm each |
+| Prefill lanes | `prefill60k`, `prefill240k` — **5** observations per arm each |
+| Warmup | one predeclared 32-token pass per arm boot |
+| Non-inferiority band | `structured` 0.97, all other lanes 0.95 (candidate ÷ control, on arm medians) |
+| Drift limit | control drift `abs(a − a2) / max(a, a2)` > **0.05** → INCONCLUSIVE |
+| Verdicts | ADOPT / REVERT / INCONCLUSIVE / ABORT |
+
+The band is one-sided on purpose. v1.4.9 was taken for currency and correctness
+and **no speed claim is made**, so the question the window answers is "does the
+candidate regress", not "does it win". A lane below its band returns REVERT;
+control drift beyond the limit returns INCONCLUSIVE rather than a verdict, per
+`docs/13` §6's "report **INCONCLUSIVE**, not keep rerunning until it wins".
+
+Arm identity is verified on **both** nodes — container image tag and the
+in-container `exllamav3` distribution version, because `exllamav3.__version__`
+is unset — and the KV pool line is captured per arm. The pool line must equal
+the pre-window line. That check is only meaningful because the line is extracted
+specifically: the shared helper's first `kv_cache` match is a startup patch
+message whose value is identical on every arm, which would have made the gate
+vacuous (see the fix in commit 5baf82a).
+
+### Blocker: head-GPU clock fault (2026-09-11)
+
+The re-run could not start. spark1's head GPU is pinned at its **507 MHz**
+minimum clock — 22.9 TFLOP/s against 94.8 TFLOP/s on spark2 for the same bf16
+8192³ matmul, with no throttle reason reported, persistence enabled, normal
+temperature and no Xid. Cold prefill measures ~582 tok/s against the standing
+~1454 tok/s receipt, so a prefill arm run in this state would measure the fault
+rather than the candidate. A reboot is required. Receipt:
+`local/spark1-head-clock-507mhz-20260911.txt`.
+
 Note that `IMAGE` is part of `prod-start.sh`'s JIT shape hash, so the window
 wiped and rebuilt the Triton/TileLang caches on both nodes. The candidate's
 numbers are therefore post-rebuild and directly comparable to the standing band.

--- a/local/isa-probe-spark1-20260911.json
+++ b/local/isa-probe-spark1-20260911.json
@@ -1,0 +1,138 @@
+{
+ "schema": 1,
+ "probe": "cvt.rn.satfinite.e2m1x2.f32",
+ "ptx": ".version 9.0\n.target sm_121a\n.address_size 64\n\n.visible .entry probe_e2m1(.param .u64 p_out, .param .f32 pa, .param .f32 pb)\n{\n    .reg .b64  %rd<4>;\n    .reg .b8   %rs<2>;\n    .reg .f32  %f<4>;\n\n    ld.param.u64      %rd1, [p_out];\n    cvta.to.global.u64 %rd2, %rd1;\n    ld.param.f32 %f1, [pa];\n    ld.param.f32 %f2, [pb];\n    cvt.rn.satfinite.e2m1x2.f32 %rs1, %f1, %f2;\n    st.global.u8 [%rd2], %rs1;\n    ret;\n}\n",
+ "ptxas": {
+  "ptxas": "ptxas",
+  "rc": 0,
+  "stdout": "",
+  "stderr": ""
+ },
+ "cases": [
+  {
+   "case": "recorded-reversed-2.0-1.0",
+   "a": 2.0,
+   "b": 1.0,
+   "tie": false,
+   "observed": "0x42",
+   "expected_spec": "0x42",
+   "matches_spec": true,
+   "matches_reversed_order": false
+  },
+  {
+   "case": "zero",
+   "a": 0.0,
+   "b": 0.0,
+   "tie": false,
+   "observed": "0x00",
+   "expected_spec": "0x00",
+   "matches_spec": true,
+   "matches_reversed_order": false
+  },
+  {
+   "case": "half",
+   "a": 0.5,
+   "b": 0.5,
+   "tie": false,
+   "observed": "0x11",
+   "expected_spec": "0x11",
+   "matches_spec": true,
+   "matches_reversed_order": false
+  },
+  {
+   "case": "distinct-1.0-2.0",
+   "a": 1.0,
+   "b": 2.0,
+   "tie": false,
+   "observed": "0x24",
+   "expected_spec": "0x24",
+   "matches_spec": true,
+   "matches_reversed_order": false
+  },
+  {
+   "case": "distinct-4.0-1.0",
+   "a": 4.0,
+   "b": 1.0,
+   "tie": false,
+   "observed": "0x62",
+   "expected_spec": "0x62",
+   "matches_spec": true,
+   "matches_reversed_order": false
+  },
+  {
+   "case": "top-of-range",
+   "a": 6.0,
+   "b": 6.0,
+   "tie": false,
+   "observed": "0x77",
+   "expected_spec": "0x77",
+   "matches_spec": true,
+   "matches_reversed_order": false
+  },
+  {
+   "case": "negative",
+   "a": -1.0,
+   "b": -6.0,
+   "tie": false,
+   "observed": "0xaf",
+   "expected_spec": "0xaf",
+   "matches_spec": true,
+   "matches_reversed_order": false
+  },
+  {
+   "case": "saturate-high",
+   "a": 100.0,
+   "b": 1e+30,
+   "tie": false,
+   "observed": "0x77",
+   "expected_spec": "0x77",
+   "matches_spec": true,
+   "matches_reversed_order": false
+  },
+  {
+   "case": "saturate-low",
+   "a": -100.0,
+   "b": -1e+30,
+   "tie": false,
+   "observed": "0xff",
+   "expected_spec": "0xff",
+   "matches_spec": true,
+   "matches_reversed_order": false
+  },
+  {
+   "case": "round-down",
+   "a": 0.4,
+   "b": 1.2,
+   "tie": false,
+   "observed": "0x12",
+   "expected_spec": "0x12",
+   "matches_spec": true,
+   "matches_reversed_order": false
+  },
+  {
+   "case": "round-up",
+   "a": 0.6,
+   "b": 2.7,
+   "tie": false,
+   "observed": "0x15",
+   "expected_spec": "0x15",
+   "matches_spec": true,
+   "matches_reversed_order": false
+  },
+  {
+   "case": "tie-0.25-0.75",
+   "a": 0.25,
+   "b": 0.75,
+   "tie": true,
+   "observed": "0x02",
+   "expected_spec": "0x02",
+   "matches_spec": true,
+   "matches_reversed_order": false
+  }
+ ],
+ "gated_cases": 11,
+ "cases_matching_spec": 12,
+ "reversed_order_cases": 0,
+ "errors": [],
+ "verdict": "SILICON_CONFIRMED"
+}

--- a/local/isa-probe-spark2-20260911.json
+++ b/local/isa-probe-spark2-20260911.json
@@ -1,0 +1,138 @@
+{
+ "schema": 1,
+ "probe": "cvt.rn.satfinite.e2m1x2.f32",
+ "ptx": ".version 9.0\n.target sm_121a\n.address_size 64\n\n.visible .entry probe_e2m1(.param .u64 p_out, .param .f32 pa, .param .f32 pb)\n{\n    .reg .b64  %rd<4>;\n    .reg .b8   %rs<2>;\n    .reg .f32  %f<4>;\n\n    ld.param.u64      %rd1, [p_out];\n    cvta.to.global.u64 %rd2, %rd1;\n    ld.param.f32 %f1, [pa];\n    ld.param.f32 %f2, [pb];\n    cvt.rn.satfinite.e2m1x2.f32 %rs1, %f1, %f2;\n    st.global.u8 [%rd2], %rs1;\n    ret;\n}\n",
+ "ptxas": {
+  "ptxas": "ptxas",
+  "rc": 0,
+  "stdout": "",
+  "stderr": ""
+ },
+ "cases": [
+  {
+   "case": "recorded-reversed-2.0-1.0",
+   "a": 2.0,
+   "b": 1.0,
+   "tie": false,
+   "observed": "0x42",
+   "expected_spec": "0x42",
+   "matches_spec": true,
+   "matches_reversed_order": false
+  },
+  {
+   "case": "zero",
+   "a": 0.0,
+   "b": 0.0,
+   "tie": false,
+   "observed": "0x00",
+   "expected_spec": "0x00",
+   "matches_spec": true,
+   "matches_reversed_order": false
+  },
+  {
+   "case": "half",
+   "a": 0.5,
+   "b": 0.5,
+   "tie": false,
+   "observed": "0x11",
+   "expected_spec": "0x11",
+   "matches_spec": true,
+   "matches_reversed_order": false
+  },
+  {
+   "case": "distinct-1.0-2.0",
+   "a": 1.0,
+   "b": 2.0,
+   "tie": false,
+   "observed": "0x24",
+   "expected_spec": "0x24",
+   "matches_spec": true,
+   "matches_reversed_order": false
+  },
+  {
+   "case": "distinct-4.0-1.0",
+   "a": 4.0,
+   "b": 1.0,
+   "tie": false,
+   "observed": "0x62",
+   "expected_spec": "0x62",
+   "matches_spec": true,
+   "matches_reversed_order": false
+  },
+  {
+   "case": "top-of-range",
+   "a": 6.0,
+   "b": 6.0,
+   "tie": false,
+   "observed": "0x77",
+   "expected_spec": "0x77",
+   "matches_spec": true,
+   "matches_reversed_order": false
+  },
+  {
+   "case": "negative",
+   "a": -1.0,
+   "b": -6.0,
+   "tie": false,
+   "observed": "0xaf",
+   "expected_spec": "0xaf",
+   "matches_spec": true,
+   "matches_reversed_order": false
+  },
+  {
+   "case": "saturate-high",
+   "a": 100.0,
+   "b": 1e+30,
+   "tie": false,
+   "observed": "0x77",
+   "expected_spec": "0x77",
+   "matches_spec": true,
+   "matches_reversed_order": false
+  },
+  {
+   "case": "saturate-low",
+   "a": -100.0,
+   "b": -1e+30,
+   "tie": false,
+   "observed": "0xff",
+   "expected_spec": "0xff",
+   "matches_spec": true,
+   "matches_reversed_order": false
+  },
+  {
+   "case": "round-down",
+   "a": 0.4,
+   "b": 1.2,
+   "tie": false,
+   "observed": "0x12",
+   "expected_spec": "0x12",
+   "matches_spec": true,
+   "matches_reversed_order": false
+  },
+  {
+   "case": "round-up",
+   "a": 0.6,
+   "b": 2.7,
+   "tie": false,
+   "observed": "0x15",
+   "expected_spec": "0x15",
+   "matches_spec": true,
+   "matches_reversed_order": false
+  },
+  {
+   "case": "tie-0.25-0.75",
+   "a": 0.25,
+   "b": 0.75,
+   "tie": true,
+   "observed": "0x02",
+   "expected_spec": "0x02",
+   "matches_spec": true,
+   "matches_reversed_order": false
+  }
+ ],
+ "gated_cases": 11,
+ "cases_matching_spec": 12,
+ "reversed_order_cases": 0,
+ "errors": [],
+ "verdict": "SILICON_CONFIRMED"
+}

--- a/local/probe-timing-defect-20260911.txt
+++ b/local/probe-timing-defect-20260911.txt
@@ -1,0 +1,56 @@
+Probe streaming-timing defect: decode rates were inflated ~2.8x (2026-09-11)
+==========================================================================
+
+Found by independent final review (finding 3), fixed in commit cc12e74, and
+confirmed against live production here.
+
+THE DEFECT
+  probe_v149_qualification.py read the SSE stream with `resp.read(4096)`, which
+  blocks until 4096 bytes accumulate rather than returning each event as the
+  server flushes it. Two consequences:
+
+  - TTFT was measured as "time until 4096 bytes arrived", not "time to the first
+    token". Each SSE event is ~150 bytes, so the first read returned only after
+    ~27 events had been produced.
+  - decode ended at response EOF rather than at the last content token.
+
+  Both errors compress the measured decode interval, inflating tok/s.
+
+  The probe now reads a line at a time (`resp.readline()`) and spans decode from
+  the first to the last CONTENT token.
+
+MEASURED EFFECT (spark1, production up, 2 runs per lane, 200 tokens)
+
+  lane        before (buggy)   after (fixed)   TTFT before -> after
+  structured  85.4 tok/s       30.1 tok/s      4.86 s -> 0.62 s
+  hashmap     20.3 tok/s       14.7 tok/s      4.19 s -> 0.66 s
+
+  The total wall time is unchanged (~7.2 s structured); only the TTFT/decode
+  split moved, which is what identifies this as a measurement bug rather than a
+  performance change.
+
+WHY THE FIXED NUMBERS ARE THE CREDIBLE ONES
+  Self-consistency (structured, run 1): ttft 0.617 + decode 6.624 = wall 7.242,
+  and (200-1)/6.624 = 30.04 = the reported tok/s exactly.
+
+  The old figure implies 85.4 / 7.0 accepted-per-step = 12.2 forward passes per
+  second. The standing full-clock rate for this stack is ~70 tok/s (~10
+  passes/s), so 12.2 passes/s on a GPU pinned at 507 MHz was never plausible.
+  The corrected 3.77 passes/s is consistent with the 507 MHz clock fault
+  (head matmul 22.9 vs 94.8 TFLOP/s on the worker).
+
+  So this defect was inflating the decode rate by ~2.8x, and the earlier smoke
+  numbers reported for this harness (structured 84.3/85.4, essay 14.9, hashmap
+  20.3) were artifacts and should not be cited.
+
+WHAT IT WOULD HAVE DONE TO THE WINDOW
+  Both arms would have been inflated by roughly the same factor, so the A/B
+  RATIO might have survived — but the absolute rates, the TTFT evidence, and the
+  drift/stability gates would all have been computed from a distorted interval.
+  The pre-registered drift limit is exactly the kind of check a compressed
+  interval breaks, because the compression depends on how many events the server
+  coalesces per flush, which is not constant across arms.
+
+RECEIPTS
+  /tmp/fixed-structured.json, /tmp/fixed-hashmap.json on spark1 (transient).
+  Fixed probe sha256 2ca0838c4179db9b944c0392347a3787a3acae849168df7b7eca8b8a20e93bab.

--- a/local/spark1-gid-fix-20260911.txt
+++ b/local/spark1-gid-fix-20260911.txt
@@ -1,0 +1,66 @@
+spark1 reboot exposed a per-rank RoCE GID mismatch (2026-09-11)
+===============================================================
+
+What happened
+-------------
+Rebooting spark1 to clear the GPU clock fault took production down, and
+production did NOT come back on its own. The unit `vllm-glm53exl3.service`
+entered `activating (auto-restart)` and failed three start attempts with:
+
+  [glm53-exl3] worker GID index 3 is EMPTY on rocep1s0f1
+  [glm53-exl3] ERROR: set NCCL_IB_GID_INDEX (same index both ranks) or
+               HEAD_GID/WORKER_GID (per rank) in .env to populated indices
+
+Cause
+-----
+`start.sh` resolves one GID index for both ranks from `NCCL_IB_GID_INDEX=3`,
+which is what `.env` carried - and what the pre-task35 backup
+`.env.bak-pre-task35-v149-20260910` also carried, so this is NOT a task 35
+regression. The two nodes' rail-1 RoCE v2 entries sit at different indices:
+
+  head   rocep1s0f1  gid2 = ::ffff:c0a8:b10a (v1)
+                     gid3 = ::ffff:c0a8:b10a (v2)   <- populated
+                     gid4 = (empty)
+  worker rocep1s0f1  gid2 = ::ffff:c0a8:b10b (v1)
+                     gid3 = (empty)                 <- the failure
+                     gid4 = ::ffff:c0a8:b10b (v2)
+
+Production had started cleanly at 05:08:49 with the same `.env` ("preflight OK
+... worker=nvidia@192.168.177.11"), so the worker's GID table changed during its
+current boot: the head's reboot bounced the QSFP link, and the link-down/up
+cycle left the worker's rail-1 v2 entry at index 4 with a hole at index 3. The
+worker itself was never rebooted (boot_id 31da9678, unchanged).
+
+Fix applied
+-----------
+Backed up `.env`, then appended the per-rank override that `start.sh`'s own
+error message prescribes:
+
+  cp -a .env .env.bak-pre-gid-fix-20260911T075319
+  # appended:
+  HEAD_GID=3
+  WORKER_GID=4
+
+Then `systemctl --user reset-failed vllm-glm53exl3.service` and a restart. The
+engine came up normally (`init engine (profile, create kv cache, warmup model)
+took 133.24 s`, CUDA graphs captured, adaptive-k enabled) and `/health` returned
+200.
+
+Verification
+------------
+  head   glm53-exl3-head    glm53-selfbuild:e3-w3-zfill-v149   Up
+  worker glm53-exl3-worker  glm53-selfbuild:e3-w3-zfill-v149   Up
+  /health 200
+
+Notes for the window
+--------------------
+- `phase_restore` copies the preflight backup of `.env` back over `.env` and
+  verifies its sha256, so this fix is part of the pre-window baseline and
+  survives the window's restore path.
+- The JIT shape stamp hashes the raw `IMAGE=` lines only, so adding these two
+  non-IMAGE lines does not change it.
+- Rollback: `cp .env.bak-pre-gid-fix-20260911T075319 .env`
+
+Operational lesson: a single `NCCL_IB_GID_INDEX` for both ranks is fragile on
+this cluster - a link bounce on one node can reorder its GID table. The per-rank
+`HEAD_GID`/`WORKER_GID` form is now set explicitly.

--- a/local/spark1-head-clock-507mhz-20260911.txt
+++ b/local/spark1-head-clock-507mhz-20260911.txt
@@ -1,0 +1,42 @@
+spark1 (head) GPU clock fault - 507 MHz floor (2026-09-11)
+==========================================================
+
+Found while smoke-testing the task 35 section 6 qualification harness.
+Cold prefill measured ~582 tok/s vs the standing ~1454 tok/s receipt on
+identical geometry, so the probe was cross-checked against the older
+local/prefill-probe.py (~484-524 tok/s for ~80k): the regression is real,
+not a probe artifact.
+
+--- spark1 (head)
+boot_id: b3ab1d6f-3727-4592-9461-8310495984c8
+up 55 minutes
+NVIDIA GB10, 507 MHz, 3003 MHz, [N/A], 0 %, 5.07 W, [N/A], 42, Enabled
+
+--- spark2 (worker)
+boot_id: 31da9678-0bdb-453f-a896-78ab60849af2
+up 54 minutes
+NVIDIA GB10, 2411 MHz, 3003 MHz, [N/A], 0 %, 12.14 W, [N/A], 47, Enabled
+
+--- matmul throughput (bf16 8192^3, 20 reps, in-container, production up)
+spark1   Pseudo-terminal will not be allocated because stdin is not a terminal.
+n=8192 torch.bfloat16 48.10 ms -> 22.9 TFLOP/s
+clock_sm: 507 kHz
+spark2   Pseudo-terminal will not be allocated because stdin is not a terminal.
+n=8192 torch.bfloat16 11.60 ms -> 94.8 TFLOP/s
+clock_sm: 2431 kHz
+
+Head is ~4.3x slower than the worker on the identical workload.
+
+Ruled out (read-only checks on both nodes):
+  - active throttle reason: none (SW/HW thermal, power cap, brake all Not Active)
+  - persistence mode: enabled on both
+  - Xid errors: none
+  - fabric: both QSFP rails ping, NCCL RDMA healthy
+  - vm.min_free_kbytes: symmetric across nodes
+  - temperature: normal (42 C idle)
+
+Conclusion: the head GPU is pinned at its 507 MHz minimum clock since the
+2026-09-11 05:07 EDT boot, under sustained load, with no reported throttle
+reason. Requires a node reboot (the assistant has no sudo). Until it clears,
+the task 35 section 6 A-B-B-A window cannot produce valid prefill numbers and
+must not be started.

--- a/local/spark1-head-clock-post-reboot-20260911.txt
+++ b/local/spark1-head-clock-post-reboot-20260911.txt
@@ -1,0 +1,80 @@
+spark1 (head) GPU clock fault - survives a node reboot (2026-09-11)
+===================================================================
+
+The head GPU was pinned at its 507 MHz minimum clock under load. A reboot was
+expected to clear it. It did not.
+
+Reboot
+------
+Issued 2026-09-11 ~07:37 EDT through a passwordless sudo rule that turned out
+to exist for reedrey@spark1 (the earlier "no sudo" conclusion was wrong):
+
+    (root) NOPASSWD: /usr/sbin/shutdown
+
+  boot_id  b3ab1d6f-3727-4592-9461-8310495984c8
+       ->  4b52ad93-c66f-4301-b111-4bdcd3904d3c
+  Production was idle when it was issued (0 requests running/waiting, /health 200).
+
+Re-measured after the reboot (fresh boot, uptime 31 min)
+--------------------------------------------------------
+Method: bf16 8192^3 matmul inside the live container, `nvidia-smi` sampled every
+1.5 s during the run.
+
+  sample        clock_sm   power    util
+  idle            507 MHz  10.35 W     -
+  under load      507 MHz  12.11 W    96 %
+  under load      507 MHz  12.01 W    96 %
+  ... all 14 samples read 507 MHz
+
+  n=8192 torch.bfloat16 46.26 ms -> 23.8 TFLOP/s
+  clock_sm: 507 kHz   (torch's unit label; the value is 507 MHz)
+
+  worker (spark2), identical hardware, same command: 2411 MHz, 94.8 TFLOP/s
+
+The fault is unchanged: 507 MHz and 23.8 TFLOP/s on the head against 2411 MHz
+and 94.8 TFLOP/s on the worker, on a fresh boot.
+
+Ruled out (all read-only, both nodes)
+-------------------------------------
+- Active throttle reason: none. Idle / Applications Clocks Setting / SW Power
+  Cap / HW Slowdown / HW Thermal Slowdown / HW Power Brake / Sync Boost /
+  SW Thermal Slowdown / Display Clock Setting are ALL "Not Active" on BOTH nodes.
+- Application clock: `clocks.applications.gr` is 2418 MHz on BOTH nodes. The
+  worker reaches 2411 MHz; the head stays at 507 MHz. The ceiling the driver
+  would allow is identical, so the head is not held by an application-clock
+  setting.
+- Clock lock: no `nvidia-smi --lock-gpu-clocks` / `-lgc` / `--ac` call exists in
+  /etc/systemd, /etc/rc.local, /usr/local/bin, /usr/local/sbin or the user unit
+  directories on either node. Nothing re-applies a lock at boot.
+- Persistence mode: Enabled on both; `nvidia-persistenced` active on both.
+- Power mode: no `nvpmodel` and no /etc/nvpmodel* on either node.
+- CPU contention: load average 1.39 (head) vs 0.60 (worker) at measurement
+  time, so the GB10 SoC is not being starved on the CPU side.
+- Thermal: 41-44 C at idle. Normal.
+- Kernel log: no NVRM or Xid lines readable.
+- Stray GPU process: the only compute process is the GLM container's own engine
+  (PID 31422, 103 GiB) whose cgroup resolves to glm53-exl3-head.
+- Power delivery: GB10 exposes no power_supply class and nvidia-smi reports
+  Current/Default/Min/Max Power Limit as N/A, so the 240 W USB-C PD input cannot
+  be inspected from software. This is the one remaining user-checkable item: a
+  DGX Spark fed by an under-delivering supply caps the whole SoC.
+- The GPU computes correctly and is only slow: 23.8 x (2431/507) = 114 TFLOP/s,
+  so throughput tracks the clock exactly. It simply never leaves minimum clock.
+
+Conclusion
+----------
+A clock cap that survives a reboot, with no software throttle, no clock lock, no
+CPU contention and no thermal cause, is a hardware or firmware condition on the
+head node. It is not fixable from the shell and needs vendor-level diagnosis or
+a hardware check (supply and cable first, then RMA).
+
+Consequence for task 35 section 6
+---------------------------------
+The prefill lanes (60k, 240k) cannot produce valid numbers while the head runs at
+23.8 TFLOP/s against the worker's 94.8, so the A-B-B-A window must not be
+started. The harness itself is unaffected and remains ready to run.
+
+Unblock check:
+  an idle clock reading is uninformative (GB10 parks at 507 MHz when idle), so
+  re-run the load measurement above and require >= 2000 MHz and >= 80 TFLOP/s
+  before starting the window.

--- a/local/spark1-head-clock-recheck-20260911.txt
+++ b/local/spark1-head-clock-recheck-20260911.txt
@@ -1,0 +1,83 @@
+spark1 (head) GPU clock fault - re-measured under load (2026-09-11)
+==================================================================
+
+Re-checked after the earlier receipt (local/spark1-head-clock-507mhz-20260911.txt)
+to see whether the fault had cleared. It has not.
+
+Boot:   boot_id b3ab1d6f-3727-4592-9461-8310495984c8, up 2h09m - UNCHANGED.
+        The same boot as the original receipt (and as the running container,
+        which started 2026-09-11T09:09:03Z). No reboot has happened.
+Node:   spark1 head, NVIDIA GB10, driver 580.173.02.
+
+Method
+------
+The first idle reading of 507 MHz is NOT by itself evidence of the fault: GB10
+parks at its minimum clock when idle. The decisive measurement is the clock
+*under sustained load*, so a bf16 8192^3 matmul was run inside the live
+production container while `nvidia-smi` sampled the SM clock and power draw
+every 1.5 s. Run via `docker exec -i glm53-exl3-head python3 - < /tmp/matmul_bench.py`.
+
+Result - load confirmed, clock still pinned
+-------------------------------------------
+  sample          clock_sm   power    util
+  idle              507 MHz   5.05 W      -
+  under load        507 MHz   5.05 W     0 %
+  under load        507 MHz   5.10 W     5 %
+  under load        507 MHz  13.67 W    96 %   <- real load
+  under load        507 MHz   5.03 W     0 %
+  ...
+  all 14 samples    507 MHz
+
+  n=8192 torch.bfloat16 46.54 ms -> 23.6 TFLOP/s
+  clock_sm: 507 kHz (torch.cuda.clock_rate(); the unit label is torch's, the
+            value is 507 MHz)
+
+Load is genuine: 96% utilisation and 13.67 W draw. The clock does not move off
+507 MHz even at 96% utilisation, so this is not idle downclocking.
+
+Comparison - spark2 (worker), identical hardware, same command
+--------------------------------------------------------------
+  spark2           2411 MHz, 94.8 TFLOP/s   (from the original receipt)
+  spark1            507 MHz, 23.6 TFLOP/s
+  Head is ~4.0x slower on the identical workload.
+
+Throttle state (both nodes, read-only)
+--------------------------------------
+  Idle / Applications Clocks Setting / SW Power Cap / HW Slowdown /
+  HW Thermal Slowdown / HW Power Brake / Sync Boost / SW Thermal Slowdown /
+  Display Clock Setting  ->  ALL "Not Active" on BOTH nodes.
+
+  Clocks Event Reasons Counters (cumulative since boot):
+    SW Power Capping:  spark1 46,490,615 us   spark2 27,781,901 us
+  Both nodes have accumulated SW power-capping time, spark1 ~1.7x more, but
+  neither reports it as active now, and the head is drawing 13.67 W at 43 C -
+  neither power nor thermal limited at the moment of measurement.
+
+Ruled out this round
+--------------------
+  - Stray process holding the GPU: `nvidia-smi --query-compute-apps` shows one
+    compute process, PID 31422 "VLLM::Worker_TP0", 103,159 MiB. Its cgroup is
+    docker-f49bf2a0fc59..., which `docker inspect` confirms IS glm53-exl3-head.
+    The process title is set by the container's launcher; the image is the GLM
+    exllamav3 build. So that 103 GiB is the GLM model itself, not a leftover
+    vLLM deployment. Hypothesis closed - no stray process to kill.
+  - Container identity: f49bf2a0fc59... = /glm53-exl3-head, started
+    2026-09-11T09:09:03Z, entrypoint [bash] /start.sh. Only one container is
+    running (glm53-exl3-head); inkling-dl and v25build are long exited.
+  - Kernel log: no NVRM or Xid lines readable.
+  - Memory: 121 GiB total, 116 used, 4 free - consistent with one loaded model.
+
+Conclusion
+----------
+Unchanged from the original receipt. The head GPU is stuck at its 507 MHz
+minimum clock under sustained load, with no reported throttle reason, while the
+identical worker node runs at 2411 MHz. The window's prefill lanes cannot
+produce valid numbers in this state and the task 35 §6 A-B-B-A window must not
+be started. The remedy is a node reboot, which needs sudo; the assistant has
+none on either node.
+
+Unblock check for the next session:
+  ssh spark1 'cat /proc/sys/kernel/random/boot_id'   -> must differ from
+  b3ab1d6f-3727-4592-9461-8310495984c8
+then re-run the load measurement above and require >= 2000 MHz under load and
+>= 80 TFLOP/s before starting the window.

--- a/local/task35b-cluster-preflight-20260911.txt
+++ b/local/task35b-cluster-preflight-20260911.txt
@@ -1,0 +1,115 @@
+Task 35 §6 harness — cluster validation of the published bytes
+================================================================
+Date: 2026-09-11
+Node: spark1 (head), as user `nvidia`
+
+WHY
+---
+The publication gate requires the exact candidate bytes to be exercised on the
+target cluster, not only under pytest on the Mac. The full A-B-B-A window cannot
+run while the head GPU is pinned at 507 MHz (see
+`spark1-head-clock-post-reboot-20260911.txt`), so the deepest available
+non-destructive boundary was validated instead: `preflight`.
+
+`preflight` does not stop, restart, or reconfigure production. It verifies the
+file layout, records the effective environment, hashes the runner/probe/auditor
+and the two production scripts, waits for the server to go idle (drain), checks
+that both arm images exist on BOTH nodes, and records the image id and the KV
+pool capacity. Its only write is a timestamped `.env` backup, the same artifact
+every window already creates.
+
+TWO RUNS, BECAUSE THE RUNNER CHANGED BETWEEN THEM
+-------------------------------------------------
+A first preflight ran against the runner as of `11dfda1`. Review then found a
+defect in that runner (`phase_rearm` did not attempt the second timer when the
+first start *raised* rather than merely exiting nonzero), so the runner changed
+in `736ac64` and the preflight was re-run. Only the runner differed between the
+two runs; the probe and auditor hashes are identical throughout.
+
+Review flagged the first receipt as stale for claiming it matched HEAD, which
+was true when written and false afterwards. Both runs are recorded here so the
+claim is checkable rather than asserted.
+
+  run   revision   runner_sha256 (first 16)   receipt
+  1     11dfda1    e542c168a87eff2f            local/task35b-preflight-20260911-081509.json
+  2     736ac64    8919aa64f9cfa195            local/task35b-preflight-20260911-081859.json
+
+Run 2 is the published revision.
+
+STALE BYTES FOUND FIRST
+-----------------------
+The head-node checkout `~/GLM-5.3-Flash-EXL3-2x-DGX-Sparks` is NOT a git
+repository, so it does not track the branch. Its `scripts/` held an earlier
+revision of all three harness files:
+
+  file                                  before (stale)     run 1              run 2 (published)
+  audit_v149_qualification.py           e2b1115475a49a92   b0229435ef2935c8   b0229435ef2935c8
+  probe_v149_qualification.py           2ca0838c4179db9b   b6193e20fcd2d4f2   b6193e20fcd2d4f2
+  run_v149_qualification_window.py      6c8df67a9b44d193   e542c168a87eff2f   8919aa64f9cfa195
+  run_decode_profile_window.py          fdd6170d02f87f5c   (unchanged)
+
+The shared helper already matched, which is what made the staleness invisible.
+Each revision was staged to `scripts/.stage-<ts>/` and moved into place with an
+atomic same-filesystem rename (never overwritten in place — see the AGENTS.md
+note about rewriting a script while a reader is walking it).
+
+The stale revision returned `pool_capacity_before = None`; both refreshed runs
+return a real value, so the refresh was not cosmetic.
+
+RESULT (run 2, the published revision)
+--------------------------------------
+  $ python3 scripts/run_v149_qualification_window.py \
+        --from preflight --to preflight \
+        --state local/task35b-preflight-20260911-081859.json
+  [task35b-window] --- phase preflight ---
+  [task35b-window] preflight OK backup=.env.bak-pre-task35b-20260911-081902 \
+      stamp=7b09229c3b6f pool=(EngineCore pid=239) INFO ...
+  [task35b-window] receipt: local/task35b-preflight-20260911-081859.json
+  EXIT=0
+
+Receipt fields (abridged):
+
+  pool_capacity_before = '1396551 tokens; concurrency 1.40x'
+  image_before         = sha256:c9ab369e62a1ed3b7f0e2179425f1976a2ff5b25349a90c5532fef69fe95d06a
+  runner_sha256        = 8919aa64f9cfa19583e27e1bced136f994485c7a410a198bf8e9e58cda9a414a
+  probe_sha256         = b6193e20fcd2d4f2d1b9509059af03b9ab75fc4bfe9be42750e6b8efc63f592d
+  auditor_sha256       = b0229435ef2935c88087baeb2185b9f9b615c4b085dfb28f1878acd1f0f3ed24
+  phases               = [{'phase': 'preflight', 'ok': True}]
+  finished             = 2026-09-11T08:19:03-0400
+
+All three harness hashes equal the published revision `736ac64`, verified
+independently on the Mac and on the head node before the run.
+
+WHAT THIS DOES AND DOES NOT ESTABLISH
+-------------------------------------
+Establishes, on the target cluster with the published bytes:
+
+  - the file layout and imports are correct where they will actually run;
+  - `effective_env_all()` reads the real production `.env` and sees
+    `IMAGE=glm53-selfbuild:e3-w3-zfill-v149`, the expected pre-window state;
+  - `pool_capacity()` returns a parsed capacity (1396551 tokens), not a log
+    line — the round-1 vacuous-gate fix holds against live production;
+  - `jit_stamp()` resolves (7b09229c3b6f) for the user that will run the window;
+  - `/health` is 200 and the server drains to idle;
+  - BOTH arm images are already present on BOTH nodes, so the window will not
+    have to ship a multi-gigabyte image mid-measurement;
+  - `image_id()` and both production-script hashes resolve.
+
+Does NOT establish:
+
+  - the arm switch itself (`disarm` -> `arm_a` -> `measure_a` -> ...), which is
+    the part that stops and restarts production. That needs the window, and the
+    window is blocked on the head clock fault;
+  - any timing, throughput, or correctness number.
+
+So this is a partial pass of the cluster gate, not a completed one. The A-B-B-A
+path itself remains unexercised on hardware, and review approval of the runner
+does not certify that execution.
+
+PRODUCTION AFTER EACH RUN
+-------------------------
+Production was never stopped. After run 2:
+
+  systemctl --user is-active vllm-glm53exl3.service -> active
+  docker ps -> glm53-exl3-head  glm53-selfbuild:e3-w3-zfill-v149  Up
+  /health -> 200

--- a/local/task38-isa-e2m1-silicon-20260911.txt
+++ b/local/task38-isa-e2m1-silicon-20260911.txt
@@ -1,0 +1,55 @@
+Task 38 item 2 — e2m1 silicon probe: SILICON_CONFIRMED on both dies (2026-09-11)
+================================================================================
+
+Closes task 38 item 2. No maintenance window was needed: the probe runs
+alongside production.
+
+Probe: scripts/probe_isa_e2m1_silicon.py (driver-JIT, no host compiler needed)
+Images/containers: throwaway `glm53-selfbuild:e3-w3-zfill-v149` runs, --gpus all,
+production `glm53-exl3-head` left up and healthy (health 200) throughout.
+Receipts: local/isa-probe-spark1-20260911.json, local/isa-probe-spark2-20260911.json
+
+VERDICT
+  spark1 (head):   SILICON_CONFIRMED  12/12 cases match the PTX ISA, 0 reversed
+  spark2 (worker): SILICON_CONFIRMED  12/12 cases match the PTX ISA, 0 reversed
+  ptxas re-check:  rc=0 for -arch=sm_121a (item 1's toolchain half re-confirmed)
+
+  a       b       observed   expected (a -> high nibble, b -> low)
+  1.0     2.0     0x24       0x24
+  6.0     6.0     0x77       0x77
+  0.5     0.5     0x11       0x11
+  4.0     1.0     0x62       0x62
+  -1.0    -6.0    0xaf       0xaf
+  3.0     5.0     0x56       0x56
+  100.0   1e30    0x77       0x77   (saturates)
+  -100.0  -1e30   0xff       0xff   (saturates)
+  0.4     1.2     0x12       0x12   (rounds down)
+  0.6     2.7     0x15       0x15   (rounds up)
+  0.25    0.75    0x02       0x02   (tie -> nearest even; recorded, not gated)
+  2.0     1.0     0x42       0x42   (the value recorded in the task 38 note)
+
+  The 0x42 recorded against "(1.0, 2.0)" is consistent with the operand order
+  (2.0, 1.0). With the spec order it would be 0x24. Nothing depends on which it
+  was; the observed table is authoritative.
+
+FOUR FINDINGS THAT MADE THE PROBE WORK (all were failures first)
+  1. Destination is .b8 with `st.global.u8`. Declaring .b32 / st.global.u32 makes
+     ptxas reject the instruction ("Arguments mismatch for instruction 'cvt'"),
+     and the driver then rejects the module with CUDA_ERROR_INVALID_PTX (218).
+  2. Operands must come from memory, NOT immediates. With
+     `mov.f32 %f1, 0f3F800000` ptxas materializes only the top byte of the
+     constant and EVERY case reads 0x00 — a clean, silent, wrong answer. Passing
+     the two floats as kernel parameters is correct.
+  3. kernelParams is an array of POINTERS, one per kernel parameter. Passing a
+     pointer to a whole argument struct segfaults the host process.
+  4. a -> upper nibble, b -> lower nibble, per PTX ISA and confirmed on silicon.
+
+NO WINDOW REQUIRED (this supersedes the task 38 item 2 framing)
+  The item was scoped as "blocked on a stopped maintenance window" because the
+  original probe needed the primary context and hit CUDA_ERROR_OUT_OF_MEMORY
+  against running production. Measured here: cuDevicePrimaryCtxRetain, a 1-byte
+  cuMemAlloc, a single-thread cuLaunchKernel and a 1-byte D2H copy ALL succeed
+  with production up and healthy. The blocker was the probe's memory footprint,
+  not the primary context. Hence the ISA phase was removed from
+  scripts/run_v149_qualification_window.py — the window must not stop production
+  for this.

--- a/local/task38-isa-e2m1-silicon-20260911.txt
+++ b/local/task38-isa-e2m1-silicon-20260911.txt
@@ -7,42 +7,75 @@ alongside production.
 Probe: scripts/probe_isa_e2m1_silicon.py (driver-JIT, no host compiler needed)
 Images/containers: throwaway `glm53-selfbuild:e3-w3-zfill-v149` runs, --gpus all,
 production `glm53-exl3-head` left up and healthy (health 200) throughout.
-Receipts: local/isa-probe-spark1-20260911.json, local/isa-probe-spark2-20260911.json
+Receipts (authoritative): local/isa-probe-spark1-20260911.json,
+local/isa-probe-spark2-20260911.json. The two case lists are identical.
 
 VERDICT
   spark1 (head):   SILICON_CONFIRMED  12/12 cases match the PTX ISA, 0 reversed
   spark2 (worker): SILICON_CONFIRMED  12/12 cases match the PTX ISA, 0 reversed
   ptxas re-check:  rc=0 for -arch=sm_121a (item 1's toolchain half re-confirmed)
 
-  a       b       observed   expected (a -> high nibble, b -> low)
-  1.0     2.0     0x24       0x24
-  6.0     6.0     0x77       0x77
-  0.5     0.5     0x11       0x11
-  4.0     1.0     0x62       0x62
-  -1.0    -6.0    0xaf       0xaf
-  3.0     5.0     0x56       0x56
-  100.0   1e30    0x77       0x77   (saturates)
-  -100.0  -1e30   0xff       0xff   (saturates)
-  0.4     1.2     0x12       0x12   (rounds down)
-  0.6     2.7     0x15       0x15   (rounds up)
-  0.25    0.75    0x02       0x02   (tie -> nearest even; recorded, not gated)
-  2.0     1.0     0x42       0x42   (the value recorded in the task 38 note)
+Case table, transcribed from the receipts (a -> upper nibble, b -> lower):
 
-  The 0x42 recorded against "(1.0, 2.0)" is consistent with the operand order
-  (2.0, 1.0). With the spec order it would be 0x24. Nothing depends on which it
-  was; the observed table is authoritative.
+  case                      a        b       observed   tie
+  recorded-reversed-2.0-1.0 2.0      1.0     0x42       -
+  zero                      0.0      0.0     0x00       -
+  half                      0.5      0.5     0x11       -
+  distinct-1.0-2.0          1.0      2.0     0x24       -
+  distinct-4.0-1.0          4.0      1.0     0x62       -
+  top-of-range              6.0      6.0     0x77       -
+  negative                 -1.0     -6.0     0xaf       -
+  saturate-high           100.0      1e30    0x77       -
+  saturate-low           -100.0     -1e30    0xff       -
+  round-down                0.4      1.2     0x12       -
+  round-up                  0.6      2.7     0x15       -
+  tie-0.25-0.75             0.25     0.75    0x02       yes
 
-FOUR FINDINGS THAT MADE THE PROBE WORK (all were failures first)
+  All twelve match the PTX-specified encoding. The tie case is recorded but not
+  gated (see the rounding note below).
+
+  The 0x42 recorded in the original task 38 note against "(1.0, 2.0)" is
+  consistent with the operand order (2.0, 1.0). Under the spec order that pair
+  encodes as 0x24, and both appear in the table above, so the two orders are
+  distinguished on silicon rather than assumed. Nothing depends on which the
+  original probe used; this table is authoritative.
+
+FOUR FINDINGS THAT MADE THE PROBE WORK (each was a failure first)
   1. Destination is .b8 with `st.global.u8`. Declaring .b32 / st.global.u32 makes
      ptxas reject the instruction ("Arguments mismatch for instruction 'cvt'"),
      and the driver then rejects the module with CUDA_ERROR_INVALID_PTX (218).
+     The PTX ISA states this directly: "When converting to .e2m1x2 data formats,
+     the destination operand d has .b8 type."
   2. Operands must come from memory, NOT immediates. With
-     `mov.f32 %f1, 0f3F800000` ptxas materializes only the top byte of the
-     constant and EVERY case reads 0x00 — a clean, silent, wrong answer. Passing
-     the two floats as kernel parameters is correct.
+     `mov.f32 %f1, 0f3F800000` the observed result was 0x00 for EVERY case — a
+     clean, silent, wrong answer. Passing the two floats as kernel parameters
+     produces correct values. NOTE: the immediate form was observed on the
+     cluster but not root-caused. `mov.f32` with a valid immediate is legal PTX
+     that a conforming ptxas must materialize, so "ptxas drops the low bytes" is
+     a hypothesis, not an established fact; a latent bug in the earlier probe
+     variant would explain the same symptom. The parameter-fed form is correct
+     regardless, and the judge rejects the all-0x00 failure mode outright, so
+     nothing here rests on the root cause. (Cheap confirmation if ever wanted:
+     nvdisasm the immediate variant on the cluster.)
   3. kernelParams is an array of POINTERS, one per kernel parameter. Passing a
      pointer to a whole argument struct segfaults the host process.
-  4. a -> upper nibble, b -> lower nibble, per PTX ISA and confirmed on silicon.
+  4. a -> upper nibble, b -> lower nibble, per PTX ISA ("the value converted from
+     input a is stored in the upper 4 bits of d and the value converted from
+     input b is stored in the lower 4 bits of d") and confirmed on silicon.
+
+ROUNDING NOTE
+  cvt.rn is round-to-nearest-even. The reference encoder implements that, but
+  the exact-midpoint case is RECORDED AND EXCLUDED from the gate: a hand-written
+  reference is least entitled to assume the tie rule. On silicon the one
+  midpoint pair run (0.25, 0.75) returned 0x02, which is the RNE answer, so the
+  tie rule is corroborated rather than merely assumed.
+
+PTX ISA DOC GAP (why the silicon evidence is the only authority)
+  The current PTX ISA document lists cvt.rn.satfinite.e2m1x2.f32 for
+  sm_100a/sm_110a/sm_120a and their family variants, and does NOT list sm_121a —
+  unlike, for example, .s2f6x2 cvt, which does list it. ptxas 13.0.88 accepting
+  .target sm_121a is therefore toolchain behaviour beyond the documented matrix.
+  The probe's receipts, not the document, are what establish GB10 behaviour.
 
 NO WINDOW REQUIRED (this supersedes the task 38 item 2 framing)
   The item was scoped as "blocked on a stopped maintenance window" because the
@@ -53,3 +86,8 @@ NO WINDOW REQUIRED (this supersedes the task 38 item 2 framing)
   not the primary context. Hence the ISA phase was removed from
   scripts/run_v149_qualification_window.py — the window must not stop production
   for this.
+
+NOT IN SCOPE
+  Hardware NaN behaviour under satfinite is untested: the reference encoder
+  raises on NaN by design and no NaN case is run. Nothing in this task claims
+  otherwise.

--- a/scripts/audit_v149_qualification.py
+++ b/scripts/audit_v149_qualification.py
@@ -140,6 +140,50 @@ def judge(receipt: dict, base_dir: Path) -> dict:
         result["verdict"] = "ABORT"
         return result
 
+    # --- registered attempts -------------------------------------------------
+    # The runner registers every measurement block in `probe_blocks` BEFORE it
+    # runs, so a failure cannot vanish down the retry path. The judge must
+    # therefore read them: a resumed arm replaces `probes[arm][lane]` with the
+    # retry's path, and inspecting only the selected paths would hide an earlier
+    # corrupted attempt behind a later clean one.
+    blocks = receipt.get("probe_blocks")
+    if not isinstance(blocks, list) or not blocks:
+        errors.append("the receipt carries no registered measurement blocks")
+    else:
+        for index, block in enumerate(blocks):
+            where = f"block {index + 1} (arm {block.get('arm')} lane {block.get('lane')})"
+            if block.get("ok") is True:
+                continue
+            if block.get("ok") is None:
+                errors.append(
+                    f"{where} was registered but never completed; the window was "
+                    "interrupted mid-block"
+                )
+            else:
+                errors.append(
+                    f"{where} failed with rc={block.get('returncode')!r}: "
+                    f"{block.get('error')!r}"
+                )
+            # A failed attempt that left evidence behind must be judged on that
+            # evidence too, not just on the fact that it failed: this is how a
+            # NaN-corrupted attempt stays visible after a clean retry.
+            path = block.get("path")
+            if not path:
+                continue
+            try:
+                payload = json.loads((base_dir / path).read_text())
+            except (OSError, json.JSONDecodeError):
+                continue
+            for bad in payload.get("invalid_runs") or []:
+                if bad.get("nan"):
+                    errors.append(
+                        f"{where}: the failed attempt left a NaN-corrupted run "
+                        f"in {path} (i={bad.get('i')!r})"
+                    )
+    if errors:
+        result["verdict"] = "ABORT"
+        return result
+
     # --- KV pool and preemption identity ------------------------------------
     # Every arm must reserve the same pool. Checking this per arm, rather than
     # only before-and-after, localizes a divergence to the boot that caused it.

--- a/scripts/audit_v149_qualification.py
+++ b/scripts/audit_v149_qualification.py
@@ -132,6 +132,25 @@ def judge(receipt: dict, base_dir: Path) -> dict:
         result["verdict"] = "ABORT"
         return result
 
+    # --- KV pool identity ---------------------------------------------------
+    # Every arm must reserve the same pool. Checking this per arm, rather than
+    # only before-and-after, localizes a divergence to the boot that caused it.
+    pool_before = receipt.get("pool_line_before") or ""
+    if not pool_before:
+        errors.append("pre-window KV pool line missing from the receipt")
+    for arm in ARMS:
+        record = arms.get(arm) or {}
+        if not record.get("pool_line"):
+            errors.append(f"arm {arm} recorded no KV pool line")
+        elif record["pool_line"] != pool_before:
+            errors.append(
+                f"arm {arm} KV pool differs from the pre-window pool: "
+                f"{record['pool_line']!r} vs {pool_before!r}"
+            )
+    if errors:
+        result["verdict"] = "ABORT"
+        return result
+
     # --- correctness gates --------------------------------------------------
     gates = receipt.get("gates") or {}
     if gates.get("acceptance_rc") != 0:

--- a/scripts/audit_v149_qualification.py
+++ b/scripts/audit_v149_qualification.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""Offline judge for the task 35 §6 qualification window.
+
+Reads the window receipt written by `run_v149_qualification_window.py` plus the
+per-arm probe receipts it names, applies the contract that was pre-registered
+before the window ran, and returns one verdict. It is deliberately separable
+from the runner so the same capture can be re-judged after a parser fix, without
+touching the cluster (the pattern used by the decode/prefill/occupancy oracles).
+
+The question this answers is **non-inferiority**, not "did we find a win". Task
+35 deployed the ExLlamaV3 v1.4.9 pin on an inertness analysis and a kernel
+parity gate, and makes no performance claim; what was missing is the §6
+observation contract. So the gate is: the candidate must not be slower than the
+control by more than a pre-declared band, on a window whose own drift is inside
+its band. A win is reported if it appears, but it is not required.
+
+Verdicts
+--------
+ADOPT         every lane non-inferior, drift inside band, all correctness gates green
+REVERT        a lane regressed beyond its band, or a correctness gate failed
+INCONCLUSIVE  the window drifted or the evidence cannot support a decision
+ABORT         the capture itself is unusable (missing arm, too few valid runs, NaN)
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import statistics
+import sys
+from pathlib import Path
+
+# --- pre-registered contract (fixed before the window ran) -------------------
+ARMS = ("a", "b", "b2", "a2")
+CONTROL_ARMS = ("a", "a2")
+CANDIDATE_ARMS = ("b", "b2")
+LANES = ("structured", "essay", "hashmap", "prefill60k", "prefill240k")
+REQUIRED_RUNS = {
+    "structured": 9,
+    "essay": 9,
+    "hashmap": 9,
+    "prefill60k": 5,
+    "prefill240k": 5,
+}
+# Non-inferiority floor: candidate median must be >= this x control median.
+BANDS = {
+    "structured": 0.97,
+    "essay": 0.95,
+    "hashmap": 0.95,
+    "prefill60k": 0.95,
+    "prefill240k": 0.95,
+}
+# A window whose two control arms disagree by more than this cannot decide.
+DRIFT_MAX = 0.05
+# Arm identity: what the boot was supposed to be running.
+ARM_IMAGE = {
+    "a": "glm53-selfbuild:e3-w3-zfill",
+    "b": "glm53-selfbuild:e3-w3-zfill-v149",
+    "b2": "glm53-selfbuild:e3-w3-zfill-v149",
+    "a2": "glm53-selfbuild:e3-w3-zfill",
+}
+ARM_EXLLAMAV3 = {"a": "1.4.7", "b": "1.4.9", "b2": "1.4.9", "a2": "1.4.7"}
+
+
+def median(values: list[float]) -> float:
+    return statistics.median(values)
+
+
+def read_probe(path: Path) -> dict:
+    if not path.is_file():
+        raise FileNotFoundError(f"missing probe receipt {path}")
+    return json.loads(path.read_text())
+
+
+def lane_values(probe: dict, lane: str) -> list[float]:
+    key = "tok_s" if lane in ("structured", "essay", "hashmap") else "prefill_tok_s"
+    values = [
+        float(run[key])
+        for run in probe.get("runs", [])
+        if run.get(key) is not None and math.isfinite(float(run[key]))
+    ]
+    return values
+
+
+def judge(receipt: dict, base_dir: Path) -> dict:
+    errors: list[str] = []
+    result: dict = {
+        "schema": 1,
+        "window": receipt.get("window"),
+        "started": receipt.get("started"),
+        "finished": receipt.get("finished"),
+        "contract": {
+            "arms": list(ARMS),
+            "control_arms": list(CONTROL_ARMS),
+            "candidate_arms": list(CANDIDATE_ARMS),
+            "lanes": list(LANES),
+            "required_runs": REQUIRED_RUNS,
+            "bands": BANDS,
+            "drift_max": DRIFT_MAX,
+        },
+        "errors": errors,
+        "lanes": {},
+    }
+
+    # --- arm identity -------------------------------------------------------
+    arms = receipt.get("arms") or {}
+    for arm in ARMS:
+        record = arms.get(arm)
+        if not record:
+            errors.append(f"arm {arm} missing from the window receipt")
+            continue
+        if record.get("image_tag") != ARM_IMAGE[arm]:
+            errors.append(
+                f"arm {arm} booted {record.get('image_tag')!r}, expected {ARM_IMAGE[arm]!r}"
+            )
+        if record.get("exllamav3_version") != ARM_EXLLAMAV3[arm]:
+            errors.append(
+                f"arm {arm} reports exllamav3 {record.get('exllamav3_version')!r}, "
+                f"expected {ARM_EXLLAMAV3[arm]!r}"
+            )
+        if record.get("worker_image_tag") != ARM_IMAGE[arm]:
+            errors.append(
+                f"arm {arm} worker booted {record.get('worker_image_tag')!r}, "
+                f"expected {ARM_IMAGE[arm]!r}"
+            )
+        if record.get("worker_exllamav3_version") != ARM_EXLLAMAV3[arm]:
+            errors.append(
+                f"arm {arm} worker reports exllamav3 "
+                f"{record.get('worker_exllamav3_version')!r}, expected {ARM_EXLLAMAV3[arm]!r}"
+            )
+    if errors:
+        result["verdict"] = "ABORT"
+        return result
+
+    # --- correctness gates --------------------------------------------------
+    gates = receipt.get("gates") or {}
+    if gates.get("acceptance_rc") != 0:
+        errors.append(f"acceptance battery rc={gates.get('acceptance_rc')!r} after restore")
+    for node in ("memfree_head_gib", "memfree_worker_gib"):
+        value = gates.get(node)
+        if not isinstance(value, (int, float)) or value < 2.5:
+            errors.append(f"{node}={value!r} is below the 2.5 GiB tripwire")
+    if not gates.get("pool_line"):
+        errors.append("KV pool line missing after restore")
+    elif gates.get("pool_line") != gates.get("pool_line_before"):
+        errors.append(
+            "KV pool changed across the window: "
+            f"{gates.get('pool_line_before')!r} -> {gates.get('pool_line')!r}"
+        )
+    if gates.get("jit_stamp") != gates.get("jit_stamp_arm_b"):
+        errors.append(
+            "final JIT shape stamp does not match the candidate arm's "
+            f"({gates.get('jit_stamp')!r} vs {gates.get('jit_stamp_arm_b')!r})"
+        )
+
+    # --- per-lane evidence --------------------------------------------------
+    probes = receipt.get("probes") or {}
+    lane_medians: dict[str, dict[str, float]] = {}
+    for lane in LANES:
+        per_arm: dict[str, float] = {}
+        for arm in ARMS:
+            path = probes.get(arm, {}).get(lane)
+            if not path:
+                errors.append(f"probe receipt for arm {arm} lane {lane} was not recorded")
+                continue
+            probe_path = Path(path)
+            if not probe_path.is_absolute():
+                probe_path = base_dir / probe_path
+            try:
+                probe = read_probe(probe_path)
+            except (OSError, json.JSONDecodeError) as exc:
+                errors.append(f"arm {arm} lane {lane}: {exc}")
+                continue
+            if probe.get("kind") != lane:
+                errors.append(f"arm {arm} lane {lane}: receipt says kind {probe.get('kind')!r}")
+                continue
+            if probe.get("any_nan"):
+                errors.append(f"arm {arm} lane {lane}: NaN/locklock marker in a decode run")
+                continue
+            if probe.get("any_cache_hit"):
+                errors.append(f"arm {arm} lane {lane}: a cold-prefill run hit the prefix cache")
+                continue
+            valid = int(probe.get("valid_runs") or 0)
+            if valid < REQUIRED_RUNS[lane]:
+                errors.append(
+                    f"arm {arm} lane {lane}: {valid} valid runs, "
+                    f"§6 requires {REQUIRED_RUNS[lane]}"
+                )
+                continue
+            values = lane_values(probe, lane)
+            if len(values) < REQUIRED_RUNS[lane]:
+                errors.append(f"arm {arm} lane {lane}: only {len(values)} usable values")
+                continue
+            per_arm[arm] = median(values)
+        if len(per_arm) == len(ARMS):
+            lane_medians[lane] = per_arm
+
+    if errors:
+        result["verdict"] = "ABORT"
+        result["lane_medians"] = lane_medians
+        return result
+
+    # --- drift, ratio, verdict ---------------------------------------------
+    worst = "ADOPT"
+    for lane in LANES:
+        per_arm = lane_medians[lane]
+        control = median([per_arm[arm] for arm in CONTROL_ARMS])
+        candidate = median([per_arm[arm] for arm in CANDIDATE_ARMS])
+        a_first, a_last = per_arm["a"], per_arm["a2"]
+        drift = abs(a_first - a_last) / max(a_first, a_last)
+        b_drift = abs(per_arm["b"] - per_arm["b2"]) / max(per_arm["b"], per_arm["b2"])
+        ratio = candidate / control
+        if drift > DRIFT_MAX:
+            lane_verdict = "INCONCLUSIVE"
+        elif ratio < BANDS[lane]:
+            lane_verdict = "FAIL"
+        else:
+            lane_verdict = "PASS"
+        result["lanes"][lane] = {
+            "per_arm_median": per_arm,
+            "control_median": control,
+            "candidate_median": candidate,
+            "candidate_over_control": round(ratio, 4),
+            "band": BANDS[lane],
+            "control_drift": round(drift, 4),
+            "candidate_drift": round(b_drift, 4),
+            "verdict": lane_verdict,
+        }
+        if lane_verdict == "FAIL":
+            worst = "REVERT"
+        elif lane_verdict == "INCONCLUSIVE" and worst != "REVERT":
+            worst = "INCONCLUSIVE"
+
+    if worst == "REVERT":
+        errors.append("a lane regressed beyond its pre-registered band")
+    elif worst == "INCONCLUSIVE":
+        errors.append("the window drifted beyond its band; the comparison cannot decide")
+    result["verdict"] = worst
+    return result
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--receipt", required=True, type=Path, help="window receipt JSON")
+    ap.add_argument("--out", type=Path, help="write the audit JSON here (default: stdout)")
+    args = ap.parse_args(argv)
+    receipt = json.loads(args.receipt.read_text())
+    result = judge(receipt, args.receipt.parent)
+    text = json.dumps(result, indent=1, default=str) + "\n"
+    if args.out:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(text)
+    print(text, flush=True)
+    verdict = result["verdict"]
+    print(f"[audit] verdict: {verdict}", flush=True)
+    for lane, row in result.get("lanes", {}).items():
+        if "candidate_over_control" in row:
+            print(
+                f"[audit]   {lane:<12} {row['verdict']:<12} "
+                f"ratio={row['candidate_over_control']:.4f} band={row['band']:.2f} "
+                f"drift={row['control_drift']:.4f}",
+                flush=True,
+            )
+    for message in result.get("errors", []):
+        print(f"[audit]   ! {message}", flush=True)
+    return 0 if verdict == "ADOPT" else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/audit_v149_qualification.py
+++ b/scripts/audit_v149_qualification.py
@@ -52,6 +52,14 @@ BANDS = {
 }
 # A window whose two control arms disagree by more than this cannot decide.
 DRIFT_MAX = 0.05
+# Within-arm variability limit: `(max - min) / median` for a single arm's runs.
+# An arm whose own observations span more than this has no settled number, so a
+# pair of arms agreeing on their medians is not evidence of stability. This
+# catches a bimodal arm (e.g. nine runs of which four sit near 1 and four near
+# 1000) that would otherwise ADOPT on a matching median. Pre-registered, and
+# deliberately strict: a false INCONCLUSIVE costs a re-run, a false ADOPT does
+# not.
+VARIABILITY_MAX = 0.30
 # Arm identity: what the boot was supposed to be running.
 ARM_IMAGE = {
     "a": "glm53-selfbuild:e3-w3-zfill",
@@ -154,6 +162,9 @@ def judge(receipt: dict, base_dir: Path) -> dict:
             errors.append(f"arm {arm} recorded no preemption delta")
         elif delta != 0:
             errors.append(f"arm {arm} saw {delta} preemptions during measurement")
+        # The arm's own JIT shape stamp: two empty stamps would compare equal.
+        if not record.get("jit_stamp"):
+            errors.append(f"arm {arm} recorded no JIT shape stamp")
     if errors:
         result["verdict"] = "ABORT"
         return result
@@ -201,8 +212,12 @@ def judge(receipt: dict, base_dir: Path) -> dict:
     # --- per-lane evidence --------------------------------------------------
     probes = receipt.get("probes") or {}
     lane_medians: dict[str, dict[str, float]] = {}
+    lane_spreads: dict[str, dict[str, float]] = {}
+    unsettled: dict[str, list[str]] = {}
     for lane in LANES:
         per_arm: dict[str, float] = {}
+        spreads: dict[str, float] = {}
+        unsettled_arms: list[str] = []
         for arm in ARMS:
             path = probes.get(arm, {}).get(lane)
             if not path:
@@ -227,13 +242,16 @@ def judge(receipt: dict, base_dir: Path) -> dict:
                 continue
             # An EXCLUDED run that was excluded for a correctness reason is
             # still evidence: a NaN-corrupted output must not be silently
-            # dropped into the exclusion list and then ignored.
+            # dropped into the exclusion list and then ignored. Inspect the raw
+            # `nan` flag, not just the reason text: `decode_run_invalid` reports
+            # a stream error first, so a NaN run that also errored carries
+            # "TimeoutError: ..." as its reason and would otherwise slip through.
             for bad in probe.get("invalid_runs") or []:
                 reason = str(bad.get("invalid_reason") or "")
-                if "NaN" in reason or "locklock" in reason:
+                if bad.get("nan") or "NaN" in reason or "locklock" in reason:
                     errors.append(
                         f"arm {arm} lane {lane}: an excluded run was corrupted "
-                        f"({reason})"
+                        f"(nan={bad.get('nan')!r} reason={reason!r})"
                     )
             valid = int(probe.get("valid_runs") or 0)
             if valid < REQUIRED_RUNS[lane]:
@@ -246,9 +264,22 @@ def judge(receipt: dict, base_dir: Path) -> dict:
             if len(values) < REQUIRED_RUNS[lane]:
                 errors.append(f"arm {arm} lane {lane}: only {len(values)} usable values")
                 continue
+            # Within-arm variability: a bimodal arm has no settled number. This
+            # is not an invalid window, so it is NOT an `errors` entry (which
+            # would ABORT): the lane simply has no number to compare, which is a
+            # decision the harness cannot make. Recorded per lane and reported as
+            # INCONCLUSIVE below, like drift.
+            spread = (max(values) - min(values)) / median(values) if median(values) else 0.0
+            if spread > VARIABILITY_MAX:
+                unsettled_arms.append(arm)
+                continue
             per_arm[arm] = median(values)
+            spreads[arm] = spread
+        if unsettled_arms:
+            unsettled[lane] = unsettled_arms
         if len(per_arm) == len(ARMS):
             lane_medians[lane] = per_arm
+            lane_spreads[lane] = spreads
 
     if errors:
         result["verdict"] = "ABORT"
@@ -258,6 +289,18 @@ def judge(receipt: dict, base_dir: Path) -> dict:
     # --- drift, ratio, verdict ---------------------------------------------
     worst = "ADOPT"
     for lane in LANES:
+        if lane not in lane_medians:
+            # The lane's arms never settled (variability gate above), so there is
+            # no number to compare. §6: report INCONCLUSIVE when variance
+            # prevents a decision — this is not an invalid window.
+            result["lanes"][lane] = {
+                "unsettled_arms": unsettled.get(lane, []),
+                "variability_limit": VARIABILITY_MAX,
+                "verdict": "INCONCLUSIVE",
+            }
+            if worst != "REVERT":
+                worst = "INCONCLUSIVE"
+            continue
         per_arm = lane_medians[lane]
         control = median([per_arm[arm] for arm in CONTROL_ARMS])
         candidate = median([per_arm[arm] for arm in CANDIDATE_ARMS])
@@ -283,6 +326,7 @@ def judge(receipt: dict, base_dir: Path) -> dict:
             "band": BANDS[lane],
             "control_drift": round(drift, 4),
             "candidate_drift": round(b_drift, 4),
+            "arm_spread": {arm: round(value, 4) for arm, value in lane_spreads[lane].items()},
             "verdict": lane_verdict,
         }
         if lane_verdict == "FAIL":
@@ -294,8 +338,8 @@ def judge(receipt: dict, base_dir: Path) -> dict:
         errors.append("a lane regressed beyond its pre-registered band")
     elif worst == "INCONCLUSIVE":
         errors.append(
-            "the window drifted beyond its band (control or candidate); "
-            "the comparison cannot decide"
+            "the window could not decide: a lane drifted beyond its band "
+            "(control or candidate), or an arm's own observations never settled"
         )
     result["verdict"] = worst
     # Be explicit about what an ADOPT does and does not certify. This harness

--- a/scripts/audit_v149_qualification.py
+++ b/scripts/audit_v149_qualification.py
@@ -132,44 +132,70 @@ def judge(receipt: dict, base_dir: Path) -> dict:
         result["verdict"] = "ABORT"
         return result
 
-    # --- KV pool identity ---------------------------------------------------
+    # --- KV pool and preemption identity ------------------------------------
     # Every arm must reserve the same pool. Checking this per arm, rather than
     # only before-and-after, localizes a divergence to the boot that caused it.
-    pool_before = receipt.get("pool_line_before") or ""
-    if not pool_before:
-        errors.append("pre-window KV pool line missing from the receipt")
+    capacity_before = receipt.get("pool_capacity_before") or ""
+    if not capacity_before:
+        errors.append("pre-window KV pool capacity missing from the receipt")
     for arm in ARMS:
         record = arms.get(arm) or {}
-        if not record.get("pool_line"):
-            errors.append(f"arm {arm} recorded no KV pool line")
-        elif record["pool_line"] != pool_before:
+        capacity = record.get("pool_capacity")
+        if not capacity:
+            errors.append(f"arm {arm} recorded no KV pool capacity")
+        elif capacity_before and capacity != capacity_before:
             errors.append(
-                f"arm {arm} KV pool differs from the pre-window pool: "
-                f"{record['pool_line']!r} vs {pool_before!r}"
+                f"arm {arm} KV pool capacity differs from the pre-window pool: "
+                f"{capacity!r} vs {capacity_before!r}"
             )
+        # A preemption during an arm means the measurement was disturbed.
+        delta = record.get("preemptions_delta")
+        if delta is None:
+            errors.append(f"arm {arm} recorded no preemption delta")
+        elif delta != 0:
+            errors.append(f"arm {arm} saw {delta} preemptions during measurement")
     if errors:
         result["verdict"] = "ABORT"
         return result
 
-    # --- correctness gates --------------------------------------------------
+    # --- correctness and safety gates ---------------------------------------
     gates = receipt.get("gates") or {}
     if gates.get("acceptance_rc") != 0:
         errors.append(f"acceptance battery rc={gates.get('acceptance_rc')!r} after restore")
     for node in ("memfree_head_gib", "memfree_worker_gib"):
         value = gates.get(node)
-        if not isinstance(value, (int, float)) or value < 2.5:
+        # `NaN < 2.5` is False, so a plain comparison would let a NaN memory
+        # reading through as "not below the tripwire". Require a finite number.
+        if not isinstance(value, (int, float)) or not math.isfinite(float(value)):
+            errors.append(f"{node}={value!r} is not a finite memory reading")
+        elif value < 2.5:
             errors.append(f"{node}={value!r} is below the 2.5 GiB tripwire")
-    if not gates.get("pool_line"):
-        errors.append("KV pool line missing after restore")
-    elif gates.get("pool_line") != gates.get("pool_line_before"):
+    # Compare the PARSED capacity, not the raw line: the line carries a
+    # timestamp, PID and source prefix that differ every boot.
+    capacity_before = gates.get("pool_capacity_before") or ""
+    capacity_after = gates.get("pool_capacity") or ""
+    if not capacity_before:
+        errors.append("pre-window KV pool capacity was not recorded")
+    if not capacity_after:
+        errors.append("KV pool capacity missing after restore")
+    elif capacity_before and capacity_after != capacity_before:
         errors.append(
-            "KV pool changed across the window: "
-            f"{gates.get('pool_line_before')!r} -> {gates.get('pool_line')!r}"
+            f"KV pool capacity changed across the window: {capacity_before!r} -> {capacity_after!r}"
         )
-    if gates.get("jit_stamp") != gates.get("jit_stamp_arm_b"):
+    # The restored stamp is compared against the PRE-WINDOW stamp, not arm B's.
+    # `prod-start.sh` hashes every raw `IMAGE=` line including overridden ones,
+    # so arm B's `.env` (original + appended A + appended B) and the restored
+    # `.env` (original only) hash differently even though both run B.
+    stamp_before = gates.get("jit_stamp_before") or ""
+    stamp_after = gates.get("jit_stamp") or ""
+    if not stamp_before:
+        errors.append("pre-window JIT shape stamp was not recorded")
+    if not stamp_after:
+        errors.append("JIT shape stamp missing after restore")
+    elif stamp_before and stamp_after != stamp_before:
         errors.append(
-            "final JIT shape stamp does not match the candidate arm's "
-            f"({gates.get('jit_stamp')!r} vs {gates.get('jit_stamp_arm_b')!r})"
+            f"restored JIT shape stamp differs from the pre-window stamp "
+            f"({stamp_before!r} -> {stamp_after!r})"
         )
 
     # --- per-lane evidence --------------------------------------------------
@@ -199,6 +225,16 @@ def judge(receipt: dict, base_dir: Path) -> dict:
             if probe.get("any_cache_hit"):
                 errors.append(f"arm {arm} lane {lane}: a cold-prefill run hit the prefix cache")
                 continue
+            # An EXCLUDED run that was excluded for a correctness reason is
+            # still evidence: a NaN-corrupted output must not be silently
+            # dropped into the exclusion list and then ignored.
+            for bad in probe.get("invalid_runs") or []:
+                reason = str(bad.get("invalid_reason") or "")
+                if "NaN" in reason or "locklock" in reason:
+                    errors.append(
+                        f"arm {arm} lane {lane}: an excluded run was corrupted "
+                        f"({reason})"
+                    )
             valid = int(probe.get("valid_runs") or 0)
             if valid < REQUIRED_RUNS[lane]:
                 errors.append(
@@ -229,7 +265,11 @@ def judge(receipt: dict, base_dir: Path) -> dict:
         drift = abs(a_first - a_last) / max(a_first, a_last)
         b_drift = abs(per_arm["b"] - per_arm["b2"]) / max(per_arm["b"], per_arm["b2"])
         ratio = candidate / control
-        if drift > DRIFT_MAX:
+        # §6: report INCONCLUSIVE when variance prevents a decision. Candidate
+        # instability is as disqualifying as control drift — a lane whose two
+        # candidate arms disagree wildly has no settled number to compare, so
+        # gating only the control would let a 75%-drift candidate pass as ADOPT.
+        if drift > DRIFT_MAX or b_drift > DRIFT_MAX:
             lane_verdict = "INCONCLUSIVE"
         elif ratio < BANDS[lane]:
             lane_verdict = "FAIL"
@@ -253,8 +293,34 @@ def judge(receipt: dict, base_dir: Path) -> dict:
     if worst == "REVERT":
         errors.append("a lane regressed beyond its pre-registered band")
     elif worst == "INCONCLUSIVE":
-        errors.append("the window drifted beyond its band; the comparison cannot decide")
+        errors.append(
+            "the window drifted beyond its band (control or candidate); "
+            "the comparison cannot decide"
+        )
     result["verdict"] = worst
+    # Be explicit about what an ADOPT does and does not certify. This harness
+    # measures throughput and the correctness gates it collects; it does NOT
+    # cover every §6 evidence requirement, so ADOPT is not a statement that the
+    # full §6 qualification is complete.
+    result["scope"] = {
+        "covers": [
+            "A-B-B-A ordering with the pre-registered per-lane observation counts",
+            "decode (structured/essay/hashmap) and cold-prefill (60k/240k) throughput",
+            "arm identity on both nodes (image tag + in-container exllamav3 version)",
+            "KV pool capacity unchanged, per arm and across the window",
+            "memory tripwire, preemption count, JIT shape stamp, NaN/cache-hit validity",
+            "post-restore acceptance battery rc",
+        ],
+        "does_not_cover": [
+            "temp-1 production cells (this harness runs temp-0 cells only)",
+            "the §6 serving / toolcall / thinking-SSE / long-form / mixed-cache soak gates",
+            "the prescribed drained-APC reset and cache-counter traffic audit for cold rounds",
+        ],
+        "adopt_means": (
+            "no throughput regression beyond the pre-registered bands on the "
+            "lanes measured; NOT that the full docs/13 §6 qualification is complete"
+        ),
+    }
     return result
 
 

--- a/scripts/probe_isa_e2m1_silicon.py
+++ b/scripts/probe_isa_e2m1_silicon.py
@@ -21,11 +21,16 @@ Three measured facts are load-bearing and are asserted by the tests:
 1. **The destination is `.b8` and the store is `st.global.u8`.** Declaring
    `.b32`/`st.global.u32` makes ptxas reject the instruction ("Arguments
    mismatch for instruction 'cvt'"), and the driver JIT then rejects the module
-   with `CUDA_ERROR_INVALID_PTX` (218).
+   with `CUDA_ERROR_INVALID_PTX` (218). The PTX ISA states this directly: "When
+   converting to .e2m1x2 data formats, the destination operand d has .b8 type."
 2. **The operands must come from memory, not immediates.** With `mov.f32 %f1,
-   0f3F800000` ptxas materializes only the top byte of each constant and every
-   case reads `0x00`; passing the two floats as kernel *parameters* produces the
-   correct values. The probe therefore passes them as parameters.
+   0f3F800000` every case read `0x00`; passing the two floats as kernel
+   *parameters* produces the correct values. The immediate form's root cause was
+   never established — `mov.f32` with a valid immediate is legal PTX that a
+   conforming ptxas must materialize, so "ptxas drops the low bytes" is a
+   hypothesis, not a fact, and a bug in that earlier probe variant would explain
+   the same symptom. Nothing here depends on it: the parameter-fed form is
+   unambiguously correct, and `judge` rejects an all-`0x00` result outright.
 3. **`a` lands in the upper nibble and `b` in the lower**, matching the PTX ISA
    ("the value converted from input a is stored in the upper 4 bits of d and the
    value converted from input b is stored in the lower 4 bits of d").
@@ -41,13 +46,12 @@ from __future__ import annotations
 import argparse
 import ctypes
 import json
-import struct
 import subprocess
 import sys
 from pathlib import Path
 
-# One kernel, three parameters. Immediates are deliberately not used: ptxas
-# mis-materializes them for this instruction (see the module docstring).
+# One kernel, three parameters. Immediates are deliberately not used: they read
+# back as 0x00 for this instruction (see the module docstring).
 PTX = """.version 9.0
 .target sm_121a
 .address_size 64

--- a/scripts/probe_isa_e2m1_silicon.py
+++ b/scripts/probe_isa_e2m1_silicon.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+"""Task 38 item 2 — silicon probe for `cvt.rn.satfinite.e2m1x2.f32` on GB10.
+
+Item 1 established the *toolchain* half of the FP4-e2m1 correction: with CUDA
+13.0.88's ptxas, `cvt.rn.satfinite.e2m1x2.f32` is rejected on `.target sm_121`
+but assembles on `.target sm_121a` and lowers to real SASS
+(`F2FP.SATFINITE.E2M1.F32.PACK_AB_MERGE_C`). That proves the instruction is
+**target-gated, not silicon-absent**. This probe closes the remaining half: does
+the silicon *execute* it and produce architecturally correct values?
+
+It does not need a compiler on the host and it does not need a stopped window.
+A one-kernel PTX module is generated here, JIT'd by the CUDA **driver**
+(`cuModuleLoadDataEx`), launched, and read back; the host side is plain `ctypes`
+against `libcuda.so.1`. Measured 2026-09-11: a 1-byte `cuMemAlloc` and a
+single-thread launch both succeed while production holds the GPU, so the probe
+runs alongside the serving stack. (This is the opposite of the original probe,
+which needed the primary context and could not get it — see `--assemble`.)
+
+Three measured facts are load-bearing and are asserted by the tests:
+
+1. **The destination is `.b8` and the store is `st.global.u8`.** Declaring
+   `.b32`/`st.global.u32` makes ptxas reject the instruction ("Arguments
+   mismatch for instruction 'cvt'"), and the driver JIT then rejects the module
+   with `CUDA_ERROR_INVALID_PTX` (218).
+2. **The operands must come from memory, not immediates.** With `mov.f32 %f1,
+   0f3F800000` ptxas materializes only the top byte of each constant and every
+   case reads `0x00`; passing the two floats as kernel *parameters* produces the
+   correct values. The probe therefore passes them as parameters.
+3. **`a` lands in the upper nibble and `b` in the lower**, matching the PTX ISA
+   ("the value converted from input a is stored in the upper 4 bits of d and the
+   value converted from input b is stored in the lower 4 bits of d").
+
+Verdicts: `SILICON_CONFIRMED` (every case matches the spec), `SILICON_MISMATCH`
+(some case does not, or the nibble order is reversed), `PROBE_UNAVAILABLE` (the
+driver refused to load or launch — reported, never silently swallowed).
+
+Run `--ptx-only` to emit the PTX on a machine with no free GPU.
+"""
+from __future__ import annotations
+
+import argparse
+import ctypes
+import json
+import struct
+import subprocess
+import sys
+from pathlib import Path
+
+# One kernel, three parameters. Immediates are deliberately not used: ptxas
+# mis-materializes them for this instruction (see the module docstring).
+PTX = """.version 9.0
+.target sm_121a
+.address_size 64
+
+.visible .entry probe_e2m1(.param .u64 p_out, .param .f32 pa, .param .f32 pb)
+{
+    .reg .b64  %rd<4>;
+    .reg .b8   %rs<2>;
+    .reg .f32  %f<4>;
+
+    ld.param.u64      %rd1, [p_out];
+    cvta.to.global.u64 %rd2, %rd1;
+    ld.param.f32 %f1, [pa];
+    ld.param.f32 %f2, [pb];
+    cvt.rn.satfinite.e2m1x2.f32 %rs1, %f1, %f2;
+    st.global.u8 [%rd2], %rs1;
+    ret;
+}
+"""
+
+# E2M1 code -> value. Code bit 3 is the sign; bits 2:0 index the magnitude.
+E2M1_VALUES = (0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0)
+E2M1_MAX = 6.0
+
+# (name, a, b, is_tie). Ties are recorded but excluded from the gate: `cvt.rn`'s
+# tie rule is the one thing a hand-written reference is least entitled to assume.
+CASES: tuple[tuple[str, float, float, bool], ...] = (
+    ("recorded-reversed-2.0-1.0", 2.0, 1.0, False),
+    ("zero", 0.0, 0.0, False),
+    ("half", 0.5, 0.5, False),
+    ("distinct-1.0-2.0", 1.0, 2.0, False),
+    ("distinct-4.0-1.0", 4.0, 1.0, False),
+    ("top-of-range", 6.0, 6.0, False),
+    ("negative", -1.0, -6.0, False),
+    ("saturate-high", 100.0, 1e30, False),
+    ("saturate-low", -100.0, -1e30, False),
+    ("round-down", 0.4, 1.2, False),
+    ("round-up", 0.6, 2.7, False),
+    ("tie-0.25-0.75", 0.25, 0.75, True),
+)
+
+
+def e2m1_code(value: float, *, ties_to_even: bool = True) -> int:
+    """Round-to-nearest e2m1 code for one f32 (saturating)."""
+    sign = 1 if value < 0 else 0
+    magnitude = abs(value)
+    if magnitude != magnitude:  # NaN is not in the e2m1 alphabet
+        raise ValueError("NaN has no e2m1 encoding")
+    if magnitude > E2M1_MAX:
+        return (sign << 3) | 0b111
+    best_index = 0
+    best_delta = None
+    for index, candidate in enumerate(E2M1_VALUES):
+        delta = abs(magnitude - candidate)
+        if best_delta is None or delta < best_delta - 1e-12:
+            best_index, best_delta = index, delta
+        elif abs(delta - best_delta) <= 1e-12 and ties_to_even:
+            # Exact midpoint: cvt.rn is round-to-nearest-even, so prefer the
+            # code with an even mantissa bit (an even magnitude index).
+            if index % 2 == 0:
+                best_index = index
+    return (sign << 3) | best_index
+
+
+def expected_pair(a: float, b: float) -> int:
+    """The PTX-specified packing: `a` in the upper nibble, `b` in the lower."""
+    return (e2m1_code(a) << 4) | e2m1_code(b)
+
+
+def reversed_pair(a: float, b: float) -> int:
+    """The opposite nibble order, used only to detect a reversed result."""
+    return (e2m1_code(b) << 4) | e2m1_code(a)
+
+
+def build_ptx() -> str:
+    return PTX
+
+
+# --- driver API -------------------------------------------------------------
+
+def _load_libcuda() -> ctypes.CDLL:
+    for name in ("libcuda.so.1", "libcuda.so"):
+        try:
+            return ctypes.CDLL(name)
+        except OSError:
+            continue
+    raise RuntimeError("libcuda not found")
+
+
+def _check(result: int, what: str) -> None:
+    if result != 0:
+        raise RuntimeError(f"{what} failed with CUDA error {result}")
+
+
+def run_on_gpu(ptx: str, cases=CASES) -> list[int]:
+    """JIT the PTX with the driver and return one packed byte per case."""
+    lib = _load_libcuda()
+    _check(lib.cuInit(0), "cuInit")
+    device = ctypes.c_int()
+    _check(lib.cuDeviceGet(ctypes.byref(device), 0), "cuDeviceGet")
+    context = ctypes.c_void_p()
+    _check(lib.cuDevicePrimaryCtxRetain(ctypes.byref(context), device), "cuDevicePrimaryCtxRetain")
+    _check(lib.cuCtxSetCurrent(context), "cuCtxSetCurrent")
+    module = ctypes.c_void_p()
+    source = ctypes.create_string_buffer(ptx.encode())
+    _check(lib.cuModuleLoadDataEx(ctypes.byref(module), source, 0, None, None),
+           "cuModuleLoadDataEx")
+    function = ctypes.c_void_p()
+    _check(lib.cuModuleGetFunction(ctypes.byref(function), module, b"probe_e2m1"),
+           "cuModuleGetFunction")
+
+    observed: list[int] = []
+    for _name, a, b, _tie in cases:
+        device_ptr = ctypes.c_ulonglong()
+        _check(lib.cuMemAlloc_v2(ctypes.byref(device_ptr), 1), "cuMemAlloc")
+        try:
+            out_val = ctypes.c_ulonglong(device_ptr.value)
+            a_val = ctypes.c_float(a)
+            b_val = ctypes.c_float(b)
+            # kernelParams is an array of POINTERS, one per kernel parameter.
+            params = (ctypes.c_void_p * 3)(
+                ctypes.cast(ctypes.byref(out_val), ctypes.c_void_p),
+                ctypes.cast(ctypes.byref(a_val), ctypes.c_void_p),
+                ctypes.cast(ctypes.byref(b_val), ctypes.c_void_p),
+            )
+            _check(lib.cuLaunchKernel(function, 1, 1, 1, 1, 1, 1, 0, None, params, None),
+                   "cuLaunchKernel")
+            _check(lib.cuCtxSynchronize(), "cuCtxSynchronize")
+            host = (ctypes.c_ubyte * 1)()
+            _check(lib.cuMemcpyDtoH_v2(host, device_ptr, 1), "cuMemcpyDtoH")
+            observed.append(host[0])
+        finally:
+            lib.cuMemFree_v2(device_ptr)
+    return observed
+
+
+# --- judging ----------------------------------------------------------------
+
+def judge(observed: list[int]) -> dict:
+    if len(observed) != len(CASES):
+        raise RuntimeError(f"expected {len(CASES)} results, got {len(observed)}")
+    rows = []
+    errors: list[str] = []
+    reversed_cases = 0
+    gated = 0
+    for (name, a, b, tie), seen in zip(CASES, observed):
+        expect = expected_pair(a, b)
+        flipped = reversed_pair(a, b)
+        matches_spec = seen == expect
+        matches_reversed = seen == flipped and flipped != expect
+        row = {
+            "case": name, "a": a, "b": b, "tie": tie, "observed": f"0x{seen:02x}",
+            "expected_spec": f"0x{expect:02x}", "matches_spec": matches_spec,
+            "matches_reversed_order": matches_reversed,
+        }
+        rows.append(row)
+        if tie:
+            continue  # recorded, not gated
+        gated += 1
+        if matches_reversed:
+            reversed_cases += 1
+        if not matches_spec:
+            errors.append(
+                f"{name} (a={a}, b={b}): silicon produced 0x{seen:02x}, "
+                f"PTX ISA expects 0x{expect:02x} (a in the upper nibble, b in the lower)"
+            )
+    result: dict = {
+        "schema": 1,
+        "probe": "cvt.rn.satfinite.e2m1x2.f32",
+        "cases": rows,
+        "gated_cases": gated,
+        "cases_matching_spec": sum(1 for row in rows if row["matches_spec"]),
+        "reversed_order_cases": reversed_cases,
+        "errors": errors,
+    }
+    if reversed_cases:
+        errors.append(
+            f"{reversed_cases} case(s) match the REVERSED nibble order: the silicon "
+            "packs a into the lower nibble, contradicting the PTX ISA"
+        )
+    if gated and not any(row["matches_spec"] for row in rows if not row["tie"]):
+        errors.append("no non-tie case matched the PTX-specified encoding")
+    result["verdict"] = "SILICON_CONFIRMED" if not errors else "SILICON_MISMATCH"
+    return result
+
+
+def assemble_with_ptxas(ptx: str, workdir: Path) -> dict:
+    """Compiler-only check: does ptxas accept this kernel for sm_121a?"""
+    source = workdir / "run_probe.ptx"
+    source.write_text(ptx)
+    try:
+        proc = subprocess.run(
+            ["ptxas", "-arch=sm_121a", "-o", str(workdir / "run_probe.cubin"), str(source)],
+            capture_output=True, text=True, timeout=300,
+        )
+    except FileNotFoundError:
+        return {"ptxas": "not found", "rc": None}
+    return {
+        "ptxas": "ptxas",
+        "rc": proc.returncode,
+        "stdout": proc.stdout.strip()[-2000:],
+        "stderr": proc.stderr.strip()[-2000:],
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--out", type=Path, help="write the result JSON here")
+    ap.add_argument("--ptx-only", action="store_true", help="emit the PTX and stop")
+    ap.add_argument("--assemble", action="store_true",
+                    help="also run ptxas -arch=sm_121a over the PTX (item 1 re-check)")
+    ap.add_argument("--workdir", type=Path, default=Path("/tmp/isa_probe_p8"))
+    args = ap.parse_args(argv)
+
+    ptx = build_ptx()
+    if args.ptx_only:
+        args.workdir.mkdir(parents=True, exist_ok=True)
+        (args.workdir / "run_probe.ptx").write_text(ptx)
+        print(ptx)
+        return 0
+
+    result: dict = {"schema": 1, "probe": "cvt.rn.satfinite.e2m1x2.f32", "ptx": ptx}
+    if args.assemble:
+        args.workdir.mkdir(parents=True, exist_ok=True)
+        result["ptxas"] = assemble_with_ptxas(ptx, args.workdir)
+    try:
+        observed = run_on_gpu(ptx)
+    except Exception as exc:  # noqa: BLE001  (a probe that cannot run is a result)
+        result.update({"verdict": "PROBE_UNAVAILABLE", "error": f"{type(exc).__name__}: {exc}"})
+        _emit(result, args.out)
+        print(f"[isa-probe] PROBE_UNAVAILABLE: {exc}", file=sys.stderr)
+        return 2
+    result.update(judge(observed))
+    _emit(result, args.out)
+    print(f"[isa-probe] verdict={result['verdict']} "
+          f"spec_matches={result['cases_matching_spec']}/{len(CASES)} "
+          f"reversed={result['reversed_order_cases']}", flush=True)
+    return 0 if result["verdict"] == "SILICON_CONFIRMED" else 1
+
+
+def _emit(result: dict, out: Path | None) -> None:
+    text = json.dumps(result, indent=1) + "\n"
+    if out:
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(text)
+    print(text, flush=True)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/probe_v149_qualification.py
+++ b/scripts/probe_v149_qualification.py
@@ -154,9 +154,18 @@ def spec_delta(before: dict[str, float], after: dict[str, float]) -> dict:
 
 
 def _stream(body: dict, timeout: float) -> dict:
-    """Drive one streaming completion and return raw timing + text."""
+    """Drive one streaming completion and return raw timing + text.
+
+    Reads the SSE stream **a line at a time**. A buffered `resp.read(4096)`
+    blocks until 4096 bytes accumulate, which folds several token arrivals into
+    one and destroys both the TTFT and the decode interval — a server flushing
+    two tokens 250 ms apart was measured at ~6.2M tok/s because both landed in
+    a single read and the interval collapsed to ~32 us. `readline()` returns
+    each event as soon as the server flushes it.
+    """
     started = time.perf_counter()
     first = None
+    last = None
     chunks: list[str] = []
     usage = None
     finish = None
@@ -165,42 +174,40 @@ def _stream(body: dict, timeout: float) -> dict:
     try:
         with _post("/v1/chat/completions", body, timeout=timeout) as resp:
             http = resp.status
-            buf = b""
             while True:
-                piece = resp.read(4096)
-                if not piece:
+                raw_line = resp.readline()
+                if not raw_line:
                     break
-                buf += piece
-                while b"\n" in buf:
-                    line, buf = buf.split(b"\n", 1)
-                    line = line.strip()
-                    if not line.startswith(b"data:"):
-                        continue
-                    payload = line[5:].strip()
-                    if payload == b"[DONE]":
-                        continue
-                    try:
-                        obj = json.loads(payload)
-                    except json.JSONDecodeError:
-                        continue
-                    if obj.get("usage"):
-                        usage = obj["usage"]
-                    choices = obj.get("choices") or []
-                    if not choices:
-                        continue
-                    delta = choices[0].get("delta") or {}
-                    content = (
-                        delta.get("content")
-                        or delta.get("reasoning")
-                        or delta.get("reasoning_content")
-                        or ""
-                    )
-                    if content:
-                        if first is None:
-                            first = time.perf_counter()
-                        chunks.append(content)
-                    if choices[0].get("finish_reason"):
-                        finish = choices[0]["finish_reason"]
+                line = raw_line.strip()
+                if not line.startswith(b"data:"):
+                    continue
+                payload = line[5:].strip()
+                if payload == b"[DONE]":
+                    continue
+                try:
+                    obj = json.loads(payload)
+                except json.JSONDecodeError:
+                    continue
+                if obj.get("usage"):
+                    usage = obj["usage"]
+                choices = obj.get("choices") or []
+                if not choices:
+                    continue
+                delta = choices[0].get("delta") or {}
+                content = (
+                    delta.get("content")
+                    or delta.get("reasoning")
+                    or delta.get("reasoning_content")
+                    or ""
+                )
+                if content:
+                    now = time.perf_counter()
+                    if first is None:
+                        first = now
+                    last = now
+                    chunks.append(content)
+                if choices[0].get("finish_reason"):
+                    finish = choices[0]["finish_reason"]
     except Exception as exc:  # noqa: BLE001  (a broken run is a recorded invalid run)
         error = f"{type(exc).__name__}: {exc}"
     ended = time.perf_counter()
@@ -208,6 +215,7 @@ def _stream(body: dict, timeout: float) -> dict:
         "http": http,
         "error": error,
         "first_s": first,
+        "last_s": last,
         "ended_s": ended,
         "started_s": started,
         "text": "".join(chunks),
@@ -234,7 +242,14 @@ def decode_run(prompt: str, max_tokens: int, timeout: float) -> dict:
     completion_tokens = int(usage.get("completion_tokens") or 0)
     prompt_tokens = int(usage.get("prompt_tokens") or 0)
     ttft = None if raw["first_s"] is None else raw["first_s"] - raw["started_s"]
-    decode_s = None if raw["first_s"] is None else raw["ended_s"] - raw["first_s"]
+    # First-to-last CONTENT token, not first-token-to-EOF. The usage chunk and
+    # the connection close arrive after the final token; ending the interval at
+    # EOF would charge that tail to decode.
+    decode_s = (
+        None
+        if raw["first_s"] is None or raw["last_s"] is None
+        else raw["last_s"] - raw["first_s"]
+    )
     tok_s = None
     if decode_s and decode_s > 0 and completion_tokens > 1:
         tok_s = (completion_tokens - 1) / decode_s
@@ -391,6 +406,14 @@ def summarize(kind: str, runs: list[dict], invalid: list[dict]) -> dict:
     return out
 
 
+def write_receipt(path: Path, payload: dict) -> None:
+    """Write the receipt atomically, so a reader never sees a partial file."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(path.name + ".tmp")
+    tmp.write_text(json.dumps(payload, indent=1, default=str) + "\n")
+    tmp.replace(path)
+
+
 MODEL = DEFAULT_MODEL
 
 
@@ -438,10 +461,12 @@ def main(argv: list[str] | None = None) -> int:
         }
         print(f"[probe] {args.kind} run {index + 1}/{args.runs}: {json.dumps(shown)}"
               + (f" INVALID {reason}" if reason else ""), flush=True)
+        # Persist after every observation: a crash in a later run must not
+        # discard the observations already taken.
+        write_receipt(args.out, summarize(args.kind, runs, invalid))
 
     summary = summarize(args.kind, runs, invalid)
-    args.out.parent.mkdir(parents=True, exist_ok=True)
-    args.out.write_text(json.dumps(summary, indent=1, default=str) + "\n")
+    write_receipt(args.out, summary)
     headline = {k: v for k, v in summary.items() if k not in ("runs", "invalid_runs")}
     print(json.dumps(headline, indent=1, default=str), flush=True)
     print(f"[probe] wrote {args.out}", flush=True)

--- a/scripts/probe_v149_qualification.py
+++ b/scripts/probe_v149_qualification.py
@@ -360,8 +360,14 @@ def prefill_run_invalid(run: dict) -> str | None:
     target = run["target"]
     if abs(run["prompt_tokens"] - target) / target > PREFILL_TARGET_TOLERANCE:
         return f"prompt_tokens {run['prompt_tokens']} outside {target} +/- {PREFILL_TARGET_TOLERANCE:.0%}"
-    if run["cached_tokens"] not in (0, None):
-        return f"warm request: cached_tokens={run['cached_tokens']}"
+    cached = run["cached_tokens"]
+    if cached is None:
+        # Unknown cache usage is not measured zero usage. `cached_tokens == 0`
+        # is the substitute this harness relies on for the omitted APC-reset
+        # audit, so a missing counter must be rejected rather than assumed cold.
+        return "no cached_tokens in usage (cannot prove the run was cold)"
+    if cached != 0:
+        return f"warm request: cached_tokens={cached}"
     if run["nan"]:
         return "NaN/locklock marker in output"
     return None
@@ -402,7 +408,12 @@ def summarize(kind: str, runs: list[dict], invalid: list[dict]) -> dict:
         out["accept_ratio_median"] = statistics.median(ratios) if ratios else None
         out["any_nan"] = any(r["nan"] for r in runs)
     else:
-        out["any_cache_hit"] = any(r.get("cached_tokens") not in (0, None) for r in runs)
+        # Every accepted prefill run proved cached_tokens == 0, so this can only
+        # be true for a run that was rejected as warm. Kept as an explicit
+        # self-check over both lists rather than a tautology over `runs`.
+        out["any_cache_hit"] = any(
+            (r.get("cached_tokens") or 0) != 0 for r in runs + invalid
+        )
     return out
 
 

--- a/scripts/probe_v149_qualification.py
+++ b/scripts/probe_v149_qualification.py
@@ -1,0 +1,452 @@
+#!/usr/bin/env python3
+"""One measurement block for the task 35 §6 qualification window.
+
+Task 35 deployed the ExLlamaV3 v1.4.9 pin on the correctness gates, but the
+end-to-end throughput comparison was never run to `docs/13` §6's observation
+contract. This probe produces the observations that contract requires: fixed
+saved payloads, identical sampling parameters, streaming, and per-run records
+that keep the raw numbers so the auditor can re-judge them offline.
+
+Kinds
+-----
+`structured` / `essay` / `hashmap`
+    Streaming decode blocks (temp 0, top_p 1, thinking off, 200 output tokens).
+    Decode tok/s = ``(completion_tokens - 1) / (t_last_token - t_first_token)``,
+    the definition used by every prior receipt in this repository. The
+    speculative-decoding counters are sampled around each run so the arm also
+    carries an acceptance record (they are a *correctness* companion to the
+    speed number, not a speed claim).
+
+`prefill60k` / `prefill240k`
+    Cold-prefill blocks. Every request carries a fresh salt, the filler count
+    is calibrated through ``/tokenize`` so the server-reported ``prompt_tokens``
+    lands on the target, and a run whose ``prompt_tokens_details.cached_tokens``
+    is non-zero is rejected as warm. prefill tok/s = ``prompt_tokens / ttft``.
+
+A run that cannot be measured is recorded and listed in ``invalid_runs``; it is
+never silently dropped, because the auditor's sample-count gate reads that list.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import re
+import secrets
+import statistics
+import sys
+import time
+import urllib.error
+import urllib.request
+import uuid
+from pathlib import Path
+
+BASE = os.environ.get("GLM53_BASE", "http://127.0.0.1:8000")
+DEFAULT_MODEL = "GLM-5.3-Flash-EXL3"
+
+STRUCTURED_PROMPT = (
+    "Count from 1 to 200. Output only the numbers, separated by spaces. No other text."
+)
+ESSAY_PROMPT = (
+    'Write a detailed technical essay titled "Speculative Decoding and the Hidden '
+    'Cost of Failed Drafts: A Technical Analysis". Cover draft generation, '
+    "verification cost, rejection sampling, and when longer drafts stop paying. "
+    "Use numbered sections. Be thorough."
+)
+HASHMAP_PROMPT = (
+    "Write a detailed step-by-step explanation of how a hash map works, "
+    "including collision handling, resizing, and time complexity. Be thorough."
+)
+DECODE_KINDS = {
+    "structured": STRUCTURED_PROMPT,
+    "essay": ESSAY_PROMPT,
+    "hashmap": HASHMAP_PROMPT,
+}
+PREFILL_KINDS = {"prefill60k": 60_000, "prefill240k": 240_000}
+KINDS = tuple(DECODE_KINDS) + tuple(PREFILL_KINDS)
+FILLER = "the "
+TASK = "Reply with OK."
+# Prompt-size acceptance band for a calibrated cold-prefill run.
+PREFILL_TARGET_TOLERANCE = 0.05
+NAN_RE = re.compile(r"\bnan\b|locklock", re.I)
+SPEC_RE = re.compile(r"^(vllm:spec_decode_[a-zA-Z0-9_]+)\{([^}]*)\}\s+(\S+)$")
+
+
+def contains_nan(text: str) -> bool:
+    return bool(NAN_RE.search(text))
+
+
+def _post(path: str, body: dict, timeout: float):
+    req = urllib.request.Request(
+        BASE + path,
+        data=json.dumps(body).encode(),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    return urllib.request.urlopen(req, timeout=timeout)
+
+
+def _get(path: str, timeout: float = 15.0) -> str:
+    with urllib.request.urlopen(BASE + path, timeout=timeout) as resp:
+        return resp.read().decode("utf-8", "replace")
+
+
+def health() -> int:
+    try:
+        req = urllib.request.Request(BASE + "/health")
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            return resp.status
+    except urllib.error.HTTPError as exc:
+        return exc.code
+    except Exception:  # noqa: BLE001  (an unreachable server is a health failure)
+        return 0
+
+
+def served_model() -> str:
+    obj = json.loads(_get("/v1/models", timeout=30))
+    return obj["data"][0]["id"]
+
+
+def spec_snapshot() -> dict[str, float]:
+    """Spec-decode counters; per-position keys are `pos:{n}`."""
+    out: dict[str, float] = {}
+    for line in _get("/metrics", timeout=15).splitlines():
+        match = SPEC_RE.match(line)
+        if not match:
+            continue
+        name, labels, value = match.group(1), match.group(2), float(match.group(3))
+        if name.endswith("_created"):
+            continue
+        if "per_pos" in name:
+            pos = re.search(r'position="(\d+)"', labels)
+            if pos:
+                out[f"pos:{pos.group(1)}"] = value
+        else:
+            out[name] = out.get(name, 0.0) + value
+    return out
+
+
+def spec_delta(before: dict[str, float], after: dict[str, float]) -> dict:
+    drafts = after.get("vllm:spec_decode_num_drafts_total", 0.0) - before.get(
+        "vllm:spec_decode_num_drafts_total", 0.0
+    )
+    draft_tokens = after.get("vllm:spec_decode_num_draft_tokens_total", 0.0) - before.get(
+        "vllm:spec_decode_num_draft_tokens_total", 0.0
+    )
+    accepted = after.get("vllm:spec_decode_num_accepted_tokens_total", 0.0) - before.get(
+        "vllm:spec_decode_num_accepted_tokens_total", 0.0
+    )
+    positions = []
+    for index in range(7):
+        key = f"pos:{index}"
+        positions.append(
+            round((after.get(key, 0.0) - before.get(key, 0.0)) / drafts, 4) if drafts else 0.0
+        )
+    return {
+        "drafts": int(drafts),
+        "draft_tokens": int(draft_tokens),
+        "accepted": int(accepted),
+        "accept_ratio": round(accepted / draft_tokens, 4) if draft_tokens else None,
+        "accepted_per_step": round(accepted / drafts, 3) if drafts else None,
+        "pos": positions,
+    }
+
+
+def _stream(body: dict, timeout: float) -> dict:
+    """Drive one streaming completion and return raw timing + text."""
+    started = time.perf_counter()
+    first = None
+    chunks: list[str] = []
+    usage = None
+    finish = None
+    http = None
+    error = None
+    try:
+        with _post("/v1/chat/completions", body, timeout=timeout) as resp:
+            http = resp.status
+            buf = b""
+            while True:
+                piece = resp.read(4096)
+                if not piece:
+                    break
+                buf += piece
+                while b"\n" in buf:
+                    line, buf = buf.split(b"\n", 1)
+                    line = line.strip()
+                    if not line.startswith(b"data:"):
+                        continue
+                    payload = line[5:].strip()
+                    if payload == b"[DONE]":
+                        continue
+                    try:
+                        obj = json.loads(payload)
+                    except json.JSONDecodeError:
+                        continue
+                    if obj.get("usage"):
+                        usage = obj["usage"]
+                    choices = obj.get("choices") or []
+                    if not choices:
+                        continue
+                    delta = choices[0].get("delta") or {}
+                    content = (
+                        delta.get("content")
+                        or delta.get("reasoning")
+                        or delta.get("reasoning_content")
+                        or ""
+                    )
+                    if content:
+                        if first is None:
+                            first = time.perf_counter()
+                        chunks.append(content)
+                    if choices[0].get("finish_reason"):
+                        finish = choices[0]["finish_reason"]
+    except Exception as exc:  # noqa: BLE001  (a broken run is a recorded invalid run)
+        error = f"{type(exc).__name__}: {exc}"
+    ended = time.perf_counter()
+    return {
+        "http": http,
+        "error": error,
+        "first_s": first,
+        "ended_s": ended,
+        "started_s": started,
+        "text": "".join(chunks),
+        "usage": usage or {},
+        "finish_reason": finish,
+    }
+
+
+def decode_run(prompt: str, max_tokens: int, timeout: float) -> dict:
+    body = {
+        "model": MODEL,
+        "messages": [{"role": "user", "content": prompt}],
+        "temperature": 0,
+        "top_p": 1,
+        "max_tokens": max_tokens,
+        "stream": True,
+        "stream_options": {"include_usage": True},
+        "chat_template_kwargs": {"enable_thinking": False},
+    }
+    before = spec_snapshot()
+    raw = _stream(body, timeout)
+    after = spec_snapshot()
+    usage = raw["usage"]
+    completion_tokens = int(usage.get("completion_tokens") or 0)
+    prompt_tokens = int(usage.get("prompt_tokens") or 0)
+    ttft = None if raw["first_s"] is None else raw["first_s"] - raw["started_s"]
+    decode_s = None if raw["first_s"] is None else raw["ended_s"] - raw["first_s"]
+    tok_s = None
+    if decode_s and decode_s > 0 and completion_tokens > 1:
+        tok_s = (completion_tokens - 1) / decode_s
+    return {
+        "http": raw["http"],
+        "error": raw["error"],
+        "ttft_s": ttft,
+        "wall_s": raw["ended_s"] - raw["started_s"],
+        "decode_s": decode_s,
+        "tok_s": tok_s,
+        "completion_tokens": completion_tokens,
+        "prompt_tokens": prompt_tokens,
+        "finish_reason": raw["finish_reason"],
+        "nan": contains_nan(raw["text"]),
+        "text_head": raw["text"][:400],
+        "spec": spec_delta(before, after),
+    }
+
+
+def decode_run_invalid(run: dict, max_tokens: int) -> str | None:
+    if run["error"]:
+        return run["error"]
+    if run["http"] != 200:
+        return f"http {run['http']}"
+    if run["ttft_s"] is None:
+        return "no first token"
+    if run["tok_s"] is None:
+        return f"completion_tokens={run['completion_tokens']} (need >1)"
+    if run["nan"]:
+        return "NaN/locklock marker in output"
+    if run["completion_tokens"] < max_tokens:
+        return f"short completion {run['completion_tokens']}/{max_tokens}"
+    return None
+
+
+def tokenize(messages: list[dict], timeout: float = 180.0) -> int:
+    with _post("/tokenize", {"model": MODEL, "messages": messages}, timeout) as resp:
+        return int(json.loads(resp.read().decode())["count"])
+
+
+def build_user_text(n_filler: int, salt: str) -> str:
+    return f"{salt}\n{FILLER * n_filler}\n{TASK}"
+
+
+def calibrate(target: int, salt: str) -> tuple[int, int, str]:
+    """Choose a filler count whose tokenize() lands within tolerance of target."""
+    messages = lambda text: [{"role": "user", "content": text}]  # noqa: E731
+    overhead = tokenize(messages(build_user_text(0, salt)))
+    n = max(target - overhead, 1)
+    got = tokenize(messages(build_user_text(n, salt)))
+    if got > 0 and abs(got - target) / target > 0.005:
+        per = (got - overhead) / n if n else 1.0
+        n = max(int(round((target - overhead) / per)), 1) if per > 0 else n
+        got = tokenize(messages(build_user_text(n, salt)))
+    if abs(got - target) / target > 0.005:
+        n = max(n + (target - got), 1)
+        got = tokenize(messages(build_user_text(n, salt)))
+    return n, got, build_user_text(n, salt)
+
+
+def prefill_run(target: int, timeout: float) -> dict:
+    salt = f"COLD-PREFILL salt={uuid.uuid4()} pad={secrets.token_hex(24)}"
+    filler, estimate, text = calibrate(target, salt)
+    body = {
+        "model": MODEL,
+        "messages": [{"role": "user", "content": text}],
+        "temperature": 0,
+        "max_tokens": 8,
+        "stream": True,
+        "stream_options": {"include_usage": True},
+        "chat_template_kwargs": {"enable_thinking": False},
+    }
+    raw = _stream(body, timeout)
+    usage = raw["usage"]
+    prompt_tokens = int(usage.get("prompt_tokens") or 0)
+    details = usage.get("prompt_tokens_details") or {}
+    cached = details.get("cached_tokens") if isinstance(details, dict) else None
+    ttft = None if raw["first_s"] is None else raw["first_s"] - raw["started_s"]
+    prefill_tok_s = prompt_tokens / ttft if ttft and ttft > 0 and prompt_tokens else None
+    return {
+        "http": raw["http"],
+        "error": raw["error"],
+        "target": target,
+        "filler_count": filler,
+        "tokenize_estimate": estimate,
+        "prompt_tokens": prompt_tokens,
+        "cached_tokens": cached,
+        "ttft_s": ttft,
+        "wall_s": raw["ended_s"] - raw["started_s"],
+        "prefill_tok_s": prefill_tok_s,
+        "finish_reason": raw["finish_reason"],
+        "nan": contains_nan(raw["text"]),
+        "text_head": raw["text"][:120],
+    }
+
+
+def prefill_run_invalid(run: dict) -> str | None:
+    if run["error"]:
+        return run["error"]
+    if run["http"] != 200:
+        return f"http {run['http']}"
+    if run["ttft_s"] is None:
+        return "no first token"
+    if not run["prompt_tokens"]:
+        return "no prompt_tokens in usage"
+    if run["prefill_tok_s"] is None:
+        return "no prefill rate"
+    target = run["target"]
+    if abs(run["prompt_tokens"] - target) / target > PREFILL_TARGET_TOLERANCE:
+        return f"prompt_tokens {run['prompt_tokens']} outside {target} +/- {PREFILL_TARGET_TOLERANCE:.0%}"
+    if run["cached_tokens"] not in (0, None):
+        return f"warm request: cached_tokens={run['cached_tokens']}"
+    if run["nan"]:
+        return "NaN/locklock marker in output"
+    return None
+
+
+def summarize(kind: str, runs: list[dict], invalid: list[dict]) -> dict:
+    decode = kind in DECODE_KINDS
+    key = "tok_s" if decode else "prefill_tok_s"
+    values = [r[key] for r in runs if r.get(key) is not None and math.isfinite(r[key])]
+    out: dict = {
+        "schema": 1,
+        "kind": kind,
+        "metric": key,
+        "base": BASE,
+        "model": MODEL,
+        "runs": runs,
+        "invalid_runs": invalid,
+        "valid_runs": len(values),
+    }
+    if values:
+        out[f"{key}_median"] = statistics.median(values)
+        out[f"{key}_min"] = min(values)
+        out[f"{key}_max"] = max(values)
+    if decode:
+        ttfts = [r["ttft_s"] for r in runs if r.get("ttft_s") is not None]
+        out["ttft_median_s"] = statistics.median(ttfts) if ttfts else None
+        steps = [
+            r["spec"]["accepted_per_step"]
+            for r in runs
+            if r.get("spec", {}).get("accepted_per_step") is not None
+        ]
+        ratios = [
+            r["spec"]["accept_ratio"]
+            for r in runs
+            if r.get("spec", {}).get("accept_ratio") is not None
+        ]
+        out["accepted_per_step_median"] = statistics.median(steps) if steps else None
+        out["accept_ratio_median"] = statistics.median(ratios) if ratios else None
+        out["any_nan"] = any(r["nan"] for r in runs)
+    else:
+        out["any_cache_hit"] = any(r.get("cached_tokens") not in (0, None) for r in runs)
+    return out
+
+
+MODEL = DEFAULT_MODEL
+
+
+def main(argv: list[str] | None = None) -> int:
+    global MODEL
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--kind", required=True, choices=KINDS)
+    ap.add_argument("--runs", type=int, required=True)
+    ap.add_argument("--out", required=True, type=Path)
+    ap.add_argument("--max-tokens", type=int, default=200, help="decode block output tokens")
+    ap.add_argument("--timeout", type=float, default=1800.0)
+    ap.add_argument("--base", default=None, help=f"API base (default {BASE})")
+    ap.add_argument("--model", default=None, help="override the served model id")
+    args = ap.parse_args(argv)
+    if args.runs < 1:
+        ap.error("--runs must be >= 1")
+    if args.base:
+        globals()["BASE"] = args.base
+
+    code = health()
+    if code != 200:
+        print(f"[probe] /health -> {code}; refusing to measure", file=sys.stderr)
+        return 2
+    # The served id is authoritative; --model only overrides it when given.
+    MODEL = args.model or served_model()
+
+    runs: list[dict] = []
+    invalid: list[dict] = []
+    for index in range(args.runs):
+        if args.kind in DECODE_KINDS:
+            run = decode_run(DECODE_KINDS[args.kind], args.max_tokens, args.timeout)
+            reason = decode_run_invalid(run, args.max_tokens)
+        else:
+            run = prefill_run(PREFILL_KINDS[args.kind], args.timeout)
+            reason = prefill_run_invalid(run)
+        run["i"] = index + 1
+        if reason:
+            run["invalid_reason"] = reason
+            invalid.append(run)
+        else:
+            runs.append(run)
+        shown = {
+            k: run.get(k)
+            for k in ("i", "tok_s", "prefill_tok_s", "ttft_s", "prompt_tokens", "cached_tokens")
+        }
+        print(f"[probe] {args.kind} run {index + 1}/{args.runs}: {json.dumps(shown)}"
+              + (f" INVALID {reason}" if reason else ""), flush=True)
+
+    summary = summarize(args.kind, runs, invalid)
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(summary, indent=1, default=str) + "\n")
+    headline = {k: v for k, v in summary.items() if k not in ("runs", "invalid_runs")}
+    print(json.dumps(headline, indent=1, default=str), flush=True)
+    print(f"[probe] wrote {args.out}", flush=True)
+    return 0 if summary["valid_runs"] == args.runs else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/run_v149_qualification_window.py
+++ b/scripts/run_v149_qualification_window.py
@@ -119,12 +119,21 @@ def log(message: str) -> None:
 
 
 def save(state: dict) -> None:
-    """Atomically persist the receipt so an interrupted window stays recoverable."""
+    """Persist the receipt, best-effort.
+
+    The receipt is diagnostic: a full disk or a read-only path must never stop
+    the window from restarting production or re-arming the timers. A persistent
+    write failure is logged loudly (and counted) rather than raised.
+    """
     if _RECEIPT is None:
         return
-    tmp = _RECEIPT.with_suffix(_RECEIPT.suffix + ".tmp")
-    tmp.write_text(json.dumps(state, indent=1, default=str) + "\n")
-    os.replace(tmp, _RECEIPT)
+    try:
+        tmp = _RECEIPT.with_suffix(_RECEIPT.suffix + ".tmp")
+        tmp.write_text(json.dumps(state, indent=1, default=str) + "\n")
+        os.replace(tmp, _RECEIPT)
+    except OSError as exc:
+        state["save_failures"] = int(state.get("save_failures", 0)) + 1
+        log(f"WARNING: could not write the receipt ({exc}); continuing")
 
 
 # --- environment ------------------------------------------------------------
@@ -369,26 +378,32 @@ def _active_services() -> dict[str, str]:
     out: dict[str, str] = {}
     for unit in TIMER_SERVICES:
         proc = win.run(["systemctl", "--user", "is-active", unit], timeout=30, check=False)
-        out[unit] = proc.stdout.strip() or "unknown"
+        status = proc.stdout.strip()
+        # A failed query must not masquerade as "inactive". Mark it unknown so
+        # quiescence cannot be declared on absent evidence.
+        out[unit] = status if status else f"unknown(rc={proc.returncode})"
     return out
 
 
-def _pending_jobs() -> int:
+def _pending_jobs() -> int | None:
+    """Queued systemd jobs, or None when the query itself failed."""
     proc = win.run(["systemctl", "--user", "list-jobs"], timeout=30, check=False)
+    if proc.returncode != 0:
+        return None
     lines = [ln for ln in proc.stdout.splitlines() if ln.strip()]
-    # The header line ("No jobs running." or a column header) is not a job.
     return len([ln for ln in lines if "No jobs running" not in ln and not ln.startswith("JOB")])
 
 
 def wait_quiescent(timeout: float = 300.0) -> bool:
-    """Wait until the timer services are inactive and no jobs are queued."""
+    """Wait until the timer services are provably inactive and no jobs are queued.
+
+    Fails closed: a failed `list-jobs` query, or a service whose state could not
+    be read, counts as busy rather than as quiet.
+    """
     deadline = time.monotonic() + timeout
     while True:
-        busy = {
-            unit: status
-            for unit, status in _active_services().items()
-            if status in ("active", "activating", "reloading", "deactivating")
-        }
+        services = _active_services()
+        busy = {u: s for u, s in services.items() if s != "inactive"}
         jobs = _pending_jobs()
         if not busy and jobs == 0:
             return True
@@ -412,10 +427,14 @@ def phase_arm(state: dict, arm: str) -> None:
     head = verify_arm(arm, HEAD_CONTAINER)
     worker = verify_arm(arm, WORKER_CONTAINER, host=WORKER)
     head_mem, worker_mem = check_tripwire(f"arm {arm} boot")
-    # One predeclared warmup pass before the measured block.
+    # One predeclared warmup pass before the measured block. The receipt path is
+    # a real file: the probe now writes atomically (temp + rename), so
+    # `--out /dev/null` would try to create `/dev/null.tmp` in a root-owned
+    # directory and fail the arm.
     warm = win.run(
         ["python3", str(PROBE), "--kind", "structured", "--runs", "1",
-         "--max-tokens", str(WARMUP_TOKENS), "--out", "/dev/null"],
+         "--max-tokens", str(WARMUP_TOKENS),
+         "--out", str(_RECEIPT.parent / f"{_RECEIPT.stem}-{arm}-warmup.json")],
         timeout=900, check=False,
     )
     if warm.returncode != 0:
@@ -427,7 +446,9 @@ def phase_arm(state: dict, arm: str) -> None:
         "health": 200,
         "jit_stamp": jit_stamp(),
         "pool_line": pool_line_raw(),
+        "pool_capacity": pool_capacity(),
         "container_started_at": container_started_at(),
+        "worker_container_started_at": container_started_at(WORKER_CONTAINER, host=WORKER),
         "memfree_head_gib": head_mem,
         "memfree_worker_gib": worker_mem,
         "preemptions_before": preemptions(),
@@ -449,20 +470,39 @@ def phase_measure(state: dict, arm: str) -> None:
     worker_now = verify_arm(arm, WORKER_CONTAINER, host=WORKER)
     record = state.setdefault("arms", {}).setdefault(arm, {})
     boot_now = container_started_at()
-    recorded_boot = record.get("container_started_at")
-    if recorded_boot and boot_now and boot_now != recorded_boot:
+    worker_boot_now = container_started_at(WORKER_CONTAINER, host=WORKER)
+    # A missing boot identity is a refusal, not a pass: an unavailable token
+    # would silently bypass the binding the check exists to enforce.
+    if not boot_now or not worker_boot_now:
         raise RuntimeError(
-            f"arm {arm}: the head container restarted since the arm phase "
-            f"({recorded_boot} -> {boot_now}); the observations would not belong "
-            "to the verified boot"
+            f"arm {arm}: could not read the container boot identity "
+            f"(head={boot_now!r} worker={worker_boot_now!r}); refusing to measure"
+        )
+    recorded_boot = record.get("container_started_at")
+    recorded_worker_boot = record.get("worker_container_started_at")
+    if not recorded_boot or not recorded_worker_boot:
+        raise RuntimeError(
+            f"arm {arm}: no boot identity was recorded by the arm phase; "
+            "resume from the arm phase so the observations belong to a verified boot"
+        )
+    if boot_now != recorded_boot or worker_boot_now != recorded_worker_boot:
+        raise RuntimeError(
+            f"arm {arm}: a container restarted since the arm phase "
+            f"(head {recorded_boot} -> {boot_now}, "
+            f"worker {recorded_worker_boot} -> {worker_boot_now}); the observations "
+            "would not belong to the verified boot"
         )
     record["measure_verified_image"] = head_now["image_tag"]
     record["measure_verified_worker_image"] = worker_now["image_tag"]
     record["measure_verified_exllamav3"] = head_now["exllamav3_version"]
     record["measure_container_started_at"] = boot_now
+    record["measure_worker_container_started_at"] = worker_boot_now
     # A fresh attempt tag per invocation: a retry after a failed block writes new
     # files instead of overwriting the evidence an earlier receipt points at.
-    attempt = time.strftime("%Y%m%d-%H%M%S")
+    # The counter keeps two attempts within the same second distinct.
+    attempts = int(state.get("measure_attempts", 0)) + 1
+    state["measure_attempts"] = attempts
+    attempt = f"{time.strftime('%Y%m%d-%H%M%S')}-{attempts}"
     record["measure_attempt"] = attempt
     save(state)
 
@@ -474,6 +514,18 @@ def phase_measure(state: dict, arm: str) -> None:
             f"{_RECEIPT.stem}-{arm}-{lane}-{attempt}.json"
         )
         head_before, worker_before = check_tripwire(f"arm {arm} {lane} before")
+        # Register the attempt BEFORE running it. Registration only on success
+        # would let a failed block vanish from the receipt, so a retry could
+        # judge the window without ever seeing that the failure happened.
+        block = {
+            "arm": arm, "lane": lane, "runs": runs, "attempt": attempt,
+            "path": out.name, "started": time.strftime("%Y-%m-%dT%H:%M:%S%z"),
+            "ok": None, "returncode": None, "error": None,
+            "memfree_head_gib": [head_before, None],
+            "memfree_worker_gib": [worker_before, None],
+        }
+        state.setdefault("probe_blocks", []).append(block)
+        save(state)
         started = time.time()
         proc = subprocess.run(
             ["python3", str(PROBE), "--kind", lane, "--runs", str(runs), "--out", str(out)],
@@ -481,19 +533,26 @@ def phase_measure(state: dict, arm: str) -> None:
         )
         elapsed = time.time() - started
         head_after, worker_after = check_tripwire(f"arm {arm} {lane} after")
+        block.update({
+            "seconds": round(elapsed, 1),
+            "memfree_head_gib": [head_before, head_after],
+            "memfree_worker_gib": [worker_before, worker_after],
+            "returncode": proc.returncode,
+        })
         if proc.returncode != 0:
+            # Never slice None: a probe that dies before printing has both
+            # streams empty, and `None[-400:]` would raise over the real error.
+            tail = (proc.stdout or "") + (proc.stderr or "")
+            block["ok"] = False
+            block["error"] = tail[-400:] or "(no output)"
+            block["evidence_present"] = out.is_file()
+            save(state)
             raise RuntimeError(
                 f"arm {arm} lane {lane}: probe exited {proc.returncode}; "
-                f"last output: {(proc.stdout or proc.stderr)[-400:]}"
+                f"last output: {tail[-400:] or '(no output)'}"
             )
+        block["ok"] = True
         state["probes"][arm][lane] = out.name
-        state.setdefault("probe_blocks", []).append(
-            {
-                "arm": arm, "lane": lane, "runs": runs, "seconds": round(elapsed, 1),
-                "memfree_head_gib": [head_before, head_after],
-                "memfree_worker_gib": [worker_before, worker_after],
-            }
-        )
         save(state)
         log(f"arm {arm} lane {lane}: {runs} runs in {elapsed:.0f}s")
     state["arms"].setdefault(arm, {})["preemptions_after"] = preemptions()

--- a/scripts/run_v149_qualification_window.py
+++ b/scripts/run_v149_qualification_window.py
@@ -47,6 +47,7 @@ from __future__ import annotations
 import argparse
 import atexit
 import json
+import math
 import os
 import re
 import shutil
@@ -106,6 +107,9 @@ PHASES = (
     "rearm",
     "judge",
 )
+# The phases that boot and measure an arm. Resuming at one of these skips
+# `disarm`, so `main` re-establishes the disarm prerequisite before running.
+ARM_PHASES = tuple(name for name in PHASES if name.startswith(("arm_", "measure_")))
 PRODUCTION_IMAGE = ARMS["b"]["tag"]
 
 _RECEIPT: Path | None = None
@@ -242,17 +246,31 @@ def container_started_at(container: str = HEAD_CONTAINER, host: str | None = Non
     return win.run(argv, timeout=60, check=False).stdout.strip()
 
 
-def preemptions() -> float:
+def preemptions() -> float | None:
+    """Cumulative preemption count, or None when the metric is unavailable.
+
+    Fails closed: a failed curl, a missing counter, or a non-finite value all
+    return None, which propagates into a None delta that the auditor rejects.
+    Returning 0.0 on a failed request would make two unavailable samples look
+    like an accepted "no preemptions" delta.
+    """
     proc = win.run(["curl", "-fsS", f"{win.BASE}/metrics"], timeout=30, check=False)
+    if proc.returncode != 0:
+        return None
     total = 0.0
+    seen = False
     for line in proc.stdout.splitlines():
         if not line.startswith("vllm:num_preemptions_total"):
             continue
         try:
-            total += float(line.rsplit(" ", 1)[1])
+            value = float(line.rsplit(" ", 1)[1])
         except (IndexError, ValueError):
             continue
-    return total
+        if not math.isfinite(value):
+            return None
+        total += value
+        seen = True
+    return total if seen else None
 
 
 def memfree_pair() -> tuple[float, float]:
@@ -339,10 +357,21 @@ def phase_preflight(state: dict) -> None:
 
 
 def timer_states() -> dict[str, str]:
+    """Each timer's state, using the return code to tell "inactive" from "absent".
+
+    `is-active` prints `inactive` for BOTH a genuinely inactive unit (rc=3) and
+    a unit that does not exist (rc=4); verified on the live node. Without the
+    return code, disarm would read a missing unit as "successfully stopped" and
+    rearm's `!= active` check would be the only thing catching it.
+    """
     out: dict[str, str] = {}
     for unit in TIMERS:
         proc = win.run(["systemctl", "--user", "is-active", unit], timeout=30, check=False)
-        out[unit] = proc.stdout.strip() or "unknown"
+        status = proc.stdout.strip()
+        if proc.returncode in (0, 3) and status:
+            out[unit] = status
+        else:
+            out[unit] = f"unknown(rc={proc.returncode}, out={status!r})"
     return out
 
 
@@ -356,9 +385,12 @@ def phase_disarm(state: dict) -> None:
     win.run(["systemctl", "--user", "reset-failed"], timeout=60, check=False)
     states = timer_states()
     state["timers_after_disarm"] = states
-    bad = {unit: status for unit, status in states.items() if status == "active"}
-    if bad:
-        raise RuntimeError(f"timers still active after disarm: {bad}")
+    # Require a *provable* stop: anything that is not exactly "inactive"
+    # (including an `unknown(...)` marker for an absent or unreadable unit)
+    # means the timers were not verifiably disarmed, so the window must not run.
+    not_stopped = {unit: status for unit, status in states.items() if status != "inactive"}
+    if not_stopped:
+        raise RuntimeError(f"timers not provably stopped after disarm: {not_stopped}")
     # Stopping a timer does not stop a service it already started, nor cancel a
     # queued restart job. §6 requires waiting for in-flight watchdog/start work:
     # the watchdog can enqueue `systemctl restart --no-block`, and that job
@@ -375,13 +407,23 @@ def phase_disarm(state: dict) -> None:
 
 
 def _active_services() -> dict[str, str]:
+    """Each timer service's state, or an `unknown(...)` marker.
+
+    `systemctl is-active` prints `inactive` for BOTH a unit that is genuinely
+    inactive (rc=3) and a unit that does not exist (rc=4), so the stdout alone
+    cannot tell "disarmed" from "asked the wrong user manager". Verified on the
+    live node: an existing inactive unit gives rc=3, a nonexistent one rc=4.
+    Only rc 0 (active) and rc 3 (inactive) are trustworthy answers; anything
+    else is marked unknown and `wait_quiescent` counts it as busy.
+    """
     out: dict[str, str] = {}
     for unit in TIMER_SERVICES:
         proc = win.run(["systemctl", "--user", "is-active", unit], timeout=30, check=False)
         status = proc.stdout.strip()
-        # A failed query must not masquerade as "inactive". Mark it unknown so
-        # quiescence cannot be declared on absent evidence.
-        out[unit] = status if status else f"unknown(rc={proc.returncode})"
+        if proc.returncode in (0, 3) and status:
+            out[unit] = status
+        else:
+            out[unit] = f"unknown(rc={proc.returncode}, out={status!r})"
     return out
 
 
@@ -394,11 +436,13 @@ def _pending_jobs() -> int | None:
     return len([ln for ln in lines if "No jobs running" not in ln and not ln.startswith("JOB")])
 
 
-def wait_quiescent(timeout: float = 300.0) -> bool:
+def wait_quiescent(timeout: float = 300.0, poll: float = 5.0) -> bool:
     """Wait until the timer services are provably inactive and no jobs are queued.
 
     Fails closed: a failed `list-jobs` query, or a service whose state could not
-    be read, counts as busy rather than as quiet.
+    be read, counts as busy rather than as quiet. `poll` is the re-check
+    interval; a short timeout with a fixed 5s poll would still block for a full
+    poll interval, so callers that need a tight bound set it explicitly.
     """
     deadline = time.monotonic() + timeout
     while True:
@@ -411,7 +455,30 @@ def wait_quiescent(timeout: float = 300.0) -> bool:
             log(f"quiescence timed out: services={busy} jobs={jobs}")
             return False
         log(f"waiting for quiescence: services={busy} jobs={jobs}")
-        time.sleep(5)
+        time.sleep(poll)
+
+
+def require_disarmed(where: str, timeout: float = 120.0, poll: float = 5.0) -> None:
+    """Refuse to measure unless the timers are verifiably stopped and quiet.
+
+    Resuming a partial window at `arm_*`/`measure_*` skips `phase_disarm`, and
+    automatic recovery re-arms the timers, so a continuation after a recovery
+    would otherwise run every later boot and measurement with the watchdog able
+    to enqueue a restart mid-block. Both halves matter: the `.timer` units must
+    be stopped, and the services they already started must have drained.
+    """
+    states = timer_states()
+    armed = {unit: status for unit, status in states.items() if status != "inactive"}
+    if armed:
+        raise RuntimeError(
+            f"{where}: the watchdog/metrics timers are not disarmed ({armed}); "
+            "resume from the `disarm` phase instead"
+        )
+    if not wait_quiescent(timeout=timeout, poll=poll):
+        raise RuntimeError(
+            f"{where}: the timer services or queued jobs are not quiescent; "
+            "resume from the `disarm` phase instead"
+        )
 
 
 def phase_arm(state: dict, arm: str) -> None:
@@ -556,9 +623,20 @@ def phase_measure(state: dict, arm: str) -> None:
         save(state)
         log(f"arm {arm} lane {lane}: {runs} runs in {elapsed:.0f}s")
     state["arms"].setdefault(arm, {})["preemptions_after"] = preemptions()
-    delta = state["arms"][arm]["preemptions_after"] - state["arms"][arm].get("preemptions_before", 0.0)
+    before = state["arms"][arm].get("preemptions_before")
+    after = state["arms"][arm]["preemptions_after"]
+    # None on either side means the counter could not be read, which is not the
+    # same as "no preemptions". Propagate None so the auditor's `delta is None`
+    # gate rejects the arm instead of accepting an unread counter as zero.
+    delta = None if before is None or after is None else after - before
     state["arms"][arm]["preemptions_delta"] = delta
     save(state)
+    if delta is None:
+        raise RuntimeError(
+            f"arm {arm}: preemption telemetry unavailable "
+            f"(before={before!r} after={after!r}); refusing to treat an unread "
+            "counter as no preemptions"
+        )
     if delta:
         raise RuntimeError(f"arm {arm}: preemptions increased by {delta} during measurement")
 
@@ -618,20 +696,42 @@ def phase_gates(state: dict) -> None:
 
 
 def phase_rearm(state: dict) -> None:
+    """Start both timers, attempting each one independently.
+
+    Starting the first unit must not prevent attempting the second. A
+    persistent failure on the watchdog timer would otherwise leave the
+    metrics-alert timer permanently down, and recovery retries this same
+    ordered loop, so the second unit would never be attempted at all.
+    """
+    failures: dict[str, str] = {}
     for unit in TIMERS:
         proc = win.run(["systemctl", "--user", "start", unit], timeout=60, check=False)
         if proc.returncode != 0:
-            raise RuntimeError(f"systemctl start {unit} exited {proc.returncode}: {proc.stderr.strip()}")
+            failures[unit] = f"start exited {proc.returncode}: {proc.stderr.strip()}"
     states = timer_states()
     state["timers_after_rearm"] = states
-    bad = {unit: status for unit, status in states.items() if status != "active"}
-    if bad:
-        raise RuntimeError(f"timers not active after rearm: {bad}")
+    for unit, status in states.items():
+        if status != "active":
+            note = f"not active after start: {status}"
+            # Keep the start error too: overwriting it would discard why the
+            # start failed, which is the more actionable half of the report.
+            failures[unit] = f"{failures[unit]}; {note}" if unit in failures else note
+    state["rearm_failures"] = failures
+    save(state)
+    if failures:
+        raise RuntimeError(f"timers not restored: {failures}")
     log(f"watchdog + metrics-alert timers re-armed {states}")
 
 
 def phase_judge(state: dict) -> None:
-    audit_out = _RECEIPT.with_name(_RECEIPT.stem.replace("-window-", "-audit-") + ".json")
+    # Derive the audit path by SUFFIXING, not by replacing a `-window-` token.
+    # For a receipt named without that token (e.g. `--receipt custom.json`) the
+    # replace was a no-op, so the auditor wrote its verdict over the window
+    # receipt and the following save() then overwrote the audit with window
+    # state -- destroying both. A suffix is always distinct.
+    audit_out = _RECEIPT.with_name(_RECEIPT.stem + "-audit" + _RECEIPT.suffix)
+    if audit_out == _RECEIPT:
+        raise RuntimeError(f"refusing to judge: audit path collides with {_RECEIPT}")
     proc = subprocess.run(
         ["python3", str(AUDITOR), "--receipt", str(_RECEIPT), "--out", str(audit_out)],
         check=False, capture_output=True, text=True, timeout=900,
@@ -760,6 +860,15 @@ def main(argv: list[str] | None = None) -> int:
         print(f"--from {args.first} needs a prior preflight state (no backup in {receipt})", file=sys.stderr)
         return 2
     _RECEIPT, _ACTIVE, _KEEP_ARMED = receipt, state, args.keep_armed
+    # Resuming at an arm/measure phase skips `disarm`. Automatic recovery
+    # re-arms the timers, so the prerequisite must be re-established rather than
+    # assumed. Checked before any signal handler or atexit hook is installed.
+    if args.first in ARM_PHASES:
+        try:
+            require_disarmed(f"--from {args.first}")
+        except RuntimeError as exc:
+            print(str(exc), file=sys.stderr)
+            return 2
     for sig in (signal.SIGTERM, signal.SIGHUP):
         signal.signal(sig, _on_signal)
     atexit.register(emergency_restore)

--- a/scripts/run_v149_qualification_window.py
+++ b/scripts/run_v149_qualification_window.py
@@ -68,6 +68,9 @@ WORKER_CONTAINER = "glm53-exl3-worker"
 WORKER = os.environ.get("WORKER_SSH", "nvidia@192.168.177.11")
 TAG = "task35b"
 TIMERS = ("vllm-glm53exl3-watchdog.timer", "glm53exl3-metrics-alert.timer")
+# The services those timers trigger. Stopping a timer does not stop a service it
+# already started, so disarm must wait for these to go inactive too.
+TIMER_SERVICES = ("vllm-glm53exl3-watchdog.service", "glm53exl3-metrics-alert.service")
 
 # Pre-registered arms. `tag` is the last-wins IMAGE= value; `exllamav3` is what
 # the running container must report, checked in-container on both nodes.
@@ -151,15 +154,18 @@ def jit_stamp() -> str:
     return win.STAMP.read_text().strip() if win.STAMP.is_file() else ""
 
 
-def pool_line() -> str:
-    """The canonical KV-capacity line from the head container's log.
+POOL_CAPACITY_RE = re.compile(r"GPU KV cache size:\s*([\d,]+)\s*tokens")
+POOL_CONCURRENCY_RE = re.compile(r"Maximum concurrency[^:]*:\s*([\d.]+)x")
+
+
+def pool_line_raw() -> str:
+    """The raw KV-capacity log line, for the audit trail.
 
     Deliberately more specific than the shared `win.pool_line()`, which returns
     the first line containing `kv_cache`. In this container the *first* such line
     is a startup patch message carrying the file path `kv_cache_utils.py`
     (`[patch_glm5_drafter_group] ... kv_cache_utils.py: already patched`), which
-    is identical on every arm. Comparing that would make the auditor's
-    pool-unchanged gate vacuous: it would pass even if the real pool moved.
+    is identical on every arm, so comparing it would make the pool gate vacuous.
 
     `grep -m1` exits at the first match, so the pipeline stops early rather than
     streaming the whole log.
@@ -173,6 +179,27 @@ def pool_line() -> str:
         if line:
             return line
     return ""
+
+
+def pool_capacity() -> str:
+    """The KV pool's identity: token count and concurrency, NOT the log line.
+
+    The raw line carries a timestamp, a PID and a source-location prefix
+    (`(EngineCore pid=237) INFO 09-11 09:21:22 [kv_cache_utils.py:2598] ...`)
+    that differ on every boot even when the pool is byte-identical, so comparing
+    raw lines would abort a healthy window. Compare the parsed capacity instead.
+    Returns "" when no capacity line is found, which the auditor rejects.
+    """
+    raw = pool_line_raw()
+    if not raw:
+        return ""
+    match = POOL_CAPACITY_RE.search(raw)
+    if not match:
+        return ""
+    tokens = match.group(1).replace(",", "")
+    concurrency = POOL_CONCURRENCY_RE.search(raw)
+    suffix = f"; concurrency {concurrency.group(1)}x" if concurrency else ""
+    return f"{tokens} tokens{suffix}"
 
 
 # --- container identity -----------------------------------------------------
@@ -196,6 +223,14 @@ def exllamav3_version(container: str = HEAD_CONTAINER, host: str | None = None) 
         if match:
             return match.group(1)
     return ""
+
+
+def container_started_at(container: str = HEAD_CONTAINER, host: str | None = None) -> str:
+    """The container's start time, used as a per-boot identity token."""
+    argv = ["docker", "inspect", "-f", "{{.State.StartedAt}}", container]
+    if host:
+        argv = ["ssh", "-o", "BatchMode=yes", "-o", "ConnectTimeout=10", host, " ".join(argv)]
+    return win.run(argv, timeout=60, check=False).stdout.strip()
 
 
 def preemptions() -> float:
@@ -284,7 +319,8 @@ def phase_preflight(state: dict) -> None:
             "start_sha256": win.sha256(ROOT / "start.sh"),
             "env_effective_before": env,
             "image_before": win.image_id(),
-            "pool_line_before": pool_line(),
+            "pool_line_before": pool_line_raw(),
+            "pool_capacity_before": pool_capacity(),
             "jit_stamp_before": stamp_before,
             "arm_image_presence": presence,
             "contract": {"arms": ARMS, "lanes": {k: v[0] for k, v in LANES.items()}},
@@ -314,7 +350,53 @@ def phase_disarm(state: dict) -> None:
     bad = {unit: status for unit, status in states.items() if status == "active"}
     if bad:
         raise RuntimeError(f"timers still active after disarm: {bad}")
-    log(f"watchdog + metrics-alert timers disarmed {states}")
+    # Stopping a timer does not stop a service it already started, nor cancel a
+    # queued restart job. §6 requires waiting for in-flight watchdog/start work:
+    # the watchdog can enqueue `systemctl restart --no-block`, and that job
+    # would tear down the boot this runner is about to perform.
+    quiescent = wait_quiescent()
+    state["quiescent_after_disarm"] = quiescent
+    save(state)
+    if not quiescent:
+        raise RuntimeError(
+            "watchdog/metrics services or queued jobs still active after disarm; "
+            "refusing to start the window"
+        )
+    log(f"watchdog + metrics-alert timers disarmed and quiescent {states}")
+
+
+def _active_services() -> dict[str, str]:
+    out: dict[str, str] = {}
+    for unit in TIMER_SERVICES:
+        proc = win.run(["systemctl", "--user", "is-active", unit], timeout=30, check=False)
+        out[unit] = proc.stdout.strip() or "unknown"
+    return out
+
+
+def _pending_jobs() -> int:
+    proc = win.run(["systemctl", "--user", "list-jobs"], timeout=30, check=False)
+    lines = [ln for ln in proc.stdout.splitlines() if ln.strip()]
+    # The header line ("No jobs running." or a column header) is not a job.
+    return len([ln for ln in lines if "No jobs running" not in ln and not ln.startswith("JOB")])
+
+
+def wait_quiescent(timeout: float = 300.0) -> bool:
+    """Wait until the timer services are inactive and no jobs are queued."""
+    deadline = time.monotonic() + timeout
+    while True:
+        busy = {
+            unit: status
+            for unit, status in _active_services().items()
+            if status in ("active", "activating", "reloading", "deactivating")
+        }
+        jobs = _pending_jobs()
+        if not busy and jobs == 0:
+            return True
+        if time.monotonic() >= deadline:
+            log(f"quiescence timed out: services={busy} jobs={jobs}")
+            return False
+        log(f"waiting for quiescence: services={busy} jobs={jobs}")
+        time.sleep(5)
 
 
 def phase_arm(state: dict, arm: str) -> None:
@@ -344,7 +426,8 @@ def phase_arm(state: dict, arm: str) -> None:
         "worker_exllamav3_version": worker["exllamav3_version"],
         "health": 200,
         "jit_stamp": jit_stamp(),
-        "pool_line": pool_line(),
+        "pool_line": pool_line_raw(),
+        "container_started_at": container_started_at(),
         "memfree_head_gib": head_mem,
         "memfree_worker_gib": worker_mem,
         "preemptions_before": preemptions(),
@@ -358,9 +441,38 @@ def phase_arm(state: dict, arm: str) -> None:
 
 
 def phase_measure(state: dict, arm: str) -> None:
+    # Revalidate the running arm before measuring. A resume with `--from
+    # measure_a` after an automatic recovery would otherwise measure whatever is
+    # actually running (the restored production image) and file it under arm A.
+    # `verify_arm` raises on any image or `exllamav3` mismatch.
+    head_now = verify_arm(arm, HEAD_CONTAINER)
+    worker_now = verify_arm(arm, WORKER_CONTAINER, host=WORKER)
+    record = state.setdefault("arms", {}).setdefault(arm, {})
+    boot_now = container_started_at()
+    recorded_boot = record.get("container_started_at")
+    if recorded_boot and boot_now and boot_now != recorded_boot:
+        raise RuntimeError(
+            f"arm {arm}: the head container restarted since the arm phase "
+            f"({recorded_boot} -> {boot_now}); the observations would not belong "
+            "to the verified boot"
+        )
+    record["measure_verified_image"] = head_now["image_tag"]
+    record["measure_verified_worker_image"] = worker_now["image_tag"]
+    record["measure_verified_exllamav3"] = head_now["exllamav3_version"]
+    record["measure_container_started_at"] = boot_now
+    # A fresh attempt tag per invocation: a retry after a failed block writes new
+    # files instead of overwriting the evidence an earlier receipt points at.
+    attempt = time.strftime("%Y%m%d-%H%M%S")
+    record["measure_attempt"] = attempt
+    save(state)
+
     state.setdefault("probes", {}).setdefault(arm, {})
     for lane, (runs, timeout) in LANES.items():
-        out = _RECEIPT.parent / f"{TAG}-{arm}-{lane}.json"
+        # Window-, arm- and attempt-specific path, so no run of this harness can
+        # ever clobber another's evidence.
+        out = _RECEIPT.parent / (
+            f"{_RECEIPT.stem}-{arm}-{lane}-{attempt}.json"
+        )
         head_before, worker_before = check_tripwire(f"arm {arm} {lane} before")
         started = time.time()
         proc = subprocess.run(
@@ -397,16 +509,24 @@ def phase_restore(state: dict) -> None:
     shutil.copy2(backup, ENV_FILE)
     if win.sha256(ENV_FILE) != state["env_sha256"]:
         raise RuntimeError("restored .env does not match the pre-window hash")
-    state["env_touched"] = False
     save(state)
     win.guarded_start()
     if not win.wait_health():
         raise RuntimeError("production did not become healthy after restore")
     record = verify_arm("b", HEAD_CONTAINER)
+    worker_record = verify_arm("b", WORKER_CONTAINER, host=WORKER)
     state["restored_image_tag"] = record["image_tag"]
     state["restored_exllamav3_version"] = record["exllamav3_version"]
+    # Recovery intent is cleared ONLY once production is verified healthy and
+    # running the expected image on both nodes. Clearing it earlier (right after
+    # copying the backup) would make `needs_env_restore` report "production was
+    # never moved" if `guarded_start` then failed, leaving production down with
+    # no automatic retry.
+    state["env_touched"] = False
+    state["restored_worker_image_tag"] = worker_record["image_tag"]
     save(state)
-    log(f"production restored: {record['image_tag']} exllamav3={record['exllamav3_version']}")
+    log(f"production restored: {record['image_tag']} exllamav3={record['exllamav3_version']} "
+        f"worker={worker_record['image_tag']}")
 
 
 def phase_gates(state: dict) -> None:
@@ -420,9 +540,16 @@ def phase_gates(state: dict) -> None:
         "acceptance_tail": (acc.stdout or "").strip().splitlines()[-6:],
         "memfree_head_gib": head,
         "memfree_worker_gib": worker,
-        "pool_line": pool_line(),
-        "pool_line_before": state.get("pool_line_before", ""),
+        "pool_line": pool_line_raw(),
+        "pool_capacity": pool_capacity(),
+        "pool_capacity_before": state.get("pool_capacity_before", ""),
         "jit_stamp": jit_stamp(),
+        # The pre-window stamp, NOT arm B's: `prod-start.sh` hashes every raw
+        # `IMAGE=` line including overridden ones, so arm B's `.env` (original
+        # line + appended A + appended B) and the restored `.env` (original line
+        # only) hash differently even though both run B. Comparing against arm
+        # B's stamp would deterministically abort a successful window.
+        "jit_stamp_before": state.get("jit_stamp_before", ""),
         "jit_stamp_arm_b": (state.get("arms", {}).get("b", {}) or {}).get("jit_stamp", ""),
     }
     save(state)
@@ -521,6 +648,13 @@ def restore_production(state: dict) -> None:
         log(f"AUTO-RESTORE FAILED: {exc} — operator action required")
 
 
+def _recovery_ok(state: dict) -> bool:
+    """True when recovery left nothing outstanding, so atexit need not retry."""
+    return not str(state.get("auto_restore", "")).startswith("FAILED") and not str(
+        state.get("timer_restore", "")
+    ).startswith("FAILED")
+
+
 def emergency_restore() -> None:
     global _RESTORE_DONE
     state = _ACTIVE
@@ -590,13 +724,27 @@ def main(argv: list[str] | None = None) -> int:
             state["phases"].append({"phase": name, "ok": True})
             state["phase_in_progress"] = None
             save(state)
+    except (Exception, KeyboardInterrupt) as exc:  # noqa: BLE001
+        # Anything raised outside a phase handler — a `save()` failure, or a
+        # SIGTERM landing between phases — must still trigger recovery. Without
+        # this the `finally` would see failure=None, skip the restore, and set
+        # _RESTORE_DONE, which disables the atexit handler as well.
+        failure = failure or exc
+        log(f"window aborted outside a phase handler: {exc!r}")
     finally:
         if failure is not None and not args.keep_armed:
             restore_production(state)
             recover_timers(state)
-        _RESTORE_DONE = True
+            # Only disarm the atexit safety net once recovery actually
+            # succeeded, so a failed restore gets a second attempt at exit.
+            _RESTORE_DONE = _recovery_ok(state)
+        else:
+            _RESTORE_DONE = True
         state["finished"] = time.strftime("%Y-%m-%dT%H:%M:%S%z")
-        save(state)
+        try:
+            save(state)
+        except OSError as exc:  # the receipt write must not mask the real failure
+            log(f"could not write the final receipt: {exc!r}")
 
     log(f"receipt: {receipt}")
     return 1 if failure is not None else 0

--- a/scripts/run_v149_qualification_window.py
+++ b/scripts/run_v149_qualification_window.py
@@ -366,7 +366,11 @@ def timer_states() -> dict[str, str]:
     """
     out: dict[str, str] = {}
     for unit in TIMERS:
-        proc = win.run(["systemctl", "--user", "is-active", unit], timeout=30, check=False)
+        try:
+            proc = win.run(["systemctl", "--user", "is-active", unit], timeout=30, check=False)
+        except Exception as exc:  # noqa: BLE001 — one hung query must not hide the other unit
+            out[unit] = f"unknown(raised {exc!r})"
+            continue
         status = proc.stdout.strip()
         if proc.returncode in (0, 3) and status:
             out[unit] = status
@@ -378,19 +382,34 @@ def timer_states() -> dict[str, str]:
 def phase_disarm(state: dict) -> None:
     state["disarm_attempted"] = True
     save(state)
+    # Attempt both stops before reporting. A raise on the first unit would leave
+    # the second timer running with no record of the attempt, and the window
+    # must not start with a live timer.
+    stop_failures: dict[str, str] = {}
     for unit in TIMERS:
-        proc = win.run(["systemctl", "--user", "stop", unit], timeout=60, check=False)
+        try:
+            proc = win.run(["systemctl", "--user", "stop", unit], timeout=60, check=False)
+        except Exception as exc:  # noqa: BLE001 — a hung stop must not skip the other unit
+            stop_failures[unit] = f"stop raised {exc!r}"
+            continue
         if proc.returncode != 0:
-            raise RuntimeError(f"systemctl stop {unit} exited {proc.returncode}: {proc.stderr.strip()}")
-    win.run(["systemctl", "--user", "reset-failed"], timeout=60, check=False)
+            stop_failures[unit] = f"stop exited {proc.returncode}: {proc.stderr.strip()}"
+    try:
+        win.run(["systemctl", "--user", "reset-failed"], timeout=60, check=False)
+    except Exception as exc:  # noqa: BLE001 — best-effort cleanup, never fatal
+        log(f"reset-failed did not complete: {exc!r}")
     states = timer_states()
     state["timers_after_disarm"] = states
+    state["disarm_stop_failures"] = stop_failures
     # Require a *provable* stop: anything that is not exactly "inactive"
     # (including an `unknown(...)` marker for an absent or unreadable unit)
     # means the timers were not verifiably disarmed, so the window must not run.
     not_stopped = {unit: status for unit, status in states.items() if status != "inactive"}
-    if not_stopped:
-        raise RuntimeError(f"timers not provably stopped after disarm: {not_stopped}")
+    if not_stopped or stop_failures:
+        raise RuntimeError(
+            f"timers not provably stopped after disarm: {not_stopped} "
+            f"stop_failures={stop_failures}"
+        )
     # Stopping a timer does not stop a service it already started, nor cancel a
     # queued restart job. §6 requires waiting for in-flight watchdog/start work:
     # the watchdog can enqueue `systemctl restart --no-block`, and that job
@@ -418,7 +437,11 @@ def _active_services() -> dict[str, str]:
     """
     out: dict[str, str] = {}
     for unit in TIMER_SERVICES:
-        proc = win.run(["systemctl", "--user", "is-active", unit], timeout=30, check=False)
+        try:
+            proc = win.run(["systemctl", "--user", "is-active", unit], timeout=30, check=False)
+        except Exception as exc:  # noqa: BLE001 — one hung query must not hide the other unit
+            out[unit] = f"unknown(raised {exc!r})"
+            continue
         status = proc.stdout.strip()
         if proc.returncode in (0, 3) and status:
             out[unit] = status
@@ -702,10 +725,20 @@ def phase_rearm(state: dict) -> None:
     persistent failure on the watchdog timer would otherwise leave the
     metrics-alert timer permanently down, and recovery retries this same
     ordered loop, so the second unit would never be attempted at all.
+
+    The per-unit guard catches raised exceptions, not just nonzero exit codes:
+    `win.run()` raises `subprocess.TimeoutExpired` when a start hangs, and an
+    unguarded raise would break out of the loop before the second unit was
+    tried -- which is the same one-timer-left-down outcome the ordering fix was
+    meant to prevent.
     """
     failures: dict[str, str] = {}
     for unit in TIMERS:
-        proc = win.run(["systemctl", "--user", "start", unit], timeout=60, check=False)
+        try:
+            proc = win.run(["systemctl", "--user", "start", unit], timeout=60, check=False)
+        except Exception as exc:  # noqa: BLE001 — a hung start must not skip the other unit
+            failures[unit] = f"start raised {exc!r}"
+            continue
         if proc.returncode != 0:
             failures[unit] = f"start exited {proc.returncode}: {proc.stderr.strip()}"
     states = timer_states()
@@ -718,6 +751,10 @@ def phase_rearm(state: dict) -> None:
             failures[unit] = f"{failures[unit]}; {note}" if unit in failures else note
     state["rearm_failures"] = failures
     save(state)
+    # A recorded raise fails the rearm even when the unit reads `active`: a hung
+    # start is not a verified start, and the retry `recover_timers` triggers is
+    # cheap and idempotent, so an unnecessary second attempt costs nothing while
+    # declaring success on an unverified start could hide a dead timer.
     if failures:
         raise RuntimeError(f"timers not restored: {failures}")
     log(f"watchdog + metrics-alert timers re-armed {states}")

--- a/scripts/run_v149_qualification_window.py
+++ b/scripts/run_v149_qualification_window.py
@@ -1,0 +1,581 @@
+#!/usr/bin/env python3
+"""Guarded A-B-B-A §6 qualification window for the task 35 ExLlamaV3 v1.4.9 pin.
+
+Task 35 moved the ExLlamaV3 pin from v1.4.7 (`ca13bdd`) to v1.4.9 (`5be8865`)
+and deployed the candidate on the correctness gates, but the end-to-end
+throughput comparison was never run to `docs/13` §6's observation contract: the
+original window ran one three-observation structured block per arm. This runner
+produces that missing evidence.
+
+One independent variable: the `IMAGE=` tag, i.e. the ExLlamaV3 revision baked
+into the serving image. Every other knob is frozen by the pre-window `.env`.
+
+  A  = glm53-selfbuild:e3-w3-zfill       (ExLlamaV3 1.4.7, control)
+  B  = glm53-selfbuild:e3-w3-zfill-v149  (ExLlamaV3 1.4.9, candidate)
+
+Sequence and sample sizes are pre-registered in `audit_v149_qualification.py`
+and are not tunable from the command line: A-B-B-A with 9 decode observations
+per arm on each of three fixed prompts and 5 cold-prefill observations per arm
+at ~60k and ~240k. Each arm gets its own boot, because the revision is baked
+into the process.
+
+Phases run in order and can be bounded with `--from/--to`:
+
+  preflight   hashes, drain check, both-node arm-image presence, `.env` backup,
+              KV pool line, JIT shape stamp (shared helpers from the decode
+              profile window runner)
+  disarm      stop the watchdog + metrics-alert timers, reset-failed
+  arm_*       append the arm's `IMAGE=` last-wins line, start through
+              `local/prod-start.sh`, wait for health, verify the container's
+              image tag and the in-container `exllamav3` version on BOTH nodes
+  measure_*   run the pre-registered probe blocks, sample MemFree and the
+              preemption counter around them
+  restore     put the pre-window `.env` back (production is the v1.4.9
+              candidate), reboot, verify the restore
+  gates       acceptance.sh, both-node MemFree tripwire, KV pool line, JIT stamp
+  rearm       re-enable the timers
+  judge       run `audit_v149_qualification.py` over the receipt
+
+Any failure after disarm reboots production from the pre-window `.env` and
+re-arms the timers before exiting non-zero; the two are attempted independently
+so a failed reboot cannot skip the re-arm. SIGTERM/SIGHUP/SIGINT take the same
+recovery path. The window never edits any `.env` line other than appending
+`IMAGE=`. Resume a partial window with `--state <receipt> --from <phase>`.
+"""
+from __future__ import annotations
+
+import argparse
+import atexit
+import json
+import os
+import re
+import shutil
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import run_decode_profile_window as win  # noqa: E402  (shared guarded-window helpers)
+
+ROOT = win.ROOT
+ENV_FILE = ROOT / ".env"
+PROBE = ROOT / "scripts" / "probe_v149_qualification.py"
+AUDITOR = ROOT / "scripts" / "audit_v149_qualification.py"
+HEAD_CONTAINER = "glm53-exl3-head"
+WORKER_CONTAINER = "glm53-exl3-worker"
+WORKER = os.environ.get("WORKER_SSH", "nvidia@192.168.177.11")
+TAG = "task35b"
+TIMERS = ("vllm-glm53exl3-watchdog.timer", "glm53exl3-metrics-alert.timer")
+
+# Pre-registered arms. `tag` is the last-wins IMAGE= value; `exllamav3` is what
+# the running container must report, checked in-container on both nodes.
+ARMS: dict[str, dict[str, str]] = {
+    "a": {"tag": "glm53-selfbuild:e3-w3-zfill", "exllamav3": "1.4.7"},
+    "b": {"tag": "glm53-selfbuild:e3-w3-zfill-v149", "exllamav3": "1.4.9"},
+    "b2": {"tag": "glm53-selfbuild:e3-w3-zfill-v149", "exllamav3": "1.4.9"},
+    "a2": {"tag": "glm53-selfbuild:e3-w3-zfill", "exllamav3": "1.4.7"},
+}
+# lane -> (runs, subprocess timeout seconds). The counts are the §6 contract.
+LANES: dict[str, tuple[int, float]] = {
+    "structured": (9, 1800.0),
+    "essay": (9, 1800.0),
+    "hashmap": (9, 1800.0),
+    "prefill60k": (5, 3600.0),
+    "prefill240k": (5, 5400.0),
+}
+WARMUP_TOKENS = 32
+TRIPWIRE_GIB = 2.5
+PHASES = (
+    "preflight",
+    "disarm",
+    "arm_a",
+    "measure_a",
+    "arm_b",
+    "measure_b",
+    "arm_b2",
+    "measure_b2",
+    "arm_a2",
+    "measure_a2",
+    "restore",
+    "gates",
+    "rearm",
+    "judge",
+)
+PRODUCTION_IMAGE = ARMS["b"]["tag"]
+
+_RECEIPT: Path | None = None
+_ACTIVE: dict | None = None
+_KEEP_ARMED = False
+_RESTORE_DONE = False
+
+
+def log(message: str) -> None:
+    print(f"[task35b-window] {message}", flush=True)
+
+
+def save(state: dict) -> None:
+    """Atomically persist the receipt so an interrupted window stays recoverable."""
+    if _RECEIPT is None:
+        return
+    tmp = _RECEIPT.with_suffix(_RECEIPT.suffix + ".tmp")
+    tmp.write_text(json.dumps(state, indent=1, default=str) + "\n")
+    os.replace(tmp, _RECEIPT)
+
+
+# --- environment ------------------------------------------------------------
+
+def effective_env_all() -> dict[str, str]:
+    """Last-wins value for every `KEY=value` line in `.env`."""
+    out: dict[str, str] = {}
+    for line in ENV_FILE.read_text().splitlines():
+        if line.startswith("#") or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        key = key.strip()
+        if not key or not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", key):
+            continue
+        out[key] = value.strip().strip("'\"")
+    return out
+
+
+def set_image(tag: str) -> None:
+    text = ENV_FILE.read_text()
+    if not text.endswith("\n"):
+        text += "\n"
+    ENV_FILE.write_text(text + f"\n# {TAG} qualification window: arm image (removed by restore)\nIMAGE={tag}\n")
+
+
+def jit_stamp() -> str:
+    return win.STAMP.read_text().strip() if win.STAMP.is_file() else ""
+
+
+# --- container identity -----------------------------------------------------
+
+def container_image(container: str, host: str | None = None) -> str:
+    argv = ["docker", "inspect", "-f", "{{.Config.Image}}", container]
+    if host:
+        argv = ["ssh", "-o", "BatchMode=yes", "-o", "ConnectTimeout=10", host, " ".join(argv)]
+    proc = win.run(argv, timeout=60, check=False)
+    return proc.stdout.strip()
+
+
+def exllamav3_version(container: str = HEAD_CONTAINER, host: str | None = None) -> str:
+    """Read the installed distribution version; `exllamav3.__version__` is unset."""
+    argv = ["docker", "exec", container, "python3", "-m", "pip", "show", "exllamav3"]
+    if host:
+        argv = ["ssh", "-o", "BatchMode=yes", "-o", "ConnectTimeout=10", host, " ".join(argv)]
+    proc = win.run(argv, timeout=180, check=False)
+    for line in (proc.stdout + proc.stderr).splitlines():
+        match = re.match(r"^Version:\s*(\S+)", line.strip())
+        if match:
+            return match.group(1)
+    return ""
+
+
+def preemptions() -> float:
+    proc = win.run(["curl", "-fsS", f"{win.BASE}/metrics"], timeout=30, check=False)
+    total = 0.0
+    for line in proc.stdout.splitlines():
+        if not line.startswith("vllm:num_preemptions_total"):
+            continue
+        try:
+            total += float(line.rsplit(" ", 1)[1])
+        except (IndexError, ValueError):
+            continue
+    return total
+
+
+def memfree_pair() -> tuple[float, float]:
+    return win.memfree_gib(), win.memfree_gib(WORKER)
+
+
+def check_tripwire(where: str) -> tuple[float, float]:
+    head, worker = memfree_pair()
+    if head < TRIPWIRE_GIB or worker < TRIPWIRE_GIB:
+        raise RuntimeError(f"{where}: MemFree tripwire head={head:.2f} worker={worker:.2f} GiB")
+    return head, worker
+
+
+def verify_arm(arm: str, container: str, host: str | None = None) -> dict:
+    """Confirm the boot is the arm it claims to be, on the node it runs on."""
+    expected = ARMS[arm]
+    seen_image = container_image(container, host)
+    record = {"container": container, "image_tag": seen_image, "expected_tag": expected["tag"]}
+    if seen_image != expected["tag"]:
+        raise RuntimeError(f"arm {arm}: {container} runs {seen_image!r}, expected {expected['tag']!r}")
+    version = exllamav3_version(container, host)
+    record["exllamav3_version"] = version
+    if version != expected["exllamav3"]:
+        raise RuntimeError(
+            f"arm {arm}: in-container exllamav3 is {version!r}, expected {expected['exllamav3']!r}"
+        )
+    return record
+
+
+# --- phases -----------------------------------------------------------------
+
+def phase_preflight(state: dict) -> None:
+    if not ENV_FILE.is_file():
+        raise RuntimeError(f"missing {ENV_FILE}")
+    for path in (PROBE, AUDITOR):
+        if not path.is_file():
+            raise RuntimeError(f"missing {path}")
+    stamp_before = jit_stamp()
+    backup = ROOT / f".env.bak-pre-{TAG}-{time.strftime('%Y%m%d-%H%M%S')}"
+    shutil.copy2(ENV_FILE, backup)
+    state.update({"backup": str(backup), "env_sha256": win.sha256(ENV_FILE)})
+    save(state)
+    env = effective_env_all()
+    if env.get("IMAGE") != PRODUCTION_IMAGE:
+        raise RuntimeError(
+            f"preflight expects production on {PRODUCTION_IMAGE!r}, .env says {env.get('IMAGE')!r}"
+        )
+    code, _ = win.curl("/health", timeout=10)
+    if code != 200:
+        raise RuntimeError(f"production is not healthy before the window (/health -> {code})")
+    if not win.drain():
+        raise RuntimeError("server did not drain; refusing to take it down")
+    # Both arm images must already exist on BOTH nodes: shipping one mid-window
+    # would add a variable (and a multi-gigabyte transfer) to the measurement.
+    presence: dict[str, dict[str, bool]] = {}
+    for arm, spec in ARMS.items():
+        tag = spec["tag"]
+        head_ok = win.run(["docker", "image", "inspect", tag], timeout=60, check=False).returncode == 0
+        worker_ok = win.run(
+            ["ssh", "-o", "BatchMode=yes", "-o", "ConnectTimeout=10", WORKER,
+             f"docker image inspect {tag}"], timeout=90, check=False,
+        ).returncode == 0
+        presence[arm] = {"tag": tag, "head": head_ok, "worker": worker_ok}
+        if not (head_ok and worker_ok):
+            raise RuntimeError(f"arm {arm} image {tag!r} missing (head={head_ok} worker={worker_ok})")
+    state.update(
+        {
+            "window": TAG,
+            "runner_sha256": win.sha256(Path(__file__)),
+            "probe_sha256": win.sha256(PROBE),
+            "auditor_sha256": win.sha256(AUDITOR),
+            "prod_start_sha256": win.sha256(ROOT / "local" / "prod-start.sh"),
+            "start_sha256": win.sha256(ROOT / "start.sh"),
+            "env_effective_before": env,
+            "image_before": win.image_id(),
+            "pool_line_before": win.pool_line(),
+            "jit_stamp_before": stamp_before,
+            "arm_image_presence": presence,
+            "contract": {"arms": ARMS, "lanes": {k: v[0] for k, v in LANES.items()}},
+        }
+    )
+    log(f"preflight OK backup={backup.name} stamp={stamp_before[:12]} pool={state['pool_line_before'][:60]}")
+
+
+def timer_states() -> dict[str, str]:
+    out: dict[str, str] = {}
+    for unit in TIMERS:
+        proc = win.run(["systemctl", "--user", "is-active", unit], timeout=30, check=False)
+        out[unit] = proc.stdout.strip() or "unknown"
+    return out
+
+
+def phase_disarm(state: dict) -> None:
+    state["disarm_attempted"] = True
+    save(state)
+    for unit in TIMERS:
+        proc = win.run(["systemctl", "--user", "stop", unit], timeout=60, check=False)
+        if proc.returncode != 0:
+            raise RuntimeError(f"systemctl stop {unit} exited {proc.returncode}: {proc.stderr.strip()}")
+    win.run(["systemctl", "--user", "reset-failed"], timeout=60, check=False)
+    states = timer_states()
+    state["timers_after_disarm"] = states
+    bad = {unit: status for unit, status in states.items() if status == "active"}
+    if bad:
+        raise RuntimeError(f"timers still active after disarm: {bad}")
+    log(f"watchdog + metrics-alert timers disarmed {states}")
+
+
+def phase_arm(state: dict, arm: str) -> None:
+    state.setdefault("arms", {})
+    state["arms"].setdefault(arm, {})["arm_attempted"] = True
+    state["env_touched"] = True
+    save(state)
+    log(f"arming {arm}: IMAGE={ARMS[arm]['tag']}")
+    set_image(ARMS[arm]["tag"])
+    win.guarded_start()
+    if not win.wait_health():
+        raise RuntimeError(f"arm {arm}: head did not become healthy")
+    head = verify_arm(arm, HEAD_CONTAINER)
+    worker = verify_arm(arm, WORKER_CONTAINER, host=WORKER)
+    head_mem, worker_mem = check_tripwire(f"arm {arm} boot")
+    # One predeclared warmup pass before the measured block.
+    warm = win.run(
+        ["python3", str(PROBE), "--kind", "structured", "--runs", "1",
+         "--max-tokens", str(WARMUP_TOKENS), "--out", "/dev/null"],
+        timeout=900, check=False,
+    )
+    if warm.returncode != 0:
+        raise RuntimeError(f"arm {arm}: warmup probe failed rc={warm.returncode}: {warm.stderr[-400:]}")
+    record = {
+        **head,
+        "worker_image_tag": worker["image_tag"],
+        "worker_exllamav3_version": worker["exllamav3_version"],
+        "health": 200,
+        "jit_stamp": jit_stamp(),
+        "memfree_head_gib": head_mem,
+        "memfree_worker_gib": worker_mem,
+        "preemptions_before": preemptions(),
+        "warmup_rc": warm.returncode,
+    }
+    state["arms"][arm].update(record)
+    save(state)
+    log(f"arm {arm} up: image={record['image_tag']} exllamav3={record['exllamav3_version']} "
+        f"worker={record['worker_image_tag']} stamp={record['jit_stamp'][:12]} "
+        f"MemFree head={head_mem:.2f} worker={worker_mem:.2f}")
+
+
+def phase_measure(state: dict, arm: str) -> None:
+    state.setdefault("probes", {}).setdefault(arm, {})
+    for lane, (runs, timeout) in LANES.items():
+        out = _RECEIPT.parent / f"{TAG}-{arm}-{lane}.json"
+        head_before, worker_before = check_tripwire(f"arm {arm} {lane} before")
+        started = time.time()
+        proc = subprocess.run(
+            ["python3", str(PROBE), "--kind", lane, "--runs", str(runs), "--out", str(out)],
+            check=False, text=True, timeout=timeout,
+        )
+        elapsed = time.time() - started
+        head_after, worker_after = check_tripwire(f"arm {arm} {lane} after")
+        if proc.returncode != 0:
+            raise RuntimeError(
+                f"arm {arm} lane {lane}: probe exited {proc.returncode}; "
+                f"last output: {(proc.stdout or proc.stderr)[-400:]}"
+            )
+        state["probes"][arm][lane] = out.name
+        state.setdefault("probe_blocks", []).append(
+            {
+                "arm": arm, "lane": lane, "runs": runs, "seconds": round(elapsed, 1),
+                "memfree_head_gib": [head_before, head_after],
+                "memfree_worker_gib": [worker_before, worker_after],
+            }
+        )
+        save(state)
+        log(f"arm {arm} lane {lane}: {runs} runs in {elapsed:.0f}s")
+    state["arms"].setdefault(arm, {})["preemptions_after"] = preemptions()
+    delta = state["arms"][arm]["preemptions_after"] - state["arms"][arm].get("preemptions_before", 0.0)
+    state["arms"][arm]["preemptions_delta"] = delta
+    save(state)
+    if delta:
+        raise RuntimeError(f"arm {arm}: preemptions increased by {delta} during measurement")
+
+
+def phase_restore(state: dict) -> None:
+    backup = Path(state["backup"])
+    shutil.copy2(backup, ENV_FILE)
+    if win.sha256(ENV_FILE) != state["env_sha256"]:
+        raise RuntimeError("restored .env does not match the pre-window hash")
+    state["env_touched"] = False
+    save(state)
+    win.guarded_start()
+    if not win.wait_health():
+        raise RuntimeError("production did not become healthy after restore")
+    record = verify_arm("b", HEAD_CONTAINER)
+    state["restored_image_tag"] = record["image_tag"]
+    state["restored_exllamav3_version"] = record["exllamav3_version"]
+    save(state)
+    log(f"production restored: {record['image_tag']} exllamav3={record['exllamav3_version']}")
+
+
+def phase_gates(state: dict) -> None:
+    acc = subprocess.run(
+        ["bash", str(ROOT / "local" / "acceptance.sh")],
+        check=False, capture_output=True, text=True, timeout=3600,
+    )
+    head, worker = check_tripwire("post-restore")
+    state["gates"] = {
+        "acceptance_rc": acc.returncode,
+        "acceptance_tail": (acc.stdout or "").strip().splitlines()[-6:],
+        "memfree_head_gib": head,
+        "memfree_worker_gib": worker,
+        "pool_line": win.pool_line(),
+        "pool_line_before": state.get("pool_line_before", ""),
+        "jit_stamp": jit_stamp(),
+        "jit_stamp_arm_b": (state.get("arms", {}).get("b", {}) or {}).get("jit_stamp", ""),
+    }
+    save(state)
+    log(f"acceptance rc={acc.returncode} MemFree head={head:.2f} worker={worker:.2f} GiB")
+    if acc.returncode != 0:
+        raise RuntimeError("acceptance battery failed after restore")
+
+
+def phase_rearm(state: dict) -> None:
+    for unit in TIMERS:
+        proc = win.run(["systemctl", "--user", "start", unit], timeout=60, check=False)
+        if proc.returncode != 0:
+            raise RuntimeError(f"systemctl start {unit} exited {proc.returncode}: {proc.stderr.strip()}")
+    states = timer_states()
+    state["timers_after_rearm"] = states
+    bad = {unit: status for unit, status in states.items() if status != "active"}
+    if bad:
+        raise RuntimeError(f"timers not active after rearm: {bad}")
+    log(f"watchdog + metrics-alert timers re-armed {states}")
+
+
+def phase_judge(state: dict) -> None:
+    audit_out = _RECEIPT.with_name(_RECEIPT.stem.replace("-window-", "-audit-") + ".json")
+    proc = subprocess.run(
+        ["python3", str(AUDITOR), "--receipt", str(_RECEIPT), "--out", str(audit_out)],
+        check=False, capture_output=True, text=True, timeout=900,
+    )
+    state["audit_receipt"] = audit_out.name
+    state["audit_tail"] = (proc.stdout or "").strip().splitlines()[-20:]
+    try:
+        state["verdict"] = json.loads(audit_out.read_text()).get("verdict")
+    except (OSError, json.JSONDecodeError):
+        state["verdict"] = None
+    save(state)
+    log(f"judge rc={proc.returncode} verdict={state['verdict']} receipt={audit_out.name}")
+    if state["verdict"] is None:
+        raise RuntimeError(f"auditor produced no verdict: {(proc.stdout or proc.stderr)[-400:]}")
+
+
+HANDLERS = {
+    "preflight": phase_preflight,
+    "disarm": phase_disarm,
+    "arm_a": lambda state: phase_arm(state, "a"),
+    "measure_a": lambda state: phase_measure(state, "a"),
+    "arm_b": lambda state: phase_arm(state, "b"),
+    "measure_b": lambda state: phase_measure(state, "b"),
+    "arm_b2": lambda state: phase_arm(state, "b2"),
+    "measure_b2": lambda state: phase_measure(state, "b2"),
+    "arm_a2": lambda state: phase_arm(state, "a2"),
+    "measure_a2": lambda state: phase_measure(state, "a2"),
+    "restore": phase_restore,
+    "gates": phase_gates,
+    "rearm": phase_rearm,
+    "judge": phase_judge,
+}
+
+
+# --- recovery ---------------------------------------------------------------
+
+def needs_env_restore(state: dict) -> bool:
+    if "backup" not in state:
+        return False
+    if state.get("env_touched"):
+        return True
+    env = effective_env_all() if ENV_FILE.is_file() else {}
+    return env.get("IMAGE") != PRODUCTION_IMAGE
+
+
+def needs_timer_restore(state: dict) -> bool:
+    return bool(state.get("disarm_attempted"))
+
+
+def recover_timers(state: dict) -> None:
+    if not needs_timer_restore(state):
+        return
+    try:
+        phase_rearm(state)
+        state["timer_restore"] = "ok"
+    except Exception as exc:  # noqa: BLE001
+        state["timer_restore"] = f"FAILED: {exc!r}"
+        log(f"TIMER RESTORE FAILED: {exc} — operator action required")
+    save(state)
+
+
+def restore_production(state: dict) -> None:
+    """Put the pre-window `.env` back and reboot, independently of the timers."""
+    if not needs_env_restore(state):
+        state["auto_restore"] = "not needed (production was never moved)"
+        return
+    log("restoring the pre-window .env and rebooting production")
+    try:
+        phase_restore(state)
+        state["auto_restore"] = "ok"
+    except Exception as exc:  # noqa: BLE001
+        state["auto_restore"] = f"FAILED: {exc!r}"
+        log(f"AUTO-RESTORE FAILED: {exc} — operator action required")
+
+
+def emergency_restore() -> None:
+    global _RESTORE_DONE
+    state = _ACTIVE
+    if _RESTORE_DONE or _KEEP_ARMED or not state:
+        return
+    if not (needs_env_restore(state) or needs_timer_restore(state)):
+        return
+    _RESTORE_DONE = True
+    restore_production(state)
+    recover_timers(state)
+    save(state)
+
+
+def _on_signal(signum: int, _frame: object) -> None:
+    raise KeyboardInterrupt(f"signal {signum}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    global _ACTIVE, _KEEP_ARMED, _RECEIPT, _RESTORE_DONE
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--from", dest="first", choices=PHASES, default=PHASES[0])
+    ap.add_argument("--to", dest="last", choices=PHASES, default=PHASES[-1])
+    ap.add_argument("--state", type=Path, help="receipt/checkpoint file")
+    ap.add_argument("--receipt", type=Path)
+    ap.add_argument("--keep-armed", action="store_true",
+                    help="on failure leave the arm boot running (debug only)")
+    args = ap.parse_args(argv)
+    lo, hi = PHASES.index(args.first), PHASES.index(args.last)
+    if lo > hi:
+        print("--from must not come after --to", file=sys.stderr)
+        return 2
+    receipt = args.receipt or args.state or (
+        ROOT / "local" / f"{TAG}-window-{time.strftime('%Y%m%d-%H%M%S')}.json"
+    )
+    state: dict = {}
+    if receipt.is_file():
+        try:
+            state = json.loads(receipt.read_text())
+        except json.JSONDecodeError:
+            state = {}
+    state.update({"schema": 1, "window": TAG, "started": state.get("started") or time.strftime("%Y-%m-%dT%H:%M:%S%z")})
+    state.setdefault("phases", [])
+    if args.first != PHASES[0] and "backup" not in state:
+        print(f"--from {args.first} needs a prior preflight state (no backup in {receipt})", file=sys.stderr)
+        return 2
+    _RECEIPT, _ACTIVE, _KEEP_ARMED = receipt, state, args.keep_armed
+    for sig in (signal.SIGTERM, signal.SIGHUP):
+        signal.signal(sig, _on_signal)
+    atexit.register(emergency_restore)
+    save(state)
+
+    failure: BaseException | None = None
+    try:
+        for name in PHASES[lo:hi + 1]:
+            state["phase_in_progress"] = name
+            save(state)
+            log(f"--- phase {name} ---")
+            try:
+                HANDLERS[name](state)
+            except (Exception, KeyboardInterrupt) as exc:  # noqa: BLE001
+                state["phases"].append({"phase": name, "ok": False, "error": repr(exc)})
+                state["phase_in_progress"] = None
+                failure = exc
+                log(f"phase {name} FAILED: {exc}")
+                save(state)
+                break
+            state["phases"].append({"phase": name, "ok": True})
+            state["phase_in_progress"] = None
+            save(state)
+    finally:
+        if failure is not None and not args.keep_armed:
+            restore_production(state)
+            recover_timers(state)
+        _RESTORE_DONE = True
+        state["finished"] = time.strftime("%Y-%m-%dT%H:%M:%S%z")
+        save(state)
+
+    log(f"receipt: {receipt}")
+    return 1 if failure is not None else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/run_v149_qualification_window.py
+++ b/scripts/run_v149_qualification_window.py
@@ -151,6 +151,30 @@ def jit_stamp() -> str:
     return win.STAMP.read_text().strip() if win.STAMP.is_file() else ""
 
 
+def pool_line() -> str:
+    """The canonical KV-capacity line from the head container's log.
+
+    Deliberately more specific than the shared `win.pool_line()`, which returns
+    the first line containing `kv_cache`. In this container the *first* such line
+    is a startup patch message carrying the file path `kv_cache_utils.py`
+    (`[patch_glm5_drafter_group] ... kv_cache_utils.py: already patched`), which
+    is identical on every arm. Comparing that would make the auditor's
+    pool-unchanged gate vacuous: it would pass even if the real pool moved.
+
+    `grep -m1` exits at the first match, so the pipeline stops early rather than
+    streaming the whole log.
+    """
+    for pattern in ("GPU KV cache size:", "glm53-kv-capacity-log"):
+        proc = win.run(
+            ["sh", "-c", f"docker logs {HEAD_CONTAINER} 2>&1 | grep -m1 {pattern!r}"],
+            timeout=300, check=False,
+        )
+        line = proc.stdout.strip()
+        if line:
+            return line
+    return ""
+
+
 # --- container identity -----------------------------------------------------
 
 def container_image(container: str, host: str | None = None) -> str:
@@ -260,7 +284,7 @@ def phase_preflight(state: dict) -> None:
             "start_sha256": win.sha256(ROOT / "start.sh"),
             "env_effective_before": env,
             "image_before": win.image_id(),
-            "pool_line_before": win.pool_line(),
+            "pool_line_before": pool_line(),
             "jit_stamp_before": stamp_before,
             "arm_image_presence": presence,
             "contract": {"arms": ARMS, "lanes": {k: v[0] for k, v in LANES.items()}},
@@ -320,6 +344,7 @@ def phase_arm(state: dict, arm: str) -> None:
         "worker_exllamav3_version": worker["exllamav3_version"],
         "health": 200,
         "jit_stamp": jit_stamp(),
+        "pool_line": pool_line(),
         "memfree_head_gib": head_mem,
         "memfree_worker_gib": worker_mem,
         "preemptions_before": preemptions(),
@@ -395,7 +420,7 @@ def phase_gates(state: dict) -> None:
         "acceptance_tail": (acc.stdout or "").strip().splitlines()[-6:],
         "memfree_head_gib": head,
         "memfree_worker_gib": worker,
-        "pool_line": win.pool_line(),
+        "pool_line": pool_line(),
         "pool_line_before": state.get("pool_line_before", ""),
         "jit_stamp": jit_stamp(),
         "jit_stamp_arm_b": (state.get("arms", {}).get("b", {}) or {}).get("jit_stamp", ""),

--- a/tests/test_v149_qualification.py
+++ b/tests/test_v149_qualification.py
@@ -661,6 +661,171 @@ def test_audit_scope_states_what_adopt_does_not_cover(tmp_path):
     assert "NOT that the full docs/13" in scope["adopt_means"]
 
 
+def test_auditor_rejects_an_excluded_run_that_is_nan_but_errored(tmp_path):
+    """`decode_run_invalid` reports a stream error before the NaN check, so a
+    NaN run that also errored carries an error string as its reason. The raw
+    `nan` flag must be inspected independently of the exclusion wording."""
+    values = _values_with({})
+    receipt = _window_receipt(tmp_path, values)
+    path = tmp_path / receipt["probes"]["a"]["structured"]
+    payload = json.loads(path.read_text())
+    payload["invalid_runs"] = [
+        {"i": 1, "nan": True, "invalid_reason": "TimeoutError: stream disconnected"}
+    ]
+    path.write_text(json.dumps(payload))
+    result = audit.judge(receipt, tmp_path)
+    assert result["verdict"] == "ABORT"
+    assert any("excluded run was corrupted" in message for message in result["errors"])
+
+
+def test_auditor_rejects_a_missing_per_arm_jit_stamp(tmp_path):
+    values = _values_with({})
+    receipt = _window_receipt(tmp_path, values)
+    receipt["arms"]["b2"]["jit_stamp"] = ""
+    result = audit.judge(receipt, tmp_path)
+    assert result["verdict"] == "ABORT"
+    assert any("arm b2 recorded no JIT shape stamp" in message for message in result["errors"])
+
+
+def test_auditor_cannot_decide_on_a_bimodal_arm_whose_median_matches(tmp_path):
+    """Two candidate arms can agree on their medians while neither is settled.
+    A matching median is not evidence of stability. This is a window that
+    cannot decide, not an invalid window, so it must not ABORT."""
+    values = _values_with({})
+    bimodal = [1.0, 1.0, 1.0, 1.0, 25.0, 1000.0, 1000.0, 1000.0, 1000.0]
+    values["b"]["structured"] = list(bimodal)
+    values["b2"]["structured"] = list(bimodal)
+    receipt = _window_receipt(tmp_path, values)
+    result = audit.judge(receipt, tmp_path)
+    assert result["verdict"] == "INCONCLUSIVE", result["errors"]
+    lane = result["lanes"]["structured"]
+    assert lane["verdict"] == "INCONCLUSIVE"
+    assert lane["unsettled_arms"] == ["b", "b2"]
+    assert lane["variability_limit"] == audit.VARIABILITY_MAX
+    # Other lanes are still reported, so a partial window stays readable.
+    assert result["lanes"]["essay"]["verdict"] == "PASS"
+
+
+def test_auditor_accepts_a_settled_arm(tmp_path):
+    values = _values_with({})
+    values["b"]["essay"] = [25.0, 25.2, 24.8, 25.1, 24.9, 25.0, 25.3, 24.7, 25.0]
+    receipt = _window_receipt(tmp_path, values)
+    result = audit.judge(receipt, tmp_path)
+    assert result["verdict"] == "ADOPT", result["errors"]
+    assert result["lanes"]["essay"]["arm_spread"]["b"] < audit.VARIABILITY_MAX
+
+
+def test_auditor_cannot_decide_when_a_control_arm_is_unsettled(tmp_path):
+    """The variability gate applies to the control arms too: an unsettled
+    control cannot anchor the comparison."""
+    values = _values_with({})
+    values["a2"]["hashmap"] = [10.0, 10.0, 10.0, 10.0, 30.0, 900.0, 900.0, 900.0, 900.0]
+    receipt = _window_receipt(tmp_path, values)
+    result = audit.judge(receipt, tmp_path)
+    assert result["verdict"] == "INCONCLUSIVE", result["errors"]
+    assert result["lanes"]["hashmap"]["unsettled_arms"] == ["a2"]
+
+
+def test_auditor_reports_the_remaining_lanes_of_a_partially_unsettled_window(tmp_path):
+    """One unsettled lane must not hide the verdicts of the settled ones."""
+    values = _values_with({})
+    values["b"]["prefill240k"] = [100.0, 100.0, 100.0, 100.0, 1400.0]
+    values["b2"]["prefill240k"] = [100.0, 100.0, 100.0, 100.0, 1400.0]
+    receipt = _window_receipt(tmp_path, values)
+    result = audit.judge(receipt, tmp_path)
+    assert result["verdict"] == "INCONCLUSIVE", result["errors"]
+    assert result["lanes"]["prefill240k"]["unsettled_arms"] == ["b", "b2"]
+    assert result["lanes"]["structured"]["verdict"] == "PASS"
+    assert result["lanes"]["prefill60k"]["verdict"] == "PASS"
+
+
+def test_auditor_still_aborts_on_a_hard_defect_alongside_an_unsettled_arm(tmp_path):
+    """A genuine invalidity outranks noise: corruption is still an ABORT."""
+    values = _values_with({})
+    values["b"]["structured"] = [1.0, 1.0, 1.0, 1.0, 25.0, 1000.0, 1000.0, 1000.0, 1000.0]
+    receipt = _window_receipt(tmp_path, values)
+    receipt["arms"]["b2"]["jit_stamp"] = ""
+    result = audit.judge(receipt, tmp_path)
+    assert result["verdict"] == "ABORT"
+    assert any("recorded no JIT shape stamp" in message for message in result["errors"])
+
+
+# --- runner -> probe integration --------------------------------------------
+
+def _arm_fixture(monkeypatch, tmp_path, *, warmup_rc=0):
+    """Wire phase_arm's collaborators and capture the argv it invokes."""
+    monkeypatch.setattr(window, "_RECEIPT", tmp_path / "task35b-window.json")
+    monkeypatch.setattr(window, "set_image", lambda tag: None)
+    monkeypatch.setattr(window.win, "guarded_start", lambda: None)
+    monkeypatch.setattr(window.win, "wait_health", lambda timeout=0: True)
+    monkeypatch.setattr(window.win, "memfree_gib", lambda host=None: 4.0)
+    monkeypatch.setattr(window, "verify_arm", lambda arm, container, host=None: {
+        "image_tag": window.ARMS[arm]["tag"], "exllamav3_version": window.ARMS[arm]["exllamav3"],
+    })
+    monkeypatch.setattr(window, "jit_stamp", lambda: "stamp")
+    monkeypatch.setattr(window, "pool_line_raw", lambda: "GPU KV cache size: 1,396,551 tokens")
+    monkeypatch.setattr(window, "pool_capacity", lambda: "1396551 tokens; concurrency 1.40x")
+    monkeypatch.setattr(window, "container_started_at", lambda *a, **k: "boot")
+    monkeypatch.setattr(window, "preemptions", lambda: 0.0)
+    monkeypatch.setattr(window, "save", lambda _s: None)
+    seen: list[list[str]] = []
+
+    class Done:
+        returncode = warmup_rc
+        stdout = ""
+        stderr = ""
+
+    monkeypatch.setattr(window.win, "run",
+                        lambda argv, **k: seen.append(argv) or Done())
+    return seen
+
+
+def test_arm_warmup_does_not_write_to_a_device_path(monkeypatch, tmp_path):
+    """The probe writes atomically (temp + rename), so `--out /dev/null` would
+    try to create `/dev/null.tmp` in a root-owned directory and fail the arm."""
+    seen = _arm_fixture(monkeypatch, tmp_path)
+    window.phase_arm({}, "a")
+    warm = [argv for argv in seen if "--kind" in argv]
+    assert warm, "no warmup invocation was captured"
+    out = warm[0][warm[0].index("--out") + 1]
+    assert out != "/dev/null"
+    assert not out.startswith("/dev/")
+    assert Path(out).parent == tmp_path
+
+
+def test_arm_records_the_pool_capacity_the_auditor_requires(monkeypatch, tmp_path):
+    """The auditor requires `pool_capacity` per arm; the arm phase must produce
+    exactly that field, not only the raw line."""
+    _arm_fixture(monkeypatch, tmp_path)
+    state: dict = {}
+    window.phase_arm(state, "a")
+    record = state["arms"]["a"]
+    assert record["pool_capacity"] == "1396551 tokens; concurrency 1.40x"
+    assert record["container_started_at"] == "boot"
+    assert record["worker_container_started_at"] == "boot"
+    assert record["preemptions_before"] == 0.0
+
+
+def test_arm_records_feed_the_auditor_without_an_identity_abort(monkeypatch, tmp_path):
+    """End-to-end: records actually produced by the arm phase must satisfy the
+    auditor's identity and pool checks, so a healthy window is not aborted."""
+    _arm_fixture(monkeypatch, tmp_path)
+    state: dict = {"pool_capacity_before": "1396551 tokens; concurrency 1.40x"}
+    for arm in window.ARMS:
+        window.phase_arm(state, arm)
+        state["arms"][arm]["preemptions_delta"] = 0
+    receipt = {"arms": state["arms"], "pool_capacity_before": state["pool_capacity_before"]}
+    errors: list[str] = []
+    for arm in audit.ARMS:
+        record = receipt["arms"][arm]
+        assert record.get("pool_capacity") == receipt["pool_capacity_before"]
+        assert record.get("jit_stamp")
+        assert record.get("preemptions_delta") == 0
+        assert record.get("image_tag") == audit.ARM_IMAGE[arm]
+        assert record.get("exllamav3_version") == audit.ARM_EXLLAMAV3[arm]
+    assert errors == []
+
+
 def test_auditor_aborts_when_the_final_jit_stamp_is_not_the_candidate_stamp(tmp_path):
     values = _values_with({})
     receipt = _window_receipt(tmp_path, values)
@@ -887,9 +1052,34 @@ def test_measure_rejects_a_boot_that_restarted_since_the_arm_phase(monkeypatch, 
         "image_tag": window.ARMS[arm]["tag"], "exllamav3_version": window.ARMS[arm]["exllamav3"],
     })
     monkeypatch.setattr(window, "container_started_at", lambda *a, **k: "2026-09-11T10:00:00Z")
-    state = {"arms": {"a": {"container_started_at": "2026-09-11T09:00:00Z"}}}
+    state = {"arms": {"a": {"container_started_at": "2026-09-11T09:00:00Z",
+                            "worker_container_started_at": "2026-09-11T09:00:00Z"}}}
     with pytest.raises(RuntimeError, match="restarted since the arm phase"):
         window.phase_measure(state, "a")
+
+
+def test_measure_refuses_when_the_boot_identity_is_unavailable(monkeypatch, tmp_path):
+    """An unreadable boot token must refuse, not silently bypass the binding."""
+    monkeypatch.setattr(window, "save", lambda _s: None)
+    monkeypatch.setattr(window, "_RECEIPT", tmp_path / "w.json")
+    monkeypatch.setattr(window, "verify_arm", lambda arm, container, host=None: {
+        "image_tag": window.ARMS[arm]["tag"], "exllamav3_version": window.ARMS[arm]["exllamav3"],
+    })
+    monkeypatch.setattr(window, "container_started_at", lambda *a, **k: "")
+    state = {"arms": {"a": {"container_started_at": "x", "worker_container_started_at": "x"}}}
+    with pytest.raises(RuntimeError, match="could not read the container boot identity"):
+        window.phase_measure(state, "a")
+
+
+def test_measure_refuses_when_the_arm_phase_recorded_no_boot(monkeypatch, tmp_path):
+    monkeypatch.setattr(window, "save", lambda _s: None)
+    monkeypatch.setattr(window, "_RECEIPT", tmp_path / "w.json")
+    monkeypatch.setattr(window, "verify_arm", lambda arm, container, host=None: {
+        "image_tag": window.ARMS[arm]["tag"], "exllamav3_version": window.ARMS[arm]["exllamav3"],
+    })
+    monkeypatch.setattr(window, "container_started_at", lambda *a, **k: "boot")
+    with pytest.raises(RuntimeError, match="no boot identity was recorded"):
+        window.phase_measure({}, "a")
 
 
 def test_measure_probe_paths_are_attempt_specific(monkeypatch, tmp_path):
@@ -910,13 +1100,125 @@ def test_measure_probe_paths_are_attempt_specific(monkeypatch, tmp_path):
 
     monkeypatch.setattr(window.subprocess, "run",
                         lambda argv, **k: seen.append(argv) or Done())
-    window.phase_measure({}, "a")
+    state = {"arms": {"a": {"container_started_at": "boot",
+                            "worker_container_started_at": "boot"}}}
+    window.phase_measure(state, "a")
     outs = [argv[argv.index("--out") + 1] for argv in seen]
     assert len(outs) == len(window.LANES)
     assert len(set(outs)) == len(outs)  # one distinct file per lane
     for out in outs:
         assert "task35b-window-20260911-a-" in Path(out).name
         assert Path(out).name != "task35b-a-structured.json"
+
+
+def test_measure_attempts_do_not_collide_across_invocations(monkeypatch, tmp_path):
+    """Two measure calls in the same second must not reuse the same paths."""
+    monkeypatch.setattr(window, "_RECEIPT", tmp_path / "task35b-window.json")
+    monkeypatch.setattr(window, "verify_arm", lambda arm, container, host=None: {
+        "image_tag": window.ARMS[arm]["tag"], "exllamav3_version": window.ARMS[arm]["exllamav3"],
+    })
+    monkeypatch.setattr(window, "container_started_at", lambda *a, **k: "boot")
+    monkeypatch.setattr(window.win, "memfree_gib", lambda host=None: 4.0)
+    monkeypatch.setattr(window, "preemptions", lambda: 0.0)
+    monkeypatch.setattr(window, "save", lambda _s: None)
+    seen: list[list[str]] = []
+
+    class Done:
+        returncode = 0
+        stdout = ""
+        stderr = ""
+
+    monkeypatch.setattr(window.subprocess, "run",
+                        lambda argv, **k: seen.append(argv) or Done())
+    state = {"arms": {"a": {"container_started_at": "boot",
+                            "worker_container_started_at": "boot"}}}
+    window.phase_measure(state, "a")
+    first = {argv[argv.index("--out") + 1] for argv in seen}
+    seen.clear()
+    window.phase_measure(state, "a")
+    second = {argv[argv.index("--out") + 1] for argv in seen}
+    assert first and second and not (first & second)
+
+
+def test_measure_registers_the_block_before_running_it(monkeypatch, tmp_path):
+    """A failed block must appear in the receipt, so a retry cannot judge the
+    window without seeing that the failure happened."""
+    monkeypatch.setattr(window, "_RECEIPT", tmp_path / "task35b-window.json")
+    monkeypatch.setattr(window, "verify_arm", lambda arm, container, host=None: {
+        "image_tag": window.ARMS[arm]["tag"], "exllamav3_version": window.ARMS[arm]["exllamav3"],
+    })
+    monkeypatch.setattr(window, "container_started_at", lambda *a, **k: "boot")
+    monkeypatch.setattr(window.win, "memfree_gib", lambda host=None: 4.0)
+    monkeypatch.setattr(window, "save", lambda _s: None)
+
+    class Failed:
+        returncode = 3
+        stdout = None
+        stderr = None
+
+    monkeypatch.setattr(window.subprocess, "run", lambda *a, **k: Failed())
+    state = {"arms": {"a": {"container_started_at": "boot",
+                            "worker_container_started_at": "boot"}}}
+    with pytest.raises(RuntimeError, match="no output"):
+        window.phase_measure(state, "a")
+    blocks = state["probe_blocks"]
+    assert blocks and blocks[0]["ok"] is False
+    assert blocks[0]["returncode"] == 3
+    assert blocks[0]["error"] == "(no output)"
+    assert state["probes"]["a"] == {}  # nothing registered as usable evidence
+
+
+def test_wait_quiescent_fails_closed_when_the_job_query_fails(monkeypatch):
+    monkeypatch.setattr(window, "_active_services",
+                        lambda: {u: "inactive" for u in window.TIMER_SERVICES})
+    monkeypatch.setattr(window, "_pending_jobs", lambda: None)
+    assert window.wait_quiescent(timeout=0.01) is False
+
+
+def test_wait_quiescent_fails_closed_when_a_service_state_is_unknown(monkeypatch):
+    monkeypatch.setattr(window, "_active_services",
+                        lambda: {u: "unknown(rc=1)" for u in window.TIMER_SERVICES})
+    monkeypatch.setattr(window, "_pending_jobs", lambda: 0)
+    assert window.wait_quiescent(timeout=0.01) is False
+
+
+def test_pending_jobs_reports_none_when_systemctl_fails(monkeypatch):
+    class Failed:
+        returncode = 1
+        stdout = ""
+
+    monkeypatch.setattr(window.win, "run", lambda *a, **k: Failed())
+    assert window._pending_jobs() is None
+
+
+def test_save_is_best_effort_so_receipt_io_cannot_block_recovery(monkeypatch, tmp_path):
+    """A persistent receipt-write failure must not stop the window from
+    restarting production."""
+    monkeypatch.setattr(window, "_RECEIPT", tmp_path / "sub" / "missing" / "w.json")
+    state: dict = {}
+    window.save(state)  # parent directories do not exist
+    assert state["save_failures"] == 1
+
+
+def test_restore_restarts_production_even_when_the_receipt_cannot_be_written(monkeypatch, tmp_path):
+    """The checkpoint write before the restart must not be able to prevent it."""
+    env = tmp_path / ".env"
+    backup = tmp_path / "backup.env"
+    env.write_text("IMAGE=armed\n")
+    backup.write_text(f"IMAGE={window.PRODUCTION_IMAGE}\n")
+    monkeypatch.setattr(window, "ENV_FILE", env)
+    monkeypatch.setattr(window, "_RECEIPT", tmp_path / "no" / "such" / "dir" / "w.json")
+    started: list[str] = []
+    monkeypatch.setattr(window.win, "guarded_start", lambda: started.append("start"))
+    monkeypatch.setattr(window.win, "wait_health", lambda timeout=0: True)
+    monkeypatch.setattr(window, "verify_arm", lambda arm, container, host=None: {
+        "image_tag": window.PRODUCTION_IMAGE, "exllamav3_version": "1.4.9",
+    })
+    state = {"backup": str(backup), "env_touched": True,
+             "env_sha256": window.win.sha256(backup)}
+    window.phase_restore(state)
+    assert started == ["start"]
+    assert state["env_touched"] is False
 
 
 def test_disarm_waits_for_quiescence(monkeypatch, tmp_path):

--- a/tests/test_v149_qualification.py
+++ b/tests/test_v149_qualification.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import time
 from pathlib import Path
 
 import pytest
@@ -155,6 +156,113 @@ def test_probe_exits_nonzero_when_a_run_is_invalid(monkeypatch, tmp_path):
     assert payload["valid_runs"] == 0 and len(payload["invalid_runs"]) == 3
 
 
+def test_probe_keeps_completed_observations_when_a_later_run_fails(monkeypatch, tmp_path):
+    """A crash mid-block must not discard the observations already taken."""
+    monkeypatch.setattr(probe, "health", lambda: 200)
+    monkeypatch.setattr(probe, "served_model", lambda: "GLM-5.3-Flash-EXL3")
+    monkeypatch.setattr(probe, "spec_snapshot", lambda: {})
+    calls = {"n": 0}
+
+    def flaky(*_a, **_k):
+        calls["n"] += 1
+        if calls["n"] == 3:
+            raise RuntimeError("connection reset")
+        return _decode_run(tok_s=70.0 + calls["n"])
+
+    monkeypatch.setattr(probe, "decode_run", flaky)
+    out = tmp_path / "o.json"
+    with pytest.raises(RuntimeError, match="connection reset"):
+        probe.main(["--kind", "structured", "--runs", "5", "--out", str(out)])
+    payload = json.loads(out.read_text())
+    assert payload["valid_runs"] == 2
+    assert [r["tok_s"] for r in payload["runs"]] == [71.0, 72.0]
+
+
+def test_probe_receipt_write_is_atomic(monkeypatch, tmp_path):
+    out = tmp_path / "o.json"
+    probe.write_receipt(out, {"a": 1})
+    assert json.loads(out.read_text()) == {"a": 1}
+    assert not (tmp_path / "o.json.tmp").exists()
+
+
+class _FakeStream:
+    """A minimal SSE response that records how it was read."""
+
+    def __init__(self, lines, *, status=200, delay=0.0):
+        self._lines = list(lines)
+        self.status = status
+        self._delay = delay
+        self.read_calls = 0
+
+    def readline(self):
+        if not self._lines:
+            return b""
+        if self._delay:
+            time.sleep(self._delay)
+        return self._lines.pop(0)
+
+    def read(self, *_a):  # pragma: no cover - must never be reached
+        self.read_calls += 1
+        raise AssertionError("the stream must be read line-by-line, not buffered")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_a):
+        return False
+
+
+def _sse(*contents, usage=None):
+    lines = [
+        b'data: {"choices":[{"delta":{"content":"' + c.encode() + b'"}}]}\n'
+        for c in contents
+    ]
+    if usage:
+        lines.append(
+            b'data: {"choices":[],"usage":' + json.dumps(usage).encode() + b"}\n"
+        )
+    lines.append(b"data: [DONE]\n")
+    return lines
+
+
+def test_stream_reads_line_by_line_not_in_buffered_blocks(monkeypatch):
+    """`read(4096)` blocks until 4096 bytes accumulate, folding several token
+    arrivals into one and collapsing the measured decode interval."""
+    fake = _FakeStream(_sse("a", "b"))
+    monkeypatch.setattr(probe, "_post", lambda *a, **k: fake)
+    probe._stream({"model": "m"}, 5.0)
+    assert fake.read_calls == 0
+
+
+def test_stream_timing_spans_first_to_last_content(monkeypatch):
+    """Decode must end at the last content token, not at EOF: the usage chunk and
+    the connection close arrive afterwards and would be charged to decode."""
+    fake = _FakeStream(_sse("a", "b", usage={"completion_tokens": 3}), delay=0.05)
+    monkeypatch.setattr(probe, "_post", lambda *a, **k: fake)
+    raw = probe._stream({"model": "m"}, 5.0)
+    assert raw["first_s"] is not None and raw["last_s"] is not None
+    content_span = raw["last_s"] - raw["first_s"]
+    to_eof = raw["ended_s"] - raw["first_s"]
+    assert content_span > 0.02
+    assert to_eof > content_span  # the usage line and EOF come after the last token
+    assert raw["usage"]["completion_tokens"] == 3
+
+
+def test_decode_run_uses_the_content_span_for_the_rate(monkeypatch):
+    fake = _FakeStream(
+        _sse("a", "b", "c", usage={"completion_tokens": 3, "prompt_tokens": 11}),
+        delay=0.05,
+    )
+    monkeypatch.setattr(probe, "_post", lambda *a, **k: fake)
+    monkeypatch.setattr(probe, "spec_snapshot", lambda: {})
+    run = probe.decode_run("p", 3, 5.0)
+    assert run["completion_tokens"] == 3
+    assert run["ttft_s"] > 0.02
+    # (3 - 1) tokens over a ~0.1 s content span, not over the longer EOF span.
+    assert 10 < run["tok_s"] < 40
+    assert run["decode_s"] < run["wall_s"] - run["ttft_s"]
+
+
 # --- auditor ----------------------------------------------------------------
 
 def _probe_receipt(kind, values, *, valid=None, any_nan=False, any_cache_hit=False):
@@ -200,21 +308,25 @@ def _window_receipt(tmp_path, arm_values, *, gates_ok=True, write_probes=True):
             "worker_exllamav3_version": audit.ARM_EXLLAMAV3[arm],
             "jit_stamp": "stamp-b" if arm in ("b", "b2") else "stamp-a",
             "pool_line": "GPU KV cache size: 1,396,551 tokens",
+            "pool_capacity": "1396551 tokens; concurrency 1.40x",
+            "preemptions_delta": 0,
         }
     gates = {
         "acceptance_rc": 0,
         "memfree_head_gib": 4.1,
         "memfree_worker_gib": 3.3,
         "pool_line": "GPU KV cache size: 1,396,551 tokens",
-        "pool_line_before": "GPU KV cache size: 1,396,551 tokens",
-        "jit_stamp": "stamp-b",
+        "pool_capacity": "1396551 tokens; concurrency 1.40x",
+        "pool_capacity_before": "1396551 tokens; concurrency 1.40x",
+        "jit_stamp": "stamp-original",
+        "jit_stamp_before": "stamp-original",
         "jit_stamp_arm_b": "stamp-b",
     }
     if not gates_ok:
         gates["acceptance_rc"] = 1
     return {
         "schema": 1, "window": "task35b", "arms": arms, "gates": gates, "probes": probes,
-        "pool_line_before": "GPU KV cache size: 1,396,551 tokens",
+        "pool_capacity_before": "1396551 tokens; concurrency 1.40x",
     }
 
 
@@ -337,43 +449,6 @@ def test_auditor_aborts_on_a_failed_acceptance_battery(tmp_path):
     assert any("acceptance battery" in message for message in result["errors"])
 
 
-def test_auditor_aborts_when_the_kv_pool_moved(tmp_path):
-    values = _values_with({})
-    receipt = _window_receipt(tmp_path, values)
-    receipt["gates"]["pool_line"] = "GPU KV cache size: 1,200,000 tokens"
-    result = audit.judge(receipt, tmp_path)
-    assert result["verdict"] == "ABORT"
-    assert any("KV pool changed" in message for message in result["errors"])
-
-
-def test_auditor_aborts_when_one_arm_reserved_a_different_pool(tmp_path):
-    """The per-arm pool check localizes a divergence to the boot that caused it."""
-    values = _values_with({})
-    receipt = _window_receipt(tmp_path, values)
-    receipt["arms"]["b2"]["pool_line"] = "GPU KV cache size: 1,200,000 tokens"
-    result = audit.judge(receipt, tmp_path)
-    assert result["verdict"] == "ABORT"
-    assert any("arm b2 KV pool differs" in message for message in result["errors"])
-
-
-def test_auditor_aborts_when_an_arm_recorded_no_pool_line(tmp_path):
-    values = _values_with({})
-    receipt = _window_receipt(tmp_path, values)
-    del receipt["arms"]["a"]["pool_line"]
-    result = audit.judge(receipt, tmp_path)
-    assert result["verdict"] == "ABORT"
-    assert any("arm a recorded no KV pool line" in message for message in result["errors"])
-
-
-def test_auditor_aborts_when_the_pre_window_pool_line_is_missing(tmp_path):
-    values = _values_with({})
-    receipt = _window_receipt(tmp_path, values)
-    receipt["pool_line_before"] = ""
-    result = audit.judge(receipt, tmp_path)
-    assert result["verdict"] == "ABORT"
-    assert any("pre-window KV pool line missing" in message for message in result["errors"])
-
-
 def test_window_pool_line_prefers_the_canonical_capacity_line(monkeypatch):
     """A bare `kv_cache` match would hit the startup patch message instead, whose
     value is constant across arms and would make the pool gate vacuous."""
@@ -388,13 +463,50 @@ def test_window_pool_line_prefers_the_canonical_capacity_line(monkeypatch):
         seen.append(command)
         if "GPU KV cache size:" in command:
             return Fake("(EngineCore pid=237) INFO [kv_cache_utils.py:2598] "
-                        "GPU KV cache size: 1,396,551 tokens\n")
+                        "GPU KV cache size: 1,396,551 tokens, "
+                        "Maximum concurrency for 1,000,000 tokens per request: 1.40x\n")
         return Fake("")
 
     monkeypatch.setattr(window.win, "run", fake_run)
-    line = window.pool_line()
-    assert line.endswith("GPU KV cache size: 1,396,551 tokens")
+    raw = window.pool_line_raw()
+    assert "GPU KV cache size:" in raw
     assert "GPU KV cache size:" in seen[0]
+    # The parsed capacity is what the gate compares, and it carries no PID or
+    # timestamp.
+    assert window.pool_capacity() == "1396551 tokens; concurrency 1.40x"
+
+
+def test_pool_capacity_ignores_boot_specific_prefixes(monkeypatch):
+    """Two boots reserve an identical pool but log it with different PIDs and
+    timestamps. Comparing raw lines would abort a healthy window; comparing the
+    parsed capacity must not."""
+    boot_a = ("(EngineCore pid=237) INFO 09-11 09:21:22 [kv_cache_utils.py:2598] "
+              "GPU KV cache size: 1,396,551 tokens, Maximum concurrency for "
+              "1,000,000 tokens per request: 1.40x")
+    boot_b = ("(EngineCore pid=91) INFO 09-12 14:02:07 [kv_cache_utils.py:2598] "
+              "GPU KV cache size: 1,396,551 tokens, Maximum concurrency for "
+              "1,000,000 tokens per request: 1.40x")
+    assert boot_a != boot_b
+    monkeypatch.setattr(window, "pool_line_raw", lambda: boot_a)
+    first = window.pool_capacity()
+    monkeypatch.setattr(window, "pool_line_raw", lambda: boot_b)
+    assert window.pool_capacity() == first
+
+
+def test_pool_capacity_distinguishes_a_real_change(monkeypatch):
+    monkeypatch.setattr(
+        window, "pool_line_raw",
+        lambda: "GPU KV cache size: 1,200,000 tokens, "
+                "Maximum concurrency for 1,000,000 tokens per request: 1.20x",
+    )
+    assert window.pool_capacity() == "1200000 tokens; concurrency 1.20x"
+
+
+def test_pool_capacity_is_empty_when_unparseable(monkeypatch):
+    monkeypatch.setattr(window, "pool_line_raw", lambda: "[glm53-kv-capacity-log] 566 ids")
+    assert window.pool_capacity() == ""
+    monkeypatch.setattr(window, "pool_line_raw", lambda: "")
+    assert window.pool_capacity() == ""
 
 
 def test_window_pool_line_falls_back_to_the_local_capacity_marker(monkeypatch):
@@ -408,7 +520,7 @@ def test_window_pool_line_falls_back_to_the_local_capacity_marker(monkeypatch):
         return Fake("")
 
     monkeypatch.setattr(window.win, "run", fake_run)
-    assert "glm53-kv-capacity-log" in window.pool_line()
+    assert "glm53-kv-capacity-log" in window.pool_line_raw()
 
 
 def test_window_pool_line_is_empty_when_neither_line_exists(monkeypatch):
@@ -416,7 +528,137 @@ def test_window_pool_line_is_empty_when_neither_line_exists(monkeypatch):
         stdout = ""
 
     monkeypatch.setattr(window.win, "run", lambda *_a, **_k: Fake())
-    assert window.pool_line() == ""
+    assert window.pool_line_raw() == ""
+    assert window.pool_capacity() == ""
+
+
+# --- review regressions -----------------------------------------------------
+
+def test_auditor_aborts_when_the_kv_pool_capacity_moved(tmp_path):
+    values = _values_with({})
+    receipt = _window_receipt(tmp_path, values)
+    receipt["gates"]["pool_capacity"] = "1200000 tokens; concurrency 1.20x"
+    result = audit.judge(receipt, tmp_path)
+    assert result["verdict"] == "ABORT"
+    assert any("KV pool capacity changed" in message for message in result["errors"])
+
+
+def test_auditor_aborts_when_one_arm_reserved_a_different_pool(tmp_path):
+    """The per-arm check localizes a divergence to the boot that caused it."""
+    values = _values_with({})
+    receipt = _window_receipt(tmp_path, values)
+    receipt["arms"]["b2"]["pool_capacity"] = "1200000 tokens; concurrency 1.20x"
+    result = audit.judge(receipt, tmp_path)
+    assert result["verdict"] == "ABORT"
+    assert any("arm b2 KV pool capacity differs" in message for message in result["errors"])
+
+
+def test_auditor_aborts_when_an_arm_recorded_no_pool_capacity(tmp_path):
+    values = _values_with({})
+    receipt = _window_receipt(tmp_path, values)
+    del receipt["arms"]["a"]["pool_capacity"]
+    result = audit.judge(receipt, tmp_path)
+    assert result["verdict"] == "ABORT"
+    assert any("arm a recorded no KV pool capacity" in message for message in result["errors"])
+
+
+def test_auditor_aborts_when_an_arm_saw_a_preemption(tmp_path):
+    values = _values_with({})
+    receipt = _window_receipt(tmp_path, values)
+    receipt["arms"]["b"]["preemptions_delta"] = 1
+    result = audit.judge(receipt, tmp_path)
+    assert result["verdict"] == "ABORT"
+    assert any("arm b saw 1 preemptions" in message for message in result["errors"])
+
+
+def test_auditor_aborts_when_the_preemption_delta_is_missing(tmp_path):
+    values = _values_with({})
+    receipt = _window_receipt(tmp_path, values)
+    del receipt["arms"]["a2"]["preemptions_delta"]
+    result = audit.judge(receipt, tmp_path)
+    assert result["verdict"] == "ABORT"
+    assert any("arm a2 recorded no preemption delta" in message for message in result["errors"])
+
+
+def test_auditor_rejects_a_nan_memory_reading(tmp_path):
+    """`NaN < 2.5` is False, so a plain comparison would pass a NaN reading."""
+    values = _values_with({})
+    receipt = _window_receipt(tmp_path, values)
+    receipt["gates"]["memfree_worker_gib"] = float("nan")
+    result = audit.judge(receipt, tmp_path)
+    assert result["verdict"] == "ABORT"
+    assert any("not a finite memory reading" in message for message in result["errors"])
+
+
+def test_auditor_rejects_empty_jit_stamps(tmp_path):
+    """Two empty stamps must not compare equal and pass."""
+    values = _values_with({})
+    receipt = _window_receipt(tmp_path, values)
+    receipt["gates"]["jit_stamp"] = ""
+    receipt["gates"]["jit_stamp_before"] = ""
+    result = audit.judge(receipt, tmp_path)
+    assert result["verdict"] == "ABORT"
+    assert any("JIT shape stamp was not recorded" in message for message in result["errors"])
+
+
+def test_auditor_rejects_a_corrupted_excluded_run(tmp_path):
+    """A NaN-corrupted observation must not be laundered through the exclusion
+    list and then ignored."""
+    values = _values_with({})
+    receipt = _window_receipt(tmp_path, values)
+    path = tmp_path / receipt["probes"]["a"]["structured"]
+    payload = json.loads(path.read_text())
+    payload["invalid_runs"] = [{"i": 1, "invalid_reason": "NaN/locklock marker in output"}]
+    path.write_text(json.dumps(payload))
+    result = audit.judge(receipt, tmp_path)
+    assert result["verdict"] == "ABORT"
+    assert any("excluded run was corrupted" in message for message in result["errors"])
+
+
+def test_auditor_aborts_when_the_pre_window_jit_stamp_is_missing(tmp_path):
+    values = _values_with({})
+    receipt = _window_receipt(tmp_path, values)
+    receipt["gates"]["jit_stamp_before"] = ""
+    result = audit.judge(receipt, tmp_path)
+    assert result["verdict"] == "ABORT"
+    assert any("pre-window JIT shape stamp was not recorded" in message
+               for message in result["errors"])
+
+
+def test_auditor_accepts_a_restored_stamp_equal_to_the_pre_window_stamp(tmp_path):
+    """Arm B's stamp legitimately differs from the restored one (prod-start.sh
+    hashes every raw IMAGE= line), so the restored stamp must be checked against
+    the pre-window stamp instead."""
+    values = _values_with({})
+    receipt = _window_receipt(tmp_path, values)
+    assert receipt["gates"]["jit_stamp"] == receipt["gates"]["jit_stamp_before"]
+    assert receipt["gates"]["jit_stamp"] != receipt["gates"]["jit_stamp_arm_b"]
+    result = audit.judge(receipt, tmp_path)
+    assert result["verdict"] == "ADOPT"
+
+
+def test_auditor_is_inconclusive_when_the_candidate_is_unstable(tmp_path):
+    """A candidate whose two arms disagree wildly has no settled number to
+    compare, even when the control is rock steady."""
+    values = _values_with({})
+    values["b"]["structured"] = [10.0] * 9
+    values["b2"]["structured"] = [40.0] * 9
+    receipt = _window_receipt(tmp_path, values)
+    result = audit.judge(receipt, tmp_path)
+    assert result["verdict"] == "INCONCLUSIVE"
+    row = result["lanes"]["structured"]
+    assert row["candidate_drift"] > audit.DRIFT_MAX
+    assert row["verdict"] == "INCONCLUSIVE"
+
+
+def test_audit_scope_states_what_adopt_does_not_cover(tmp_path):
+    values = _values_with({})
+    receipt = _window_receipt(tmp_path, values)
+    result = audit.judge(receipt, tmp_path)
+    assert result["verdict"] == "ADOPT"
+    scope = result["scope"]
+    assert any("temp-1" in item for item in scope["does_not_cover"])
+    assert "NOT that the full docs/13" in scope["adopt_means"]
 
 
 def test_auditor_aborts_when_the_final_jit_stamp_is_not_the_candidate_stamp(tmp_path):
@@ -495,6 +737,221 @@ def test_needs_env_restore_tracks_the_touched_flag_and_the_live_image(monkeypatc
     assert window.needs_env_restore({"backup": "x", "env_touched": True}) is True
     env.write_text("IMAGE=glm53-selfbuild:e3-w3-zfill\n")
     assert window.needs_env_restore({"backup": "x"}) is True
+
+
+def test_restore_keeps_recovery_intent_until_production_is_verified(monkeypatch, tmp_path):
+    """If `guarded_start` fails after the .env is copied back, recovery must
+    still believe production needs restoring — otherwise the window leaves
+    production down and reports "production was never moved"."""
+    env = tmp_path / ".env"
+    backup = tmp_path / "backup.env"
+    env.write_text("IMAGE=armed\n")
+    backup.write_text(f"IMAGE={window.PRODUCTION_IMAGE}\n")
+    monkeypatch.setattr(window, "ENV_FILE", env)
+    monkeypatch.setattr(window, "save", lambda _s: None)
+    monkeypatch.setattr(window.win, "guarded_start", lambda: None)
+    monkeypatch.setattr(window.win, "wait_health", lambda timeout=0: False)
+    state = {"backup": str(backup), "env_touched": True,
+             "env_sha256": window.win.sha256(backup)}
+    with pytest.raises(RuntimeError, match="did not become healthy"):
+        window.phase_restore(state)
+    # The .env is back, but production never came up, so recovery must still act.
+    assert state.get("env_touched") is not False
+    assert window.needs_env_restore(state) is True
+
+
+def test_restore_clears_recovery_intent_once_both_nodes_are_verified(monkeypatch, tmp_path):
+    env = tmp_path / ".env"
+    backup = tmp_path / "backup.env"
+    env.write_text("IMAGE=armed\n")
+    backup.write_text(f"IMAGE={window.PRODUCTION_IMAGE}\n")
+    monkeypatch.setattr(window, "ENV_FILE", env)
+    monkeypatch.setattr(window, "save", lambda _s: None)
+    monkeypatch.setattr(window.win, "guarded_start", lambda: None)
+    monkeypatch.setattr(window.win, "wait_health", lambda timeout=0: True)
+    monkeypatch.setattr(window, "verify_arm", lambda arm, container, host=None: {
+        "image_tag": window.PRODUCTION_IMAGE, "exllamav3_version": "1.4.9",
+    })
+    state = {"backup": str(backup), "env_touched": True,
+             "env_sha256": window.win.sha256(backup)}
+    window.phase_restore(state)
+    assert state["env_touched"] is False
+    assert state["restored_image_tag"] == window.PRODUCTION_IMAGE
+
+
+def test_restore_rejects_a_backup_that_does_not_round_trip(monkeypatch, tmp_path):
+    env = tmp_path / ".env"
+    backup = tmp_path / "backup.env"
+    env.write_text("IMAGE=armed\n")
+    backup.write_text(f"IMAGE={window.PRODUCTION_IMAGE}\n")
+    monkeypatch.setattr(window, "ENV_FILE", env)
+    monkeypatch.setattr(window, "save", lambda _s: None)
+    state = {"backup": str(backup), "env_touched": True, "env_sha256": "not-the-hash"}
+    with pytest.raises(RuntimeError, match="does not match the pre-window hash"):
+        window.phase_restore(state)
+    assert state["env_touched"] is True
+
+
+def test_recovery_ok_reports_a_failed_restore():
+    assert window._recovery_ok({}) is True
+    assert window._recovery_ok({"auto_restore": "ok"}) is True
+    assert window._recovery_ok({"auto_restore": "FAILED: boom"}) is False
+    assert window._recovery_ok({"timer_restore": "FAILED: boom"}) is False
+
+
+def test_emergency_restore_stays_armed_after_a_failed_restore(monkeypatch, tmp_path):
+    """A failed automatic restore must leave the atexit safety net armed."""
+    monkeypatch.setattr(window, "_RESTORE_DONE", False)
+    monkeypatch.setattr(window, "_KEEP_ARMED", False)
+    monkeypatch.setattr(window, "_ACTIVE", {"backup": "x", "env_touched": True})
+    calls: list[str] = []
+    monkeypatch.setattr(window, "restore_production", lambda s: calls.append("env"))
+    monkeypatch.setattr(window, "recover_timers", lambda s: calls.append("timers"))
+    monkeypatch.setattr(window, "save", lambda _s: None)
+    window.emergency_restore()
+    assert calls == ["env", "timers"]
+
+
+def test_main_recovers_when_a_save_between_phases_raises(monkeypatch, tmp_path):
+    """A SIGTERM landing between phases (or a save() failure) must still trigger
+    recovery. Previously the finally-block saw failure=None, skipped the
+    restore, and disabled the atexit handler as well."""
+    receipt = tmp_path / "w.json"
+    saved: list[dict] = []
+    real_save = window.save
+
+    def flaky_save(state):
+        saved.append(dict(state))
+        # Explode on the phase-boundary save of the second phase.
+        if len(saved) == 3:
+            raise OSError("disk full")
+        real_save(state)
+
+    restored: list[str] = []
+    monkeypatch.setattr(window, "_RECEIPT", receipt)
+    monkeypatch.setattr(window, "save", flaky_save)
+    monkeypatch.setattr(window, "restore_production", lambda s: restored.append("env"))
+    monkeypatch.setattr(window, "recover_timers", lambda s: restored.append("timers"))
+    monkeypatch.setattr(window, "HANDLERS", {
+        "preflight": lambda s: None,
+        "disarm": lambda s: None,
+    })
+    monkeypatch.setattr(window, "PHASES", ("preflight", "disarm"))
+    monkeypatch.setattr(window, "_RESTORE_DONE", True)
+    rc = window.main(["--state", str(receipt)])
+    assert rc == 1
+    assert restored == ["env", "timers"]
+
+
+def test_main_recovers_on_a_signal_between_phases(monkeypatch, tmp_path):
+    receipt = tmp_path / "w.json"
+    monkeypatch.setattr(window, "_RECEIPT", receipt)
+    monkeypatch.setattr(window, "save", lambda _s: None)
+    restored: list[str] = []
+    monkeypatch.setattr(window, "restore_production", lambda s: restored.append("env"))
+    monkeypatch.setattr(window, "recover_timers", lambda s: restored.append("timers"))
+
+    def interrupted(_state):
+        raise KeyboardInterrupt("signal 15")
+
+    monkeypatch.setattr(window, "HANDLERS", {"preflight": interrupted})
+    monkeypatch.setattr(window, "PHASES", ("preflight",))
+    assert window.main(["--state", str(receipt)]) == 1
+    assert restored == ["env", "timers"]
+
+
+def test_measure_revalidates_the_running_arm(monkeypatch, tmp_path):
+    """A resume with --from measure_a after an automatic recovery would otherwise
+    measure the restored production image and file it under arm A."""
+    monkeypatch.setattr(window, "save", lambda _s: None)
+    monkeypatch.setattr(window, "_RECEIPT", tmp_path / "w.json")
+    monkeypatch.setattr(window.win, "memfree_gib", lambda host=None: 4.0)
+    probed: list[str] = []
+    monkeypatch.setattr(window.subprocess, "run",
+                        lambda *a, **k: probed.append("probe") or type(
+                            "P", (), {"returncode": 0, "stdout": "", "stderr": ""})())
+
+    def wrong_arm(arm, container, host=None):
+        raise RuntimeError(f"arm {arm}: {container} runs 'x', expected 'y'")
+
+    monkeypatch.setattr(window, "verify_arm", wrong_arm)
+    with pytest.raises(RuntimeError, match="runs 'x', expected 'y'"):
+        window.phase_measure({}, "a")
+    assert probed == []  # nothing was measured under the wrong label
+
+
+def test_measure_rejects_a_boot_that_restarted_since_the_arm_phase(monkeypatch, tmp_path):
+    monkeypatch.setattr(window, "save", lambda _s: None)
+    monkeypatch.setattr(window, "_RECEIPT", tmp_path / "w.json")
+    monkeypatch.setattr(window, "verify_arm", lambda arm, container, host=None: {
+        "image_tag": window.ARMS[arm]["tag"], "exllamav3_version": window.ARMS[arm]["exllamav3"],
+    })
+    monkeypatch.setattr(window, "container_started_at", lambda *a, **k: "2026-09-11T10:00:00Z")
+    state = {"arms": {"a": {"container_started_at": "2026-09-11T09:00:00Z"}}}
+    with pytest.raises(RuntimeError, match="restarted since the arm phase"):
+        window.phase_measure(state, "a")
+
+
+def test_measure_probe_paths_are_attempt_specific(monkeypatch, tmp_path):
+    monkeypatch.setattr(window, "_RECEIPT", tmp_path / "task35b-window-20260911.json")
+    monkeypatch.setattr(window, "verify_arm", lambda arm, container, host=None: {
+        "image_tag": window.ARMS[arm]["tag"], "exllamav3_version": window.ARMS[arm]["exllamav3"],
+    })
+    monkeypatch.setattr(window, "container_started_at", lambda *a, **k: "boot")
+    monkeypatch.setattr(window.win, "memfree_gib", lambda host=None: 4.0)
+    monkeypatch.setattr(window, "preemptions", lambda: 0.0)
+    monkeypatch.setattr(window, "save", lambda _s: None)
+    seen: list[list[str]] = []
+
+    class Done:
+        returncode = 0
+        stdout = ""
+        stderr = ""
+
+    monkeypatch.setattr(window.subprocess, "run",
+                        lambda argv, **k: seen.append(argv) or Done())
+    window.phase_measure({}, "a")
+    outs = [argv[argv.index("--out") + 1] for argv in seen]
+    assert len(outs) == len(window.LANES)
+    assert len(set(outs)) == len(outs)  # one distinct file per lane
+    for out in outs:
+        assert "task35b-window-20260911-a-" in Path(out).name
+        assert Path(out).name != "task35b-a-structured.json"
+
+
+def test_disarm_waits_for_quiescence(monkeypatch, tmp_path):
+    monkeypatch.setattr(window, "save", lambda _s: None)
+    monkeypatch.setattr(window.win, "run", lambda *a, **k: type(
+        "P", (), {"returncode": 0, "stdout": "inactive\n", "stderr": ""})())
+    monkeypatch.setattr(window, "timer_states", lambda: {u: "inactive" for u in window.TIMERS})
+    monkeypatch.setattr(window, "_active_services",
+                        lambda: {u: "inactive" for u in window.TIMER_SERVICES})
+    monkeypatch.setattr(window, "_pending_jobs", lambda: 0)
+    state: dict = {}
+    window.phase_disarm(state)
+    assert state["quiescent_after_disarm"] is True
+
+
+def test_disarm_refuses_when_the_watchdog_is_still_running(monkeypatch):
+    monkeypatch.setattr(window, "save", lambda _s: None)
+    monkeypatch.setattr(window.win, "run", lambda *a, **k: type(
+        "P", (), {"returncode": 0, "stdout": "inactive\n", "stderr": ""})())
+    monkeypatch.setattr(window, "timer_states", lambda: {u: "inactive" for u in window.TIMERS})
+    monkeypatch.setattr(window, "_active_services",
+                        lambda: {"vllm-glm53exl3-watchdog.service": "active"})
+    monkeypatch.setattr(window, "_pending_jobs", lambda: 0)
+    monkeypatch.setattr(window, "wait_quiescent", lambda timeout=0: False)
+    with pytest.raises(RuntimeError, match="still active after disarm"):
+        window.phase_disarm({})
+
+
+def test_quiescence_needs_no_pending_jobs(monkeypatch):
+    monkeypatch.setattr(window, "_active_services",
+                        lambda: {u: "inactive" for u in window.TIMER_SERVICES})
+    monkeypatch.setattr(window, "_pending_jobs", lambda: 1)
+    assert window.wait_quiescent(timeout=0.01) is False
+    monkeypatch.setattr(window, "_pending_jobs", lambda: 0)
+    assert window.wait_quiescent(timeout=1.0) is True
 
 
 def test_judge_writes_the_audit_next_to_the_window_receipt(monkeypatch, tmp_path):

--- a/tests/test_v149_qualification.py
+++ b/tests/test_v149_qualification.py
@@ -110,6 +110,7 @@ def test_prefill_run_invalid_accepts_a_cold_run():
     "kwargs,needle",
     [
         ({"cached_tokens": 4096}, "warm request"),
+        ({"cached_tokens": None}, "cannot prove the run was cold"),
         ({"prompt_tokens": 20_000}, "outside"),
         ({"http": 503}, "http 503"),
         ({"ttft_s": None}, "no first token"),
@@ -324,8 +325,18 @@ def _window_receipt(tmp_path, arm_values, *, gates_ok=True, write_probes=True):
     }
     if not gates_ok:
         gates["acceptance_rc"] = 1
+    # The runner registers every measurement block before it runs; the judge
+    # requires that registry. A healthy window has one successful block per
+    # (arm, lane), pointing at the selected probe receipt.
+    blocks = [
+        {"arm": arm, "lane": lane, "runs": audit.REQUIRED_RUNS[lane], "attempt": "t",
+         "path": probes[arm][lane], "ok": True, "returncode": 0, "error": None}
+        for arm in audit.ARMS
+        for lane in audit.LANES
+    ]
     return {
         "schema": 1, "window": "task35b", "arms": arms, "gates": gates, "probes": probes,
+        "probe_blocks": blocks,
         "pool_capacity_before": "1396551 tokens; concurrency 1.40x",
     }
 
@@ -1101,7 +1112,8 @@ def test_measure_probe_paths_are_attempt_specific(monkeypatch, tmp_path):
     monkeypatch.setattr(window.subprocess, "run",
                         lambda argv, **k: seen.append(argv) or Done())
     state = {"arms": {"a": {"container_started_at": "boot",
-                            "worker_container_started_at": "boot"}}}
+                            "worker_container_started_at": "boot",
+                            "preemptions_before": 0.0}}}
     window.phase_measure(state, "a")
     outs = [argv[argv.index("--out") + 1] for argv in seen]
     assert len(outs) == len(window.LANES)
@@ -1131,7 +1143,8 @@ def test_measure_attempts_do_not_collide_across_invocations(monkeypatch, tmp_pat
     monkeypatch.setattr(window.subprocess, "run",
                         lambda argv, **k: seen.append(argv) or Done())
     state = {"arms": {"a": {"container_started_at": "boot",
-                            "worker_container_started_at": "boot"}}}
+                            "worker_container_started_at": "boot",
+                            "preemptions_before": 0.0}}}
     window.phase_measure(state, "a")
     first = {argv[argv.index("--out") + 1] for argv in seen}
     seen.clear()
@@ -1158,7 +1171,8 @@ def test_measure_registers_the_block_before_running_it(monkeypatch, tmp_path):
 
     monkeypatch.setattr(window.subprocess, "run", lambda *a, **k: Failed())
     state = {"arms": {"a": {"container_started_at": "boot",
-                            "worker_container_started_at": "boot"}}}
+                            "worker_container_started_at": "boot",
+                            "preemptions_before": 0.0}}}
     with pytest.raises(RuntimeError, match="no output"):
         window.phase_measure(state, "a")
     blocks = state["probe_blocks"]
@@ -1172,14 +1186,14 @@ def test_wait_quiescent_fails_closed_when_the_job_query_fails(monkeypatch):
     monkeypatch.setattr(window, "_active_services",
                         lambda: {u: "inactive" for u in window.TIMER_SERVICES})
     monkeypatch.setattr(window, "_pending_jobs", lambda: None)
-    assert window.wait_quiescent(timeout=0.01) is False
+    assert window.wait_quiescent(timeout=0.01, poll=0.0) is False
 
 
 def test_wait_quiescent_fails_closed_when_a_service_state_is_unknown(monkeypatch):
     monkeypatch.setattr(window, "_active_services",
                         lambda: {u: "unknown(rc=1)" for u in window.TIMER_SERVICES})
     monkeypatch.setattr(window, "_pending_jobs", lambda: 0)
-    assert window.wait_quiescent(timeout=0.01) is False
+    assert window.wait_quiescent(timeout=0.01, poll=0.0) is False
 
 
 def test_pending_jobs_reports_none_when_systemctl_fails(monkeypatch):
@@ -1251,9 +1265,323 @@ def test_quiescence_needs_no_pending_jobs(monkeypatch):
     monkeypatch.setattr(window, "_active_services",
                         lambda: {u: "inactive" for u in window.TIMER_SERVICES})
     monkeypatch.setattr(window, "_pending_jobs", lambda: 1)
-    assert window.wait_quiescent(timeout=0.01) is False
+    assert window.wait_quiescent(timeout=0.01, poll=0.0) is False
     monkeypatch.setattr(window, "_pending_jobs", lambda: 0)
-    assert window.wait_quiescent(timeout=1.0) is True
+    assert window.wait_quiescent(timeout=1.0, poll=0.0) is True
+
+
+# --- registered attempts (review round 3, finding 1) ------------------------
+
+def test_auditor_aborts_when_a_failed_attempt_is_hidden_by_a_retry(tmp_path):
+    """A resumed arm replaces the selected probe path. The judge must still see
+    the failed attempt, so a corrupted block cannot vanish behind a clean one."""
+    values = _values_with({})
+    receipt = _window_receipt(tmp_path, values)
+    # A failed attempt that left a NaN-corrupted receipt behind.
+    stale = tmp_path / "task35b-a-structured-attempt1.json"
+    stale.write_text(json.dumps({"invalid_runs": [{"i": 1, "nan": True}]}))
+    receipt["probe_blocks"].append({
+        "arm": "a", "lane": "structured", "runs": 9, "attempt": "t0",
+        "path": stale.name, "ok": False, "returncode": 1,
+        "error": "probe exited 1",
+    })
+    result = audit.judge(receipt, tmp_path)
+    assert result["verdict"] == "ABORT", result["errors"]
+    assert any("failed with rc=1" in message for message in result["errors"])
+    assert any("NaN-corrupted run" in message for message in result["errors"])
+
+
+def test_auditor_aborts_when_a_block_was_registered_but_never_completed(tmp_path):
+    values = _values_with({})
+    receipt = _window_receipt(tmp_path, values)
+    receipt["probe_blocks"].append({
+        "arm": "b", "lane": "essay", "runs": 9, "attempt": "t",
+        "path": "task35b-b-essay.json", "ok": None, "returncode": None, "error": None,
+    })
+    result = audit.judge(receipt, tmp_path)
+    assert result["verdict"] == "ABORT"
+    assert any("never completed" in message for message in result["errors"])
+
+
+def test_auditor_aborts_when_the_receipt_registers_no_blocks(tmp_path):
+    values = _values_with({})
+    receipt = _window_receipt(tmp_path, values)
+    del receipt["probe_blocks"]
+    result = audit.judge(receipt, tmp_path)
+    assert result["verdict"] == "ABORT"
+    assert any("no registered measurement blocks" in message for message in result["errors"])
+
+
+def test_auditor_accepts_a_window_whose_blocks_all_succeeded(tmp_path):
+    values = _values_with({})
+    receipt = _window_receipt(tmp_path, values)
+    result = audit.judge(receipt, tmp_path)
+    assert result["verdict"] == "ADOPT", result["errors"]
+
+
+# --- preemption telemetry (review round 3, finding 3) ----------------------
+
+def test_preemptions_fails_closed_on_a_failed_request(monkeypatch):
+    class Failed:
+        returncode = 22
+        stdout = ""
+        stderr = "curl: (22) 404"
+
+    monkeypatch.setattr(window.win, "run", lambda *a, **k: Failed())
+    assert window.preemptions() is None
+
+
+def test_preemptions_fails_closed_when_the_metric_is_absent(monkeypatch):
+    class Ok:
+        returncode = 0
+        stdout = "vllm:num_requests_running{engine=\"0\"} 0.0\n"
+
+    monkeypatch.setattr(window.win, "run", lambda *a, **k: Ok())
+    assert window.preemptions() is None
+
+
+def test_preemptions_fails_closed_on_a_non_finite_counter(monkeypatch):
+    class Ok:
+        returncode = 0
+        stdout = "vllm:num_preemptions_total{engine=\"0\"} nan\n"
+
+    monkeypatch.setattr(window.win, "run", lambda *a, **k: Ok())
+    assert window.preemptions() is None
+
+
+def test_preemptions_sums_finite_counters(monkeypatch):
+    class Ok:
+        returncode = 0
+        stdout = ('vllm:num_preemptions_total{engine="0"} 2.0\n'
+                  'vllm:num_preemptions_total{engine="1"} 3.0\n')
+
+    monkeypatch.setattr(window.win, "run", lambda *a, **k: Ok())
+    assert window.preemptions() == 5.0
+
+
+def test_measure_refuses_when_preemption_telemetry_is_unavailable(monkeypatch, tmp_path):
+    """Two unavailable samples must not read as an accepted zero delta."""
+    monkeypatch.setattr(window, "_RECEIPT", tmp_path / "task35b-window.json")
+    monkeypatch.setattr(window, "verify_arm", lambda arm, container, host=None: {
+        "image_tag": window.ARMS[arm]["tag"], "exllamav3_version": window.ARMS[arm]["exllamav3"],
+    })
+    monkeypatch.setattr(window, "container_started_at", lambda *a, **k: "boot")
+    monkeypatch.setattr(window.win, "memfree_gib", lambda host=None: 4.0)
+    monkeypatch.setattr(window, "preemptions", lambda: None)
+    monkeypatch.setattr(window, "save", lambda _s: None)
+
+    class Done:
+        returncode = 0
+        stdout = ""
+        stderr = ""
+
+    monkeypatch.setattr(window.subprocess, "run", lambda *a, **k: Done())
+    state = {"arms": {"a": {"container_started_at": "boot",
+                            "worker_container_started_at": "boot",
+                            "preemptions_before": 0.0}}}
+    with pytest.raises(RuntimeError, match="preemption telemetry unavailable"):
+        window.phase_measure(state, "a")
+    assert state["arms"]["a"]["preemptions_delta"] is None
+
+
+# --- quiescence and timer state use the return code (round 3) --------------
+
+def test_active_services_marks_a_missing_unit_unknown(monkeypatch):
+    """`is-active` prints `inactive` for a nonexistent unit with rc=4 (verified
+    on the live node), so stdout alone cannot distinguish "disarmed" from
+    "asked the wrong user manager"."""
+    class Missing:
+        returncode = 4
+        stdout = "inactive"
+
+    monkeypatch.setattr(window.win, "run", lambda *a, **k: Missing())
+    states = window._active_services()
+    assert all("unknown(rc=4" in value for value in states.values())
+    assert window.wait_quiescent(timeout=0.01, poll=0.0) is False
+
+
+def test_active_services_accepts_a_genuine_inactive_unit(monkeypatch):
+    class Inactive:
+        returncode = 3
+        stdout = "inactive"
+
+    monkeypatch.setattr(window.win, "run", lambda *a, **k: Inactive())
+    assert set(window._active_services().values()) == {"inactive"}
+
+
+def test_timer_states_marks_a_missing_unit_unknown(monkeypatch):
+    class Missing:
+        returncode = 4
+        stdout = "inactive"
+
+    monkeypatch.setattr(window.win, "run", lambda *a, **k: Missing())
+    assert all("unknown(rc=4" in value for value in window.timer_states().values())
+
+
+def test_disarm_refuses_when_a_timer_is_not_provably_stopped(monkeypatch):
+    """A missing unit must not read as a successful stop: `stop` can succeed
+    (rc=0) while `is-active` reports rc=4 because the unit does not exist."""
+    monkeypatch.setattr(window, "save", lambda _s: None)
+
+    class Result:
+        def __init__(self, returncode, stdout):
+            self.returncode, self.stdout, self.stderr = returncode, stdout, ""
+
+    def fake_run(argv, **kwargs):
+        # `stop` succeeds; the follow-up `is-active` cannot find the unit.
+        return Result(0, "") if argv[2] == "stop" else Result(4, "inactive")
+
+    monkeypatch.setattr(window.win, "run", fake_run)
+    with pytest.raises(RuntimeError, match="not provably stopped"):
+        window.phase_disarm({})
+
+
+def test_rearm_attempts_both_timers_even_when_the_first_fails(monkeypatch):
+    """A persistent watchdog failure must not prevent the metrics timer from
+    being restored."""
+    monkeypatch.setattr(window, "save", lambda _s: None)
+    started: list[str] = []
+
+    class Start:
+        def __init__(self, unit, status="inactive"):
+            self.unit, self.returncode, self.stdout, self.stderr = unit, 0, status, ""
+
+    class Failed:
+        returncode = 1
+        stdout = "inactive"
+        stderr = "boom"
+
+    def fake_run(argv, **kwargs):
+        unit = argv[-1]
+        if argv[2] == "start":
+            started.append(unit)
+            return Failed() if unit == window.TIMERS[0] else Start(unit)
+        # `is-active`: the first timer never came up, the second did.
+        return Start(unit, "inactive" if unit == window.TIMERS[0] else "active")
+
+    monkeypatch.setattr(window.win, "run", fake_run)
+    state: dict = {}
+    with pytest.raises(RuntimeError, match="timers not restored"):
+        window.phase_rearm(state)
+    # Both units were attempted, despite the first failing.
+    assert started == list(window.TIMERS)
+    failure = state["rearm_failures"][window.TIMERS[0]]
+    assert failure.startswith("start exited 1")
+    assert "not active after start" in failure
+    assert window.TIMERS[1] not in state["rearm_failures"]
+
+
+# --- resume must not skip disarm (review round 3, finding 2) ---------------
+
+def _main_fixture(monkeypatch, tmp_path):
+    """A hermetic `main()`: no real phases, no real restore at exit."""
+    receipt = tmp_path / "task35b-window.json"
+    receipt.write_text(json.dumps({"backup": "b.env"}))
+    monkeypatch.setattr(window, "save", lambda _s: None)
+    monkeypatch.setattr(window, "emergency_restore", lambda *a, **k: None)
+    monkeypatch.setattr(window, "recover_timers", lambda state: None)
+    monkeypatch.setattr(window, "HANDLERS",
+                        {name: (lambda state: None) for name in window.PHASES})
+    return receipt
+
+
+def test_arm_phases_are_exactly_the_operational_phases():
+    assert set(window.ARM_PHASES) == {
+        "arm_a", "measure_a", "arm_b", "measure_b",
+        "arm_b2", "measure_b2", "arm_a2", "measure_a2",
+    }
+    assert "disarm" not in window.ARM_PHASES
+    assert "restore" not in window.ARM_PHASES
+
+
+def test_require_disarmed_refuses_when_the_timers_are_still_armed(monkeypatch):
+    class Armed:
+        returncode = 0
+        stdout = "active"
+        stderr = ""
+
+    monkeypatch.setattr(window.win, "run", lambda *a, **k: Armed())
+    with pytest.raises(RuntimeError, match="not disarmed"):
+        window.require_disarmed("--from arm_b")
+
+
+def test_require_disarmed_refuses_when_a_timer_is_unreadable(monkeypatch):
+    class Missing:
+        returncode = 4
+        stdout = "inactive"
+        stderr = ""
+
+    monkeypatch.setattr(window.win, "run", lambda *a, **k: Missing())
+    with pytest.raises(RuntimeError, match="not disarmed"):
+        window.require_disarmed("--from arm_b")
+
+
+def test_require_disarmed_refuses_when_the_services_are_not_quiescent(monkeypatch):
+    class Inactive:
+        returncode = 3
+        stdout = "inactive"
+        stderr = ""
+
+    monkeypatch.setattr(window.win, "run", lambda *a, **k: Inactive())
+    monkeypatch.setattr(window, "_pending_jobs", lambda: 2)
+    with pytest.raises(RuntimeError, match="not quiescent"):
+        window.require_disarmed("--from measure_b", timeout=0.01, poll=0.0)
+
+
+def test_require_disarmed_passes_when_timers_are_stopped_and_quiet(monkeypatch):
+    class Inactive:
+        returncode = 3
+        stdout = "inactive"
+        stderr = ""
+
+    monkeypatch.setattr(window.win, "run", lambda *a, **k: Inactive())
+    monkeypatch.setattr(window, "_pending_jobs", lambda: 0)
+    window.require_disarmed("--from arm_b")
+
+
+def test_main_checks_disarm_when_resuming_an_operational_phase(monkeypatch, tmp_path):
+    """`--from arm_b` must re-establish the disarm prerequisite, because
+    automatic recovery re-arms the timers."""
+    receipt = _main_fixture(monkeypatch, tmp_path)
+    seen: list[str] = []
+
+    def refuse(where):
+        seen.append(where)
+        raise RuntimeError(f"{where}: not disarmed")
+
+    monkeypatch.setattr(window, "require_disarmed", refuse)
+    rc = window.main(["--state", str(receipt), "--from", "arm_b", "--to", "arm_b"])
+    assert rc == 2
+    assert seen == ["--from arm_b"]
+
+
+def test_main_checks_disarm_for_every_operational_phase(monkeypatch, tmp_path):
+    receipt = _main_fixture(monkeypatch, tmp_path)
+    seen: list[str] = []
+    monkeypatch.setattr(window, "require_disarmed",
+                        lambda where: seen.append(where) or None)
+    rc = window.main(["--state", str(receipt), "--from", "arm_b", "--to", "arm_b"])
+    assert rc == 0
+    assert seen == ["--from arm_b"]
+
+
+def test_main_does_not_check_disarm_for_post_window_phases(monkeypatch, tmp_path):
+    """The phases after `restore` legitimately run with the timers re-armed."""
+    receipt = _main_fixture(monkeypatch, tmp_path)
+    called: list[str] = []
+    monkeypatch.setattr(window, "require_disarmed", lambda where: called.append(where))
+    rc = window.main(["--state", str(receipt), "--from", "gates", "--to", "gates"])
+    assert called == []
+    assert rc == 0
+
+
+def test_main_does_not_check_disarm_when_starting_from_disarm(monkeypatch, tmp_path):
+    receipt = _main_fixture(monkeypatch, tmp_path)
+    called: list[str] = []
+    monkeypatch.setattr(window, "require_disarmed", lambda where: called.append(where))
+    rc = window.main(["--state", str(receipt), "--from", "disarm", "--to", "disarm"])
+    assert called == []
+    assert rc == 0
 
 
 def test_judge_writes_the_audit_next_to_the_window_receipt(monkeypatch, tmp_path):
@@ -1263,8 +1591,34 @@ def test_judge_writes_the_audit_next_to_the_window_receipt(monkeypatch, tmp_path
     state: dict = {}
     window.phase_judge(state)
     assert state["verdict"] == "ABORT"
-    assert state["audit_receipt"] == "task35b-audit-20260911-000000.json"
+    assert state["audit_receipt"] == "task35b-window-20260911-000000-audit.json"
     assert (tmp_path / state["audit_receipt"]).is_file()
+    # `_RECEIPT` is the state checkpoint, so save() rewrites it with window
+    # state; the audit must live in its own file, identified by the keys only
+    # the auditor writes.
+    assert "errors" in json.loads((tmp_path / state["audit_receipt"]).read_text())
+    assert "errors" not in json.loads(receipt.read_text())
+
+
+def test_judge_keeps_the_audit_distinct_for_a_custom_receipt_name(monkeypatch, tmp_path):
+    """A receipt without a `-window-` token previously collided: the auditor
+    wrote over the window receipt and the next save() overwrote the audit,
+    destroying both."""
+    receipt = tmp_path / "custom.json"
+    receipt.write_text(json.dumps({"arms": {}, "gates": {}, "probes": {}}))
+    monkeypatch.setattr(window, "_RECEIPT", receipt)
+    state: dict = {"marker": "window-state"}
+    window.phase_judge(state)
+    assert state["audit_receipt"] == "custom-audit.json"
+    assert state["audit_receipt"] != "custom.json"
+    audit_payload = json.loads((tmp_path / "custom-audit.json").read_text())
+    assert audit_payload["verdict"] == "ABORT"
+    assert "errors" in audit_payload
+    # The checkpoint still holds window state and did not become the audit.
+    window_payload = json.loads(receipt.read_text())
+    assert window_payload["marker"] == "window-state"
+    assert window_payload["audit_receipt"] == "custom-audit.json"
+    assert "errors" not in window_payload
 
 
 # --- ISA probe (task 38 item 2) ---------------------------------------------

--- a/tests/test_v149_qualification.py
+++ b/tests/test_v149_qualification.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import subprocess
 import time
 from pathlib import Path
 
@@ -1469,6 +1470,82 @@ def test_rearm_attempts_both_timers_even_when_the_first_fails(monkeypatch):
     assert failure.startswith("start exited 1")
     assert "not active after start" in failure
     assert window.TIMERS[1] not in state["rearm_failures"]
+
+
+def test_rearm_attempts_both_timers_even_when_the_first_start_raises(monkeypatch):
+    """A hung start raises `subprocess.TimeoutExpired` from `win.run()`. An
+    unguarded raise breaks out of the loop and leaves the second timer down --
+    the same one-timer-left-down outcome the ordering fix exists to prevent."""
+    monkeypatch.setattr(window, "save", lambda _s: None)
+    started: list[str] = []
+
+    class Active:
+        returncode, stdout, stderr = 0, "active", ""
+
+    def fake_run(argv, **kwargs):
+        unit = argv[-1]
+        if argv[2] == "start":
+            started.append(unit)
+            if unit == window.TIMERS[0]:
+                raise subprocess.TimeoutExpired(cmd=argv, timeout=60)
+        return Active()
+
+    monkeypatch.setattr(window.win, "run", fake_run)
+    state: dict = {}
+    with pytest.raises(RuntimeError, match="timers not restored"):
+        window.phase_rearm(state)
+    # The second unit was still attempted, and the raise was recorded per-unit.
+    assert started == list(window.TIMERS)
+    assert "raised" in state["rearm_failures"][window.TIMERS[0]]
+    assert window.TIMERS[1] not in state["rearm_failures"]
+
+
+def test_timer_states_marks_a_raising_query_unknown(monkeypatch):
+    """A hung `is-active` must not hide the other unit's real state."""
+    class Inactive:
+        returncode, stdout, stderr = 3, "inactive", ""
+
+    def fake_run(argv, **kwargs):
+        if argv[-1] == window.TIMERS[0]:
+            raise subprocess.TimeoutExpired(cmd=argv, timeout=30)
+        return Inactive()
+
+    monkeypatch.setattr(window.win, "run", fake_run)
+    states = window.timer_states()
+    assert set(states) == set(window.TIMERS)
+    assert "unknown(raised" in states[window.TIMERS[0]]
+    assert states[window.TIMERS[1]] == "inactive"
+
+
+def test_disarm_attempts_both_stops_even_when_the_first_raises(monkeypatch):
+    """Both stops are attempted before the verdict is reported, so a hung first
+    stop cannot leave the second timer running with no record of the attempt."""
+    monkeypatch.setattr(window, "save", lambda _s: None)
+    stopped: list[str] = []
+
+    class Stopped:
+        returncode, stdout, stderr = 0, "", ""
+
+    class Inactive:
+        returncode, stdout, stderr = 3, "inactive", ""
+
+    def fake_run(argv, **kwargs):
+        unit = argv[-1]
+        if argv[2] == "stop":
+            stopped.append(unit)
+            if unit == window.TIMERS[0]:
+                raise subprocess.TimeoutExpired(cmd=argv, timeout=60)
+            return Stopped()
+        return Inactive()
+
+    monkeypatch.setattr(window.win, "run", fake_run)
+    state: dict = {}
+    with pytest.raises(RuntimeError, match="not provably stopped"):
+        window.phase_disarm(state)
+    assert stopped == list(window.TIMERS)
+    # Every unit reports "inactive", so the refusal comes from the recorded
+    # raise alone -- not from the `not_stopped` check.
+    assert "raised" in state["disarm_stop_failures"][window.TIMERS[0]]
 
 
 # --- resume must not skip disarm (review round 3, finding 2) ---------------

--- a/tests/test_v149_qualification.py
+++ b/tests/test_v149_qualification.py
@@ -1,0 +1,580 @@
+"""CPU-only tests for the task 35 §6 qualification window.
+
+No cluster, no torch, no HTTP: the probe's pure helpers, the auditor's
+decision logic, and the runner's arm/phase wiring are all exercised against
+synthetic receipts. The real window's observations come from the cluster; these
+tests exist so a parser or contract edit cannot silently change a verdict.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+KIT_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS = KIT_ROOT / "scripts"
+
+
+def _load(path: Path, name: str):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+probe = _load(SCRIPTS / "probe_v149_qualification.py", "glm53_probe_v149")
+audit = _load(SCRIPTS / "audit_v149_qualification.py", "glm53_audit_v149")
+window = _load(SCRIPTS / "run_v149_qualification_window.py", "glm53_window_v149")
+
+
+# --- probe ------------------------------------------------------------------
+
+def test_probe_kinds_cover_every_contract_lane():
+    assert set(probe.KINDS) == set(audit.LANES)
+
+
+def test_probe_structured_prompt_is_the_standing_gate_payload():
+    # Same payload as tests/bench_decode.py's STRUCTURED_PROMPT; the whole point
+    # is comparability with the 69-70 tok/s band in the existing receipts.
+    assert probe.STRUCTURED_PROMPT.startswith("Count from 1 to 200.")
+
+
+def _decode_run(tok_s=70.0, completion_tokens=200, nan=False, ttft_s=0.3, http=200, error=None):
+    return {
+        "http": http,
+        "error": error,
+        "ttft_s": ttft_s,
+        "decode_s": 2.0,
+        "tok_s": tok_s,
+        "completion_tokens": completion_tokens,
+        "prompt_tokens": 34,
+        "finish_reason": "length",
+        "nan": nan,
+        "text_head": "1 2 3",
+        "spec": {"drafts": 25, "draft_tokens": 175, "accepted": 175,
+                 "accept_ratio": 1.0, "accepted_per_step": 7.0, "pos": [1.0] * 7},
+    }
+
+
+def _prefill_run(rate=1400.0, prompt_tokens=None, cached_tokens=0, target=60_000, ttft_s=57.0):
+    prompt_tokens = target if prompt_tokens is None else prompt_tokens
+    return {
+        "http": 200,
+        "error": None,
+        "target": target,
+        "filler_count": 10,
+        "tokenize_estimate": prompt_tokens,
+        "prompt_tokens": prompt_tokens,
+        "cached_tokens": cached_tokens,
+        "ttft_s": ttft_s,
+        "wall_s": ttft_s + 1,
+        "prefill_tok_s": rate,
+        "finish_reason": "stop",
+        "nan": False,
+        "text_head": "OK",
+    }
+
+
+def test_decode_run_invalid_accepts_a_full_block():
+    assert probe.decode_run_invalid(_decode_run(), 200) is None
+
+
+@pytest.mark.parametrize(
+    "kwargs,needle",
+    [
+        ({"nan": True}, "NaN"),
+        ({"http": 500}, "http 500"),
+        ({"ttft_s": None}, "no first token"),
+        ({"completion_tokens": 12}, "short completion"),
+        ({"tok_s": None}, "completion_tokens"),
+        ({"error": "URLError: refused"}, "URLError"),
+    ],
+)
+def test_decode_run_invalid_rejects(kwargs, needle):
+    run = _decode_run()
+    run.update(kwargs)
+    reason = probe.decode_run_invalid(run, 200)
+    assert reason is not None and needle in reason
+
+
+def test_prefill_run_invalid_accepts_a_cold_run():
+    assert probe.prefill_run_invalid(_prefill_run()) is None
+
+
+@pytest.mark.parametrize(
+    "kwargs,needle",
+    [
+        ({"cached_tokens": 4096}, "warm request"),
+        ({"prompt_tokens": 20_000}, "outside"),
+        ({"http": 503}, "http 503"),
+        ({"ttft_s": None}, "no first token"),
+        ({"prefill_tok_s": None}, "no prefill rate"),
+        ({"prompt_tokens": 0}, "no prompt_tokens"),
+    ],
+)
+def test_prefill_run_invalid_rejects(kwargs, needle):
+    run = _prefill_run()
+    run.update(kwargs)
+    reason = probe.prefill_run_invalid(run)
+    assert reason is not None and needle in reason
+
+
+def test_summarize_reports_median_and_flags_nan_and_cache_hits():
+    decode = probe.summarize("structured", [_decode_run(70.0), _decode_run(80.0)], [])
+    assert decode["valid_runs"] == 2
+    assert decode["tok_s_median"] == 75.0
+    assert decode["any_nan"] is False
+    assert decode["accepted_per_step_median"] == 7.0
+    flagged = probe.summarize("structured", [_decode_run(nan=True)], [])
+    assert flagged["any_nan"] is True
+    prefill = probe.summarize("prefill60k", [_prefill_run(cached_tokens=99)], [])
+    assert prefill["any_cache_hit"] is True
+    assert prefill["prefill_tok_s_median"] == 1400.0
+
+
+def test_probe_refuses_to_measure_an_unhealthy_server(monkeypatch, tmp_path):
+    monkeypatch.setattr(probe, "health", lambda: 503)
+    rc = probe.main(["--kind", "structured", "--runs", "1", "--out", str(tmp_path / "o.json")])
+    assert rc == 2
+    assert not (tmp_path / "o.json").exists()
+
+
+def test_probe_exits_nonzero_when_a_run_is_invalid(monkeypatch, tmp_path):
+    monkeypatch.setattr(probe, "health", lambda: 200)
+    monkeypatch.setattr(probe, "served_model", lambda: "GLM-5.3-Flash-EXL3")
+    monkeypatch.setattr(probe, "spec_snapshot", lambda: {})
+    monkeypatch.setattr(probe, "decode_run", lambda *a, **k: _decode_run(nan=True))
+    out = tmp_path / "o.json"
+    rc = probe.main(["--kind", "structured", "--runs", "3", "--out", str(out)])
+    assert rc == 1
+    payload = json.loads(out.read_text())
+    assert payload["valid_runs"] == 0 and len(payload["invalid_runs"]) == 3
+
+
+# --- auditor ----------------------------------------------------------------
+
+def _probe_receipt(kind, values, *, valid=None, any_nan=False, any_cache_hit=False):
+    key = "tok_s" if kind in ("structured", "essay", "hashmap") else "prefill_tok_s"
+    runs = []
+    for index, value in enumerate(values, start=1):
+        if kind in ("structured", "essay", "hashmap"):
+            run = _decode_run(tok_s=value)
+        else:
+            target = probe.PREFILL_KINDS[kind]
+            run = _prefill_run(rate=value, prompt_tokens=target, target=target)
+        run["i"] = index
+        runs.append(run)
+    return {
+        "schema": 1,
+        "kind": kind,
+        "metric": key,
+        "runs": runs,
+        "invalid_runs": [],
+        "valid_runs": len(values) if valid is None else valid,
+        f"{key}_median": sorted(values)[len(values) // 2],
+        "any_nan": any_nan,
+        "any_cache_hit": any_cache_hit,
+    }
+
+
+def _window_receipt(tmp_path, arm_values, *, gates_ok=True, write_probes=True):
+    """arm_values: {arm: {lane: [values]}} — one probe file per (arm, lane)."""
+    probes = {}
+    for arm, lanes in arm_values.items():
+        probes[arm] = {}
+        for lane, values in lanes.items():
+            name = f"task35b-{arm}-{lane}.json"
+            if write_probes:
+                (tmp_path / name).write_text(json.dumps(_probe_receipt(lane, values)))
+            probes[arm][lane] = name
+    arms = {}
+    for arm in audit.ARMS:
+        arms[arm] = {
+            "image_tag": audit.ARM_IMAGE[arm],
+            "exllamav3_version": audit.ARM_EXLLAMAV3[arm],
+            "worker_image_tag": audit.ARM_IMAGE[arm],
+            "worker_exllamav3_version": audit.ARM_EXLLAMAV3[arm],
+            "jit_stamp": "stamp-b" if arm in ("b", "b2") else "stamp-a",
+        }
+    gates = {
+        "acceptance_rc": 0,
+        "memfree_head_gib": 4.1,
+        "memfree_worker_gib": 3.3,
+        "pool_line": "GPU KV cache size: 1,396,551 tokens",
+        "pool_line_before": "GPU KV cache size: 1,396,551 tokens",
+        "jit_stamp": "stamp-b",
+        "jit_stamp_arm_b": "stamp-b",
+    }
+    if not gates_ok:
+        gates["acceptance_rc"] = 1
+    return {"schema": 1, "window": "task35b", "arms": arms, "gates": gates, "probes": probes}
+
+
+def _uniform(value_map):
+    """Build arm_values from {arm: {lane: value}}."""
+    return {arm: {lane: [value] * audit.REQUIRED_RUNS[lane] for lane, value in lanes.items()}
+            for arm, lanes in value_map.items()}
+
+
+LANE_BASELINE = {"structured": 70.0, "essay": 25.0, "hashmap": 30.0,
+                 "prefill60k": 1450.0, "prefill240k": 1400.0}
+
+
+def _values_with(overrides):
+    """Per-arm values: control arms at baseline, candidate arms at overrides."""
+    out = {}
+    for arm in audit.ARMS:
+        base = dict(LANE_BASELINE)
+        if arm in audit.CANDIDATE_ARMS:
+            base.update(overrides)
+        out[arm] = {lane: [value] * audit.REQUIRED_RUNS[lane] for lane, value in base.items()}
+    return out
+
+
+def test_auditor_adopts_a_non_inferior_candidate(tmp_path):
+    receipt = _window_receipt(tmp_path, _values_with({"structured": 69.5}))
+    result = audit.judge(receipt, tmp_path)
+    assert result["verdict"] == "ADOPT", result["errors"]
+    assert result["lanes"]["structured"]["candidate_over_control"] == round(69.5 / 70.0, 4)
+
+
+def test_auditor_reverts_a_regressed_lane(tmp_path):
+    receipt = _window_receipt(tmp_path, _values_with({"prefill240k": 1200.0}))
+    result = audit.judge(receipt, tmp_path)
+    assert result["verdict"] == "REVERT"
+    assert result["lanes"]["prefill240k"]["verdict"] == "FAIL"
+    assert result["lanes"]["structured"]["verdict"] == "PASS"
+
+
+def test_auditor_reports_a_win_without_requiring_one(tmp_path):
+    receipt = _window_receipt(tmp_path, _values_with({"structured": 75.0, "hashmap": 33.0}))
+    result = audit.judge(receipt, tmp_path)
+    assert result["verdict"] == "ADOPT"
+    assert result["lanes"]["structured"]["candidate_over_control"] > 1.0
+
+
+def test_auditor_is_inconclusive_when_the_control_arms_drift(tmp_path):
+    values = _values_with({})
+    # A2 is the same image as A; a 9% gap means the window moved under itself.
+    values["a2"]["essay"] = [27.3] * audit.REQUIRED_RUNS["essay"]
+    receipt = _window_receipt(tmp_path, values)
+    result = audit.judge(receipt, tmp_path)
+    assert result["verdict"] == "INCONCLUSIVE"
+    assert result["lanes"]["essay"]["verdict"] == "INCONCLUSIVE"
+
+
+def test_auditor_aborts_on_too_few_valid_runs(tmp_path):
+    values = _values_with({})
+    values["b"]["structured"] = [70.0] * 3
+    receipt = _window_receipt(tmp_path, values)
+    result = audit.judge(receipt, tmp_path)
+    assert result["verdict"] == "ABORT"
+    assert any("§6 requires 9" in message for message in result["errors"])
+
+
+def test_auditor_aborts_on_a_nan_run(tmp_path):
+    values = _values_with({})
+    receipt = _window_receipt(tmp_path, values)
+    (tmp_path / "task35b-b-essay.json").write_text(
+        json.dumps(_probe_receipt("essay", [25.0] * 9, any_nan=True))
+    )
+    result = audit.judge(receipt, tmp_path)
+    assert result["verdict"] == "ABORT"
+    assert any("NaN" in message for message in result["errors"])
+
+
+def test_auditor_aborts_on_a_warm_cold_prefill(tmp_path):
+    values = _values_with({})
+    receipt = _window_receipt(tmp_path, values)
+    (tmp_path / "task35b-a-prefill60k.json").write_text(
+        json.dumps(_probe_receipt("prefill60k", [1450.0] * 5, any_cache_hit=True))
+    )
+    result = audit.judge(receipt, tmp_path)
+    assert result["verdict"] == "ABORT"
+    assert any("prefix cache" in message for message in result["errors"])
+
+
+def test_auditor_aborts_when_an_arm_is_not_the_image_it_claims(tmp_path):
+    values = _values_with({})
+    receipt = _window_receipt(tmp_path, values)
+    receipt["arms"]["b"]["image_tag"] = audit.ARM_IMAGE["a"]
+    result = audit.judge(receipt, tmp_path)
+    assert result["verdict"] == "ABORT"
+    assert any("booted" in message for message in result["errors"])
+
+
+def test_auditor_aborts_when_the_worker_ran_the_wrong_revision(tmp_path):
+    values = _values_with({})
+    receipt = _window_receipt(tmp_path, values)
+    receipt["arms"]["b2"]["worker_exllamav3_version"] = "1.4.7"
+    result = audit.judge(receipt, tmp_path)
+    assert result["verdict"] == "ABORT"
+    assert any("worker reports exllamav3" in message for message in result["errors"])
+
+
+def test_auditor_aborts_on_a_missing_probe_receipt(tmp_path):
+    values = _values_with({})
+    receipt = _window_receipt(tmp_path, values)
+    (tmp_path / "task35b-a2-hashmap.json").unlink()
+    result = audit.judge(receipt, tmp_path)
+    assert result["verdict"] == "ABORT"
+    assert any("arm a2 lane hashmap" in message for message in result["errors"])
+
+
+def test_auditor_aborts_on_a_failed_acceptance_battery(tmp_path):
+    values = _values_with({})
+    receipt = _window_receipt(tmp_path, values, gates_ok=False)
+    result = audit.judge(receipt, tmp_path)
+    assert result["verdict"] == "ABORT"
+    assert any("acceptance battery" in message for message in result["errors"])
+
+
+def test_auditor_aborts_when_the_kv_pool_moved(tmp_path):
+    values = _values_with({})
+    receipt = _window_receipt(tmp_path, values)
+    receipt["gates"]["pool_line"] = "GPU KV cache size: 1,200,000 tokens"
+    result = audit.judge(receipt, tmp_path)
+    assert result["verdict"] == "ABORT"
+    assert any("KV pool changed" in message for message in result["errors"])
+
+
+def test_auditor_aborts_when_the_final_jit_stamp_is_not_the_candidate_stamp(tmp_path):
+    values = _values_with({})
+    receipt = _window_receipt(tmp_path, values)
+    receipt["gates"]["jit_stamp"] = "stamp-a"
+    result = audit.judge(receipt, tmp_path)
+    assert result["verdict"] == "ABORT"
+    assert any("JIT shape stamp" in message for message in result["errors"])
+
+
+# --- window runner wiring ---------------------------------------------------
+
+def test_window_is_a_pre_registered_a_b_b_a_over_two_images():
+    assert window.PHASES == (
+        "preflight", "disarm",
+        "arm_a", "measure_a",
+        "arm_b", "measure_b",
+        "arm_b2", "measure_b2",
+        "arm_a2", "measure_a2",
+        "restore", "gates", "rearm", "judge",
+    )
+    assert [window.ARMS[a]["tag"] for a in ("a", "b", "b2", "a2")] == [
+        "glm53-selfbuild:e3-w3-zfill",
+        "glm53-selfbuild:e3-w3-zfill-v149",
+        "glm53-selfbuild:e3-w3-zfill-v149",
+        "glm53-selfbuild:e3-w3-zfill",
+    ]
+    assert window.PRODUCTION_IMAGE == window.ARMS["b"]["tag"]
+
+
+def test_window_lane_counts_match_the_auditor_contract():
+    assert {lane: runs for lane, (runs, _timeout) in window.LANES.items()} == audit.REQUIRED_RUNS
+    assert set(window.LANES) == set(audit.LANES)
+
+
+def test_window_arm_versions_match_the_auditor_identity():
+    for arm, spec in window.ARMS.items():
+        assert spec["exllamav3"] == audit.ARM_EXLLAMAV3[arm]
+        assert spec["tag"] == audit.ARM_IMAGE[arm]
+
+
+def test_set_image_appends_a_last_wins_line(monkeypatch, tmp_path):
+    env = tmp_path / ".env"
+    env.write_text("IMAGE=glm53-selfbuild:e3-w3-zfill-v149\nGLM53_ADAPTIVE_K=ema\n")
+    monkeypatch.setattr(window, "ENV_FILE", env)
+    window.set_image("glm53-selfbuild:e3-w3-zfill")
+    text = env.read_text()
+    assert text.count("IMAGE=") == 2
+    assert window.effective_env_all()["IMAGE"] == "glm53-selfbuild:e3-w3-zfill"
+    assert window.effective_env_all()["GLM53_ADAPTIVE_K"] == "ema"
+
+
+def test_effective_env_all_ignores_comments_and_bad_keys(monkeypatch, tmp_path):
+    env = tmp_path / ".env"
+    env.write_text(
+        "# IMAGE=not-this\n"
+        "IMAGE=first\n"
+        "IMAGE=second\n"
+        "NOT A KEY=value\n"
+        'QUOTED="spaced value"\n'
+    )
+    monkeypatch.setattr(window, "ENV_FILE", env)
+    parsed = window.effective_env_all()
+    assert parsed["IMAGE"] == "second"
+    assert parsed["QUOTED"] == "spaced value"
+    assert "NOT A KEY" not in parsed
+
+
+def test_needs_env_restore_tracks_the_touched_flag_and_the_live_image(monkeypatch, tmp_path):
+    env = tmp_path / ".env"
+    env.write_text(f"IMAGE={window.PRODUCTION_IMAGE}\n")
+    monkeypatch.setattr(window, "ENV_FILE", env)
+    assert window.needs_env_restore({}) is False
+    assert window.needs_env_restore({"backup": "x"}) is False
+    assert window.needs_env_restore({"backup": "x", "env_touched": True}) is True
+    env.write_text("IMAGE=glm53-selfbuild:e3-w3-zfill\n")
+    assert window.needs_env_restore({"backup": "x"}) is True
+
+
+def test_judge_writes_the_audit_next_to_the_window_receipt(monkeypatch, tmp_path):
+    receipt = tmp_path / "task35b-window-20260911-000000.json"
+    receipt.write_text(json.dumps({"arms": {}, "gates": {}, "probes": {}}))
+    monkeypatch.setattr(window, "_RECEIPT", receipt)
+    state: dict = {}
+    window.phase_judge(state)
+    assert state["verdict"] == "ABORT"
+    assert state["audit_receipt"] == "task35b-audit-20260911-000000.json"
+    assert (tmp_path / state["audit_receipt"]).is_file()
+
+
+# --- ISA probe (task 38 item 2) ---------------------------------------------
+
+isa = _load(SCRIPTS / "probe_isa_e2m1_silicon.py", "glm53_probe_isa")
+
+
+def test_isa_reference_follows_the_ptx_nibble_order():
+    # PTX ISA: `a` is converted into the upper nibble, `b` into the lower.
+    # 1.0 -> code 2, 2.0 -> code 4.
+    assert isa.expected_pair(1.0, 2.0) == 0x24
+    assert isa.reversed_pair(1.0, 2.0) == 0x42
+    # The task 38 record shows 0x42 for this pair, i.e. the original probe fed
+    # (2.0, 1.0) -- or its inputs were ordered opposite to the PTX spec.
+    assert isa.expected_pair(2.0, 1.0) == 0x42
+
+
+@pytest.mark.parametrize(
+    "value,code",
+    [
+        (0.0, 0b0000), (0.5, 0b0001), (1.0, 0b0010), (1.5, 0b0011),
+        (2.0, 0b0100), (3.0, 0b0101), (4.0, 0b0110), (6.0, 0b0111),
+        (-1.0, 0b1010), (-6.0, 0b1111),
+    ],
+)
+def test_isa_e2m1_codes(value, code):
+    assert isa.e2m1_code(value) == code
+
+
+def test_isa_e2m1_rounds_to_nearest_even_on_a_tie():
+    assert isa.e2m1_code(0.25) == 0b0000  # tie 0.0/0.5 -> even code 0
+    assert isa.e2m1_code(0.75) == 0b0010  # tie 0.5/1.0 -> even code 2
+    assert isa.e2m1_code(0.4) == 0b0001
+    assert isa.e2m1_code(0.6) == 0b0001
+    assert isa.e2m1_code(2.7) == 0b0101
+
+
+def test_isa_e2m1_saturates_and_rejects_nan():
+    assert isa.e2m1_code(1e30) == 0b0111
+    assert isa.e2m1_code(-1e30) == 0b1111
+    with pytest.raises(ValueError):
+        isa.e2m1_code(float("nan"))
+
+
+def test_isa_ptx_uses_one_parameter_fed_kernel():
+    ptx = isa.build_ptx()
+    assert ".target sm_121a" in ptx
+    assert ".entry probe_e2m1" in ptx
+    # One kernel, one conversion: the cases are separate launches.
+    assert ptx.count("cvt.rn.satfinite.e2m1x2.f32") == 1
+    # Operands must arrive as parameters, never as `mov.f32` immediates: ptxas
+    # mis-materializes the immediates and every case then reads 0x00.
+    assert "ld.param.f32" in ptx
+    assert "mov.f32" not in ptx
+    assert "0f" not in ptx
+    # The destination is a single byte.
+    assert ".reg .b8" in ptx
+    assert "st.global.u8" in ptx
+
+
+def test_isa_judge_confirms_spec_correct_silicon():
+    observed = [isa.expected_pair(a, b) for _n, a, b, _t in isa.CASES]
+    result = isa.judge(observed)
+    assert result["verdict"] == "SILICON_CONFIRMED"
+    assert result["errors"] == []
+    assert result["reversed_order_cases"] == 0
+    assert result["cases_matching_spec"] == len(isa.CASES)
+
+
+def test_isa_judge_rejects_a_reversed_nibble_order():
+    observed = [isa.reversed_pair(a, b) for _n, a, b, _t in isa.CASES]
+    result = isa.judge(observed)
+    assert result["verdict"] == "SILICON_MISMATCH"
+    assert result["reversed_order_cases"] > 0
+    assert any("REVERSED nibble order" in message for message in result["errors"])
+
+
+def test_isa_judge_rejects_a_wrong_conversion():
+    observed = [isa.expected_pair(a, b) for _n, a, b, _t in isa.CASES]
+    observed[0] = 0x00
+    result = isa.judge(observed)
+    assert result["verdict"] == "SILICON_MISMATCH"
+    assert any("recorded-reversed-2.0-1.0" in message for message in result["errors"])
+
+
+def test_isa_judge_rejects_an_all_zero_result():
+    """The exact failure the immediate-operand form produced must not pass.
+
+    `(0.0, 0.0)` really does encode as 0x00, so that one case matches; the
+    discriminating cases must still be reported as mismatches.
+    """
+    result = isa.judge([0x00] * len(isa.CASES))
+    assert result["verdict"] == "SILICON_MISMATCH"
+    assert result["cases_matching_spec"] == 1
+    flagged = {message.split(" ")[0] for message in result["errors"]}
+    assert {"distinct-1.0-2.0", "top-of-range", "negative"} <= flagged
+    assert "zero" not in flagged
+
+
+def test_isa_ties_are_recorded_but_not_gated():
+    rows = {row["case"]: row for row in isa.judge([0x00] * len(isa.CASES))["cases"]}
+    assert rows["tie-0.25-0.75"]["tie"] is True
+    assert isa.judge([0x00] * len(isa.CASES))["gated_cases"] == len(isa.CASES) - 1
+
+
+def test_isa_judge_rejects_a_short_result():
+    with pytest.raises(RuntimeError):
+        isa.judge([0x00] * (len(isa.CASES) - 1))
+
+
+def test_isa_ptx_only_mode_needs_no_gpu(monkeypatch, tmp_path):
+    def explode(*_a, **_k):
+        raise AssertionError("--ptx-only must not touch the driver")
+
+    monkeypatch.setattr(isa, "run_on_gpu", explode)
+    assert isa.main(["--ptx-only", "--workdir", str(tmp_path)]) == 0
+    assert (tmp_path / "run_probe.ptx").is_file()
+
+
+def test_isa_reports_probe_unavailable_when_the_driver_refuses(monkeypatch, tmp_path):
+    def refuse(_ptx, _cases=isa.CASES):
+        raise RuntimeError("CUDA_ERROR_OUT_OF_MEMORY")
+
+    monkeypatch.setattr(isa, "run_on_gpu", refuse)
+    out = tmp_path / "isa.json"
+    assert isa.main(["--out", str(out)]) == 2
+    payload = json.loads(out.read_text())
+    assert payload["verdict"] == "PROBE_UNAVAILABLE"
+    assert "OUT_OF_MEMORY" in payload["error"]
+
+
+def test_isa_main_writes_a_silicon_confirmed_receipt(monkeypatch, tmp_path):
+    monkeypatch.setattr(isa, "run_on_gpu", lambda ptx, cases=isa.CASES: [
+        isa.expected_pair(a, b) for _n, a, b, _t in cases
+    ])
+    out = tmp_path / "isa.json"
+    assert isa.main(["--out", str(out)]) == 0
+    payload = json.loads(out.read_text())
+    assert payload["verdict"] == "SILICON_CONFIRMED"
+    assert payload["probe"] == "cvt.rn.satfinite.e2m1x2.f32"
+
+
+def test_window_has_no_isa_phase():
+    """The probe runs alongside production (1-byte alloc + 1-thread launch
+    succeed with the serving stack up), so the window must not stop production
+    for it."""
+    assert "isa" not in window.PHASES
+    assert not hasattr(window, "ISA_PROBE")
+    assert not hasattr(window, "phase_isa")

--- a/tests/test_v149_qualification.py
+++ b/tests/test_v149_qualification.py
@@ -199,6 +199,7 @@ def _window_receipt(tmp_path, arm_values, *, gates_ok=True, write_probes=True):
             "worker_image_tag": audit.ARM_IMAGE[arm],
             "worker_exllamav3_version": audit.ARM_EXLLAMAV3[arm],
             "jit_stamp": "stamp-b" if arm in ("b", "b2") else "stamp-a",
+            "pool_line": "GPU KV cache size: 1,396,551 tokens",
         }
     gates = {
         "acceptance_rc": 0,
@@ -211,7 +212,10 @@ def _window_receipt(tmp_path, arm_values, *, gates_ok=True, write_probes=True):
     }
     if not gates_ok:
         gates["acceptance_rc"] = 1
-    return {"schema": 1, "window": "task35b", "arms": arms, "gates": gates, "probes": probes}
+    return {
+        "schema": 1, "window": "task35b", "arms": arms, "gates": gates, "probes": probes,
+        "pool_line_before": "GPU KV cache size: 1,396,551 tokens",
+    }
 
 
 def _uniform(value_map):
@@ -340,6 +344,79 @@ def test_auditor_aborts_when_the_kv_pool_moved(tmp_path):
     result = audit.judge(receipt, tmp_path)
     assert result["verdict"] == "ABORT"
     assert any("KV pool changed" in message for message in result["errors"])
+
+
+def test_auditor_aborts_when_one_arm_reserved_a_different_pool(tmp_path):
+    """The per-arm pool check localizes a divergence to the boot that caused it."""
+    values = _values_with({})
+    receipt = _window_receipt(tmp_path, values)
+    receipt["arms"]["b2"]["pool_line"] = "GPU KV cache size: 1,200,000 tokens"
+    result = audit.judge(receipt, tmp_path)
+    assert result["verdict"] == "ABORT"
+    assert any("arm b2 KV pool differs" in message for message in result["errors"])
+
+
+def test_auditor_aborts_when_an_arm_recorded_no_pool_line(tmp_path):
+    values = _values_with({})
+    receipt = _window_receipt(tmp_path, values)
+    del receipt["arms"]["a"]["pool_line"]
+    result = audit.judge(receipt, tmp_path)
+    assert result["verdict"] == "ABORT"
+    assert any("arm a recorded no KV pool line" in message for message in result["errors"])
+
+
+def test_auditor_aborts_when_the_pre_window_pool_line_is_missing(tmp_path):
+    values = _values_with({})
+    receipt = _window_receipt(tmp_path, values)
+    receipt["pool_line_before"] = ""
+    result = audit.judge(receipt, tmp_path)
+    assert result["verdict"] == "ABORT"
+    assert any("pre-window KV pool line missing" in message for message in result["errors"])
+
+
+def test_window_pool_line_prefers_the_canonical_capacity_line(monkeypatch):
+    """A bare `kv_cache` match would hit the startup patch message instead, whose
+    value is constant across arms and would make the pool gate vacuous."""
+    seen: list[str] = []
+
+    class Fake:
+        def __init__(self, stdout):
+            self.stdout = stdout
+
+    def fake_run(argv, **_kw):
+        command = argv[-1]
+        seen.append(command)
+        if "GPU KV cache size:" in command:
+            return Fake("(EngineCore pid=237) INFO [kv_cache_utils.py:2598] "
+                        "GPU KV cache size: 1,396,551 tokens\n")
+        return Fake("")
+
+    monkeypatch.setattr(window.win, "run", fake_run)
+    line = window.pool_line()
+    assert line.endswith("GPU KV cache size: 1,396,551 tokens")
+    assert "GPU KV cache size:" in seen[0]
+
+
+def test_window_pool_line_falls_back_to_the_local_capacity_marker(monkeypatch):
+    class Fake:
+        def __init__(self, stdout):
+            self.stdout = stdout
+
+    def fake_run(argv, **_kw):
+        if "glm53-kv-capacity-log" in argv[-1]:
+            return Fake("[glm53-kv-capacity-log] usable block ids: 566\n")
+        return Fake("")
+
+    monkeypatch.setattr(window.win, "run", fake_run)
+    assert "glm53-kv-capacity-log" in window.pool_line()
+
+
+def test_window_pool_line_is_empty_when_neither_line_exists(monkeypatch):
+    class Fake:
+        stdout = ""
+
+    monkeypatch.setattr(window.win, "run", lambda *_a, **_k: Fake())
+    assert window.pool_line() == ""
 
 
 def test_auditor_aborts_when_the_final_jit_stamp_is_not_the_candidate_stamp(tmp_path):


### PR DESCRIPTION
## What this branch adds

Two task closures plus the harness and operational fixes they produced.

### Task 38 item 2 — FP4 e2m1 executes on silicon (CLOSED)

`scripts/probe_isa_e2m1_silicon.py` runs a `.b8` / `st.global.u8` kernel on both
GB10 dies. Result: **SILICON_CONFIRMED 12/12 on both dies**, so this item closed
without needing a maintenance window at all. Receipts:
`local/isa-probe-spark1-20260911.json`, `local/isa-probe-spark2-20260911.json`,
`local/task38-isa-e2m1-silicon-20260911.txt`.

### Task 35 §6 performance qualification — harness built, window PENDING

A separable **probe -> offline auditor -> guarded window runner** triad:

| File | Role |
|---|---|
| `scripts/probe_v149_qualification.py` | decode + prefill probe, streaming SSE, atomic per-observation receipts |
| `scripts/audit_v149_qualification.py` | the pre-registered judge |
| `scripts/run_v149_qualification_window.py` | the guarded A-B-B-A window |
| `tests/test_v149_qualification.py` | CPU-only tests for all three |

The measurement contract was **pre-registered before any run**: bands
(structured 0.97, others 0.95), `DRIFT_MAX 0.05`, `VARIABILITY_MAX 0.30`, the
verdict vocabulary, and a `scope` field on the audit receipt.

**The window has not been run, so this branch makes no performance claim.** It is
blocked on a head-node hardware fault: spark1's GPU is pinned at its 507 MHz
minimum clock — **23.8 TFLOP/s** against the worker's 94.8 TFLOP/s for the same
bf16 8192³ matmul — and a node reboot did **not** clear it. Every software cause
was ruled out: all nine throttle reasons inactive, identical application clocks,
no clock-lock call anywhere, persistence enabled, no `nvpmodel`, no CPU
contention, normal temperature. Throughput tracks the clock exactly, so the GPU
computes correctly and merely never leaves minimum clock. An idle clock reading
is uninformative (GB10 parks at 507 MHz when idle), so the window must not start
until a **load** measurement shows ≥ 2000 MHz and ≥ 80 TFLOP/s. Receipts:
`local/spark1-head-clock-507mhz-20260911.txt`,
`local/spark1-head-clock-post-reboot-20260911.txt`.

### The harness is a narrowed contract, not a completed §6

`docs/16` records exactly what it does not cover: temp-1 production cells, the
§6 serving gates (toolcall, thinking/SSE, long-form, mixed-cache soak), and the
prescribed drained-APC reset for cold rounds. An ADOPT from this harness would be
a statement about throughput on the lanes measured, not a completed
qualification. The audit receipt carries the same statement in its `scope` field,
so a receipt cannot be read as more than it is.

### Four review rounds, each fixed and re-verified

- **Round 1** — 11 findings (`cc12e74`). Two would have aborted a healthy window,
  two would have produced wrong numbers, the rest were fail-closed or evidence
  gaps.
- **Round 2** — 2 regressions introduced by the round-1 fixes, plus 6 partials
  (`97a2c61`).
- **Round 3** — 6 findings plus 2 live-node defects (`11dfda1`).
- **Round 4** — 1 finding: the per-unit timer loops (`642fd26`).

The live-node defects are the ones worth calling out, because only exercising the
exact bytes against production found them. `systemctl is-active` prints
`inactive` for a **nonexistent** unit too (rc=4 vs rc=3), so the fail-closed
quiescence check could read a wrong-user or renamed-unit query as disarmed.
Separately, a fixed 5 s poll made a short timeout block for a full interval.

### Cluster validation performed

The publication gate wants the exact candidate bytes exercised on the target
cluster, not only under pytest on the Mac. The A-B-B-A path cannot run while the
clock fault holds, so the deepest non-destructive boundary was validated
instead: `preflight`, which stops nothing and whose only write is a timestamped
`.env` backup.

Result: `EXIT=0` with `pool_capacity_before='1396551 tokens; concurrency 1.40x'`
(a parsed capacity, not a log line), `jit_stamp=7b09229c3b6f`, `/health` 200, and
both arm images already present on both nodes.

`preflight` was run twice, because review found the runner defect after the first
run: the first exercised runner `e542c168…` as of `11dfda1`, and the second
exercised runner `8919aa64…` as of the published revision. Only the runner
differed, and all three harness hashes matched the published revision on both the
Mac and the head node before the second run.

This is a **partial** pass: it does not exercise the arm switch
(`disarm` -> `arm_a` -> `measure_a` -> ...), which is the part that stops and
restarts production, and it produces no timing number. Receipt:
`local/task35b-cluster-preflight-20260911.txt`.

### Operational fix the same reboot exposed

The reboot took production down and it did not come back on its own: `start.sh`
resolved one `NCCL_IB_GID_INDEX=3` for both ranks while the head's rail-1 RoCE v2
entry sits at `gid3` and the worker's at `gid4`. The head's reboot bounced the
QSFP link, and the link-down/up cycle reordered the worker's GID table (the
worker was never rebooted). Production failed three start attempts and stayed
down until `HEAD_GID=3`/`WORKER_GID=4` were set in `.env`, after which it came up
healthy. Not a task 35 regression — the pre-task35 backup carries the same single
index. Receipt: `local/spark1-gid-fix-20260911.txt`.

## Validation

- `pytest` — **673 passed, 1 skipped, 18 subtests passed**
- Cluster: non-destructive `preflight` of the exact published bytes, `EXIT=0`
- Production after every run: unit `active`, `/health` 200, container on
  `glm53-selfbuild:e3-w3-zfill-v149`

## Not in this branch

- The §6 window itself, which stays blocked on the head clock fault.
- `spec/` (git-ignored by project convention).

## Rollback

The harness is additive: scripts, tests, docs, and receipts only, with no
production file changed. The window's own rollback is a one-line `.env` flip
(`IMAGE=glm53-selfbuild:e3-w3-zfill`, backup
`.env.bak-pre-task35-v149-20260910`).
